### PR TITLE
fix(flowsheet): guard against an undefined entry element in /flowsheet/latest enrichment

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -191,9 +191,13 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 
 export const getLatest: RequestHandler = async (req, res) => {
   const entries = await flowsheet_service.getEntriesByPage(0, 1);
-  if (entries.length) {
+  // `entries[0]` truthy-checked rather than `entries.length`: a transient
+  // undefined element (Sentry BACKEND-SERVICE-2T) must degrade to the same
+  // 204 the empty-array case already returns, not throw on transformToV2.
+  const entry = entries[0];
+  if (entry) {
     await flowsheet_service.attachUpcomingShows(entries);
-    res.status(200).json(flowsheet_service.transformToV2(entries[0]));
+    res.status(200).json(flowsheet_service.transformToV2(entry));
   } else {
     res.status(204).end();
   }

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1198,8 +1198,11 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   // the id arm with a non-null artist_id, or the name arm with a non-empty
   // artist_name. (Almost every track carries a name, so this mainly short-
   // circuits all-marker pages.)
+  // `entry?.` guards a transient undefined array element (Sentry
+  // BACKEND-SERVICE-2T) — statically every element of `entries` should be a
+  // real IFSEntry, but a bad element must not 500 the prefilter.
   const hasMatchableTrack = entries.some(
-    (entry) => entry.entry_type === 'track' && (entry.artist_id !== null || !!entry.artist_name?.trim())
+    (entry) => entry?.entry_type === 'track' && (entry.artist_id !== null || !!entry.artist_name?.trim())
   );
   if (!hasMatchableTrack) {
     return entries;
@@ -1208,7 +1211,9 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   const { byArtistId, byNormName } = await getUpcomingShowsMapsCached(nyCalendarDate(new Date()));
 
   for (const entry of entries) {
-    if (entry.entry_type !== 'track') {
+    // Same defensive guard as the prefilter above (Sentry BACKEND-SERVICE-2T):
+    // skip a falsy element instead of reading `.entry_type` off undefined.
+    if (!entry || entry.entry_type !== 'track') {
       continue;
     }
     const byId = entry.artist_id !== null ? byArtistId.get(entry.artist_id) : undefined;

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -411,6 +411,27 @@ describe('flowsheet.controller', () => {
       expect(mockTransformToV2).not.toHaveBeenCalled();
     });
 
+    // Sentry BACKEND-SERVICE-2T: a single fired occurrence had `entries[0]`
+    // reach `transformToV2` as `undefined` (statically `getEntriesByPage`
+    // should never return a hole, so this is defensive against a transient
+    // bad element rather than a reachable-by-design case). The fix checks
+    // `entries[0]` truthiness instead of `entries.length`, degrading to the
+    // same 204 the empty-array branch already returns.
+    it('returns 204 without throwing when entries[0] is undefined (Sentry BACKEND-SERVICE-2T)', async () => {
+      mockGetEntriesByPage.mockResolvedValue([undefined] as unknown[]);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getLatest(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.end).toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(mockTransformToV2).not.toHaveBeenCalled();
+      expect(mockAttachUpcomingShows).not.toHaveBeenCalled();
+    });
+
     it('rejects with error on service failure', async () => {
       const error = new Error('DB timeout');
       mockGetEntriesByPage.mockRejectedValue(error);

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -233,6 +233,32 @@ describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
     expect(entries[0].upcoming_show).toBeUndefined();
     expect(entries[1].upcoming_show).toBeUndefined();
   });
+
+  // Sentry BACKEND-SERVICE-2T: GET /flowsheet/latest 500'd once with
+  // `TypeError: Cannot read properties of undefined (reading 'entry_type')`.
+  // Statically every element of `entries` should be a real IFSEntry
+  // (`getEntriesByPage` builds them via `raw.map(transformToIFSEntry)`), so
+  // this pins the defense against a transient bad array element rather than
+  // a reachable-by-design case: neither the `.some(...)` prefilter nor the
+  // `for...of` loop may read `.entry_type` off `undefined`.
+  it('does not throw on an undefined array element and still enriches the valid track (BACKEND-SERVICE-2T)', async () => {
+    const concert = makeConcert({ headlining_artist_id: 4211 });
+    lookup.mockResolvedValueOnce(maps(new Map([[4211, concert]])));
+    const validEntry = createTrackEntry({ id: 1, artist_id: 4211, artist_name: 'Juana Molina' });
+    // A hole in the array — the transient bad element the Sentry issue saw.
+    const entries = [validEntry, undefined] as IFSEntry[];
+
+    await expect(attachUpcomingShows(entries)).resolves.toBe(entries);
+
+    expect(validEntry.upcoming_show).toBe(concert);
+    expect(entries[1]).toBeUndefined();
+  });
+
+  it('skips the DB when the only entries are an undefined element and a non-matchable marker', async () => {
+    const entries = [undefined, createTrackEntry({ id: 2, entry_type: 'show_start' })] as IFSEntry[];
+    await expect(attachUpcomingShows(entries)).resolves.toBe(entries);
+    expect(lookup).not.toHaveBeenCalled();
+  });
 });
 
 describe('transformToV2 upcoming_show projection (BS#1607)', () => {


### PR DESCRIPTION
## What

Guards the `/flowsheet/latest` read path against a transient `undefined` entry element that 500'd the endpoint once in production (Sentry [BACKEND-SERVICE-2T](https://wxyc.sentry.io/issues/7638909864), release v0.1.704, 0 users impacted).

## Root cause

The minified stack resolves to `attachUpcomingShows`'s `for...of` loop reading `entry.entry_type`, reached from `getLatest`. Statically every element of the fetched `entries` array should be a real `IFSEntry` (`getEntriesByPage` builds them via `raw.map(transformToIFSEntry)`), so the undefined element is a transient anomaly rather than a reachable-by-design case — but the shared enrichment/projection path had no guard, so one bad element crashed the hot iOS poll endpoint instead of degrading.

## Change

- `attachUpcomingShows`: the `.some(...)` prefilter and the `for...of` loop skip a falsy entry (`entry?.entry_type` / `if (!entry || …) continue;`) instead of dereferencing it.
- `getLatest`: branches on `entries[0]` truthiness rather than `entries.length`, so an undefined head degrades to the same 204 the empty-array case already returns instead of throwing inside `transformToV2`.
- Unit coverage: a `[validTrack, undefined]` array (the exact shape — `.some` short-circuits on the valid track, then the loop hits the undefined), a prefilter-tolerance case, and a `getLatest -> 204` case.

## Verification

- `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, `npm run test:unit` (5466 passed) all green locally.
- The two affected specs re-run: 101 passed / 2 suites.

Closes #1863
