### PR TITLE
POST /flowsheet: degrade to snapshot fields on unknown album_id instead of rejecting the entry

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -241,6 +241,39 @@ const sendProjectedEntry = (res: Response, statusCode: number, entry: FSEntry): 
   res.status(statusCode).json(projectFlowsheetEntry(entry));
 };
 
+/**
+ * Build a track row from the request's own snapshot fields, with
+ * `album_id: null`. Shared by both routes that land here: an explicit
+ * `album_id: null` (BS#933) and a positive `album_id` that misses in
+ * `library` (BS#1680 — library linkage is an enrichment annotation, not a
+ * precondition for recording the play; see the not-found branch above).
+ */
+function buildSnapshotFieldsEntry(body: FSEntryRequestBody, show_id: number, dj_name: string | null): NewFSEntry {
+  if (body.album_title === undefined || body.artist_name === undefined || body.track_title === undefined) {
+    throw new WxycError('Bad Request, Missing Flowsheet Parameters: album_title, artist_name, track_title', 400);
+  }
+  // Explicit allowlist instead of `...body` spread (BS#1099). Any other body
+  // key — `metadata_status`, `legacy_entry_id`, `play_order`, etc. — would
+  // otherwise propagate verbatim into the INSERT and let a flowsheet:write
+  // caller mutate server-internal columns.
+  return {
+    artist_name: body.artist_name,
+    album_title: body.album_title,
+    track_title: body.track_title,
+    track_position: body.track_position ?? null,
+    record_label: body.record_label,
+    label_id: body.label_id,
+    album_id: null,
+    rotation_id: body.rotation_id,
+    request_flag: body.request_flag,
+    segue: body.segue ?? false,
+    message: body.message,
+    entry_type: body.entry_type,
+    show_id,
+    dj_name,
+  };
+}
+
 // either an id is provided (meaning it came from the user's bin or was fuzzy found)
 // or it's not provided in which case whe just throw the data provided into the table w/ album_id = NULL
 export const addEntry: RequestHandler = async (req: Request<object, object, FSEntryRequestBody>, res) => {
@@ -290,12 +323,26 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     // that doesn't exist in `library` — possible when the dj-site picker
     // payload references a library row that's been deleted, or when a
     // rotation→library FK has desynced. BS#933 covered the explicit-null
-    // case; this guards the equally-reachable not-found case. Without it the
-    // following `albumInfo.record_label = ...` / `...albumInfo` spread throws
-    // a bare TypeError that the centralized errorHandler maps to 500 — the
-    // signal at the root of BS#1271's POST /flowsheet internal_error bursts.
+    // case; this guards the equally-reachable not-found case. BS#1271 turned
+    // the bare TypeError (from the following `albumInfo.record_label = ...` /
+    // `...albumInfo` spread) into a clean signal, but rejecting the whole
+    // entry was the wrong disposition: library linkage is an enrichment
+    // annotation, not a precondition for recording the play. BS#1680 falls
+    // through to the same snapshot-fields path used for an explicit
+    // `album_id: null`, keeping the DJ's play recorded with `album_id: null`,
+    // and logs a Sentry warning so the desync stays visible for data-hygiene
+    // follow-up — the same asymmetric-fallback philosophy as the LML-timeout
+    // degrade (BS#873) and the nameless-DJ marker suppression (epic #1288).
     if (!albumInfo) {
-      throw new WxycError(`Album ${body.album_id} not found in library`, 404);
+      Sentry.captureMessage('Flowsheet album_id not found in library — degrading to snapshot fields', {
+        level: 'warning',
+        tags: { tool: 'flowsheet' },
+        extra: { album_id: body.album_id, show_id: latestShow.id },
+      });
+      const fsEntry = buildSnapshotFieldsEntry(body, latestShow.id, dj_name);
+      const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
+      sendProjectedEntry(res, 201, completedEntry);
+      return;
     }
 
     if (body.record_label !== undefined) {
@@ -316,33 +363,12 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
 
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
     sendProjectedEntry(res, 201, completedEntry);
-  } else if (body.album_title === undefined || body.artist_name === undefined || body.track_title === undefined) {
-    throw new WxycError('Bad Request, Missing Flowsheet Parameters: album_title, artist_name, track_title', 400);
   } else {
-    // Explicit allowlist instead of `...body` spread (BS#1099). Any other
-    // body key — `metadata_status`, `legacy_entry_id`, `play_order`, etc. —
-    // would otherwise propagate verbatim into the INSERT and let a
-    // flowsheet:write caller mutate server-internal columns.
-    // `album_id` is included so explicit `null` from the snapshot branch
-    // (BS#933) still lands on the row; in this branch `body.album_id` is
-    // already constrained to null/undefined by the discriminator above.
-    const fsEntry: NewFSEntry = {
-      artist_name: body.artist_name,
-      album_title: body.album_title,
-      track_title: body.track_title,
-      track_position: body.track_position ?? null,
-      record_label: body.record_label,
-      label_id: body.label_id,
-      album_id: body.album_id,
-      rotation_id: body.rotation_id,
-      request_flag: body.request_flag,
-      segue: body.segue ?? false,
-      message: body.message,
-      entry_type: body.entry_type,
-      show_id: latestShow.id,
-      dj_name,
-    };
-
+    // No album_id (explicit null from the dj-site rotation snapshot, BS#933,
+    // or simply omitted): insert the request's own snapshot fields with
+    // album_id: null. Shares `buildSnapshotFieldsEntry` with the lookup-miss
+    // fallback above (BS#1680) so both routes into this shape stay identical.
+    const fsEntry = buildSnapshotFieldsEntry(body, latestShow.id, dj_name);
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
     sendProjectedEntry(res, 201, completedEntry);
   }

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -334,12 +334,17 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     // follow-up — the same asymmetric-fallback philosophy as the LML-timeout
     // degrade (BS#873) and the nameless-DJ marker suppression (epic #1288).
     if (!albumInfo) {
+      // Build first so a missing snapshot field's 400 throws before we ever
+      // claim we degraded — buildSnapshotFieldsEntry validates album_title /
+      // artist_name / track_title and throws on the reject path (BS#1680
+      // review: the Sentry warning must not fire when the entry was rejected,
+      // not recorded).
+      const fsEntry = buildSnapshotFieldsEntry(body, latestShow.id, dj_name);
       Sentry.captureMessage('Flowsheet album_id not found in library — degrading to snapshot fields', {
         level: 'warning',
         tags: { tool: 'flowsheet' },
         extra: { album_id: body.album_id, show_id: latestShow.id },
       });
-      const fsEntry = buildSnapshotFieldsEntry(body, latestShow.id, dj_name);
       const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
       sendProjectedEntry(res, 201, completedEntry);
       return;

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -748,6 +748,9 @@ describe('flowsheet.controller', () => {
         statusCode: 400,
       });
       expect(mockAddTrack).not.toHaveBeenCalled();
+      // The reject path never recorded the entry, so it must not claim a
+      // degrade happened — no Sentry warning on this path.
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
     });
 
     it('passes segue field through for library-linked tracks (album_id provided)', async () => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -3,7 +3,8 @@ import type { Request, Response, NextFunction } from 'express';
 
 // Mock Sentry
 const mockCaptureException = jest.fn();
-jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
+const mockCaptureMessage = jest.fn();
+jest.mock('@sentry/node', () => ({ captureException: mockCaptureException, captureMessage: mockCaptureMessage }));
 
 // Mock the service module
 const mockGetEntriesByPage = jest.fn<() => Promise<unknown[]>>();
@@ -660,17 +661,80 @@ describe('flowsheet.controller', () => {
       );
     });
 
