### PR TITLE
BS#1826 (1/3): add per-caller LML traffic-class policy layer

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -50,6 +50,25 @@ export type {
 import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from './streaming-url-guard.js';
 export { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls };
 
+// BS#1826: per-caller traffic-class policy layer. `policy.ts` imports
+// `envInt` back from this module (below) — a deliberate circular import
+// that's safe because `envInt` is a hoisted `function` declaration, not a
+// `const`, so it's already bound by the time `policy.ts`'s module-load-time
+// `buildPolicy()` call runs, regardless of which module starts loading
+// first. See `policy.ts`'s module doc for the design.
+import {
+  resolveLmlPolicy,
+  LML_CALLER_POLICY,
+  ALL_LML_CALLERS,
+  _resetLmlPolicyForTest,
+  type LmlCaller,
+  type LmlCallerClass,
+  type LmlCallerLimiter,
+  type LmlPolicy,
+} from './policy.js';
+export { resolveLmlPolicy, LML_CALLER_POLICY, ALL_LML_CALLERS, _resetLmlPolicyForTest };
+export type { LmlCaller, LmlCallerClass, LmlCallerLimiter, LmlPolicy };
+
 class LmlClientError extends Error {
   constructor(
     message: string,
@@ -117,6 +136,27 @@ export function envInt(name: string, fallback: number): number {
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
   console.warn(`lml.client: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
   return fallback;
+}
+
+/**
+ * BS#1826: soft caller→policy lookup used internally to compute default
+ * `timeoutMs`/`budgetMs` when a call passes `{ caller }` without an
+ * explicit override. Unlike the public `resolveLmlPolicy` (which throws on
+ * an unregistered caller), this NEVER throws — `LookupOptions.caller` stays
+ * a loosely-typed `string` until `caller` becomes a compile-time-checked
+ * `LmlCaller` (BS#1826 PR 2), so a request path must never crash because of
+ * an unregistered or mistyped label. An unregistered/absent caller simply
+ * gets no policy default, and the method's own pre-existing default (e.g.
+ * `TIMEOUT_MS`) applies unchanged. Note this is NOT true for a *registered*
+ * caller: a call site already passing a known `caller` label (several do,
+ * for observability) picks up its class default the moment this lands — an
+ * intended, env-reversible behavior change, not a no-op (see policy.ts).
+ */
+function policyForCaller(caller: string | undefined): LmlPolicy | undefined {
+  if (caller === undefined) return undefined;
+  return Object.prototype.hasOwnProperty.call(LML_CALLER_POLICY, caller)
+    ? LML_CALLER_POLICY[caller as LmlCaller]
+    : undefined;
 }
 
 /**
@@ -432,6 +472,14 @@ export interface LookupOptions {
    * `enrichment-worker`, `library-track-search`). Omit at your peril — missing
    * callers project as `lml.caller=unknown`, which is meant as a Sentry
    * flag-of-shame so untracked call sites surface in queries.
+   *
+   * BS#1826: a registered caller (see `ALL_LML_CALLERS` in `policy.ts`) now
+   * also supplies the DEFAULT `timeoutMs`/`budgetMs` for this call, used
+   * only when this options object doesn't set them explicitly — explicit
+   * `timeoutMs`/`budgetMs` always win. Kept as a loose `string` (not the
+   * typed `LmlCaller` union) in this PR so an unregistered/mistyped label
+   * degrades to "no policy default" instead of a compile error or a thrown
+   * runtime error; the typed, required union lands in a follow-up PR.
    */
   caller?: string;
   /**
@@ -604,6 +652,13 @@ async function postLookup(
   // queue-time outside the http.client span — span duration reflects fetch
   // work only.
   const activeLimiter = options?.limiter ?? defaultLimiter;
+  // BS#1826: the caller-class policy supplies timeoutMs/budgetMs DEFAULTS,
+  // used only when the call site didn't pass an explicit override — see
+  // `policyForCaller`'s doc comment for why an unregistered/absent caller
+  // is a safe no-op rather than a thrown error here.
+  const policy = policyForCaller(options?.caller);
+  const effectiveTimeoutMs = options?.timeoutMs ?? policy?.timeoutMs;
+  const effectiveBudgetMs = options?.budgetMs ?? policy?.budgetMs;
   return activeLimiter.run(async () => {
     return await Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
       try {
@@ -619,10 +674,10 @@ async function postLookup(
         '/api/v1/lookup',
         {
           method: 'POST',
-          headers: buildLookupHeaders(options?.budgetMs),
+          headers: buildLookupHeaders(effectiveBudgetMs),
           body: JSON.stringify(body),
         },
-        options?.timeoutMs
+        effectiveTimeoutMs
       );
 
       // BS#1710: enforce the streaming-URL host invariant at this untrusted
@@ -821,6 +876,10 @@ export async function bulkLookupMetadata(
   }
 
   const activeLimiter = options?.limiter ?? defaultLimiter;
+  // BS#1826: same policy-supplies-the-default treatment as `postLookup`.
+  const policy = policyForCaller(options?.caller);
+  const effectiveTimeoutMs = options?.timeoutMs ?? policy?.timeoutMs;
+  const effectiveBudgetMs = options?.budgetMs ?? policy?.budgetMs;
   return activeLimiter.run(async () => {
     return await Sentry.startSpan({ name: 'lml.lookup.bulk', op: 'http.client' }, async (span) => {
       try {
@@ -845,10 +904,10 @@ export async function bulkLookupMetadata(
         bulkPath,
         {
           method: 'POST',
-          headers: buildLookupHeaders(options?.budgetMs),
+          headers: buildLookupHeaders(effectiveBudgetMs),
           body: JSON.stringify({ items: sendItems }),
         },
-        options?.timeoutMs
+        effectiveTimeoutMs
       );
 
       const parsed = (await response.json()) as BulkLookupResponse & { cache_stats?: unknown };
@@ -926,13 +985,28 @@ function buildSkippedBulkResultItem(index: number): BulkLookupResultItem {
 }
 
 /**
+ * Options accepted by the class-3 PG-cached reads (`getRelease`,
+ * `getArtistDetails`, `resolveEntity`, `searchTrackReleases`). `caller` is
+ * optional in this PR (BS#1826 PR 1) — when omitted, these methods are
+ * byte-identical to their pre-BS#1826 behavior (no timeout arg reaches
+ * `lmlFetch`, so its own `TIMEOUT_MS` default applies). When present and
+ * registered, the caller's class-3 `timeoutMs` (8 s PG-cached-read default,
+ * or a per-caller override) is threaded into the `lmlFetch` AbortController.
+ */
+export interface DiscogsReadOptions {
+  caller?: string;
+}
+
+/**
  * Get full release metadata from LML.
  *
  * @param releaseId - Discogs release ID
+ * @param options - Optional caller label. See `DiscogsReadOptions`.
  * @returns Release metadata including tracklist, genres, styles
  */
-export async function getRelease(releaseId: number): Promise<DiscogsReleaseMetadata> {
-  const response = await lmlFetch(`/api/v1/discogs/release/${releaseId}`);
+export async function getRelease(releaseId: number, options?: DiscogsReadOptions): Promise<DiscogsReleaseMetadata> {
+  const timeoutMs = policyForCaller(options?.caller)?.timeoutMs;
+  const response = await lmlFetch(`/api/v1/discogs/release/${releaseId}`, undefined, timeoutMs);
   return (await response.json()) as DiscogsReleaseMetadata;
 }
 
@@ -940,10 +1014,12 @@ export async function getRelease(releaseId: number): Promise<DiscogsReleaseMetad
  * Get artist details from LML.
  *
  * @param artistId - Discogs artist ID
+ * @param options - Optional caller label. See `DiscogsReadOptions`.
  * @returns Artist details including bio, image, URLs
  */
-export async function getArtistDetails(artistId: number): Promise<DiscogsArtistDetails> {
-  const response = await lmlFetch(`/api/v1/discogs/artist/${artistId}`);
+export async function getArtistDetails(artistId: number, options?: DiscogsReadOptions): Promise<DiscogsArtistDetails> {
+  const timeoutMs = policyForCaller(options?.caller)?.timeoutMs;
+  const response = await lmlFetch(`/api/v1/discogs/artist/${artistId}`, undefined, timeoutMs);
   return (await response.json()) as DiscogsArtistDetails;
 }
 
@@ -952,10 +1028,16 @@ export async function getArtistDetails(artistId: number): Promise<DiscogsArtistD
  *
  * @param type - Entity type: artist, release, or master
  * @param id - Discogs entity ID
+ * @param options - Optional caller label. See `DiscogsReadOptions`.
  * @returns Entity name and basic info
  */
-export async function resolveEntity(type: 'artist' | 'release' | 'master', id: number): Promise<EntityResolveResponse> {
-  const response = await lmlFetch(`/api/v1/discogs/entity/${type}/${id}`);
+export async function resolveEntity(
+  type: 'artist' | 'release' | 'master',
+  id: number,
+  options?: DiscogsReadOptions
+): Promise<EntityResolveResponse> {
+  const timeoutMs = policyForCaller(options?.caller)?.timeoutMs;
+  const response = await lmlFetch(`/api/v1/discogs/entity/${type}/${id}`, undefined, timeoutMs);
   return (await response.json()) as EntityResolveResponse;
 }
 
@@ -965,18 +1047,21 @@ export async function resolveEntity(type: 'artist' | 'release' | 'master', id: n
  * @param track - Track/song title to search for
  * @param artist - Optional artist name for filtering
  * @param limit - Maximum number of results (default 20)
+ * @param options - Optional caller label. See `DiscogsReadOptions`.
  * @returns List of releases containing the track
  */
 export async function searchTrackReleases(
   track: string,
   artist?: string,
-  limit = 20
+  limit = 20,
+  options?: DiscogsReadOptions
 ): Promise<DiscogsTrackReleasesResponse> {
   const params = new URLSearchParams({ track });
   if (artist) params.set('artist', artist);
   if (limit !== 20) params.set('limit', String(limit));
 
-  const response = await lmlFetch(`/api/v1/discogs/track-releases?${params}`);
+  const timeoutMs = policyForCaller(options?.caller)?.timeoutMs;
+  const response = await lmlFetch(`/api/v1/discogs/track-releases?${params}`, undefined, timeoutMs);
   return (await response.json()) as DiscogsTrackReleasesResponse;
 }
 
@@ -1031,9 +1116,17 @@ export async function validateTrackOnRelease(releaseId: number, track: string, a
  *
  * @param artist - Artist name
  * @param title - Album title
+ * @param options - Optional caller label (BS#1826 class 4: `library-add-
+ *   album-streaming` / `library-update-album-streaming`). Omitted callers
+ *   are byte-identical to pre-BS#1826 behavior — no timeout reaches
+ *   `lmlFetch`, so its `TIMEOUT_MS` default applies.
  * @returns Streaming availability result with per-source URLs
  */
-export async function checkStreamingAvailability(artist: string, title: string): Promise<StreamingCheckResponse> {
+export async function checkStreamingAvailability(
+  artist: string,
+  title: string,
+  options?: DiscogsReadOptions
+): Promise<StreamingCheckResponse> {
   // BS#1750 / B5: fires on every album add. Route it through the process-wide
   // `defaultLimiter` — the same shared concurrency/rate gate as `/lookup` —
   // so this call participates in the admission budget instead of being an
@@ -1042,12 +1135,17 @@ export async function checkStreamingAvailability(artist: string, title: string):
   // limiter's `semaphore.acquire()` + `tokenBucket.consume(1)`; the permit is
   // released in the limiter's `finally`. Behavior is otherwise unchanged —
   // same path, headers, body, and returned `StreamingCheckResponse`.
+  const timeoutMs = policyForCaller(options?.caller)?.timeoutMs;
   return defaultLimiter.run(async () => {
-    const response = await lmlFetch('/api/v1/streaming-check', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ artist, title }),
-    });
+    const response = await lmlFetch(
+      '/api/v1/streaming-check',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ artist, title }),
+      },
+      timeoutMs
+    );
 
     return (await response.json()) as StreamingCheckResponse;
   });
@@ -1056,7 +1154,10 @@ export async function checkStreamingAvailability(artist: string, title: string):
 /**
  * Search the library catalog via LML.
  *
- * @param params - Search parameters (artist, title, q, limit)
+ * @param params - Search parameters (artist, title, q, limit) plus an
+ *   optional caller label (BS#1826 class 1: `proxy-library-search`).
+ *   Omitted callers are byte-identical to pre-BS#1826 behavior — no timeout
+ *   reaches `lmlFetch`, so its `TIMEOUT_MS` default applies.
  * @returns Library search results
  */
 export async function searchLibrary(params: {
@@ -1064,6 +1165,7 @@ export async function searchLibrary(params: {
   title?: string;
   q?: string;
   limit?: number;
+  caller?: string;
 }): Promise<LibrarySearchResponse> {
   const searchParams = new URLSearchParams();
   if (params.artist) searchParams.set('artist', params.artist);
@@ -1071,7 +1173,8 @@ export async function searchLibrary(params: {
   if (params.q) searchParams.set('q', params.q);
   if (params.limit) searchParams.set('limit', String(params.limit));
 
-  const response = await lmlFetch(`/api/v1/library/search?${searchParams}`);
+  const timeoutMs = policyForCaller(params.caller)?.timeoutMs;
+  const response = await lmlFetch(`/api/v1/library/search?${searchParams}`, undefined, timeoutMs);
   return (await response.json()) as LibrarySearchResponse;
 }
 

--- a/shared/lml-client/src/policy.ts
+++ b/shared/lml-client/src/policy.ts
@@ -1,0 +1,315 @@
+/**
+ * BS→LML caller classification + per-class timeout/budget policy (BS#1826).
+ *
+ * Every BS→LML call already carries a `caller` string label
+ * (`LookupOptions.caller`, `index.ts`) — historically observability-only,
+ * projected onto the `lml.lookup` Sentry span but driving no timeout or
+ * fallback behavior. This module is the policy layer that closes that gap:
+ * one `caller`-keyed table mapping every registered caller to a traffic
+ * class (1-5), each with its own default `timeoutMs` / `budgetMs`.
+ *
+ * See `plans/bs1826-lml-caller-classification.md` for the full design
+ * (the "Caller → class map" and "Proposed per-class budgets" tables this
+ * module implements verbatim) and the PR slicing this file belongs to
+ * (PR 1: policy module + thread-through-client, `caller` still optional).
+ *
+ * BEHAVIORAL NOTE — this is NOT a no-op deploy. The policy is keyed on
+ * `caller`, and several production call sites already pass a registered
+ * `caller` label today (historically for observability). The moment this
+ * threading lands, those already-labeled callers pick up their class
+ * `timeoutMs`/`budgetMs` defaults — e.g. interactive `library-track-search`
+ * / `request-line` tighten from the 30s `TIMEOUT_MS` fallback to the class-2
+ * budget. This is the intended PRD #1819 behavior (bound interactive paths),
+ * and every class timeout is reversible in prod via the `LML_CLASS{1..5}_
+ * TIMEOUT_MS` env knobs. Only callers that pass NO `caller` remain
+ * byte-identical (30s). See the plan's "Risks / watch-items".
+ *
+ * This module intentionally has no side effects of its own beyond reading
+ * env vars inside `resolveLmlPolicy` — no fetch, no Sentry, no limiter
+ * construction. Those stay in `index.ts`, which is the actual chokepoint.
+ */
+
+import { envInt } from './index.js';
+
+/**
+ * The five BS→LML traffic classes (plan's "Proposed per-class budgets"
+ * table):
+ *
+ *   1. Protected local catalog search — short, no-fallback-to-5xx.
+ *   2. Interactive enrichment/lookup — user-adjacent, degrades gracefully.
+ *   3. Identity / release-metadata reads — PG-cached reads plus the
+ *      user-awaited pre-INSERT identity resolve (a per-caller override).
+ *   4. Streaming availability checks — best-effort, null-on-timeout.
+ *   5. Batch/backfill enrichment — long-lived, per-item error isolation.
+ */
+export type LmlCallerClass = 1 | 2 | 3 | 4 | 5;
+
+/**
+ * Which limiter a class's callers SHOULD use, for documentation and the
+ * eventual CI guard (Step 4) — not a live override. `index.ts` continues to
+ * decide the actual `LmlLimiter` instance via `options.limiter ??
+ * defaultLimiter`; this field never mutates that logic. `'default'` means
+ * the process-wide `defaultLimiter` is appropriate; `'none'` means either no
+ * limiter participates (classes 1 and 3 hit PG-cached / low-volume
+ * endpoints) or the caller MUST supply its own dedicated limiter (class 5 —
+ * see the per-class budget table's "dedicated per-job limiter, never
+ * defaultLimiter" note).
+ */
+export type LmlCallerLimiter = 'default' | 'none';
+
+/**
+ * Resolved policy for one caller: the class it belongs to plus the
+ * timeout/budget/limiter/fallback defaults that class (and any per-caller
+ * override) implies. `timeoutMs` is always present — every class has a
+ * default. `budgetMs` is present only for classes that set the
+ * `X-Caller-Budget-Ms` header (2, 5); classes 1/3/4 have "no budget header"
+ * per the plan table. `limiter` and `fallback` are documentation-only (see
+ * `LmlCallerLimiter`) — `index.ts` does not read them to alter transport
+ * behavior in this PR.
+ */
+export interface LmlPolicy {
+  class: LmlCallerClass;
+  timeoutMs: number;
+  budgetMs?: number;
+  limiter?: LmlCallerLimiter;
+  /** One-line description of what happens when this class's budget is exceeded. */
+  fallback?: string;
+}
+
+/**
+ * The registered caller labels, one entry per distinct label observed in
+ * the tree today (verified via `grep -rhoE "caller:\s*['\"][a-zA-Z0-9_-]+"`.
+ * across `apps/**`/`jobs/**`/`shared/**`) plus the labels this plan
+ * introduces: `proxy-library-search` (the currently-unlabeled
+ * `proxy.controller.ts:710` `searchLibrary` call, class 1 — the PRD's
+ * protected-search win), `library-add-album-streaming` /
+ * `library-update-album-streaming` (splitting the streaming-check call at
+ * `library.controller.ts` off of its sibling metadata `lookup` call, which
+ * needs a different class), and `proxy` (the shared label for the
+ * currently-hard-coded-30s `getRelease`/`getArtistDetails`/`resolveEntity`
+ * reads).
+ *
+ * `ALL_LML_CALLERS` is the single source of truth this type is derived
+ * from — tests iterate over it so "every registered caller resolves to
+ * exactly one class" can't drift from the type itself.
+ */
+export const ALL_LML_CALLERS = [
+  // Class 1 — protected local catalog search.
+  'proxy-library-search',
+  // Class 2 — interactive enrichment/lookup.
+  'library-track-search',
+  'library-rotation-picker',
+  'proxy-album-metadata',
+  'library-enrich-artwork',
+  'artwork-discogs-fallback',
+  'request-line',
+  'library-add-album',
+  'library-update-album',
+  'flowsheet-linkage',
+  // Class 3 — identity / release-metadata reads.
+  'add_to_rotation',
+  'proxy',
+  'library-canonical-entity',
+  // Class 4 — streaming availability checks.
+  'library-add-album-streaming',
+  'library-update-album-streaming',
+  // Class 5 — batch/backfill enrichment.
+  'metadata-service',
+  'enrichment-worker',
+  'flowsheet-metadata-backfill',
+  'album-level-backfill',
+  'catalog-popularity-freetext-resolve',
+  'flowsheet-linked-reenrichment',
+  'flowsheet-artwork-repair',
+  'flowsheet-reenrichment',
+  'streaming-url-upgrade',
+  'apple-music-url-backfill',
+  'concerts-genre-enrichment',
+  'concerts-artist-lml-resolver',
+] as const;
+
+export type LmlCaller = (typeof ALL_LML_CALLERS)[number];
+
+const CALLER_CLASS: Record<LmlCaller, LmlCallerClass> = {
+  'proxy-library-search': 1,
+  'library-track-search': 2,
+  'library-rotation-picker': 2,
+  'proxy-album-metadata': 2,
+  'library-enrich-artwork': 2,
+  'artwork-discogs-fallback': 2,
+  'request-line': 2,
+  'library-add-album': 2,
+  'library-update-album': 2,
+  'flowsheet-linkage': 2,
+  add_to_rotation: 3,
+  proxy: 3,
+  'library-canonical-entity': 3,
+  'library-add-album-streaming': 4,
+  'library-update-album-streaming': 4,
+  'metadata-service': 5,
+  'enrichment-worker': 5,
+  'flowsheet-metadata-backfill': 5,
+  'album-level-backfill': 5,
+  'catalog-popularity-freetext-resolve': 5,
+  'flowsheet-linked-reenrichment': 5,
+  'flowsheet-artwork-repair': 5,
+  'flowsheet-reenrichment': 5,
+  'streaming-url-upgrade': 5,
+  'apple-music-url-backfill': 5,
+  'concerts-genre-enrichment': 5,
+  'concerts-artist-lml-resolver': 5,
+};
+
+/**
+ * BS#992 exception, preserved as a per-caller override within class 2
+ * rather than a 6th class (plan Design decision #2/#3). Hardcoded — not an
+ * env lever — per the plan's explicit call-out: "carry it as a code-constant
+ * override... unless we deliberately add `LML_CLASS2_ROTATION_TIMEOUT_MS`."
+ * Mirrors the pre-existing `ROTATION_LML_LOOKUP_TIMEOUT_MS` in
+ * `apps/backend/services/library.service.ts`.
+ */
+const ROTATION_PICKER_TIMEOUT_MS = 10000;
+const ROTATION_PICKER_BUDGET_MS = 9000;
+
+/**
+ * #1828's constant, preserved as a class-2 per-caller `budgetMs` override
+ * (plan Design decision #3) rather than folding into the class-2 default —
+ * `library-enrich-artwork` is the most droppable of the interactive
+ * callers. Mirrors the pre-existing `LIBRARY_SEARCH_LML_BUDGET_MS` env var
+ * in `apps/backend/services/library.service.ts`.
+ */
+const LIBRARY_ENRICH_ARTWORK_BUDGET_ENV = 'LIBRARY_SEARCH_LML_BUDGET_MS';
+const LIBRARY_ENRICH_ARTWORK_BUDGET_FALLBACK_MS = 2000;
+
+/**
+ * `add_to_rotation`'s class-3 identity override. Mirrors the pre-existing
+ * `RESOLVE_IDENTITY_TIMEOUT_MS` fallback in `index.ts`'s `resolveIdentity` —
+ * both read the same `LML_RESOLVE_TIMEOUT_MS` env lever so the ops lever
+ * introduced by BS#1380 survives this policy layer unchanged.
+ */
+const ADD_TO_ROTATION_TIMEOUT_ENV = 'LML_RESOLVE_TIMEOUT_MS';
+const ADD_TO_ROTATION_TIMEOUT_FALLBACK_MS = 2000;
+
+const CLASS_FALLBACK: Record<LmlCallerClass, string> = {
+  1: 'on timeout/error return local/empty, never 5xx',
+  2: 'degrade to unenriched/free-text',
+  3: 'null-on-timeout; daily cron reconciles',
+  4: 'persist null; read path synthesizes search URL',
+  5: 'per-item error isolation; retry next cycle',
+};
+
+/**
+ * Read each class's `timeoutMs` (and, for class 2, its dedicated
+ * `budgetMs`) from the new `LML_CLASS{1..5}_TIMEOUT_MS` / `LML_CLASS2_
+ * BUDGET_MS` env knobs, falling back to the plan's proposed defaults. Read
+ * fresh on every call (not cached at module scope) so `_resetLmlPolicyForTest`
+ * can exercise env changes without a process restart — mirrors the
+ * `_resetLmlClientLimitersForTest` pattern in `index.ts`.
+ */
+function classDefaults(cls: LmlCallerClass): { timeoutMs: number; budgetMs?: number; limiter: LmlCallerLimiter } {
+  switch (cls) {
+    case 1:
+      return { timeoutMs: envInt('LML_CLASS1_TIMEOUT_MS', 3000), limiter: 'none' };
+    case 2: {
+      const timeoutMs = envInt('LML_CLASS2_TIMEOUT_MS', 5000);
+      const budgetMs = envInt('LML_CLASS2_BUDGET_MS', 4000);
+      return { timeoutMs, budgetMs, limiter: 'default' };
+    }
+    case 3:
+      // No budget header on class-3 reads (plan table: "—"). `timeoutMs`
+      // here is the 8 s PG-cached-read default; `add_to_rotation`'s 2 s
+      // identity override is layered on top below.
+      return { timeoutMs: envInt('LML_CLASS3_TIMEOUT_MS', 8000), limiter: 'none' };
+    case 4:
+      return { timeoutMs: envInt('LML_CLASS4_TIMEOUT_MS', 5000), limiter: 'default' };
+    case 5: {
+      const timeoutMs = envInt('LML_CLASS5_TIMEOUT_MS', 29000);
+      // Codebase convention: budgetMs ≈ timeoutMs − 1000 (plan line 27) so
+      // LML's soft cutoff fires before the socket aborts.
+      return { timeoutMs, budgetMs: Math.max(0, timeoutMs - 1000), limiter: 'none' };
+    }
+  }
+}
+
+/**
+ * Build the full caller → policy table from the current `process.env`.
+ * Exposed indirectly via `LML_CALLER_POLICY` (computed once at module
+ * load, matching every other env-derived constant in this package) and
+ * `_resetLmlPolicyForTest` (rebuilds in place after a test mutates env).
+ */
+function buildPolicy(): Record<LmlCaller, LmlPolicy> {
+  const table = {} as Record<LmlCaller, LmlPolicy>;
+
+  for (const caller of ALL_LML_CALLERS) {
+    const cls = CALLER_CLASS[caller];
+    const defaults = classDefaults(cls);
+    table[caller] = {
+      class: cls,
+      timeoutMs: defaults.timeoutMs,
+      budgetMs: defaults.budgetMs,
+      limiter: defaults.limiter,
+      fallback: CLASS_FALLBACK[cls],
+    };
+  }
+
+  // Per-caller overrides, layered on top of the class defaults above.
+  table['library-rotation-picker'] = {
+    ...table['library-rotation-picker'],
+    timeoutMs: ROTATION_PICKER_TIMEOUT_MS,
+    budgetMs: ROTATION_PICKER_BUDGET_MS,
+  };
+  table['library-enrich-artwork'] = {
+    ...table['library-enrich-artwork'],
+    budgetMs: envInt(LIBRARY_ENRICH_ARTWORK_BUDGET_ENV, LIBRARY_ENRICH_ARTWORK_BUDGET_FALLBACK_MS),
+  };
+  table.add_to_rotation = {
+    ...table.add_to_rotation,
+    timeoutMs: envInt(ADD_TO_ROTATION_TIMEOUT_ENV, ADD_TO_ROTATION_TIMEOUT_FALLBACK_MS),
+  };
+
+  return table;
+}
+
+/**
+ * The full caller → policy table, built from `process.env` at module load.
+ * A plain mutable object (not a getter) so it matches the `Record<LmlCaller,
+ * ...>` shape the plan specifies; `_resetLmlPolicyForTest` mutates it in
+ * place for tests that need to observe an env change without re-importing
+ * the module.
+ */
+export const LML_CALLER_POLICY: Record<LmlCaller, LmlPolicy> = buildPolicy();
+
+/**
+ * Test-only: rebuild `LML_CALLER_POLICY` from the current `process.env`.
+ * Production code never calls this — the table is intentionally built once
+ * at module load, matching the rest of this package's env-derived
+ * constants. Mirrors `_resetLmlClientLimitersForTest` in `index.ts`.
+ */
+export function _resetLmlPolicyForTest(): void {
+  Object.assign(LML_CALLER_POLICY, buildPolicy());
+}
+
+/**
+ * Resolve the policy for a registered caller. Throws for any caller not in
+ * `ALL_LML_CALLERS` — a loud failure at the one place every caller MUST be
+ * registered, rather than a silent `class: unknown` default that would let
+ * a new call site skip classification. New callers register themselves by
+ * adding a label to `ALL_LML_CALLERS` + `CALLER_CLASS` above.
+ *
+ * `index.ts`'s internal defaulting (still-optional `caller` in this PR)
+ * does NOT call this directly — see the "soft" lookup note in `index.ts`
+ * for why an as-yet-unregistered or mistyped `caller` string must not
+ * crash a live request path before `caller` becomes a compile-time-checked
+ * `LmlCaller` (PR 2). This function is the public, throwing contract for
+ * callers that already know they're passing a valid `LmlCaller`.
+ */
+export function resolveLmlPolicy(caller: LmlCaller): LmlPolicy {
+  const policy = LML_CALLER_POLICY[caller];
+  if (!policy) {
+    throw new Error(
+      `lml.client: unregistered LML caller "${caller}" — register it in ALL_LML_CALLERS + CALLER_CLASS ` +
+        `(shared/lml-client/src/policy.ts, BS#1826) before using it.`
+    );
+  }
+  return policy;
+}

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -191,6 +191,62 @@ describe('lml.client', () => {
       setTimeoutSpy.mockRestore();
     });
 
+    it('BS#1826: a registered caller supplies the DEFAULT timeoutMs/budgetMs when neither is passed explicitly', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      // library-track-search is a registered class-2 caller: timeoutMs 5000, budgetMs 4000.
+      await lookupMetadata('Autechre', 'Confield', undefined, { caller: 'library-track-search' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 5000)).toHaveLength(1);
+      const init = mockFetch.mock.calls[0][1];
+      expect(init?.headers).toMatchObject({ 'X-Caller-Budget-Ms': '4000' });
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: explicit timeoutMs/budgetMs still win over the caller’s policy default (no-behavior-change guarantee)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      // library-track-search resolves to timeoutMs 5000 / budgetMs 4000, but this
+      // call passes its own explicit values, which must be what actually fires.
+      await lookupMetadata('Autechre', 'Confield', undefined, {
+        caller: 'library-track-search',
+        timeoutMs: 12345,
+        budgetMs: 6789,
+      });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 12345)).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 5000)).toHaveLength(0);
+      const init = mockFetch.mock.calls[0][1];
+      expect(init?.headers).toMatchObject({ 'X-Caller-Budget-Ms': '6789' });
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: an unregistered caller string is a safe no-op (falls back to the 30 s default, no throw)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await expect(
+        lookupMetadata('Autechre', 'Confield', undefined, { caller: 'some-brand-new-caller-nobody-registered' })
+      ).resolves.toBeDefined();
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
     it('omits both option flags from the body when no options are passed', async () => {
       // Read-path callers (request-line, artwork fallback, library
       // services) don't pass options. The body must stay byte-identical
@@ -777,6 +833,42 @@ describe('lml.client', () => {
       const init = mockFetch.mock.calls[0][1];
       if (!init) throw new Error('mockFetch was not called with init args');
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
+    });
+
+    it('BS#1826: a registered caller supplies the DEFAULT timeoutMs/budgetMs when neither is passed explicitly', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      // enrichment-worker is a registered class-5 caller: timeoutMs 29000, budgetMs 28000.
+      await bulkLookupMetadata([itemFor('A', 'X')], { caller: 'enrichment-worker' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 29000)).toHaveLength(1);
+      const init = mockFetch.mock.calls[0][1];
+      expect(init?.headers).toMatchObject({ 'X-Caller-Budget-Ms': '28000' });
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: explicit timeoutMs/budgetMs still win over the caller’s policy default (no-behavior-change guarantee)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], {
+        caller: 'enrichment-worker',
+        timeoutMs: 111111,
+        budgetMs: 22222,
+      });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 111111)).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 29000)).toHaveLength(0);
+      const init = mockFetch.mock.calls[0][1];
+      expect(init?.headers).toMatchObject({ 'X-Caller-Budget-Ms': '22222' });
+      setTimeoutSpy.mockRestore();
     });
 
     it('projects lml.caller onto the bulk Sentry span when caller is provided', async () => {
@@ -1532,6 +1624,45 @@ describe('lml.client', () => {
       );
       expect(result).toEqual(mockRelease);
     });
+
+    it('BS#1826: uses the default 30 s timeout when no caller is passed (byte-identical to pre-policy behavior)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ release_id: 1 }),
+      } as unknown as globalThis.Response);
+
+      await getRelease(123);
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: threads the registered caller’s class-3 policy timeout (8 s) into the AbortController', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ release_id: 1 }),
+      } as unknown as globalThis.Response);
+
+      await getRelease(123, { caller: 'proxy' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 8000)).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(0);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: an unregistered caller string is a safe no-op (falls back to the 30 s default, no throw)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ release_id: 1 }),
+      } as unknown as globalThis.Response);
+
+      await expect(getRelease(123, { caller: 'not-a-registered-caller' })).resolves.toBeDefined();
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
   });
 
   describe('getArtistDetails', () => {
@@ -1550,6 +1681,19 @@ describe('lml.client', () => {
       );
       expect(result).toEqual(mockArtist);
     });
+
+    it('BS#1826: threads the registered caller’s class-3 policy timeout into the AbortController', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ artist_id: 3840, name: 'Autechre' }),
+      } as unknown as globalThis.Response);
+
+      await getArtistDetails(3840, { caller: 'proxy' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 8000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
   });
 
   describe('resolveEntity', () => {
@@ -1566,6 +1710,19 @@ describe('lml.client', () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
       expect(result).toEqual({ name: 'Autechre', type: 'artist', id: 3840 });
+    });
+
+    it('BS#1826: threads the registered caller’s class-3 policy timeout into the AbortController', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ name: 'Autechre', type: 'artist', id: 3840 }),
+      } as unknown as globalThis.Response);
+
+      await resolveEntity('artist', 3840, { caller: 'proxy' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 8000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
     });
   });
 
