### PR TITLE
ci(deploy): add enrichment-worker as a set-ec2-env-var.yml restart target

### DIFF
--- a/.github/workflows/set-ec2-env-var.yml
+++ b/.github/workflows/set-ec2-env-var.yml
@@ -1,18 +1,21 @@
 name: Set EC2 env var (manual)
 
 # One-shot ops workflow: upserts a single env var into the EC2 host's .env
-# file and restarts the target container (backend or auth) so it picks up
-# the change. Avoids a full image rebuild for env-var-only changes.
+# file and restarts the target container (backend, auth, or
+# enrichment-worker) so it picks up the change. Avoids a full image rebuild
+# for env-var-only changes.
 #
 # Usage:
 #   gh workflow run set-ec2-env-var.yml --ref main -f key=LML_API_KEY -f secret_name=LML_API_KEY
 #   gh workflow run set-ec2-env-var.yml --ref main -f key=AUTO_DJ_PASSWORD -f restart_target=auth
+#   gh workflow run set-ec2-env-var.yml --ref main -f key=LML_API_KEY -f restart_target=enrichment-worker
 #
 # The value is read from a GH secret whose name is provided via secret_name
 # (defaults to the same name as `key`). The value never appears in logs;
 # the verify step prints only key + length. restart_target selects which
 # container is stopped+run to re-read .env (backend by default; auth for
-# vars only the auth service consumes, e.g. AUTO_DJ_*).
+# vars only the auth service consumes, e.g. AUTO_DJ_*; enrichment-worker for
+# vars only that CDC consumer reads, e.g. its own LML_API_KEY rotations).
 
 on:
   workflow_dispatch:
@@ -26,13 +29,14 @@ on:
         required: false
         type: string
       restart_target:
-        description: 'Container to stop+run so it re-reads .env. auth for AUTO_DJ_*/auth-only vars; backend otherwise.'
+        description: 'Container to stop+run so it re-reads .env. auth for AUTO_DJ_*/auth-only vars; enrichment-worker for vars only that CDC consumer reads; backend otherwise.'
         required: false
         default: 'backend'
         type: choice
         options:
           - backend
           - auth
+          - enrichment-worker
 
 # Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
 # comments on PRs, or creates releases; all writes to external services


### PR DESCRIPTION
Closes #1802

## Root cause

`.github/workflows/set-ec2-env-var.yml`'s `restart_target` is a hardcoded `type: choice` enum with only `backend`/`auth`. `apps/enrichment-worker` is deployed as its own persistent container via the same `deploy-base.yml` `target_type == 'app'` path, but had no way to be targeted. The `.env` upsert step is target-independent (it just edits the shared file), so it silently "succeeds" for any key — but a service outside the `{backend, auth}` enum never actually restarts, and Docker only re-reads `--env-file` on `docker run`, not while a container keeps running.

This reproduced on 2026-07-23: rotating `LML_API_KEY` via `restart_target=backend` (the default) restarted `backend`, but `enrichment-worker` — the actual caller of LML's `/api/v1/lookup` on the CDC enrichment path — kept running with the stale key and kept getting 403'd.

## Fix

Add `enrichment-worker` to the `restart_target` enum and update the workflow's usage comment/examples and input description. No script changes needed: the restart step is already generic (container name == `RESTART_TARGET`, internal port 8080 via `docker port` lookup), and `enrichment-worker` already serves `/healthcheck` on 8080 (`apps/enrichment-worker/healthcheck.ts`) for the framework's health polling — it just wasn't reachable through this workflow's input.

No change to `backend`/`auth` behavior.

## Validation

Pure workflow-YAML change, no unit-testable surface. Validated with `python3 -c "yaml.safe_load(...)"` and `actionlint` (the only finding is a pre-existing shellcheck style nit on `origin/main`, unrelated to this diff). Pre-push hooks (lint, typecheck, doc checks) ran clean.