-    it('throws WxycError 404 when a positive album_id is not found in library (BS#1271)', async () => {
+    it('degrades to snapshot-fields insert when a positive album_id is not found in library (BS#1680)', async () => {
       // BS#933 narrowed the lookup-branch predicate from `!== undefined` to
       // `!= null`, fixing the explicit-null case. A positive `album_id` that
       // doesn't match any `library.id` (deleted between dj-site picker fetch
       // and POST, or rotation→library FK desync) still slipped through and
       // produced a bare TypeError on the next line — captured as a 500 with
       // no Sentry exception, the signal at the root of BS#1271's POST
-      // /flowsheet internal_error bursts. The guard now turns the not-found
-      // case into a clean 404 WxycError.
+      // /flowsheet internal_error bursts. BS#1271 turned that into a clean
+      // 404, but rejecting the whole entry was the wrong disposition: library
+      // linkage is an enrichment annotation, not a precondition for
+      // recording the play. BS#1680 flips the disposition — the entry is
+      // still inserted, with the request's own snapshot fields and
+      // album_id: null, and a Sentry warning records the desync.
       // Mock the not-found case explicitly: real `getAlbumFromDB` returns
       // `undefined` on no match (see library.service.test.ts:1759).
+      mockGetAlbumFromDB.mockResolvedValue(undefined);
+
+      const completedEntry = {
+        id: 5,
+        show_id: activeShow.id,
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        track_title: 'Crispy Duck',
+        record_label: 'Duophonic',
+        album_id: null,
+        play_order: 5,
+        add_time: new Date(),
+      };
+      mockAddTrack.mockResolvedValue(completedEntry);
+
+      const req = createMockBodyReq({
+        album_id: 9999,
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        track_title: 'Crispy Duck',
+        record_label: 'Duophonic',
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(9999);
+      // The write must still happen, with album_id nulled out rather than
+      // the not-found id propagating.
+      expect(mockAddTrack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist_name: 'Chuquimamani-Condori',
+          album_title: 'Edits',
+          track_title: 'Crispy Duck',
+          record_label: 'Duophonic',
+          album_id: null,
+          show_id: activeShow.id,
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(completedEntry);
+
+      // The desync must stay visible for data-hygiene follow-up even though
+      // the request itself succeeds.
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('not found in library'),
+        expect.objectContaining({
+          level: 'warning',
+          tags: expect.objectContaining({ tool: 'flowsheet' }),
+          extra: expect.objectContaining({ album_id: 9999, show_id: activeShow.id }),
+        })
+      );
+    });
+
+    it('returns 400 when album lookup misses and required snapshot fields are also missing', async () => {
+      // The snapshot-fields fallback still needs artist_name/album_title to
+      // write a meaningful row; a malformed request that omits both (bypassing
+      // the FSEntryRequestBody type contract) must fail cleanly rather than
+      // attempt an insert with undefined columns.
       mockGetAlbumFromDB.mockResolvedValue(undefined);
 
       const req = createMockBodyReq({
@@ -680,13 +744,9 @@ describe('flowsheet.controller', () => {
       });
       const res = createMockRes();
 
-      await expect(addEntry(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
       await expect(addEntry(req as Request, res as Response, mockNext)).rejects.toMatchObject({
-        statusCode: 404,
-        message: expect.stringContaining('9999'),
+        statusCode: 400,
       });
-      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(9999);
-      // INSERT must not run when the album lookup misses.
       expect(mockAddTrack).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Closes #1680

## Root cause

`POST /flowsheet` (`addEntry` in `apps/backend/controllers/flowsheet.controller.ts`) threw a `WxycError(404)` when `body.album_id` pointed at a `library` row that no longer resolves (deleted picker payload, or a desynced rotation->library FK), rejecting the DJ's entire entry. That 404 guard was correct as far as it went (BS#1271 turned a bare `TypeError`-> 500 into a clean signal), but library linkage is an enrichment annotation, not a precondition for recording what's playing — the write itself should never be blocked by it, matching the LML-timeout degrade precedent (BS#873) and the nameless-DJ marker suppression (epic #1288).

## Fix

When `getAlbumFromDB(body.album_id)` misses, the controller now falls through to the same snapshot-fields insert used for an explicit `album_id: null` (BS#933): the entry is written with the request's own `artist_name` / `album_title` / `record_label` / etc., `album_id` forced to `NULL`, and a `Sentry.captureMessage` warning (`tags: { tool: 'flowsheet' }`, `extra: { album_id, show_id }`) records the desync for data-hygiene follow-up. The response reflects the degradation naturally — the echoed entry has `album_id: null`.

Extracted the snapshot-fields construction into a shared `buildSnapshotFieldsEntry` helper, used by both the lookup-miss fallback and the pre-existing "no album_id" branch, so the two routes into "insert with request-provided fields, album_id: null" can't drift apart.

## Tests

- Flipped the BS#1271 regression test (`tests/unit/controllers/flowsheet.controller.test.ts`) from asserting a 404 throw to asserting a 201 insert with `album_id: null` and a Sentry warning, per the ticket's acceptance criteria.
- Added coverage for the case where the lookup misses *and* required snapshot fields (`artist_name`/`album_title`) are also absent from the request — that path still returns a clean 400 rather than attempting an insert with undefined columns.
- Confirmed both new/changed assertions fail against the pre-fix implementation (temporarily restored the old controller file, re-ran the suite, saw the expected red) before re-applying the fix.

Full unit suite (`npm run test:unit`): 362 suites / 5457 tests pass. `npm run typecheck`, `npm run lint` (0 errors, pre-existing warnings only), and `npm run format:check` all pass locally.

## Integration-test gap

No integration coverage added — this is a controller-layer behavioral change fully exercised by the mocked-DB unit suite (the existing pattern for this file), and per the autonomous-worktree constraints I didn't stand up the shared Postgres/port-8080 stack. The unit tests assert the actual DB-write payload (`mockAddTrack` call args) and HTTP response shape, which covers the acceptance criteria without needing a live DB.