@@ -1688,6 +1845,33 @@ describe('lml.client', () => {
 
       await expect(checkStreamingAvailability('Stereolab', 'Aluminum Tunes')).rejects.toThrow(LmlClientError);
     });
+
+    it('BS#1826: uses the default 30 s timeout when no caller is passed (byte-identical to pre-policy behavior)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ on_streaming: false, sources: {} }),
+      } as unknown as globalThis.Response);
+
+      await checkStreamingAvailability('Stereolab', 'Aluminum Tunes');
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: threads the registered caller’s class-4 policy timeout (5 s) into the AbortController', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ on_streaming: false, sources: {} }),
+      } as unknown as globalThis.Response);
+
+      await checkStreamingAvailability('Stereolab', 'Aluminum Tunes', { caller: 'library-add-album-streaming' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 5000)).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(0);
+      setTimeoutSpy.mockRestore();
+    });
   });
 
   describe('LML_API_KEY bearer header', () => {
@@ -1798,6 +1982,45 @@ describe('lml.client', () => {
       expect(calledUrl).toContain('title=Moon+Pix');
       expect(calledUrl).not.toContain('artist=');
       expect(calledUrl).not.toContain('limit=');
+    });
+
+    it('BS#1826: uses the default 30 s timeout when no caller is passed (byte-identical to pre-policy behavior)', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], total: 0, query: null }),
+      } as unknown as globalThis.Response);
+
+      await searchLibrary({ artist: 'Stereolab' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: threads the registered caller’s class-1 policy timeout (3 s) into the AbortController', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], total: 0, query: null }),
+      } as unknown as globalThis.Response);
+
+      await searchLibrary({ artist: 'Stereolab', caller: 'proxy-library-search' });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 3000)).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000)).toHaveLength(0);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('BS#1826: caller does not leak into the wire query string', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], total: 0, query: null }),
+      } as unknown as globalThis.Response);
+
+      await searchLibrary({ artist: 'Stereolab', caller: 'proxy-library-search' });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('caller');
     });
   });
 });

