### PR TITLE
feat(lml-client): forward X-Caller-Class + X-Caller-Reason headers to LML

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -364,15 +364,49 @@ function getBaseUrl(): string {
 const CALLER_BUDGET_HEADER = 'X-Caller-Budget-Ms';
 
 /**
+ * BS#1843: wire-signal prelim for BS#1819 Pass 2. Forwards the BS-internal
+ * `resolveLmlPolicy(caller).class` (BS#1826, `policy.ts`) as an integer
+ * `1`-`5` so LML can eventually key lane routing/guarding off of it
+ * (WXYC/library-metadata-lookup#928). Sending this ahead of any LML-side
+ * read is inert — LML ignores unknown headers today.
+ */
+const CALLER_CLASS_HEADER = 'X-Caller-Class';
+
+/**
+ * BS#1843: companion to `CALLER_CLASS_HEADER`. Forwards the raw `caller`
+ * label itself so LML can eventually attribute per-caller telemetry
+ * (WXYC/library-metadata-lookup#931) — the read seam to mirror is LML's
+ * `lookup/router.py:431` (`Header(alias="X-Caller-Budget-Ms")`).
+ */
+const CALLER_REASON_HEADER = 'X-Caller-Reason';
+
+/**
  * Build the request headers for a `/lookup` or `/lookup/bulk` POST. Returns a
  * fresh object so callers can safely mutate. `budgetMs` becomes the
  * `CALLER_BUDGET_HEADER` value when set; absent budget means no header (LML
  * keeps the pre-A10 safety branch).
+ *
+ * BS#1843: `caller` becomes `CALLER_CLASS_HEADER` + `CALLER_REASON_HEADER`
+ * when it resolves to a REGISTERED policy via the same soft `policyForCaller`
+ * lookup `postLookup`/`bulkLookupMetadata` already use for their timeout/
+ * budget defaults (as opposed to the throwing public `resolveLmlPolicy`) —
+ * an absent OR unregistered caller (e.g. a stale/mistyped label reaching here
+ * at runtime from an un-typechecked `jobs/**` call site) omits both headers
+ * rather than crashing the request path, mirroring `policyForCaller`'s
+ * documented safe-no-op contract. Both headers are otherwise inert wire
+ * enrichment until LML reads them (see the header doc comments above).
  */
-function buildLookupHeaders(budgetMs?: number): Record<string, string> {
+function buildLookupHeaders(budgetMs?: number, caller?: LmlCaller): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (budgetMs !== undefined) {
     headers[CALLER_BUDGET_HEADER] = String(budgetMs);
+  }
+  if (caller !== undefined) {
+    const policy = policyForCaller(caller);
+    if (policy !== undefined) {
+      headers[CALLER_CLASS_HEADER] = String(policy.class);
+      headers[CALLER_REASON_HEADER] = caller;
+    }
   }
   return headers;
 }
@@ -691,7 +725,7 @@ async function postLookup(
         '/api/v1/lookup',
         {
           method: 'POST',
-          headers: buildLookupHeaders(effectiveBudgetMs),
+          headers: buildLookupHeaders(effectiveBudgetMs, options?.caller),
           body: JSON.stringify(body),
         },
         effectiveTimeoutMs
@@ -929,7 +963,7 @@ export async function bulkLookupMetadata(
         bulkPath,
         {
           method: 'POST',
-          headers: buildLookupHeaders(effectiveBudgetMs),
+          headers: buildLookupHeaders(effectiveBudgetMs, options?.caller),
           body: JSON.stringify({ items: sendItems }),
         },
         effectiveTimeoutMs

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -365,9 +365,11 @@ const CALLER_BUDGET_HEADER = 'X-Caller-Budget-Ms';
 
 /**
  * BS#1843: wire-signal prelim for BS#1819 Pass 2. Forwards the BS-internal
- * `resolveLmlPolicy(caller).class` (BS#1826, `policy.ts`) as an integer
- * `1`-`5` so LML can eventually key lane routing/guarding off of it
- * (WXYC/library-metadata-lookup#928). Sending this ahead of any LML-side
+ * caller traffic class (BS#1826, `policy.ts`) as an integer `1`-`5` so LML
+ * can eventually key lane routing/guarding off of it
+ * (WXYC/library-metadata-lookup#928), resolved via the soft, non-throwing
+ * `policyForCaller` (NOT the throwing `resolveLmlPolicy`; see
+ * `buildLookupHeaders` below). Sending this ahead of any LML-side
  * read is inert — LML ignores unknown headers today.
  */
 const CALLER_CLASS_HEADER = 'X-Caller-Class';
@@ -375,8 +377,10 @@ const CALLER_CLASS_HEADER = 'X-Caller-Class';
 /**
  * BS#1843: companion to `CALLER_CLASS_HEADER`. Forwards the raw `caller`
  * label itself so LML can eventually attribute per-caller telemetry
- * (WXYC/library-metadata-lookup#931) — the read seam to mirror is LML's
- * `lookup/router.py:431` (`Header(alias="X-Caller-Budget-Ms")`).
+ * (WXYC/library-metadata-lookup#931). The read seam to mirror is LML's
+ * existing `X-Caller-Budget-Ms` declaration (near `lookup/router.py:431`) —
+ * #931 adds a SIBLING `Header(alias="X-Caller-Reason")` there, NOT a reuse
+ * of the budget alias.
  */
 const CALLER_REASON_HEADER = 'X-Caller-Reason';
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -294,6 +294,54 @@ describe('lml.client', () => {
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
     });
 
+    // BS#1843: wire-signal prelim for LML#928 (lane routing) / LML#931
+    // (caller-reason telemetry). Forwarding is inert on its own — LML ignores
+    // both headers until those sub-issues land a read seam mirroring
+    // library-metadata-lookup's `lookup/router.py:431`.
+    it('BS#1843: forwards X-Caller-Class + X-Caller-Reason for a registered class-1 caller (proxy-library-search)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', undefined, { caller: 'proxy-library-search' });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toMatchObject({ 'X-Caller-Class': '1', 'X-Caller-Reason': 'proxy-library-search' });
+    });
+
+    it('BS#1843: omits X-Caller-Class and X-Caller-Reason when caller is absent (byte-identical to pre-change)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes');
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    });
+
+    it('BS#1843: an unregistered caller string omits X-Caller-Class/X-Caller-Reason too (safe no-op, mirrors timeout/budget defaulting)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', undefined, { caller: 'some-brand-new-caller-nobody-registered' });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      const headerKeys = Object.keys(init.headers ?? {});
+      expect(headerKeys).not.toContain('X-Caller-Class');
+      expect(headerKeys).not.toContain('X-Caller-Reason');
+    });
+
     it('projects lml.caller onto the Sentry span when caller is provided', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -834,6 +882,38 @@ describe('lml.client', () => {
       const init = mockFetch.mock.calls[0][1];
       if (!init) throw new Error('mockFetch was not called with init args');
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
+    });
+
+    // BS#1843: same wire-signal prelim as the postLookup call site above,
+    // exercised here for the ~L932 bulk call site. catalog-popularity-freetext-resolve
+    // is a real class-5 bulkLookupMetadata caller (jobs/catalog-popularity-freetext-resolve).
+    it('BS#1843: forwards X-Caller-Class + X-Caller-Reason for a registered class-5 caller (catalog-popularity-freetext-resolve)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], { caller: 'catalog-popularity-freetext-resolve' });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toMatchObject({
+        'X-Caller-Class': '5',
+        'X-Caller-Reason': 'catalog-popularity-freetext-resolve',
+      });
+    });
+
+    it('BS#1843: omits X-Caller-Class and X-Caller-Reason when caller is absent (byte-identical to pre-change)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')]);
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
     });
 
     it('BS#1826: a registered caller supplies the DEFAULT timeoutMs/budgetMs when neither is passed explicitly', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -900,6 +900,9 @@ describe('lml.client', () => {
       expect(init.headers).toMatchObject({
         'X-Caller-Class': '5',
         'X-Caller-Reason': 'catalog-popularity-freetext-resolve',
+        // class-5's default budgetMs (28000) must COEXIST with the new headers —
+        // pins against a regression that drops X-Caller-Budget-Ms when they're present.
+        'X-Caller-Budget-Ms': '28000',
       });
     });
 
@@ -914,6 +917,21 @@ describe('lml.client', () => {
       const init = mockFetch.mock.calls[0][1];
       if (!init) throw new Error('mockFetch was not called with init args');
       expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    });
+
+    it('BS#1843: an unregistered caller string omits X-Caller-Class/X-Caller-Reason too (safe no-op, mirrors the postLookup call site)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], { caller: 'some-brand-new-caller-nobody-registered' });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      const headerKeys = Object.keys(init.headers ?? {});
+      expect(headerKeys).not.toContain('X-Caller-Class');
+      expect(headerKeys).not.toContain('X-Caller-Reason');
     });
 
     it('BS#1826: a registered caller supplies the DEFAULT timeoutMs/budgetMs when neither is passed explicitly', async () => {


### PR DESCRIPTION
## Summary

- `buildLookupHeaders` (`shared/lml-client/src/index.ts`) now accepts an optional `caller` alongside the existing `budgetMs`. Whenever `caller` resolves to a registered policy (via the same soft `policyForCaller` lookup `postLookup`/`bulkLookupMetadata` already use for timeout/budget defaults), it forwards two new headers on the `/lookup` and `/lookup/bulk` POST: `X-Caller-Class` (the resolved traffic class, integer `1`-`5`) and `X-Caller-Reason` (the `caller` label string itself).
- Both headers are omitted when `caller` is absent **or** unregistered (e.g. a stale/mistyped label reaching this code at runtime from an un-typechecked `jobs/**` call site) — mirroring the existing `X-Caller-Budget-Ms` opt-in and `policyForCaller`'s documented safe-no-op contract, so this never throws on the request path.
- Both call sites updated to pass `options?.caller` through: `postLookup` (~L694 pre-change) and `bulkLookupMetadata` (~L932 pre-change).
- `wxyc-shared/api.yaml` prose updated alongside `X-Caller-Budget-Ms` to document both new headers: WXYC/wxyc-shared#256.

This is a wire-signal prelim for BS#1819 Pass 2 — it unblocks WXYC/library-metadata-lookup#928 (low-priority lane routing keyed on `X-Caller-Class`) and WXYC/library-metadata-lookup#931 (caller-reason telemetry keyed on `X-Caller-Reason`). Sending the headers is inert on its own: LML ignores unknown headers today, and no behavior changes until those sub-issues land a read seam (mirroring LML's `lookup/router.py:431`).

Closes #1843

## Test plan

- [x] Unit tests added (test-first, confirmed red before implementation): class-1 caller (`proxy-library-search`) forwards `X-Caller-Class: 1` + matching `X-Caller-Reason`; class-5 caller (`catalog-popularity-freetext-resolve`) forwards `X-Caller-Class: 5` + matching `X-Caller-Reason`; an absent caller omits both headers byte-identically on both call sites; an unregistered caller string also omits both headers (safe no-op regression)
- [x] `npm run test:unit -- tests/unit/services/lml.client.test.ts` — 132 passed
- [x] `npm run test:unit -- tests/unit/shared/lml-client tests/unit/services/lml.client.test.ts tests/unit/services/lml/lookup-coordinator.test.ts` — 219 passed
- [x] `npm run test:unit` (full suite) — 5444 passed, 361 suites
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — 0 errors (795 pre-existing warnings, unchanged by this PR)
- [x] `npm run format:check` — pass
- [x] `npm run check:auth-tables-doc` (husky pre-push) — pass
- Not run: `test:integration` / `ci:testmock` — this change is unit-test-only (no DB interaction); both have known local-env pitfalls (BS#1728, BS#1729) and aren't needed to validate a pure header-forwarding change

## Related

- WXYC/wxyc-shared#256 — `api.yaml` prose documentation for both headers
- BS#1826 — the BS-internal caller→class policy this forwards (`shared/lml-client/src/policy.ts`)
- Read seam to mirror on the LML side: `library-metadata-lookup` `lookup/router.py:431`