### PR TITLE
fix(mirror): key entryIdMap by flowsheet row id, not play_order

### DIFF
--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -81,7 +81,8 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
     const entryId = await mirrorCreateEntry(entryBody);
     if (entryId != null) {
-      cacheEntryId(announcementEntry[0].play_order, entryId);
+      // BS#1103: key by the flowsheet row id, not play_order (only unique per-show).
+      cacheEntryId(announcementEntry[0].id, entryId);
       try {
         await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
       } catch (e) {
@@ -119,7 +120,8 @@ export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
     const entryId = await mirrorCreateEntry(entryBody);
     if (entryId != null) {
-      cacheEntryId(announcementEntry[0].play_order, entryId);
+      // BS#1103: key by the flowsheet row id, not play_order (only unique per-show).
+      cacheEntryId(announcementEntry[0].id, entryId);
       try {
         await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
       } catch (e) {
@@ -324,7 +326,10 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) 
   const body = mapEntryToTubafrenzy(entry, radioShowID, isRotationMatch);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
-    cacheEntryId(entry.play_order, tubafrenzyId);
+    // BS#1103: key by the flowsheet row id, not play_order — play_order
+    // resets per show, so two shows in the same process lifetime can
+    // collide on the same slot and evict each other's cached entry.
+    cacheEntryId(entry.id, tubafrenzyId);
     // Persist the mapping so the ETL can deduplicate
     try {
       await db.update(flowsheet).set({ legacy_entry_id: tubafrenzyId }).where(eq(flowsheet.id, entry.id));
@@ -338,7 +343,8 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
   // Message-only rows aren't updateable
   if (entry?.message && entry.message.trim() !== '') return;
 
-  const cachedId = getCachedEntryId(entry.play_order);
+  // BS#1103: key by the flowsheet row id, not play_order — see cacheEntryId call in addEntry above.
+  const cachedId = getCachedEntryId(entry.id);
 
   // Loop guard: entry has a legacy ID but we didn't cache it this lifecycle —
   // it was imported by the ETL, not created by our mirror. Don't mirror back.
@@ -347,7 +353,7 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
   // Use cache (fast path) or fall back to persisted legacy_entry_id (after restart)
   const tubafrenzyId = cachedId ?? entry.legacy_entry_id;
   if (tubafrenzyId == null) {
-    console.warn('[mirror] No tubafrenzy ID for play_order', entry.play_order);
+    console.warn('[mirror] No tubafrenzy ID for flowsheet row', entry.id);
     return;
   }
 

--- a/shared/legacy-mirror/src/http-mirror.ts
+++ b/shared/legacy-mirror/src/http-mirror.ts
@@ -12,7 +12,18 @@ import * as Sentry from '@sentry/node';
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MIRROR_API_KEY = process.env.MIRROR_API_KEY ?? '';
 
-/** In-memory map: Backend-Service play_order → tubafrenzy entry ID */
+/**
+ * In-memory map: Backend-Service flowsheet row ID → tubafrenzy entry ID.
+ *
+ * Keyed by the globally-unique `flowsheet.id` surrogate, NOT `play_order`
+ * (BS#1103). `play_order` only resets to 1 per show (post-#693), so two
+ * shows created back-to-back in the same process lifetime can both cache
+ * an entry at the same play_order slot — the second show's `cacheEntryId`
+ * write would silently evict the first show's cached tubafrenzy ID, and a
+ * later PATCH on the first show's entry would resolve to the second show's
+ * tubafrenzy row. The row id has no such collision: it's a serial PK
+ * unique across every show for the lifetime of the process.
+ */
 const entryIdMap = new Map<number, number>();
 
 /**
@@ -244,12 +255,14 @@ export async function mirrorUpdateEntry(tubafrenzyId: number, body: Record<strin
   }
 }
 
-export function cacheEntryId(playOrder: number, tubafrenzyId: number): void {
-  entryIdMap.set(playOrder, tubafrenzyId);
+/** `entryId` is the Backend-Service `flowsheet.id` row surrogate (BS#1103), not `play_order`. */
+export function cacheEntryId(entryId: number, tubafrenzyId: number): void {
+  entryIdMap.set(entryId, tubafrenzyId);
 }
 
-export function getCachedEntryId(playOrder: number): number | undefined {
-  return entryIdMap.get(playOrder);
+/** `entryId` is the Backend-Service `flowsheet.id` row surrogate (BS#1103), not `play_order`. */
+export function getCachedEntryId(entryId: number): number | undefined {
+  return entryIdMap.get(entryId);
 }
 
 export function clearEntryIdMap(): void {

--- a/tests/unit/middleware/legacy/entry-id-map-collision.test.ts
+++ b/tests/unit/middleware/legacy/entry-id-map-collision.test.ts
@@ -1,0 +1,146 @@
+/**
+ * BS#1103 — the in-memory entryIdMap was keyed by `play_order`, which is
+ * only unique *within* a show (post-#693, play_order resets to 1 on every
+ * new show). Two shows created back-to-back in the same process lifetime
+ * can both cache an entry at the same play_order slot; the second show's
+ * `cacheEntryId` write silently evicts the first show's cached tubafrenzy
+ * ID. A subsequent PATCH on the first show's entry then resolves to the
+ * SECOND show's tubafrenzy row and mirrors the edit onto the wrong show.
+ *
+ * This test drives the real addEntry/updateEntry middleware through two
+ * mirrored shows with overlapping play_order slots, backed by a real
+ * Map-based cacheEntryId/getCachedEntryId pair (not a bare jest.fn() —
+ * the collision only reproduces if the mock actually behaves like the
+ * production Map). Before the fix (keyed by play_order) this test is RED:
+ * show A's PATCH resolves to show B's tubafrenzy ID. After the fix (keyed
+ * by the globally-unique flowsheet row id) it's GREEN.
+ */
+
+// --- Mocks ---
+
+const mockMirrorCreateEntry = jest.fn();
+const mockMirrorUpdateEntry = jest.fn();
+
+// Real Map-backed cache functions — NOT bare jest.fn()s — so the test
+// actually exercises the collision the production entryIdMap is subject
+// to, rather than just asserting on call arguments.
+const entryIdMap = new Map<number, number>();
+const mockCacheEntryId = jest.fn((key: number, tubafrenzyId: number) => {
+  entryIdMap.set(key, tubafrenzyId);
+});
+const mockGetCachedEntryId = jest.fn((key: number) => entryIdMap.get(key));
+const mockGetCachedShowId = jest.fn();
+
+jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
+  mirrorCreateEntry: mockMirrorCreateEntry,
+  mirrorCreateShow: jest.fn(),
+  mirrorSignoffShow: jest.fn(),
+  mirrorUpdateEntry: mockMirrorUpdateEntry,
+  cacheEntryId: mockCacheEntryId,
+  cacheShowId: jest.fn(),
+  getCachedEntryId: mockGetCachedEntryId,
+  getCachedShowId: mockGetCachedShowId,
+  clearEntryIdMap: jest.fn(),
+  clearShowIdMap: jest.fn(),
+  mapEntryToTubafrenzy: jest.fn().mockReturnValue({ artistName: 'test' }),
+  mapShowToTubafrenzy: jest.fn(),
+  mapUpdateToTubafrenzy: jest.fn().mockReturnValue({ artistName: 'test' }),
+}));
+
+const mockDbUpdate = jest.fn().mockReturnValue({
+  set: jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue(undefined),
+  }),
+});
+
+const mockDbSelect = jest.fn().mockReturnValue({
+  from: jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockReturnValue({
+        limit: jest.fn().mockResolvedValue([]),
+      }),
+      limit: jest.fn().mockResolvedValue([]),
+    }),
+  }),
+});
+
+jest.mock('@wxyc/database', () => ({
+  db: {
+    select: mockDbSelect,
+    update: mockDbUpdate,
+  },
+  user: {},
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((...args: unknown[]) => args),
+  desc: jest.fn(),
+  asc: jest.fn(),
+}));
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    isFeatureEnabled: jest.fn().mockResolvedValue(true),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
+  isActiveRotationMatch: jest.fn().mockResolvedValue(false),
+}));
+
+import { runMiddleware } from './http-mirror-harness';
+import { flowsheetMirror } from '../../../../apps/backend/middleware/legacy/flowsheet.mirror';
+
+const makeEntry = (overrides: Record<string, unknown>) => ({
+  id: 1,
+  show_id: 100,
+  album_id: null,
+  rotation_id: null,
+  legacy_entry_id: null as number | null,
+  entry_type: 'track',
+  track_title: 'VI Scose Poise',
+  album_title: 'Confield',
+  artist_name: 'Autechre',
+  record_label: 'Warp',
+  play_order: 1,
+  request_flag: false,
+  segue: false,
+  message: null as string | null,
+  add_time: new Date('2024-02-01T12:00:00Z').toISOString(),
+  ...overrides,
+});
+
+describe('entryIdMap cross-show collision (BS#1103)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    entryIdMap.clear();
+    mockGetCachedShowId.mockReturnValue(171_500); // both shows resolve fine; irrelevant to the bug
+  });
+
+  it('PATCHing an earlier show entry does not target a later show entry sharing the same play_order', async () => {
+    // Show A (backend show id 100): one entry at play_order=2, flowsheet row id 502.
+    const entryA2 = makeEntry({ id: 502, show_id: 100, play_order: 2 });
+    mockMirrorCreateEntry.mockResolvedValueOnce(5002); // show A's tubafrenzy entry id
+    await runMiddleware(flowsheetMirror.addEntry, entryA2);
+
+    // Show B (backend show id 200), created after show A ends: play_order resets,
+    // so its entry also lands at play_order=2, flowsheet row id 602.
+    const entryB2 = makeEntry({ id: 602, show_id: 200, play_order: 2 });
+    mockMirrorCreateEntry.mockResolvedValueOnce(6002); // show B's tubafrenzy entry id
+    await runMiddleware(flowsheetMirror.addEntry, entryB2);
+
+    // PATCH show A's entry (still play_order=2, flowsheet row id 502).
+    await runMiddleware(flowsheetMirror.updateEntry, entryA2);
+
+    // Must resolve show A's tubafrenzy id (5002), never show B's (6002).
+    expect(mockMirrorUpdateEntry).toHaveBeenCalledTimes(1);
+    expect(mockMirrorUpdateEntry).toHaveBeenCalledWith(5002, expect.any(Object));
+  });
+});

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -133,13 +133,18 @@ describe('http.mirror', () => {
     });
   });
 
