### PR TITLE
ci: add test.yml + docker-compose.yml to the unit-tests src filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,13 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'tsconfig.base.json'
+              # BS#1807: `tests/unit/scripts/ci-env-surface-parity.test.ts`
+              # (BS#958) diffs these two files' env-var surfaces against
+              # each other. Without them in `src`, a PR that edits only one
+              # of them skips `unit-tests` entirely — the guard for these
+              # files never runs on a change to the exact files it checks.
+              - '.github/workflows/test.yml'
+              - 'dev_env/docker-compose.yml'
 
       - name: Determine if integration tests should run
         id: should-run


### PR DESCRIPTION
## Root cause

The BS#958 CI env-var parity guard (`tests/unit/scripts/ci-env-surface-parity.test.ts`) diffs the env-var surface of `.github/workflows/test.yml` against `dev_env/docker-compose.yml`. That guard runs inside the `unit-tests` job, which is gated on `detect-changes.outputs.src == 'true'`. Neither of those two files was listed in the `src` path filter, so a PR that edited only one of them skipped `unit-tests` entirely — the guard could never run against a change to the exact files it exists to check. This is what let commit `a3d2b3dc` land a broken env-block extractor undetected: it touched only `test.yml` and `README.md`, matched no filter that triggers `unit-tests`, and CI reported green until an unrelated `tests/**` PR later triggered `unit-tests` and went red on a base it hadn't caused.

## Fix

Add `.github/workflows/test.yml` and `dev_env/docker-compose.yml` to the `src` filter in `.github/workflows/test.yml`'s `detect-changes` job (option 1 from the ticket — the minimal fix). This is the filter that gates `unit-tests` (and `lint-and-typecheck`, which shares the same output), so edits to either file now trigger the job that runs the parity guard.

Closes #1807