### PR TITLE
feat(lml-client): consume the LookupResponse degraded/cache-only discriminator

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^2.3.0",
+    "@wxyc/shared": "^2.4.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^2.3.0",
+        "@wxyc/shared": "^2.4.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -6748,9 +6748,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "2.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.3.0/bfb5ca611cfa2fd263081e6e0eef410136fafeb4",
-      "integrity": "sha512-7zP4RDJ5lrvmvJrCf7JEhMdYLMCLI3vU5qO72XyhvmICjwG8W8WxReHJkg5qqv67cT01+16BXle8B77tv6IzHg==",
+      "version": "2.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.4.0/8b253aa0d0fa1a9a807c1f32445f3ac759ac666e",
+      "integrity": "sha512-ICFYS2QetuWY+ToFacWGVKjYskAJJJq1aWTXSFDOxsS/nixx7RGkejg2RCvNE2Y685nL1eh0+MT/BVKQK8+LRg==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -15286,7 +15286,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.67.0",
-        "@wxyc/shared": "^2.3.0"
+        "@wxyc/shared": "^2.4.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.67.0",
-    "@wxyc/shared": "^2.3.0"
+    "@wxyc/shared": "^2.4.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -590,6 +590,7 @@ function buildSkippedLookupResponse(): GatedLookupResponse {
     song_not_found: false,
     found_on_compilation: false,
     timeout: false,
+    degraded: false,
     outcome: 'skipped_discogs_unavailable',
   };
 }

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -599,6 +599,7 @@ describe('lml.client', () => {
         song_not_found: false,
         found_on_compilation: false,
         timeout: false,
+        degraded: false,
         outcome: 'skipped_discogs_unavailable',
       });
     });
@@ -1119,6 +1120,7 @@ describe('lml.client', () => {
           song_not_found: false,
           found_on_compilation: false,
           timeout: false,
+          degraded: false,
           outcome: 'skipped_discogs_unavailable',
         },
       });

--- a/tests/unit/shared/lml-client/degraded-discriminator.test.ts
+++ b/tests/unit/shared/lml-client/degraded-discriminator.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contract test for the LookupResponse degraded/cache-only discriminator
+ * (BS#943; gates library-metadata-lookup#930 PR1).
+ *
+ * getAlbumMetadata (apps/backend/controllers/proxy.controller.ts) returns 200
+ * on an LML timeout and falls through to synthesized search-only metadata — a
+ * silent-200 that, before this field, only latency could distinguish from a
+ * real result. `@wxyc/shared@2.4.0` adds a machine-readable `degraded` boolean
+ * (plus a `degraded_reason` enum) to LookupResponse so Backend can tell an
+ * intentionally shed-the-tail cache-only/partial result apart from a full
+ * success and from a genuine no-match. These pins prove the field is present
+ * on the type Backend consumes (via `@wxyc/lml-client` → `@wxyc/shared/dtos`)
+ * and that the three outcomes are distinguishable.
+ */
+import type { LookupResponse } from '@wxyc/lml-client';
+
+describe('LookupResponse degraded discriminator (BS#943)', () => {
+  const fullSuccess: LookupResponse = {
+    results: [
+      {
+        library_item: {
+          id: 12345,
+          title: 'DOGA',
+          artist: 'Juana Molina',
+          call_number: 'Rock CD JUA 1/2',
+        },
+      },
+    ],
+    degraded: false,
+  };
+
+  const noMatch: LookupResponse = {
+    results: [],
+    timeout: false,
+    degraded: false,
+  };
+
+  const degraded: LookupResponse = {
+    results: [],
+    degraded: true,
+    degraded_reason: 'cache_only',
+  };
+
+  it('distinguishes a degraded/cache-only response from a full success', () => {
+    expect(fullSuccess.degraded).toBe(false);
+    expect(degraded.degraded).toBe(true);
+    expect(degraded.degraded).not.toBe(fullSuccess.degraded);
+  });
+
+  it('distinguishes degraded from a genuine no-match even though both carry empty results', () => {
+    // The silent-200 gap this field closes: results alone cannot tell an
+    // over-budget/cache-only response apart from an honest no-match — `degraded`
+    // can, without the caller having to infer it from latency.
+    expect(noMatch.results).toHaveLength(0);
+    expect(degraded.results).toHaveLength(0);
+    expect(noMatch.degraded).toBe(false);
+    expect(degraded.degraded).toBe(true);
+  });
+
+  it('carries a degraded_reason only on a degraded response', () => {
+    expect(degraded.degraded_reason).toBe('cache_only');
+    expect(fullSuccess.degraded_reason).toBeUndefined();
+    expect(noMatch.degraded_reason).toBeUndefined();
+  });
+
+  it('accepts each documented degraded_reason value', () => {
+    const reasons: NonNullable<LookupResponse['degraded_reason']>[] = [
+      'deadline_exceeded',
+      'cache_only',
+      'upstream_unavailable',
+    ];
+    for (const reason of reasons) {
+      const response: LookupResponse = {
+        results: [],
+        degraded: true,
+        degraded_reason: reason,
+      };
+      expect(response.degraded_reason).toBe(reason);
+    }
+  });
+});


### PR DESCRIPTION
Backend consumer side of the `degraded`/`degraded_reason` contract (PR 2 of the multi-repo rollout for WXYC/library-metadata-lookup#943; the `@wxyc/shared` PR merged + published `@wxyc/shared@2.4.0`).

## What

- Bump `@wxyc/shared` → `^2.4.0` in the two `LookupResponse` consumers (`shared/lml-client`, `apps/backend`), so `LookupResponse.degraded` + `degraded_reason` are available on the type Backend reads.
- Add `tests/unit/shared/lml-client/degraded-discriminator.test.ts` proving Backend can distinguish a degraded/cache-only response from a full success **and** from a genuine no-match — the silent-200 gap in `getAlbumMetadata` (proxy.controller.ts) that, before this field, only latency could infer. The unit config type-checks the test against the real 2.4.0 types, so it also pins the field is present on the consumed contract.
- `degraded` is required-with-default in the generated type (mirroring `timeout`), so `buildSkippedLookupResponse` (the BS#1293 gate-skip builder) now sets `degraded: false` — a gate skip is not a degraded LML response — and the two `lml.client.test.ts` assertions pinning that shape are updated.

## Scope / deferrals

The LML `generated/api_models.py` regen and the actual **setting** of `degraded` ride with library-metadata-lookup#930 PR1, which owns the deadline/admission behavior that produces a degraded response.

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, and the full unit suite (`5467 passed / 364 suites`) all green locally.

Closes WXYC/library-metadata-lookup#943.