+  // BS#1103: entryIdMap is keyed by the flowsheet row id (a globally-unique
+  // surrogate), not play_order (only unique per-show — see
+  // entry-id-map-collision.test.ts for the cross-show collision this
+  // fixed). The Map itself is key-agnostic, so these tests just pin its
+  // basic get/set/clear contract against arbitrary numeric keys.
   describe('entryIdMap', () => {
-    it('stores and retrieves entry IDs by play_order', () => {
+    it('stores and retrieves entry IDs by flowsheet row id', () => {
       cacheEntryId(5, 42);
       expect(getCachedEntryId(5)).toBe(42);
     });
 
-    it('returns undefined for unknown play_order', () => {
+    it('returns undefined for unknown flowsheet row id', () => {
       expect(getCachedEntryId(999)).toBeUndefined();
     });
 

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -148,7 +148,8 @@ describe('mirror loop prevention', () => {
       mockMirrorCreateEntry.mockResolvedValue(99);
 
       void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
-        expect(mockCacheEntryId).toHaveBeenCalledWith(1, 99);
+        // BS#1103: cached by the flowsheet row id (baseEntry.id = 42), not play_order.
+        expect(mockCacheEntryId).toHaveBeenCalledWith(42, 99);
         expect(mockDbUpdate).toHaveBeenCalled();
         done();
       });


### PR DESCRIPTION
## Root cause

The legacy-mirror in-memory `entryIdMap` (`shared/legacy-mirror/src/http-mirror.ts`) was keyed by `play_order`. Post-#693, `play_order` resets to 1 on every new show, so it's only unique *within* a show — slot 2 of show A and slot 2 of show B both key to `2`. Show B's `cacheEntryId(2, …)` write silently evicted show A's cached tubafrenzy entry ID. A subsequent PATCH on show A's entry at that slot then resolved `getCachedEntryId(2)` to show B's tubafrenzy ID and mirrored the edit onto the wrong tubafrenzy row.

## Fix

Rekey `entryIdMap` (and `cacheEntryId`/`getCachedEntryId`) by the Backend-Service `flowsheet.id` row surrogate instead of `play_order`. The row id is a serial PK, globally unique across every show for the lifetime of the process, so two shows can no longer collide on the same cache slot. Updated all four call sites in `apps/backend/middleware/legacy/flowsheet.mirror.ts` (`startShow`'s and `endShow`'s announcement-entry caching, `addEntry`'s cache write, `updateEntry`'s cache read) plus the loop-guard's log message (referenced `play_order`, now references the row id it actually keys on).

The persisted-`legacy_entry_id` fallback path (used after a BS restart, when the in-memory cache is empty) was already row-keyed via the row itself and needed no change.

## Test coverage

- New `tests/unit/middleware/legacy/entry-id-map-collision.test.ts`: drives the real `addEntry`/`updateEntry` middleware through two shows with overlapping `play_order` slots, backed by a real `Map`-based `cacheEntryId`/`getCachedEntryId` pair (not a bare mock) so the test actually reproduces the collision the production `Map` is subject to. Confirmed RED against pre-fix code (PATCH resolved to show B's tubafrenzy id, 6002, instead of show A's, 5002) and GREEN after the fix.
- Updated `tests/unit/middleware/legacy/mirror.loop-prevention.test.ts` and `tests/unit/middleware/legacy/http.mirror.test.ts`: existing assertions/descriptions referenced the old `play_order`-keyed behavior; updated to match the row-id key.
- Full `npm run test:unit` (5457 tests), `npm run typecheck`, `npm run lint`, and `npm run format:check` all pass locally.

## Integration test gap

The ticket's acceptance criteria also calls for an integration test in `tests/integration/` driving two full mirrored shows back-to-back through the real HTTP API + mock tubafrenzy server + DB. I didn't add one: this worktree can't run integration tests (shared `:5432`/`:8080` used by concurrent agents), so I couldn't write-and-verify one without risking landing an unexercised, possibly-broken test. The unit test above exercises the real middleware functions end-to-end (only the DB/HTTP boundary is mocked) and directly reproduces the ticket's exact scenario, which I judged sufficient signal for this fix; flagging the integration-test gap explicitly per repo convention.

## Note on the issue's disposition history

Tracker #645 recorded a 2026-07-06 "ride out (close at Phase 3)" disposition comment on this issue (legacy-side-only corruption, tubafrenzy turndown at 2026-08-31 kills the premise anyway). That same tracker's later 2026-07-22 balanced-portfolio pass recategorized #1103 as "not turndown-gated" and placed it in the "Ship-now" bucket ("cheapest high-value wins ... Start here"), which is the classification this fix acted on. Worth reconciling the stale disposition comment on #1103 with the newer classification so future triage doesn't trip over the contradiction.

Closes #1103