--- a/tests/unit/shared/lml-client/policy.test.ts
+++ b/tests/unit/shared/lml-client/policy.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the BS→LML caller classification policy layer (BS#1826).
+ */
+import {
+  ALL_LML_CALLERS,
+  LML_CALLER_POLICY,
+  resolveLmlPolicy,
+  _resetLmlPolicyForTest,
+  type LmlCaller,
+  type LmlCallerClass,
+} from '@wxyc/lml-client';
+
+describe('lml-client policy', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    _resetLmlPolicyForTest();
+  });
+
+  describe('ALL_LML_CALLERS / resolveLmlPolicy', () => {
+    it('resolves every registered caller to exactly one class', () => {
+      for (const caller of ALL_LML_CALLERS) {
+        const policy = resolveLmlPolicy(caller);
+        expect(policy.class).toBeGreaterThanOrEqual(1);
+        expect(policy.class).toBeLessThanOrEqual(5);
+        expect(Number.isInteger(policy.class)).toBe(true);
+      }
+    });
+
+    it('exposes the same set of callers via LML_CALLER_POLICY as ALL_LML_CALLERS', () => {
+      expect(Object.keys(LML_CALLER_POLICY).sort()).toEqual([...ALL_LML_CALLERS].sort());
+    });
+
+    it('every resolved policy carries a positive timeoutMs', () => {
+      for (const caller of ALL_LML_CALLERS) {
+        expect(resolveLmlPolicy(caller).timeoutMs).toBeGreaterThan(0);
+      }
+    });
+
+    it('throws for an unregistered caller', () => {
+      expect(() => resolveLmlPolicy('totally-not-registered' as LmlCaller)).toThrow(
+        /unregistered LML caller "totally-not-registered"/
+      );
+    });
+
+    it('the plan’s caller→class map is represented exactly (spot check every row)', () => {
+      const expected: Record<LmlCaller, LmlCallerClass> = {
+        'proxy-library-search': 1,
+        'library-track-search': 2,
+        'library-rotation-picker': 2,
+        'proxy-album-metadata': 2,
+        'library-enrich-artwork': 2,
+        'artwork-discogs-fallback': 2,
+        'request-line': 2,
+        'library-add-album': 2,
+        'library-update-album': 2,
+        'flowsheet-linkage': 2,
+        add_to_rotation: 3,
+        proxy: 3,
+        'library-canonical-entity': 3,
+        'library-add-album-streaming': 4,
+        'library-update-album-streaming': 4,
+        'metadata-service': 5,
+        'enrichment-worker': 5,
+        'flowsheet-metadata-backfill': 5,
+        'album-level-backfill': 5,
+        'catalog-popularity-freetext-resolve': 5,
+        'flowsheet-linked-reenrichment': 5,
+        'flowsheet-artwork-repair': 5,
+        'flowsheet-reenrichment': 5,
+        'streaming-url-upgrade': 5,
+        'apple-music-url-backfill': 5,
+        'concerts-genre-enrichment': 5,
+        'concerts-artist-lml-resolver': 5,
+      };
+      for (const [caller, expectedClass] of Object.entries(expected) as [LmlCaller, LmlCallerClass][]) {
+        expect(resolveLmlPolicy(caller).class).toBe(expectedClass);
+      }
+      // No unexpected extra callers snuck in.
+      expect(ALL_LML_CALLERS.length).toBe(Object.keys(expected).length);
+    });
+  });
+
+  describe('per-class defaults', () => {
+    it('class 1 (protected local catalog search) defaults to 3 s, no budget header', () => {
+      const policy = resolveLmlPolicy('proxy-library-search');
+      expect(policy.timeoutMs).toBe(3000);
+      expect(policy.budgetMs).toBeUndefined();
+    });
+
+    it('class 2 (interactive enrichment/lookup) defaults to 5 s timeout / 4 s budget', () => {
+      const policy = resolveLmlPolicy('library-track-search');
+      expect(policy.timeoutMs).toBe(5000);
+      expect(policy.budgetMs).toBe(4000);
+    });
+
+    it('class 3 PG-cached reads default to 8 s, no budget header', () => {
+      const policy = resolveLmlPolicy('library-canonical-entity');
+      expect(policy.timeoutMs).toBe(8000);
+      expect(policy.budgetMs).toBeUndefined();
+    });
+
+    it('class 3 "proxy" reads (getRelease/getArtistDetails/resolveEntity) also default to 8 s', () => {
+      expect(resolveLmlPolicy('proxy').timeoutMs).toBe(8000);
+    });
+
+    it('class 4 (streaming availability checks) defaults to 5 s, no budget header', () => {
+      const policy = resolveLmlPolicy('library-add-album-streaming');
+      expect(policy.timeoutMs).toBe(5000);
+      expect(policy.budgetMs).toBeUndefined();
+      expect(resolveLmlPolicy('library-update-album-streaming').timeoutMs).toBe(5000);
+    });
+
+    it('class 5 (batch/backfill enrichment) defaults to 29 s timeout / 28 s budget', () => {
+      const policy = resolveLmlPolicy('enrichment-worker');
+      expect(policy.timeoutMs).toBe(29000);
+      expect(policy.budgetMs).toBe(28000);
+    });
+  });
+
+  describe('per-caller overrides', () => {
+    it('library-rotation-picker overrides to the BS#992 10 s timeout / 9 s budget', () => {
+      const policy = resolveLmlPolicy('library-rotation-picker');
+      expect(policy.timeoutMs).toBe(10000);
+      expect(policy.budgetMs).toBe(9000);
+    });
+
+    it('library-enrich-artwork overrides budgetMs to 2000 (the #1828 constant), timeoutMs stays class-2 default', () => {
+      const policy = resolveLmlPolicy('library-enrich-artwork');
+      expect(policy.budgetMs).toBe(2000);
+      expect(policy.timeoutMs).toBe(5000);
+    });
+
+    it('library-enrich-artwork honors LIBRARY_SEARCH_LML_BUDGET_MS', () => {
+      process.env.LIBRARY_SEARCH_LML_BUDGET_MS = '1500';
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy('library-enrich-artwork').budgetMs).toBe(1500);
+    });
+
+    it('add_to_rotation overrides timeoutMs to the identity default (2000), no budget header', () => {
+      const policy = resolveLmlPolicy('add_to_rotation');
+      expect(policy.timeoutMs).toBe(2000);
+      expect(policy.budgetMs).toBeUndefined();
+    });
+
+    it('add_to_rotation honors LML_RESOLVE_TIMEOUT_MS (the pre-existing resolveIdentity lever)', () => {
+      process.env.LML_RESOLVE_TIMEOUT_MS = '3500';
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy('add_to_rotation').timeoutMs).toBe(3500);
+    });
+  });
+
+  describe('LML_CLASS{1..5}_TIMEOUT_MS / LML_CLASS2_BUDGET_MS env knobs', () => {
+    it.each([
+      ['LML_CLASS1_TIMEOUT_MS', 'proxy-library-search', 'timeoutMs', 9999],
+      ['LML_CLASS2_TIMEOUT_MS', 'library-track-search', 'timeoutMs', 8888],
+      ['LML_CLASS2_BUDGET_MS', 'library-track-search', 'budgetMs', 7777],
+      ['LML_CLASS3_TIMEOUT_MS', 'library-canonical-entity', 'timeoutMs', 6666],
+      ['LML_CLASS4_TIMEOUT_MS', 'library-add-album-streaming', 'timeoutMs', 5555],
+      ['LML_CLASS5_TIMEOUT_MS', 'enrichment-worker', 'timeoutMs', 40000],
+    ] as const)('%s overrides %s.%s to %d', (envName, caller, field, value) => {
+      process.env[envName] = String(value);
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy(caller as LmlCaller)[field]).toBe(value);
+    });
+
+    it('class 5 budgetMs is derived as timeoutMs - 1000 when LML_CLASS5_TIMEOUT_MS is overridden', () => {
+      process.env.LML_CLASS5_TIMEOUT_MS = '40000';
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy('enrichment-worker').budgetMs).toBe(39000);
+    });
+
+    it('an invalid env value falls back to the documented default (envInt contract)', () => {
+      process.env.LML_CLASS1_TIMEOUT_MS = '-5';
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy('proxy-library-search').timeoutMs).toBe(3000);
+    });
+  });
+
+  describe('_resetLmlPolicyForTest', () => {
+    it('rebuilds LML_CALLER_POLICY in place so a later resolveLmlPolicy call sees the new env', () => {
+      const before = resolveLmlPolicy('library-track-search').timeoutMs;
+      process.env.LML_CLASS2_TIMEOUT_MS = String(before + 1234);
+      _resetLmlPolicyForTest();
+      expect(resolveLmlPolicy('library-track-search').timeoutMs).toBe(before + 1234);
+      // The exported binding itself didn't change identity (still a Record).
+      expect(typeof LML_CALLER_POLICY).toBe('object');
+    });
+  });
+});


### PR DESCRIPTION
Part 1 of 3 for [#1826](https://github.com/WXYC/Backend-Service/issues/1826) (BS→LML caller classification, slice of PRD #1819). Stacked: this is the base; #1826 auto-closes on part 3.

## What
Adds `shared/lml-client/src/policy.ts`: a `caller`-keyed table mapping every registered LML caller to one of five traffic classes, each with its own default `timeoutMs`/`budgetMs`, threaded through the client. A call passing `{ caller }` inherits the class default unless it passes an explicit override (explicit always wins). `caller` stays optional here.

## Behavioral note (NOT a no-op deploy)
The policy is keyed on `caller`, and several production call sites already pass a registered `caller` label today (historically observability-only). They pick up their class timeout/budget the moment this lands — e.g. interactive `library-track-search`/`request-line` tighten from the 30s fallback to the class-2 budget. This is the intended PRD #1819 behavior and is reversible in prod via `LML_CLASS{1..5}_TIMEOUT_MS`. Callers passing no `caller` stay byte-identical (30s).

## Follows
Parts 2 (call-site migration + constant retirement) and 3 (bypass guard) stack on this.