### PR TITLE
Assemble playcut-detail base fields local-first before LML enrichment

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -34,8 +34,7 @@ import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
 import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metadata.service.js';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import {
-  resolveLinkedAlbumId,
-  resolveLinkedFlowsheetBase,
+  selectLinkedFlowsheetRow,
   lookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId,
   type PersistedAlbumMetadata,
@@ -451,21 +450,27 @@ function parseDiscogsReleaseIdFromUrl(url: string): number | undefined {
  * so the p50/p95 cohort distinction stays visible.
  *
  * Local-first base fields (BS#1827): `artistName` / `releaseTitle` /
- * `trackTitle` are assembled from the request itself — and
- * `recordLabel` / `labelId` / `metadataStatus`, when a linked flowsheet row
- * is known, straight off that row via {@link resolveLinkedFlowsheetBase} —
- * BEFORE any persisted-state or LML lookup is attempted below. These are
- * "base": durable BS state, independent of Discogs/LML. Everything else this
- * handler adds afterward (`artworkUrl`, `discogsUrl`, `genres`, `label`,
- * streaming URLs, ...) is "enriched": optional, upstream-dependent, and
- * present only when known. The distinction is implicit in which fields are
- * unconditional vs. conditionally assigned — there's no separate `base` /
- * `enriched` wrapper in the wire shape, and these three new response fields
- * aren't yet in `wxyc-shared/api.yaml` (tracked for the iOS consumer,
- * iOS#685, which also formalizes the `metadata_status`/`isTerminal` contract
- * this sets up). The result: an LML timeout can blank `artworkUrl` etc., but
- * it can never blank artist/track/album/label — see the "local-first base
- * fields" test suite for the exact contract.
+ * `trackTitle` are assembled from the request itself, and `recordLabel` /
+ * `labelId` / `metadataStatus` — when a linked flowsheet row is known —
+ * come from that SAME row via {@link selectLinkedFlowsheetRow}, which also
+ * resolves `albumId`. One query serves both, so the base fields and the
+ * `album_id` the persisted-state read below keys off can never describe two
+ * different flowsheet rows for one request (a two-query version raced a
+ * concurrent flowsheet insert landing between them — fixed in round 2 of
+ * this slice). All of this runs BEFORE any LML lookup is attempted below.
+ * These are "base": durable BS state, independent of Discogs/LML. Everything
+ * else this handler adds afterward (`artworkUrl`, `discogsUrl`, `genres`,
+ * `label`, streaming URLs, ...) is "enriched": optional, upstream-dependent,
+ * and present only when known. The distinction is implicit in which fields
+ * are unconditional vs. conditionally assigned — there's no separate `base`
+ * / `enriched` wrapper in the wire shape, and these three new response
+ * fields aren't yet in `wxyc-shared/api.yaml` (tracked for the iOS consumer,
+ * iOS#685, which also formalizes the `metadata_status`/`isTerminal`
+ * contract this sets up — `metadataStatus` here is a faithful echo of the
+ * row's column, including any replay staleness; iOS#685 owns that terminal-
+ * semantics question, not this handler). The result: an LML timeout can
+ * blank `artworkUrl` etc., but it can never blank artist/track/album/label
+ * — see the "local-first base fields" test suite for the exact contract.
  */
 export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (req, res) => {
   const { artistName, releaseTitle, trackTitle } = req.query;
@@ -485,50 +490,37 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   // fills missing streaming URLs at the bottom of the handler. iOS sees
   // the same shape it would on the LML-fallthrough path.
   //
-  // Resolve the `album_id` from the normalized `(artist, album)` lookup key
-  // ONCE, then feed it to both the persisted-metadata read and (below) the
-  // critic-reviews read. Resolving per-read would let a flowsheet insert
-  // between the two calls make metadata and reviews describe different albums
-  // for the same request.
+  // Resolve the linked flowsheet row from the normalized `(artist, album)`
+  // lookup key ONCE (BS#1827: album_id plus the base catalog fields, one
+  // query), then feed the album_id to both the persisted-metadata read and
+  // (below) the critic-reviews read. Resolving per-read would let a
+  // flowsheet insert land between the calls and make them describe
+  // different albums for the same request.
   //
   // A thrown DB error here would propagate as 500 and regress availability
   // versus the LML-fallthrough path (which catches LML errors and degrades
   // to synthesized search URLs). Treat any DB failure as a cache miss and
   // fall through to LML — the caller's worst-case latency goes up, but the
-  // request still completes with a 200.
+  // request still completes with a 200. Because album_id and the base
+  // fields now come from the SAME query, a failure here can no longer
+  // "partially" fail — it drops both together, which is the correct model:
+  // there's nothing left to partially succeed at.
   let albumId: number | null = null;
   let persisted: PersistedAlbumMetadata | null = null;
   try {
-    albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
+    const linkedRow = await selectLinkedFlowsheetRow(artistName, releaseTitle);
+    albumId = linkedRow?.album_id ?? null;
+    // Base catalog fields BS wrote at play time (BS#1827): sourced from the
+    // SAME row album_id came from. A free-text row that has never linked to
+    // an album_id has no efficient local source for these three (see
+    // selectLinkedFlowsheetRow's doc comment) — its artist/release/track
+    // identity above still survives via the request echo.
+    if (linkedRow?.record_label) metadata.recordLabel = linkedRow.record_label;
+    if (linkedRow?.label_id != null) metadata.labelId = linkedRow.label_id;
+    if (linkedRow?.metadata_status) metadata.metadataStatus = linkedRow.metadata_status;
     if (albumId !== null) persisted = await lookupAlbumMetadataById(albumId);
   } catch (lookupError) {
     console.warn('[ProxyController] local metadata lookup failed; falling through to LML:', lookupError);
-  }
-
-  // Base catalog fields BS wrote at play time (BS#1827): record_label /
-  // label_id / metadata_status live on the SAME flowsheet row `albumId` was
-  // just resolved from, independent of whether `album_metadata` enrichment
-  // has ever run. Gated on `albumId !== null` — resolveLinkedFlowsheetBase
-  // shares resolveLinkedAlbumId's exact WHERE/ORDER BY/LIMIT, so when that
-  // already came back null there is no row this call could find either; a
-  // free-text row that has never linked to an album_id has no efficient
-  // local source for these three (see resolveLinkedFlowsheetBase's doc
-  // comment) — its artist/release/track identity above still survives via
-  // the request echo. Own try/catch so a failure here degrades to omitting
-  // only these three fields — it must never discard the persisted/LML
-  // metadata resolved above or below.
-  if (albumId !== null) {
-    try {
-      const localBase = await resolveLinkedFlowsheetBase(artistName, releaseTitle);
-      if (localBase?.record_label) metadata.recordLabel = localBase.record_label;
-      if (localBase?.label_id != null) metadata.labelId = localBase.label_id;
-      if (localBase?.metadata_status) metadata.metadataStatus = localBase.metadata_status;
-    } catch (baseFieldsError) {
-      console.warn(
-        '[ProxyController] local flowsheet base lookup failed; omitting base catalog fields:',
-        baseFieldsError
-      );
-    }
   }
 
   if (persisted) Object.assign(metadata, buildLocalMetadataResponse(persisted));

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -35,6 +35,7 @@ import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metada
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import {
   resolveLinkedAlbumId,
+  resolveLinkedFlowsheetBase,
   lookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId,
   type PersistedAlbumMetadata,
@@ -448,11 +449,35 @@ function parseDiscogsReleaseIdFromUrl(url: string): number | undefined {
  * `proxy.metadata.album.upstream_calls` Sentry attribute reads 0 on
  * local hit, 1 on cold fallthrough — splittable in the trace explorer
  * so the p50/p95 cohort distinction stays visible.
+ *
+ * Local-first base fields (BS#1827): `artistName` / `releaseTitle` /
+ * `trackTitle` are assembled from the request itself — and
+ * `recordLabel` / `labelId` / `metadataStatus`, when a linked flowsheet row
+ * is known, straight off that row via {@link resolveLinkedFlowsheetBase} —
+ * BEFORE any persisted-state or LML lookup is attempted below. These are
+ * "base": durable BS state, independent of Discogs/LML. Everything else this
+ * handler adds afterward (`artworkUrl`, `discogsUrl`, `genres`, `label`,
+ * streaming URLs, ...) is "enriched": optional, upstream-dependent, and
+ * present only when known. The distinction is implicit in which fields are
+ * unconditional vs. conditionally assigned — there's no separate `base` /
+ * `enriched` wrapper in the wire shape, and these three new response fields
+ * aren't yet in `wxyc-shared/api.yaml` (tracked for the iOS consumer,
+ * iOS#685, which also formalizes the `metadata_status`/`isTerminal` contract
+ * this sets up). The result: an LML timeout can blank `artworkUrl` etc., but
+ * it can never blank artist/track/album/label — see the "local-first base
+ * fields" test suite for the exact contract.
  */
 export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (req, res) => {
   const { artistName, releaseTitle, trackTitle } = req.query;
 
   if (!artistName) throw new WxycError('artistName query parameter is required', 400);
+
+  // Base identity fields (BS#1827): exactly what the caller already asked
+  // about, so assembled unconditionally before any lookup below — nothing
+  // that happens next (a DB blip, an LML timeout) can ever erase these.
+  const metadata: Record<string, unknown> = { artistName };
+  if (releaseTitle) metadata.releaseTitle = releaseTitle;
+  if (trackTitle) metadata.trackTitle = trackTitle;
 
   // Cache-first: consult BS's own persisted state before going to LML.
   // Catch-arm-shape rows (YT/BC/SC populated, Apple/Spotify/artwork null)
@@ -480,7 +505,33 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
     console.warn('[ProxyController] local metadata lookup failed; falling through to LML:', lookupError);
   }
 
-  const metadata: Record<string, unknown> = persisted ? buildLocalMetadataResponse(persisted) : {};
+  // Base catalog fields BS wrote at play time (BS#1827): record_label /
+  // label_id / metadata_status live on the SAME flowsheet row `albumId` was
+  // just resolved from, independent of whether `album_metadata` enrichment
+  // has ever run. Gated on `albumId !== null` — resolveLinkedFlowsheetBase
+  // shares resolveLinkedAlbumId's exact WHERE/ORDER BY/LIMIT, so when that
+  // already came back null there is no row this call could find either; a
+  // free-text row that has never linked to an album_id has no efficient
+  // local source for these three (see resolveLinkedFlowsheetBase's doc
+  // comment) — its artist/release/track identity above still survives via
+  // the request echo. Own try/catch so a failure here degrades to omitting
+  // only these three fields — it must never discard the persisted/LML
+  // metadata resolved above or below.
+  if (albumId !== null) {
+    try {
+      const localBase = await resolveLinkedFlowsheetBase(artistName, releaseTitle);
+      if (localBase?.record_label) metadata.recordLabel = localBase.record_label;
+      if (localBase?.label_id != null) metadata.labelId = localBase.label_id;
+      if (localBase?.metadata_status) metadata.metadataStatus = localBase.metadata_status;
+    } catch (baseFieldsError) {
+      console.warn(
+        '[ProxyController] local flowsheet base lookup failed; omitting base catalog fields:',
+        baseFieldsError
+      );
+    }
+  }
+
+  if (persisted) Object.assign(metadata, buildLocalMetadataResponse(persisted));
   let upstreamCalls = 0;
 
   if (!persisted) {

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -6,18 +6,20 @@
  *
  * Four exported helpers, keyed on the `album_id` of a matching `flowsheet`
  * row and staged so the handler resolves that id exactly once per request:
- *   - {@link resolveLinkedAlbumId} — normalized `(artist, release)` key →
- *     one `library.id`, via the partial functional index
+ *   - {@link selectLinkedFlowsheetRow} — normalized `(artist, release)` key →
+ *     the matching linked flowsheet row (`album_id` plus the base,
+ *     non-enrichment `record_label` / `label_id` / `metadata_status`
+ *     columns, BS#1827), via the partial functional index
  *     `flowsheet_album_link_lookup_idx` (migration 0081). Deterministic
  *     `ORDER BY flowsheet.id DESC LIMIT 1` row-pick so multi-`album_id` keys
  *     (V/A multi-format, dual-pressings, librarian duplicates) can't flap
- *     between distinct albums across polls.
- *   - {@link resolveLinkedFlowsheetBase} — base (non-enrichment) fields off
- *     the SAME linked flowsheet row (`record_label` / `label_id` /
- *     `metadata_status`, BS#1827): written at play time, never LML-derived,
- *     so they survive independent of whether `album_metadata` enrichment or
- *     LML has ever run for this album. See the `/proxy/metadata/album`
- *     handler's doc comment for how this feeds the local-first base block.
+ *     between distinct albums across polls. One query resolves album_id AND
+ *     the base fields together — see the `/proxy/metadata/album` handler's
+ *     doc comment for how this feeds the local-first base block without a
+ *     second, separately-racing round trip.
+ *   - {@link resolveLinkedAlbumId} — thin `number | null` wrapper over
+ *     {@link selectLinkedFlowsheetRow} for callers that only need the id
+ *     (`jobs/album-critic-reviews-etl`, `scripts/seed-critic-reviews.ts`).
  *   - {@link lookupAlbumMetadataById} — PK-lookup on `album_metadata` for a
  *     resolved id; the 10 base columns the proxy response is built from plus
  *     the 8 LML-only enrichment fields (`discogs_artist_id` / `label` /
@@ -28,9 +30,9 @@
  *     attributed snippets for a resolved id, independent of whether
  *     `album_metadata` enrichment has run.
  *
- * The `/proxy/metadata/album` handler calls {@link resolveLinkedAlbumId}
- * once and feeds the id to both the metadata and reviews reads, so a
- * concurrent flowsheet insert can't make the two reads describe two
+ * The `/proxy/metadata/album` handler calls {@link selectLinkedFlowsheetRow}
+ * once and feeds the resolved `album_id` to both the metadata and reviews
+ * reads, so a concurrent flowsheet insert can't make the reads describe two
  * different albums for one request (the reads used to each re-resolve the
  * key, which was both racy and coupled reviews to the metadata read).
  *
@@ -58,13 +60,15 @@ import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
  * need touching. New code should import from `@wxyc/database` directly, as
  * `scripts/seed-critic-reviews.ts` now does.
  *
- * `resolveLinkedFlowsheetBase` (BS#1827) lives alongside it in the same
- * `@wxyc/database` module and is re-exported here for the same reason —
- * only `apps/backend/controllers/proxy.controller.ts` needs it today, so
- * there's no `jobs/` consumer yet, but keeping both resolvers importable
- * from one place avoids a second import site to remember.
+ * `selectLinkedFlowsheetRow` (BS#1827, folded from a separate
+ * `resolveLinkedFlowsheetBase` into the combined-row shape in round 2 of the
+ * same slice) lives alongside it in the same `@wxyc/database` module and is
+ * re-exported here for the same reason — only
+ * `apps/backend/controllers/proxy.controller.ts` needs it today, so there's
+ * no `jobs/` consumer yet, but keeping both resolvers importable from one
+ * place avoids a second import site to remember.
  */
-export { resolveLinkedAlbumId, resolveLinkedFlowsheetBase, type LinkedFlowsheetBase } from '@wxyc/database';
+export { resolveLinkedAlbumId, selectLinkedFlowsheetRow, type LinkedFlowsheetRow } from '@wxyc/database';
 
 /**
  * Persisted album metadata projection. Matches the 18 columns on

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -1,10 +1,10 @@
 /**
  * Local read helpers backing the cache-first `/proxy/metadata/album` path
  * (BS#1331) and the external critic-review snippets attached to it
- * (album-critic-reviews slice, ADR 0012). All three read BS's own persisted
- * state so the steady-state serve path skips the LML cascade entirely.
+ * (album-critic-reviews slice, ADR 0012). All read BS's own persisted state
+ * so the steady-state serve path skips the LML cascade entirely.
  *
- * Three exported helpers, keyed on the `album_id` of a matching `flowsheet`
+ * Four exported helpers, keyed on the `album_id` of a matching `flowsheet`
  * row and staged so the handler resolves that id exactly once per request:
  *   - {@link resolveLinkedAlbumId} — normalized `(artist, release)` key →
  *     one `library.id`, via the partial functional index
@@ -12,6 +12,12 @@
  *     `ORDER BY flowsheet.id DESC LIMIT 1` row-pick so multi-`album_id` keys
  *     (V/A multi-format, dual-pressings, librarian duplicates) can't flap
  *     between distinct albums across polls.
+ *   - {@link resolveLinkedFlowsheetBase} — base (non-enrichment) fields off
+ *     the SAME linked flowsheet row (`record_label` / `label_id` /
+ *     `metadata_status`, BS#1827): written at play time, never LML-derived,
+ *     so they survive independent of whether `album_metadata` enrichment or
+ *     LML has ever run for this album. See the `/proxy/metadata/album`
+ *     handler's doc comment for how this feeds the local-first base block.
  *   - {@link lookupAlbumMetadataById} — PK-lookup on `album_metadata` for a
  *     resolved id; the 10 base columns the proxy response is built from plus
  *     the 8 LML-only enrichment fields (`discogs_artist_id` / `label` /
@@ -51,8 +57,14 @@ import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
  * proxy.controller.ts` still imports from here, so its import site doesn't
  * need touching. New code should import from `@wxyc/database` directly, as
  * `scripts/seed-critic-reviews.ts` now does.
+ *
+ * `resolveLinkedFlowsheetBase` (BS#1827) lives alongside it in the same
+ * `@wxyc/database` module and is re-exported here for the same reason —
+ * only `apps/backend/controllers/proxy.controller.ts` needs it today, so
+ * there's no `jobs/` consumer yet, but keeping both resolvers importable
+ * from one place avoids a second import site to remember.
  */
-export { resolveLinkedAlbumId } from '@wxyc/database';
+export { resolveLinkedAlbumId, resolveLinkedFlowsheetBase, type LinkedFlowsheetBase } from '@wxyc/database';
 
 /**
  * Persisted album metadata projection. Matches the 18 columns on

--- a/shared/database/src/album-resolve.ts
+++ b/shared/database/src/album-resolve.ts
@@ -88,3 +88,61 @@ export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: st
 
   return candidate[0]?.album_id ?? null;
 }
+
+/**
+ * Base (non-enrichment) flowsheet fields for a linked `(artistName,
+ * releaseTitle)` key — added for BS#1827 (local-first playcut details).
+ * `record_label` / `label_id` are written onto `flowsheet` at play time (by
+ * the DJ, dj-site's freeform entry, or the ETL) and never depend on LML,
+ * unlike `album_metadata.label` (Discogs enrichment, BS#1336). Reading them
+ * off the SAME row {@link resolveLinkedAlbumId} resolves its `album_id` from
+ * means `GET /proxy/metadata/album` can surface a durable label/status even
+ * when no `album_metadata` row exists yet and the LML fallthrough fails —
+ * see `apps/backend/controllers/proxy.controller.ts`'s `getAlbumMetadata`.
+ *
+ * Uses the IDENTICAL `WHERE`/`ORDER BY`/`LIMIT` as {@link resolveLinkedAlbumId}
+ * (same partial index `flowsheet_album_link_lookup_idx`, same deterministic
+ * row-pick), so a given key always describes the same flowsheet row across
+ * both calls. Kept as its own query rather than widening
+ * `resolveLinkedAlbumId`'s SELECT so that function's existing callers/mocks
+ * (`jobs/album-critic-reviews-etl`, `scripts/seed-critic-reviews.ts`, and
+ * their test suites) are untouched by this addition.
+ *
+ * Returns `null` under the same conditions `resolveLinkedAlbumId` does: blank
+ * artist/release, or no `album_id`-bearing flowsheet row for the key. A
+ * free-text row that has NEVER linked to an `album_id` has no row this query
+ * can find either — the partial index is deliberately scoped to `album_id IS
+ * NOT NULL` (migration 0081); an equivalent covering the pure free-text
+ * cohort would need its own (much larger, whole-table) index, which is out
+ * of scope here. Callers fall back to the request's own artist/release/track
+ * strings for that cohort — see the caller's doc comment.
+ */
+export interface LinkedFlowsheetBase {
+  record_label: string | null;
+  label_id: number | null;
+  metadata_status: string;
+}
+
+export async function resolveLinkedFlowsheetBase(
+  artistName: string,
+  releaseTitle?: string
+): Promise<LinkedFlowsheetBase | null> {
+  const trimmedArtist = artistName.trim();
+  const trimmedRelease = (releaseTitle ?? '').trim();
+  if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
+
+  const key = lookupKey(trimmedArtist, trimmedRelease);
+
+  const candidate = await db
+    .select({
+      record_label: flowsheet.record_label,
+      label_id: flowsheet.label_id,
+      metadata_status: flowsheet.metadata_status,
+    })
+    .from(flowsheet)
+    .where(sql`${flowsheetLookupKey} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
+    .orderBy(desc(flowsheet.id))
+    .limit(1);
+
+  return candidate[0] ?? null;
+}

--- a/shared/database/src/album-resolve.ts
+++ b/shared/database/src/album-resolve.ts
@@ -43,17 +43,41 @@ function lookupKey(artist: string, album?: string): string {
 }
 
 /**
- * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
- * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
- * exists for the key. Shared Step-1 for both the album-metadata read
- * (`lookupAlbumMetadataById`) and the critic-reviews read
- * (`lookupCriticReviewsByAlbumId`) in
- * `apps/backend/services/album-metadata-lookup.service.ts`. Callers that
- * need both — the `/proxy/metadata/album` handler — resolve the key *once*
- * here and pass the id to both reads, so a concurrent flowsheet insert can't
- * make the two reads disagree on which album they describe. The seed writer
- * (`scripts/seed-critic-reviews.ts`) imports this to key its UPSERTs against
- * the exact same normalized flowsheet key the serve path reads.
+ * The linked-flowsheet row shape both {@link resolveLinkedAlbumId} (the id
+ * alone, for its existing external callers) and the proxy controller's
+ * local-first base-field block (`record_label` / `label_id` /
+ * `metadata_status`, BS#1827) need — see {@link selectLinkedFlowsheetRow}.
+ */
+export interface LinkedFlowsheetRow {
+  album_id: number;
+  record_label: string | null;
+  label_id: number | null;
+  metadata_status: string;
+}
+
+/**
+ * Resolve `(artistName, releaseTitle)` to the matching linked flowsheet row
+ * — `album_id` plus the base (non-enrichment) columns written onto that same
+ * row at play time — or `null` when no `album_id`-bearing flowsheet row
+ * exists for the key. The single shared query behind both
+ * {@link resolveLinkedAlbumId} and the proxy controller's base-field block
+ * (BS#1827): one round trip resolves album_id AND record_label/label_id/
+ * metadata_status from the SAME row, so a concurrent flowsheet insert can't
+ * make them describe two different rows for one request the way two
+ * separate queries could (the bug this consolidation fixes — BS#1827 round
+ * 2 review). `record_label`/`label_id` are written by the DJ, dj-site's
+ * freeform entry, or the ETL and never depend on LML, unlike
+ * `album_metadata.label` (Discogs enrichment, BS#1336); `metadata_status` is
+ * reported faithfully off this row — a replayed/stale value here (e.g. a
+ * re-aired play defaulting back to `pending`) is the terminal-semantics
+ * question iOS#685 owns, not addressed by this function.
+ *
+ * Not part of the small public surface other workspaces import — only
+ * {@link resolveLinkedAlbumId} (used by `jobs/album-critic-reviews-etl` and
+ * `scripts/seed-critic-reviews.ts`, which need only the id) and the proxy
+ * controller's re-export shim (which needs the whole row) call this
+ * directly. Exported because both live outside this file, but treat it as
+ * an internal accessor, not a third general-purpose resolver to reach for.
  *
  * Uses the partial functional index `flowsheet_album_link_lookup_idx`. The
  * explicit `flowsheet.album_id IS NOT NULL` predicate matches the index's
@@ -71,62 +95,19 @@ function lookupKey(artist: string, album?: string): string {
  * `null`: the key `'<artist>-'` (blank release) would otherwise match any
  * linked flowsheet row whose DJ left `album_title` blank and return an
  * arbitrary `album_id`.
- */
-export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
-  const trimmedArtist = artistName.trim();
-  const trimmedRelease = (releaseTitle ?? '').trim();
-  if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
-
-  const key = lookupKey(trimmedArtist, trimmedRelease);
-
-  const candidate = await db
-    .select({ album_id: flowsheet.album_id })
-    .from(flowsheet)
-    .where(sql`${flowsheetLookupKey} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
-    .orderBy(desc(flowsheet.id))
-    .limit(1);
-
-  return candidate[0]?.album_id ?? null;
-}
-
-/**
- * Base (non-enrichment) flowsheet fields for a linked `(artistName,
- * releaseTitle)` key — added for BS#1827 (local-first playcut details).
- * `record_label` / `label_id` are written onto `flowsheet` at play time (by
- * the DJ, dj-site's freeform entry, or the ETL) and never depend on LML,
- * unlike `album_metadata.label` (Discogs enrichment, BS#1336). Reading them
- * off the SAME row {@link resolveLinkedAlbumId} resolves its `album_id` from
- * means `GET /proxy/metadata/album` can surface a durable label/status even
- * when no `album_metadata` row exists yet and the LML fallthrough fails —
- * see `apps/backend/controllers/proxy.controller.ts`'s `getAlbumMetadata`.
  *
- * Uses the IDENTICAL `WHERE`/`ORDER BY`/`LIMIT` as {@link resolveLinkedAlbumId}
- * (same partial index `flowsheet_album_link_lookup_idx`, same deterministic
- * row-pick), so a given key always describes the same flowsheet row across
- * both calls. Kept as its own query rather than widening
- * `resolveLinkedAlbumId`'s SELECT so that function's existing callers/mocks
- * (`jobs/album-critic-reviews-etl`, `scripts/seed-critic-reviews.ts`, and
- * their test suites) are untouched by this addition.
- *
- * Returns `null` under the same conditions `resolveLinkedAlbumId` does: blank
- * artist/release, or no `album_id`-bearing flowsheet row for the key. A
- * free-text row that has NEVER linked to an `album_id` has no row this query
- * can find either — the partial index is deliberately scoped to `album_id IS
- * NOT NULL` (migration 0081); an equivalent covering the pure free-text
- * cohort would need its own (much larger, whole-table) index, which is out
- * of scope here. Callers fall back to the request's own artist/release/track
- * strings for that cohort — see the caller's doc comment.
+ * A free-text row that has NEVER linked to an `album_id` has no row this
+ * query can find either — the partial index is deliberately scoped to
+ * `album_id IS NOT NULL` (migration 0081); an equivalent covering the pure
+ * free-text cohort would need its own (much larger, whole-table) index,
+ * which is out of scope here. Callers fall back to the request's own
+ * artist/release/track strings for that cohort — see the proxy controller's
+ * doc comment.
  */
-export interface LinkedFlowsheetBase {
-  record_label: string | null;
-  label_id: number | null;
-  metadata_status: string;
-}
-
-export async function resolveLinkedFlowsheetBase(
+export async function selectLinkedFlowsheetRow(
   artistName: string,
   releaseTitle?: string
-): Promise<LinkedFlowsheetBase | null> {
+): Promise<LinkedFlowsheetRow | null> {
   const trimmedArtist = artistName.trim();
   const trimmedRelease = (releaseTitle ?? '').trim();
   if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
@@ -135,6 +116,7 @@ export async function resolveLinkedFlowsheetBase(
 
   const candidate = await db
     .select({
+      album_id: flowsheet.album_id,
       record_label: flowsheet.record_label,
       label_id: flowsheet.label_id,
       metadata_status: flowsheet.metadata_status,
@@ -144,5 +126,35 @@ export async function resolveLinkedFlowsheetBase(
     .orderBy(desc(flowsheet.id))
     .limit(1);
 
-  return candidate[0] ?? null;
+  const row = candidate[0];
+  // The WHERE clause already guarantees album_id IS NOT NULL for any
+  // returned row; the null check here is a defensive type-narrowing (not a
+  // reachable runtime branch) so `LinkedFlowsheetRow.album_id` can be typed
+  // as a definite `number` rather than `number | null`.
+  if (!row || row.album_id === null) return null;
+  return {
+    album_id: row.album_id,
+    record_label: row.record_label,
+    label_id: row.label_id,
+    metadata_status: row.metadata_status,
+  };
+}
+
+/**
+ * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
+ * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
+ * exists for the key. Thin wrapper over {@link selectLinkedFlowsheetRow} —
+ * kept as its own named export with this exact `number | null` signature so
+ * its existing external callers (`jobs/album-critic-reviews-etl`,
+ * `scripts/seed-critic-reviews.ts`, and their test suites) are untouched by
+ * the BS#1827 consolidation. Shared Step-1 for both the album-metadata read
+ * (`lookupAlbumMetadataById`) and the critic-reviews read
+ * (`lookupCriticReviewsByAlbumId`) in
+ * `apps/backend/services/album-metadata-lookup.service.ts`. The seed writer
+ * (`scripts/seed-critic-reviews.ts`) imports this to key its UPSERTs against
+ * the exact same normalized flowsheet key the serve path reads.
+ */
+export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
+  const row = await selectLinkedFlowsheetRow(artistName, releaseTitle);
+  return row?.album_id ?? null;
 }

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -459,19 +459,22 @@ export const resolveLinkedAlbumId = jest
   .fn<(artistName: string, releaseTitle?: string) => Promise<number | null>>()
   .mockResolvedValue(null);
 
-// Stub of shared/database/src/album-resolve.ts's `resolveLinkedFlowsheetBase`
-// (BS#1827, local-first playcut details). The one consumer today (the
-// service's thin re-export, read by apps/backend/controllers/
-// proxy.controller.ts) only needs a controllable resolved value here — the
-// real lookup-key + ORDER BY contract is pinned against the actual module by
-// tests/unit/database/album-resolve.test.ts.
-export interface LinkedFlowsheetBase {
+// Stub of shared/database/src/album-resolve.ts's `selectLinkedFlowsheetRow`
+// (BS#1827, local-first playcut details — folded from a separate
+// resolveLinkedFlowsheetBase into this combined-row shape in round 2 of the
+// same slice, eliminating the two-query re-resolution race). The one
+// consumer today (the service's thin re-export, read by
+// apps/backend/controllers/proxy.controller.ts) only needs a controllable
+// resolved value here — the real lookup-key + ORDER BY contract is pinned
+// against the actual module by tests/unit/database/album-resolve.test.ts.
+export interface LinkedFlowsheetRow {
+  album_id: number;
   record_label: string | null;
   label_id: number | null;
   metadata_status: string;
 }
-export const resolveLinkedFlowsheetBase = jest
-  .fn<(artistName: string, releaseTitle?: string) => Promise<LinkedFlowsheetBase | null>>()
+export const selectLinkedFlowsheetRow = jest
+  .fn<(artistName: string, releaseTitle?: string) => Promise<LinkedFlowsheetRow | null>>()
   .mockResolvedValue(null);
 
 export { requirePositiveInt, requireNonNegativeInt } from '../../shared/database/src/env-parsers.js';

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -459,6 +459,21 @@ export const resolveLinkedAlbumId = jest
   .fn<(artistName: string, releaseTitle?: string) => Promise<number | null>>()
   .mockResolvedValue(null);
 
+// Stub of shared/database/src/album-resolve.ts's `resolveLinkedFlowsheetBase`
+// (BS#1827, local-first playcut details). The one consumer today (the
+// service's thin re-export, read by apps/backend/controllers/
+// proxy.controller.ts) only needs a controllable resolved value here — the
+// real lookup-key + ORDER BY contract is pinned against the actual module by
+// tests/unit/database/album-resolve.test.ts.
+export interface LinkedFlowsheetBase {
+  record_label: string | null;
+  label_id: number | null;
+  metadata_status: string;
+}
+export const resolveLinkedFlowsheetBase = jest
+  .fn<(artistName: string, releaseTitle?: string) => Promise<LinkedFlowsheetBase | null>>()
+  .mockResolvedValue(null);
+
 export { requirePositiveInt, requireNonNegativeInt } from '../../shared/database/src/env-parsers.js';
 export type { IntParserOptions } from '../../shared/database/src/env-parsers.js';
 

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -64,8 +64,21 @@ jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
 const mockResolveLinkedAlbumId = jest.fn<(artist: string, release?: string) => Promise<number | null>>();
 const mockLookupAlbumMetadataById = jest.fn<(albumId: number) => Promise<unknown>>();
 const mockLookupCriticReviewsByAlbumId = jest.fn<(albumId: number) => Promise<unknown[]>>();
+// BS#1827 (local-first playcut details): base fields (record_label/label_id/
+// metadata_status) off the SAME linked flowsheet row `resolveLinkedAlbumId`
+// resolves its album_id from. Mocked separately so a test can drive the
+// base-field survival contract independent of `lookupAlbumMetadataById` /
+// LML — the whole point is these must NOT depend on either succeeding.
+const mockResolveLinkedFlowsheetBase =
+  jest.fn<
+    (
+      artist: string,
+      release?: string
+    ) => Promise<{ record_label: string | null; label_id: number | null; metadata_status: string } | null>
+  >();
 jest.mock('../../../apps/backend/services/album-metadata-lookup.service', () => ({
   resolveLinkedAlbumId: mockResolveLinkedAlbumId,
+  resolveLinkedFlowsheetBase: mockResolveLinkedFlowsheetBase,
   lookupAlbumMetadataById: mockLookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId: mockLookupCriticReviewsByAlbumId,
 }));
@@ -288,6 +301,10 @@ describe('proxy.controller', () => {
       // value a prior test set, so both defaults are re-asserted here. BS#1331.
       mockResolveLinkedAlbumId.mockResolvedValue(DEFAULT_LINKED_ALBUM_ID);
       mockLookupAlbumMetadataById.mockResolvedValue(null);
+      // Default: no local flowsheet base row (inert — existing tests predate
+      // BS#1827 and assert nothing about recordLabel/labelId/metadataStatus).
+      // The base-field-survival suite below overrides this per test.
+      mockResolveLinkedFlowsheetBase.mockResolvedValue(null);
     });
 
     // ADR 0012: attach external critic-review snippets, flag-gated. These run
@@ -1410,6 +1427,204 @@ describe('proxy.controller', () => {
         await getAlbumMetadata(req, res as Response, mockNext);
 
         expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.album.upstream_calls': 0 });
+      });
+    });
+
+    // --- Local-first base fields (BS#1827) ---
+    //
+    // Base playcut metadata (artist/release/track identity, plus
+    // record_label/label_id/metadata_status when a linked flowsheet row is
+    // known) is assembled from durable BS state BEFORE any LML lookup is
+    // attempted, so an LML failure/timeout can only drop OPTIONAL enrichment
+    // fields (artworkUrl, discogsUrl, genres, ...) — it can never blank the
+    // base fields. This is the acceptance gate for #1827: simulate an LML
+    // failure and assert base fields survive while enrichment fields don't.
+    describe('local-first base fields (BS#1827)', () => {
+      it('always echoes artistName/releaseTitle/trackTitle from the query, before any lookup is attempted', async () => {
+        // No mocks configured to resolve anything — the point is these three
+        // never depend on a successful local or LML lookup in the first place.
+        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Chuquimamani-Condori', releaseTitle: 'Edits', trackTitle: 'Call Your Name' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.artistName).toBe('Chuquimamani-Condori');
+        expect(result.releaseTitle).toBe('Edits');
+        expect(result.trackTitle).toBe('Call Your Name');
+      });
+
+      it('omits releaseTitle/trackTitle when not supplied on the request (no fabrication)', async () => {
+        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+
+        const req = { query: { artistName: 'Solo Artist Name Only' } } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.artistName).toBe('Solo Artist Name Only');
+        expect('releaseTitle' in result).toBe(false);
+        expect('trackTitle' in result).toBe(false);
+      });
+
+      it('free-text row (no linked album_id) + LML failure: artist/release/track survive; recordLabel/labelId/metadataStatus are not fabricated', async () => {
+        // The core free-text scenario the issue names: resolveLinkedAlbumId
+        // returns null (no album_id-bearing flowsheet row for this key), so
+        // resolveLinkedFlowsheetBase is never even reachable for it — there is
+        // no efficient local source for record_label/label_id in that cohort
+        // (see resolveLinkedFlowsheetBase's doc comment). The identity fields
+        // still must not blank out just because LML also fails.
+        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockLookupMetadata.mockRejectedValue(new Error('LML timeout'));
+
+        const req = {
+          query: { artistName: 'Free Text Artist', releaseTitle: 'Free Text Album', trackTitle: 'Some Track' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockResolveLinkedFlowsheetBase).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        // Base identity: survives.
+        expect(result.artistName).toBe('Free Text Artist');
+        expect(result.releaseTitle).toBe('Free Text Album');
+        expect(result.trackTitle).toBe('Some Track');
+        // No locally-known label/status for this cohort — omitted, not null.
+        expect('recordLabel' in result).toBe(false);
+        expect('labelId' in result).toBe(false);
+        expect('metadataStatus' in result).toBe(false);
+        // Enriched-only fields are genuinely absent (LML failed).
+        expect('discogsUrl' in result).toBe(false);
+        expect('artworkUrl' in result).toBe(false);
+      });
+
+      it('linked row known locally + LML failure: recordLabel/labelId/metadataStatus ALSO survive, only enrichment fields go missing', async () => {
+        // The other half of the acceptance criterion: a linked flowsheet row
+        // (album_id resolved) that hasn't been enriched into album_metadata
+        // yet (persisted stays null, same as the existing "cold" default) —
+        // an LML outage must not blank the record_label/label_id/
+        // metadata_status this endpoint can read straight off that row.
+        mockResolveLinkedAlbumId.mockResolvedValue(DEFAULT_LINKED_ALBUM_ID);
+        mockLookupAlbumMetadataById.mockResolvedValue(null);
+        mockResolveLinkedFlowsheetBase.mockResolvedValue({
+          record_label: 'Drag City',
+          label_id: 12,
+          metadata_status: 'pending',
+        });
+        mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+
+        const req = {
+          query: { artistName: 'Jessica Pratt', releaseTitle: 'On Your Own Love Again', trackTitle: 'Back, Baby' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockResolveLinkedFlowsheetBase).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again');
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        // Base identity.
+        expect(result.artistName).toBe('Jessica Pratt');
+        expect(result.releaseTitle).toBe('On Your Own Love Again');
+        expect(result.trackTitle).toBe('Back, Baby');
+        // Base catalog fields sourced locally — survive the LML failure.
+        expect(result.recordLabel).toBe('Drag City');
+        expect(result.labelId).toBe(12);
+        expect(result.metadataStatus).toBe('pending');
+        // Enrichment-only fields are genuinely absent (nothing persisted, LML failed).
+        expect('discogsUrl' in result).toBe(false);
+        expect('artworkUrl' in result).toBe(false);
+        expect('genres' in result).toBe(false);
+      });
+
+      it('omits labelId/recordLabel individually when the linked row only knows one of them', async () => {
+        mockResolveLinkedFlowsheetBase.mockResolvedValue({
+          record_label: null,
+          label_id: 9,
+          metadata_status: 'enriching',
+        });
+        mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+
+        const req = {
+          query: { artistName: 'Partial Base Artist', releaseTitle: 'Partial Base Album' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect('recordLabel' in result).toBe(false);
+        expect(result.labelId).toBe(9);
+        expect(result.metadataStatus).toBe('enriching');
+      });
+
+      it('does not call resolveLinkedFlowsheetBase when no linked album_id resolves (avoids a redundant guaranteed-empty query)', async () => {
+        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Never Linked Artist', releaseTitle: 'Never Linked Album' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockResolveLinkedFlowsheetBase).not.toHaveBeenCalled();
+      });
+
+      it('resolveLinkedFlowsheetBase throws: degrades to omitting base catalog fields only, still responds 200 with persisted data intact', async () => {
+        // Mirrors the critic-reviews / local-metadata try/catch convention
+        // elsewhere in this handler: a failure fetching the NEW base fields
+        // must not regress the EXISTING persisted-metadata response.
+        mockLookupAlbumMetadataById.mockResolvedValue({
+          artwork_url: 'https://i.discogs.com/x.jpg',
+          discogs_url: 'https://www.discogs.com/release/321',
+          release_year: 2018,
+          spotify_url: null,
+          apple_music_url: null,
+          youtube_music_url: null,
+          bandcamp_url: null,
+          soundcloud_url: null,
+          artist_bio: null,
+          artist_wikipedia_url: null,
+        });
+        mockResolveLinkedFlowsheetBase.mockRejectedValue(new Error('db blip'));
+
+        const req = {
+          query: { artistName: 'Resilient Artist', releaseTitle: 'Resilient Album' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.artistName).toBe('Resilient Artist');
+        expect('recordLabel' in result).toBe(false);
+        expect('labelId' in result).toBe(false);
+        expect('metadataStatus' in result).toBe(false);
+        // Persisted metadata from the (unrelated, successful) by-id lookup
+        // still comes through — the base-field failure is fully isolated.
+        expect(result.discogsUrl).toBe('https://www.discogs.com/release/321');
       });
     });
   });

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -6,6 +6,9 @@
  */
 import { jest } from '@jest/globals';
 import type { Request, Response, NextFunction } from 'express';
+// Type-only: erased at compile time, so this is safe alongside the
+// jest.mock(...) of the same module's runtime exports below (BS#1827).
+import type { LinkedFlowsheetRow } from '../../../apps/backend/services/album-metadata-lookup.service';
 
 // --- Mocks ---
 
@@ -53,32 +56,22 @@ jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
   lmlLookupCoordinator: { lookup: mockLookupMetadata },
 }));
 
-// BS#1331 + ADR 0012: getAlbumMetadata resolves the linked `album_id` ONCE via
-// `resolveLinkedAlbumId`, then feeds it to the by-id persisted-metadata read
-// (`lookupAlbumMetadataById`) and — flag-gated — the by-id critic-reviews read
-// (`lookupCriticReviewsByAlbumId`). Resolving once makes the metadata and
-// reviews reads observe the same album_id atomically and decouples the reviews
-// attach from metadata-enrichment state. Each is mocked so a test can set the
-// resolved id, a local-hit/catch-arm/cold metadata row, or the returned
-// snippets independently.
-const mockResolveLinkedAlbumId = jest.fn<(artist: string, release?: string) => Promise<number | null>>();
+// BS#1331 + ADR 0012 + BS#1827: getAlbumMetadata resolves the linked flowsheet
+// row ONCE via `selectLinkedFlowsheetRow` (album_id + the base catalog fields
+// off the SAME row), then feeds the album_id to the by-id persisted-metadata
+// read (`lookupAlbumMetadataById`) and — flag-gated — the by-id critic-reviews
+// read (`lookupCriticReviewsByAlbumId`). Resolving once makes the base fields,
+// album_id, metadata, and reviews all describe the same row atomically — a
+// two-query version (album_id then a separate base-fields lookup) could let a
+// concurrent flowsheet insert land between the two calls and describe two
+// different rows for one request. Each mock lets a test drive its slice of
+// the contract independently.
+const mockSelectLinkedFlowsheetRow =
+  jest.fn<(artist: string, release?: string) => Promise<LinkedFlowsheetRow | null>>();
 const mockLookupAlbumMetadataById = jest.fn<(albumId: number) => Promise<unknown>>();
 const mockLookupCriticReviewsByAlbumId = jest.fn<(albumId: number) => Promise<unknown[]>>();
-// BS#1827 (local-first playcut details): base fields (record_label/label_id/
-// metadata_status) off the SAME linked flowsheet row `resolveLinkedAlbumId`
-// resolves its album_id from. Mocked separately so a test can drive the
-// base-field survival contract independent of `lookupAlbumMetadataById` /
-// LML — the whole point is these must NOT depend on either succeeding.
-const mockResolveLinkedFlowsheetBase =
-  jest.fn<
-    (
-      artist: string,
-      release?: string
-    ) => Promise<{ record_label: string | null; label_id: number | null; metadata_status: string } | null>
-  >();
 jest.mock('../../../apps/backend/services/album-metadata-lookup.service', () => ({
-  resolveLinkedAlbumId: mockResolveLinkedAlbumId,
-  resolveLinkedFlowsheetBase: mockResolveLinkedFlowsheetBase,
+  selectLinkedFlowsheetRow: mockSelectLinkedFlowsheetRow,
   lookupAlbumMetadataById: mockLookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId: mockLookupCriticReviewsByAlbumId,
 }));
@@ -89,6 +82,16 @@ jest.mock('../../../apps/backend/services/album-metadata-lookup.service', () => 
 // mock's resolved value; the resolved id itself only matters where a test pins
 // the call argument.
 const DEFAULT_LINKED_ALBUM_ID = 4242;
+
+// Default linked-row fixture (BS#1827): album_id resolves but no base catalog
+// fields are known — the pre-existing "cold" cohort every test predating
+// BS#1827 already assumed. Individual base-field tests override this.
+const defaultLinkedRow = (): LinkedFlowsheetRow => ({
+  album_id: DEFAULT_LINKED_ALBUM_ID,
+  record_label: null,
+  label_id: null,
+  metadata_status: 'pending',
+});
 
 // ADR 0012 flag: getConfig().enabled gates the criticReviews attach. Default
 // off (matches prod) so unrelated getAlbumMetadata tests keep their exact
@@ -297,14 +300,14 @@ describe('proxy.controller', () => {
       // Default: a linked album_id resolves (so the reviews attach is
       // reachable) but no persisted metadata row exists — the cold case, so
       // existing tests fall through to LML. Local-hit tests override the by-id
-      // metadata mock below. `clearAllMocks` clears calls, not the resolved
-      // value a prior test set, so both defaults are re-asserted here. BS#1331.
-      mockResolveLinkedAlbumId.mockResolvedValue(DEFAULT_LINKED_ALBUM_ID);
+      // metadata mock below. No base catalog fields on the default row either
+      // (inert — existing tests predate BS#1827 and assert nothing about
+      // recordLabel/labelId/metadataStatus; the base-field-survival suite
+      // below overrides this per test). `clearAllMocks` clears calls, not the
+      // resolved value a prior test set, so the default is re-asserted here.
+      // BS#1331 / BS#1827.
+      mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
       mockLookupAlbumMetadataById.mockResolvedValue(null);
-      // Default: no local flowsheet base row (inert — existing tests predate
-      // BS#1827 and assert nothing about recordLabel/labelId/metadataStatus).
-      // The base-field-survival suite below overrides this per test.
-      mockResolveLinkedFlowsheetBase.mockResolvedValue(null);
     });
 
     // ADR 0012: attach external critic-review snippets, flag-gated. These run
@@ -345,7 +348,7 @@ describe('proxy.controller', () => {
 
         // Reviews are read by the resolved album_id, not by artist/release —
         // the resolve happened once and both reads observe the same id.
-        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledWith('Juana Molina', 'DOGA');
         expect(mockLookupCriticReviewsByAlbumId).toHaveBeenCalledWith(DEFAULT_LINKED_ALBUM_ID);
         const result = (res.json as jest.Mock).mock.calls[0][0];
         expect(result.criticReviews).toEqual(sampleReviews);
@@ -1023,7 +1026,7 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Cached Artist', 'Cached Album');
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledWith('Cached Artist', 'Cached Album');
         expect(mockLookupAlbumMetadataById).toHaveBeenCalledWith(DEFAULT_LINKED_ALBUM_ID);
         expect(mockLookupMetadata).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(200);
@@ -1362,7 +1365,7 @@ describe('proxy.controller', () => {
 
       it('falls through to LML when no local row matches (true cold case)', async () => {
         // No linked album resolves at all — the by-id metadata read never runs.
-        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [
             {
@@ -1390,7 +1393,7 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Cold Artist', 'Cold Album');
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledWith('Cold Artist', 'Cold Album');
         expect(mockLookupAlbumMetadataById).not.toHaveBeenCalled();
         // LML was consulted because the resolve step found no linked album.
         expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
@@ -1439,11 +1442,18 @@ describe('proxy.controller', () => {
     // fields (artworkUrl, discogsUrl, genres, ...) — it can never blank the
     // base fields. This is the acceptance gate for #1827: simulate an LML
     // failure and assert base fields survive while enrichment fields don't.
+    //
+    // Round 2 (post-review): album_id and the base catalog fields now come
+    // from ONE `selectLinkedFlowsheetRow` call instead of two separate reads
+    // (`resolveLinkedAlbumId` then `resolveLinkedFlowsheetBase`), eliminating
+    // a re-resolution race where a concurrent flowsheet insert between the
+    // two calls could make them describe different rows. Tests that care
+    // assert `toHaveBeenCalledTimes(1)` to pin the single-round-trip contract.
     describe('local-first base fields (BS#1827)', () => {
       it('always echoes artistName/releaseTitle/trackTitle from the query, before any lookup is attempted', async () => {
         // No mocks configured to resolve anything — the point is these three
         // never depend on a successful local or LML lookup in the first place.
-        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [],
           search_type: 'none',
@@ -1465,7 +1475,7 @@ describe('proxy.controller', () => {
       });
 
       it('omits releaseTitle/trackTitle when not supplied on the request (no fabrication)', async () => {
-        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
         mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
         const req = { query: { artistName: 'Solo Artist Name Only' } } as unknown as Request;
@@ -1480,13 +1490,12 @@ describe('proxy.controller', () => {
       });
 
       it('free-text row (no linked album_id) + LML failure: artist/release/track survive; recordLabel/labelId/metadataStatus are not fabricated', async () => {
-        // The core free-text scenario the issue names: resolveLinkedAlbumId
-        // returns null (no album_id-bearing flowsheet row for this key), so
-        // resolveLinkedFlowsheetBase is never even reachable for it — there is
-        // no efficient local source for record_label/label_id in that cohort
-        // (see resolveLinkedFlowsheetBase's doc comment). The identity fields
-        // still must not blank out just because LML also fails.
-        mockResolveLinkedAlbumId.mockResolvedValue(null);
+        // The core free-text scenario the issue names: selectLinkedFlowsheetRow
+        // returns null (no album_id-bearing flowsheet row for this key) — there
+        // is no efficient local source for record_label/label_id in that
+        // cohort (see selectLinkedFlowsheetRow's doc comment). The identity
+        // fields still must not blank out just because LML also fails.
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
         mockLookupMetadata.mockRejectedValue(new Error('LML timeout'));
 
         const req = {
@@ -1496,7 +1505,8 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockResolveLinkedFlowsheetBase).not.toHaveBeenCalled();
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(1);
+        expect(mockLookupAlbumMetadataById).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(200);
         const result = (res.json as jest.Mock).mock.calls[0][0];
         // Base identity: survives.
@@ -1517,14 +1527,16 @@ describe('proxy.controller', () => {
         // (album_id resolved) that hasn't been enriched into album_metadata
         // yet (persisted stays null, same as the existing "cold" default) —
         // an LML outage must not blank the record_label/label_id/
-        // metadata_status this endpoint can read straight off that row.
-        mockResolveLinkedAlbumId.mockResolvedValue(DEFAULT_LINKED_ALBUM_ID);
-        mockLookupAlbumMetadataById.mockResolvedValue(null);
-        mockResolveLinkedFlowsheetBase.mockResolvedValue({
+        // metadata_status this endpoint can read straight off that row. One
+        // call resolves both album_id and the base fields (`toHaveBeenCalledTimes(1)`
+        // pins that there's no second, separately-racing query anymore).
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
           record_label: 'Drag City',
           label_id: 12,
           metadata_status: 'pending',
         });
+        mockLookupAlbumMetadataById.mockResolvedValue(null);
         mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
         const req = {
@@ -1534,7 +1546,9 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockResolveLinkedFlowsheetBase).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again');
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again');
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(1);
+        expect(mockLookupAlbumMetadataById).toHaveBeenCalledWith(DEFAULT_LINKED_ALBUM_ID);
         expect(res.status).toHaveBeenCalledWith(200);
         const result = (res.json as jest.Mock).mock.calls[0][0];
         // Base identity.
@@ -1552,7 +1566,8 @@ describe('proxy.controller', () => {
       });
 
       it('omits labelId/recordLabel individually when the linked row only knows one of them', async () => {
-        mockResolveLinkedFlowsheetBase.mockResolvedValue({
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
           record_label: null,
           label_id: 9,
           metadata_status: 'enriching',
@@ -1572,42 +1587,17 @@ describe('proxy.controller', () => {
         expect(result.metadataStatus).toBe('enriching');
       });
 
-      it('does not call resolveLinkedFlowsheetBase when no linked album_id resolves (avoids a redundant guaranteed-empty query)', async () => {
-        mockResolveLinkedAlbumId.mockResolvedValue(null);
-        mockLookupMetadata.mockResolvedValue({
-          results: [],
-          search_type: 'none',
-          song_not_found: false,
-          found_on_compilation: false,
-        });
-
-        const req = {
-          query: { artistName: 'Never Linked Artist', releaseTitle: 'Never Linked Album' },
-        } as unknown as Request;
-        const res = createMockRes();
-
-        await getAlbumMetadata(req, res as Response, mockNext);
-
-        expect(mockResolveLinkedFlowsheetBase).not.toHaveBeenCalled();
-      });
-
-      it('resolveLinkedFlowsheetBase throws: degrades to omitting base catalog fields only, still responds 200 with persisted data intact', async () => {
-        // Mirrors the critic-reviews / local-metadata try/catch convention
-        // elsewhere in this handler: a failure fetching the NEW base fields
-        // must not regress the EXISTING persisted-metadata response.
-        mockLookupAlbumMetadataById.mockResolvedValue({
-          artwork_url: 'https://i.discogs.com/x.jpg',
-          discogs_url: 'https://www.discogs.com/release/321',
-          release_year: 2018,
-          spotify_url: null,
-          apple_music_url: null,
-          youtube_music_url: null,
-          bandcamp_url: null,
-          soundcloud_url: null,
-          artist_bio: null,
-          artist_wikipedia_url: null,
-        });
-        mockResolveLinkedFlowsheetBase.mockRejectedValue(new Error('db blip'));
+      it('selectLinkedFlowsheetRow throws: falls through to LML, omitting both base and persisted-state fields, still responds 200', async () => {
+        // Mirrors the local-metadata try/catch convention elsewhere in this
+        // handler: a DB blip resolving the row degrades to a cache miss and
+        // falls through to LML, rather than 500ing the request. Because
+        // album_id and the base fields now come from the SAME query (round-2
+        // refactor), a failure here can no longer "partially" fail — the
+        // persisted-metadata read is never reached either, unlike the old
+        // two-query version where a base-fields-only failure could leave an
+        // already-resolved album_id/persisted response intact.
+        mockSelectLinkedFlowsheetRow.mockRejectedValue(new Error('db blip'));
+        mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
         const req = {
           query: { artistName: 'Resilient Artist', releaseTitle: 'Resilient Album' },
@@ -1616,15 +1606,17 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
+        expect(mockLookupAlbumMetadataById).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(200);
         const result = (res.json as jest.Mock).mock.calls[0][0];
+        // Base identity survives — it never depended on this lookup.
         expect(result.artistName).toBe('Resilient Artist');
+        expect(result.releaseTitle).toBe('Resilient Album');
+        // Base catalog fields and enrichment fields are both genuinely absent.
         expect('recordLabel' in result).toBe(false);
         expect('labelId' in result).toBe(false);
         expect('metadataStatus' in result).toBe(false);
-        // Persisted metadata from the (unrelated, successful) by-id lookup
-        // still comes through — the base-field failure is fully isolated.
-        expect(result.discogsUrl).toBe('https://www.discogs.com/release/321');
+        expect('discogsUrl' in result).toBe(false);
       });
     });
   });

--- a/tests/unit/database/album-resolve.test.ts
+++ b/tests/unit/database/album-resolve.test.ts
@@ -86,7 +86,7 @@ jest.mock(
   { virtual: true }
 );
 
-import { resolveLinkedAlbumId } from '../../../shared/database/src/album-resolve';
+import { resolveLinkedAlbumId, resolveLinkedFlowsheetBase } from '../../../shared/database/src/album-resolve';
 
 describe('album-resolve (shared/database)', () => {
   beforeEach(() => {
@@ -146,6 +146,65 @@ describe('album-resolve (shared/database)', () => {
       const albumId = await resolveLinkedAlbumId('Multi Artist', 'Same Title Different Pressings');
       expect(albumId).toBe(42);
       expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // BS#1827 (local-first playcut details): record_label/label_id/
+  // metadata_status live on the SAME flowsheet row `resolveLinkedAlbumId`
+  // resolves its album_id from — written at play time, never LML-derived —
+  // so they survive independent of `album_metadata` enrichment / LML health.
+  // Shares the identical WHERE/ORDER BY/LIMIT (same partial index), so a
+  // given key always describes the same row across both functions.
+  describe('resolveLinkedFlowsheetBase', () => {
+    describe('empty-key guard', () => {
+      it('returns null without touching the DB when artistName is empty', async () => {
+        expect(await resolveLinkedFlowsheetBase('', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when artistName is whitespace-only', async () => {
+        expect(await resolveLinkedFlowsheetBase('   ', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is undefined', async () => {
+        expect(await resolveLinkedFlowsheetBase('Some Artist', undefined)).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is empty', async () => {
+        expect(await resolveLinkedFlowsheetBase('Some Artist', '')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is whitespace-only', async () => {
+        expect(await resolveLinkedFlowsheetBase('Some Artist', '\t  ')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+    });
+
+    it('returns null on the cold case (no matching album_id-bearing flowsheet row)', async () => {
+      mockRowsQueue.push([]);
+      expect(await resolveLinkedFlowsheetBase('Unknown Artist', 'Unknown Album')).toBeNull();
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns record_label/label_id/metadata_status on a hit', async () => {
+      mockRowsQueue.push([{ record_label: 'Drag City', label_id: 7, metadata_status: 'enriched_match' }]);
+      const result = await resolveLinkedFlowsheetBase('Jessica Pratt', 'On Your Own Love Again');
+      expect(result).toEqual({ record_label: 'Drag City', label_id: 7, metadata_status: 'enriched_match' });
+    });
+
+    it('issues ORDER BY for a deterministic row-pick on multi-album_id keys', async () => {
+      mockRowsQueue.push([{ record_label: 'Sonamos', label_id: 3, metadata_status: 'pending' }]);
+      await resolveLinkedFlowsheetBase('Multi Artist', 'Same Title Different Pressings');
+      expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes through a null record_label/label_id (free-text-entered label never captured)', async () => {
+      mockRowsQueue.push([{ record_label: null, label_id: null, metadata_status: 'pending' }]);
+      const result = await resolveLinkedFlowsheetBase('Some Artist', 'Some Album');
+      expect(result).toEqual({ record_label: null, label_id: null, metadata_status: 'pending' });
     });
   });
 });

--- a/tests/unit/database/album-resolve.test.ts
+++ b/tests/unit/database/album-resolve.test.ts
@@ -86,7 +86,7 @@ jest.mock(
   { virtual: true }
 );
 
-import { resolveLinkedAlbumId, resolveLinkedFlowsheetBase } from '../../../shared/database/src/album-resolve';
+import { resolveLinkedAlbumId, selectLinkedFlowsheetRow } from '../../../shared/database/src/album-resolve';
 
 describe('album-resolve (shared/database)', () => {
   beforeEach(() => {
@@ -149,62 +149,79 @@ describe('album-resolve (shared/database)', () => {
     });
   });
 
-  // BS#1827 (local-first playcut details): record_label/label_id/
-  // metadata_status live on the SAME flowsheet row `resolveLinkedAlbumId`
-  // resolves its album_id from — written at play time, never LML-derived —
-  // so they survive independent of `album_metadata` enrichment / LML health.
-  // Shares the identical WHERE/ORDER BY/LIMIT (same partial index), so a
-  // given key always describes the same row across both functions.
-  describe('resolveLinkedFlowsheetBase', () => {
+  // BS#1827 (local-first playcut details, round 2 post-review): ONE query
+  // resolves album_id AND record_label/label_id/metadata_status together —
+  // written at play time, never LML-derived, so they survive independent of
+  // `album_metadata` enrichment / LML health. `resolveLinkedAlbumId` above is
+  // now a thin wrapper over this same function (its own tests, unchanged,
+  // already pin the id-only contract); these tests cover the full row shape.
+  describe('selectLinkedFlowsheetRow', () => {
     describe('empty-key guard', () => {
       it('returns null without touching the DB when artistName is empty', async () => {
-        expect(await resolveLinkedFlowsheetBase('', 'Some Album')).toBeNull();
+        expect(await selectLinkedFlowsheetRow('', 'Some Album')).toBeNull();
         expect(mockSelect).not.toHaveBeenCalled();
       });
 
       it('returns null when artistName is whitespace-only', async () => {
-        expect(await resolveLinkedFlowsheetBase('   ', 'Some Album')).toBeNull();
+        expect(await selectLinkedFlowsheetRow('   ', 'Some Album')).toBeNull();
         expect(mockSelect).not.toHaveBeenCalled();
       });
 
       it('returns null when releaseTitle is undefined', async () => {
-        expect(await resolveLinkedFlowsheetBase('Some Artist', undefined)).toBeNull();
+        expect(await selectLinkedFlowsheetRow('Some Artist', undefined)).toBeNull();
         expect(mockSelect).not.toHaveBeenCalled();
       });
 
       it('returns null when releaseTitle is empty', async () => {
-        expect(await resolveLinkedFlowsheetBase('Some Artist', '')).toBeNull();
+        expect(await selectLinkedFlowsheetRow('Some Artist', '')).toBeNull();
         expect(mockSelect).not.toHaveBeenCalled();
       });
 
       it('returns null when releaseTitle is whitespace-only', async () => {
-        expect(await resolveLinkedFlowsheetBase('Some Artist', '\t  ')).toBeNull();
+        expect(await selectLinkedFlowsheetRow('Some Artist', '\t  ')).toBeNull();
         expect(mockSelect).not.toHaveBeenCalled();
       });
     });
 
     it('returns null on the cold case (no matching album_id-bearing flowsheet row)', async () => {
       mockRowsQueue.push([]);
-      expect(await resolveLinkedFlowsheetBase('Unknown Artist', 'Unknown Album')).toBeNull();
+      expect(await selectLinkedFlowsheetRow('Unknown Artist', 'Unknown Album')).toBeNull();
       expect(mockSelect).toHaveBeenCalledTimes(1);
     });
 
-    it('returns record_label/label_id/metadata_status on a hit', async () => {
-      mockRowsQueue.push([{ record_label: 'Drag City', label_id: 7, metadata_status: 'enriched_match' }]);
-      const result = await resolveLinkedFlowsheetBase('Jessica Pratt', 'On Your Own Love Again');
-      expect(result).toEqual({ record_label: 'Drag City', label_id: 7, metadata_status: 'enriched_match' });
+    it('returns album_id/record_label/label_id/metadata_status together on a hit', async () => {
+      mockRowsQueue.push([{ album_id: 99, record_label: 'Drag City', label_id: 7, metadata_status: 'enriched_match' }]);
+      const result = await selectLinkedFlowsheetRow('Jessica Pratt', 'On Your Own Love Again');
+      expect(result).toEqual({
+        album_id: 99,
+        record_label: 'Drag City',
+        label_id: 7,
+        metadata_status: 'enriched_match',
+      });
     });
 
     it('issues ORDER BY for a deterministic row-pick on multi-album_id keys', async () => {
-      mockRowsQueue.push([{ record_label: 'Sonamos', label_id: 3, metadata_status: 'pending' }]);
-      await resolveLinkedFlowsheetBase('Multi Artist', 'Same Title Different Pressings');
+      mockRowsQueue.push([{ album_id: 42, record_label: 'Sonamos', label_id: 3, metadata_status: 'pending' }]);
+      await selectLinkedFlowsheetRow('Multi Artist', 'Same Title Different Pressings');
       expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
     });
 
     it('passes through a null record_label/label_id (free-text-entered label never captured)', async () => {
-      mockRowsQueue.push([{ record_label: null, label_id: null, metadata_status: 'pending' }]);
-      const result = await resolveLinkedFlowsheetBase('Some Artist', 'Some Album');
-      expect(result).toEqual({ record_label: null, label_id: null, metadata_status: 'pending' });
+      mockRowsQueue.push([{ album_id: 55, record_label: null, label_id: null, metadata_status: 'pending' }]);
+      const result = await selectLinkedFlowsheetRow('Some Artist', 'Some Album');
+      expect(result).toEqual({ album_id: 55, record_label: null, label_id: null, metadata_status: 'pending' });
+    });
+
+    it('backs resolveLinkedAlbumId: the id-only wrapper reads album_id off this same row shape', async () => {
+      // Pins that resolveLinkedAlbumId's thin-wrapper refactor (BS#1827 round
+      // 2) still issues exactly one query and extracts the same album_id a
+      // direct selectLinkedFlowsheetRow caller would see.
+      mockRowsQueue.push([
+        { album_id: 123, record_label: 'Some Label', label_id: 4, metadata_status: 'enriched_match' },
+      ]);
+      const albumId = await resolveLinkedAlbumId('Shared Row Artist', 'Shared Row Album');
+      expect(albumId).toBe(123);
+      expect(mockSelect).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `GET /proxy/metadata/album` now assembles `artistName`/`releaseTitle`/`trackTitle` from the request itself, and `recordLabel`/`labelId`/`metadataStatus` from the same linked `flowsheet` row `selectLinkedFlowsheetRow` resolves its `album_id` from — all BEFORE any persisted-state or LML lookup runs. These are true base fields: written at play time, independent of `album_metadata` enrichment and independent of LML entirely.
- Everything the handler adds afterward (`artworkUrl`, `discogsUrl`, `genres`, `label`, streaming URLs, ...) stays enriched: optional and upstream-dependent, present only when known — unchanged from today. An LML timeout/failure can now only drop those optional fields; it can never blank the base identity/catalog fields.
- Adds `selectLinkedFlowsheetRow` to `shared/database/src/album-resolve.ts`: **one** query resolves `album_id` and `record_label`/`label_id`/`metadata_status` together off the same partial index (`flowsheet_album_link_lookup_idx`), so base fields and `album_id` can never describe two different flowsheet rows for one request. `resolveLinkedAlbumId` is now a thin `number | null` wrapper over it, preserving its exact signature so its other callers (`jobs/album-critic-reviews-etl`, `scripts/seed-critic-reviews.ts`) and their tests are untouched.
- Free-text rows that have never linked to an `album_id` still get artist/release/track survival via the request echo; `recordLabel`/`labelId` aren't available for that cohort without a new whole-table index, which is out of scope here (documented explicitly on the new resolver's doc comment).
- `metadataStatus` is reported faithfully off the resolved row; replay/terminal-semantics staleness questions stay deferred to the iOS#685 follow-up, unaddressed here.
- These three new response fields aren't yet reflected in `wxyc-shared/api.yaml` — the wire-contract formalization and iOS consumption are tracked in the blocked iOS#685 follow-up.

Closes #1827

## Update (post-review)

Per review feedback, folded the two separate reads (`resolveLinkedAlbumId` then a since-removed `resolveLinkedFlowsheetBase`) into the single `selectLinkedFlowsheetRow` described above, eliminating a re-resolution race where a concurrent flowsheet insert between the two calls could make base fields and `album_id` describe different rows for one request. The controller test suite now asserts the combined lookup is called exactly once per request, making the race-elimination directly assertable.

## Test plan

- [x] `npm run test:unit` — full suite passes (5439 tests), including a "local-first base fields (BS#1827)" suite in `proxy.controller.test.ts` that simulates an LML failure against both the free-text and linked-but-unenriched cohorts and asserts base fields survive while enrichment fields go missing, a resilience case where the combined lookup itself throws (dropping album_id and base fields together, never partially), and `toHaveBeenCalledTimes(1)` assertions pinning the single-round-trip contract
- [x] Database-layer tests for `selectLinkedFlowsheetRow` in `tests/unit/database/album-resolve.test.ts`, mirroring the existing `resolveLinkedAlbumId` coverage (empty-key guard, cold case, deterministic row-pick) plus a case confirming `resolveLinkedAlbumId`'s thin-wrapper refactor still issues exactly one query
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run lint:migrations`, cross-cache-identity / precondition-guard / legacy-entry-id / bulk-update-analyze / auth-tables-doc checks
- [x] `npm run ci:testmock` (Docker-based CI mirror, fresh end-to-end run, `CI_DB_PORT=5453`) — 664/672 integration tests pass (8 pre-existing skips), zero failures; every test exercising this change (`/proxy/metadata/album`, `/proxy/metadata/artist`, `/proxy/entity/resolve`, `LmlLookupCoordinator` coalescing) passes cleanly
- [x] GitHub Actions CI green end-to-end after rebasing onto the BS#1826 LML-policy-layer merge (detect-changes, auth-tables-doc-drift, unit-tests, lint-and-typecheck incl. the new LML-caller-classification check, Integration-Tests)