### PR TITLE
fix(flowsheet): tolerate a nullish flowsheet entry across all V2 read paths

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -134,7 +134,10 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     const entries = await flowsheet_service.getEntriesByRange(startId, endId);
     if (entries.length) {
       await flowsheet_service.attachUpcomingShows(entries);
-      res.status(200).json(entries.map(flowsheet_service.transformToV2));
+      // `.filter(Boolean)` guards a transient nullish array element (Sentry
+      // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
+      // one, but transformToV2 still dereferences .entry_type unguarded.
+      res.status(200).json(entries.filter(Boolean).map(flowsheet_service.transformToV2));
     } else {
       res.status(404).json({ message: 'No Tracks found' });
     }
@@ -179,8 +182,13 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   // which 304s on the flowsheet watermark. A rare `on_air` change that writes no
   // flowsheet row (e.g. a mid-show dj_name_override edit) can be masked behind a
   // stale 304 until the next flowsheet mutation.
+  // `.filter(Boolean)` guards a transient nullish array element (Sentry
+  // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
+  // one, but transformToV2 still dereferences .entry_type unguarded. Kept at
+  // the call site rather than inside transformToV2 so every other caller's
+  // wire shape stays untouched.
   res.status(200).json({
-    entries: entries.map(flowsheet_service.transformToV2),
+    entries: entries.filter(Boolean).map(flowsheet_service.transformToV2),
     total,
     page,
     limit,
@@ -191,9 +199,13 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 
 export const getLatest: RequestHandler = async (req, res) => {
   const entries = await flowsheet_service.getEntriesByPage(0, 1);
-  if (entries.length) {
+  // `entries[0]` truthy-checked rather than `entries.length`: a transient
+  // nullish element (Sentry BACKEND-SERVICE-2T / BS#1864) must degrade to the
+  // same 204 the empty-array case already returns, not throw on transformToV2.
+  const entry = entries[0];
+  if (entry) {
     await flowsheet_service.attachUpcomingShows(entries);
-    res.status(200).json(flowsheet_service.transformToV2(entries[0]));
+    res.status(200).json(flowsheet_service.transformToV2(entry));
   } else {
     res.status(204).end();
   }

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -105,7 +105,10 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 
     if (entries.length) {
       await flowsheet_service.attachUpcomingShows(entries);
-      res.status(200).json(entries.map(flowsheet_service.transformToV2));
+      // `.filter(Boolean)` guards a transient nullish array element (Sentry
+      // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
+      // one, but transformToV2 still dereferences .entry_type unguarded.
+      res.status(200).json(entries.filter(Boolean).map(flowsheet_service.transformToV2));
     } else {
       res.status(404).json({
         message: 'No Tracks found',
@@ -645,8 +648,11 @@ export const getShowInfo: RequestHandler<object, unknown, object, { show_id: str
 
   await flowsheet_service.attachUpcomingShows(entries);
 
+  // `.filter(Boolean)` guards a transient nullish array element (Sentry
+  // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
+  // one, but transformToV2 still dereferences .entry_type unguarded.
   res.status(200).json({
     ...showMetadata,
-    entries: entries.map(flowsheet_service.transformToV2),
+    entries: entries.filter(Boolean).map(flowsheet_service.transformToV2),
   });
 };

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -89,6 +89,35 @@ export interface IFSEntry extends Omit<
 
 const MAX_ITEMS = 200;
 const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual number of tracks due to deletions
+
+/**
+ * Project a page of flowsheet entries to their V2 wire shape, tolerating — but
+ * not hiding — a transient nullish array element (Sentry BACKEND-SERVICE-2T /
+ * BS#1864). Every producer feeds this a dense `.map(transformToIFSEntry)`
+ * array, so a nullish slot is an unexplained anomaly: we drop it rather than
+ * 500 a public read path (`transformToV2` dereferences `.entry_type`
+ * unguarded), but capture it to Sentry so the producer defect stays
+ * diagnosable instead of silently vanishing from the feed. The 500 was the
+ * only signal that surfaced this in the first place; swallowing it wholesale
+ * would leave a recurrence invisible.
+ *
+ * This is the single choke point shared by every list read path
+ * (`getEntries`'s three branches + `getShowInfo`); guarding here rather than
+ * inside `transformToV2` keeps the single-entry callers' wire shape untouched.
+ */
+const projectEntriesV2 = (entries: IFSEntry[]): Record<string, unknown>[] => {
+  const dense = entries.filter(Boolean);
+  const dropped = entries.length - dense.length;
+  if (dropped > 0) {
+    Sentry.captureException(
+      new Error(
+        `Dropped ${dropped} nullish flowsheet ${dropped === 1 ? 'entry' : 'entries'} before V2 projection (BS#1864)`
+      )
+    );
+  }
+  return dense.map(flowsheet_service.transformToV2);
+};
+
 export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res) => {
   const { query } = req;
 
@@ -105,10 +134,7 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 
     if (entries.length) {
       await flowsheet_service.attachUpcomingShows(entries);
-      // `.filter(Boolean)` guards a transient nullish array element (Sentry
-      // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
-      // one, but transformToV2 still dereferences .entry_type unguarded.
-      res.status(200).json(entries.filter(Boolean).map(flowsheet_service.transformToV2));
+      res.status(200).json(projectEntriesV2(entries));
     } else {
       res.status(404).json({
         message: 'No Tracks found',
@@ -137,10 +163,7 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     const entries = await flowsheet_service.getEntriesByRange(startId, endId);
     if (entries.length) {
       await flowsheet_service.attachUpcomingShows(entries);
-      // `.filter(Boolean)` guards a transient nullish array element (Sentry
-      // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
-      // one, but transformToV2 still dereferences .entry_type unguarded.
-      res.status(200).json(entries.filter(Boolean).map(flowsheet_service.transformToV2));
+      res.status(200).json(projectEntriesV2(entries));
     } else {
       res.status(404).json({ message: 'No Tracks found' });
     }
@@ -185,13 +208,8 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   // which 304s on the flowsheet watermark. A rare `on_air` change that writes no
   // flowsheet row (e.g. a mid-show dj_name_override edit) can be masked behind a
   // stale 304 until the next flowsheet mutation.
-  // `.filter(Boolean)` guards a transient nullish array element (Sentry
-  // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
-  // one, but transformToV2 still dereferences .entry_type unguarded. Kept at
-  // the call site rather than inside transformToV2 so every other caller's
-  // wire shape stays untouched.
   res.status(200).json({
-    entries: entries.filter(Boolean).map(flowsheet_service.transformToV2),
+    entries: projectEntriesV2(entries),
     total,
     page,
     limit,
@@ -210,6 +228,12 @@ export const getLatest: RequestHandler = async (req, res) => {
     await flowsheet_service.attachUpcomingShows(entries);
     res.status(200).json(flowsheet_service.transformToV2(entry));
   } else {
+    // A non-empty page whose head is nullish is the same unexplained anomaly
+    // projectEntriesV2 captures on the list paths — surface it here too rather
+    // than letting it hide behind an ordinary empty-flowsheet 204.
+    if (entries.length > 0) {
+      Sentry.captureException(new Error('Dropped a nullish flowsheet head entry before V2 projection (BS#1864)'));
+    }
     res.status(204).end();
   }
 };
@@ -648,11 +672,8 @@ export const getShowInfo: RequestHandler<object, unknown, object, { show_id: str
 
   await flowsheet_service.attachUpcomingShows(entries);
 
-  // `.filter(Boolean)` guards a transient nullish array element (Sentry
-  // BACKEND-SERVICE-2T / BS#1864) — attachUpcomingShows already tolerates
-  // one, but transformToV2 still dereferences .entry_type unguarded.
   res.status(200).json({
     ...showMetadata,
-    entries: entries.filter(Boolean).map(flowsheet_service.transformToV2),
+    entries: projectEntriesV2(entries),
   });
 };

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1198,8 +1198,11 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   // the id arm with a non-null artist_id, or the name arm with a non-empty
   // artist_name. (Almost every track carries a name, so this mainly short-
   // circuits all-marker pages.)
+  // `entry?.` guards a transient nullish array element (Sentry
+  // BACKEND-SERVICE-2T / BS#1864) — statically every element of `entries`
+  // should be a real IFSEntry, but a bad element must not 500 the prefilter.
   const hasMatchableTrack = entries.some(
-    (entry) => entry.entry_type === 'track' && (entry.artist_id !== null || !!entry.artist_name?.trim())
+    (entry) => entry?.entry_type === 'track' && (entry.artist_id !== null || !!entry.artist_name?.trim())
   );
   if (!hasMatchableTrack) {
     return entries;
@@ -1208,7 +1211,9 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   const { byArtistId, byNormName } = await getUpcomingShowsMapsCached(nyCalendarDate(new Date()));
 
   for (const entry of entries) {
-    if (entry.entry_type !== 'track') {
+    // Same defensive guard as the prefilter above (Sentry BACKEND-SERVICE-2T /
+    // BS#1864): skip a falsy element instead of reading `.entry_type` off it.
+    if (!entry || entry.entry_type !== 'track') {
       continue;
     }
     const byId = entry.artist_id !== null ? byArtistId.get(entry.artist_id) : undefined;

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -257,6 +257,22 @@ describe('flowsheet.controller', () => {
         expect(mockGetEntriesByRange).toHaveBeenCalledWith(100, 105);
         expect(res.status).toHaveBeenCalledWith(200);
       });
+
+      // Sentry BACKEND-SERVICE-2T / BS#1864: the range branch shares the same
+      // unguarded `.map(transformToV2)` shape as the default branch — apply
+      // the same call-site guard for symmetry.
+      it('omits a nullish entry from the range-mode projected array without throwing', async () => {
+        const validEntry = createMockEntry(100);
+        mockGetEntriesByRange.mockResolvedValue([validEntry, undefined] as unknown[]);
+
+        const req = createMockReq({ start_id: '100', end_id: '105' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith([{ ...validEntry, v2: true }]);
+      });
     });
 
     it('calculates offset from page and limit', async () => {
@@ -309,6 +325,30 @@ describe('flowsheet.controller', () => {
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[0], 0, entries);
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[1], 1, entries);
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[2], 2, entries);
+    });
+
+    // Sentry BACKEND-SERVICE-2T / BS#1864: this is the higher-traffic branch
+    // (dj-site's 60s poll + the iOS app) that shares the same unguarded
+    // `.map(transformToV2)` deref as getLatest. A nullish element must be
+    // dropped from the projected array rather than throwing; the guard lives
+    // at the call site (not inside transformToV2), so every other caller's
+    // wire shape stays untouched.
+    it('omits a nullish entry from the projected entries array without throwing', async () => {
+      const validEntry = createMockEntry(1);
+      const entries = [validEntry, undefined] as unknown[];
+      mockGetEntriesByPage.mockResolvedValue(entries);
+      mockGetEntryCount.mockResolvedValue(2);
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body.entries).toEqual([{ ...validEntry, v2: true }]);
+      expect(mockTransformToV2).toHaveBeenCalledTimes(1);
     });
 
     describe('validation', () => {
@@ -409,6 +449,24 @@ describe('flowsheet.controller', () => {
       expect(res.end).toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();
       expect(mockTransformToV2).not.toHaveBeenCalled();
+    });
+
+    // Sentry BACKEND-SERVICE-2T / BS#1864: a transient nullish entries[0] must
+    // degrade to the same 204 the empty-array case already returns, rather
+    // than throwing inside transformToV2's unguarded `.entry_type` deref.
+    it('returns 204 without throwing when entries[0] is nullish', async () => {
+      mockGetEntriesByPage.mockResolvedValue([undefined] as unknown[]);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getLatest(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.end).toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(mockTransformToV2).not.toHaveBeenCalled();
+      expect(mockAttachUpcomingShows).not.toHaveBeenCalled();
     });
 
     it('rejects with error on service failure', async () => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -203,6 +203,23 @@ describe('flowsheet.controller', () => {
       expect(Array.isArray(body)).toBe(true);
     });
 
+    // Sentry BACKEND-SERVICE-2T / BS#1864: the shows_limit branch shares the
+    // same unguarded `.map(transformToV2)` shape as the other getEntries
+    // branches — apply the same call-site guard for symmetry.
+    it('omits a nullish entry from the shows_limit projected array without throwing', async () => {
+      const validEntry = createMockEntry(1);
+      mockGetNShows.mockResolvedValue([{ id: 1 }]);
+      mockGetEntriesByShow.mockResolvedValue([validEntry, undefined] as unknown[]);
+
+      const req = createMockReq({ shows_limit: '1' });
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([{ ...validEntry, v2: true }]);
+    });
+
     // BS#1110: non-numeric start_id/end_id used to flow straight into
     // parseInt arithmetic (yielding NaN), pass the MAX_ITEMS check, and blow up
     // downstream as a Postgres "invalid input syntax for type integer: NaN"
@@ -531,6 +548,26 @@ describe('flowsheet.controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         ...mockShowMetadata,
         entries: entries.map((e) => ({ ...e, v2: true })),
+      });
+    });
+
+    // Sentry BACKEND-SERVICE-2T / BS#1864: getShowInfo shares the same
+    // unguarded `.map(transformToV2)` shape as getEntries — apply the same
+    // call-site guard for symmetry.
+    it('omits a nullish entry from the projected entries array without throwing', async () => {
+      const validEntry = createMockEntry(1);
+      mockGetShowMetadata.mockResolvedValue(mockShowMetadata);
+      mockGetEntriesByShow.mockResolvedValue([validEntry, undefined] as unknown[]);
+
+      const req = createMockReq({ show_id: '1' });
+      const res = createMockRes();
+
+      await getShowInfo(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        ...mockShowMetadata,
+        entries: [{ ...validEntry, v2: true }],
       });
     });
 

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -205,8 +205,9 @@ describe('flowsheet.controller', () => {
 
     // Sentry BACKEND-SERVICE-2T / BS#1864: the shows_limit branch shares the
     // same unguarded `.map(transformToV2)` shape as the other getEntries
-    // branches — apply the same call-site guard for symmetry.
-    it('omits a nullish entry from the shows_limit projected array without throwing', async () => {
+    // branches — the shared projectEntriesV2 guard drops the nullish slot and
+    // captures the anomaly rather than 500ing or silently swallowing it.
+    it('omits a nullish entry from the shows_limit projected array and captures the anomaly', async () => {
       const validEntry = createMockEntry(1);
       mockGetNShows.mockResolvedValue([{ id: 1 }]);
       mockGetEntriesByShow.mockResolvedValue([validEntry, undefined] as unknown[]);
@@ -218,6 +219,7 @@ describe('flowsheet.controller', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith([{ ...validEntry, v2: true }]);
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 
     // BS#1110: non-numeric start_id/end_id used to flow straight into
@@ -276,9 +278,9 @@ describe('flowsheet.controller', () => {
       });
 
       // Sentry BACKEND-SERVICE-2T / BS#1864: the range branch shares the same
-      // unguarded `.map(transformToV2)` shape as the default branch — apply
-      // the same call-site guard for symmetry.
-      it('omits a nullish entry from the range-mode projected array without throwing', async () => {
+      // unguarded `.map(transformToV2)` shape as the default branch — the
+      // shared projectEntriesV2 guard drops the nullish slot and captures it.
+      it('omits a nullish entry from the range-mode projected array and captures the anomaly', async () => {
         const validEntry = createMockEntry(100);
         mockGetEntriesByRange.mockResolvedValue([validEntry, undefined] as unknown[]);
 
@@ -289,6 +291,7 @@ describe('flowsheet.controller', () => {
 
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith([{ ...validEntry, v2: true }]);
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -347,10 +350,9 @@ describe('flowsheet.controller', () => {
     // Sentry BACKEND-SERVICE-2T / BS#1864: this is the higher-traffic branch
     // (dj-site's 60s poll + the iOS app) that shares the same unguarded
     // `.map(transformToV2)` deref as getLatest. A nullish element must be
-    // dropped from the projected array rather than throwing; the guard lives
-    // at the call site (not inside transformToV2), so every other caller's
-    // wire shape stays untouched.
-    it('omits a nullish entry from the projected entries array without throwing', async () => {
+    // dropped from the projected array rather than throwing; the shared
+    // projectEntriesV2 guard captures the anomaly so the drop isn't silent.
+    it('omits a nullish entry from the projected entries array and captures the anomaly', async () => {
       const validEntry = createMockEntry(1);
       const entries = [validEntry, undefined] as unknown[];
       mockGetEntriesByPage.mockResolvedValue(entries);
@@ -366,6 +368,24 @@ describe('flowsheet.controller', () => {
       const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
       expect(body.entries).toEqual([{ ...validEntry, v2: true }]);
       expect(mockTransformToV2).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    });
+
+    // A dense page (the normal case) must NOT emit the BS#1864 anomaly signal —
+    // otherwise the capture is noise and can't be alerted on.
+    it('does not capture when the page has no nullish entries', async () => {
+      const entries = [createMockEntry(1), createMockEntry(2)];
+      mockGetEntriesByPage.mockResolvedValue(entries);
+      mockGetEntryCount.mockResolvedValue(2);
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
 
     describe('validation', () => {
@@ -466,12 +486,17 @@ describe('flowsheet.controller', () => {
       expect(res.end).toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();
       expect(mockTransformToV2).not.toHaveBeenCalled();
+      // An ordinary empty flowsheet is not an anomaly — it must not emit the
+      // BS#1864 signal, or the capture becomes un-alertable noise.
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
 
     // Sentry BACKEND-SERVICE-2T / BS#1864: a transient nullish entries[0] must
     // degrade to the same 204 the empty-array case already returns, rather
-    // than throwing inside transformToV2's unguarded `.entry_type` deref.
-    it('returns 204 without throwing when entries[0] is nullish', async () => {
+    // than throwing inside transformToV2's unguarded `.entry_type` deref — but
+    // unlike the genuinely-empty case above, the nullish head IS an anomaly and
+    // is captured so it doesn't hide behind the 204.
+    it('returns 204 without throwing when entries[0] is nullish, and captures the anomaly', async () => {
       mockGetEntriesByPage.mockResolvedValue([undefined] as unknown[]);
 
       const req = createMockReq();
@@ -484,6 +509,7 @@ describe('flowsheet.controller', () => {
       expect(res.json).not.toHaveBeenCalled();
       expect(mockTransformToV2).not.toHaveBeenCalled();
       expect(mockAttachUpcomingShows).not.toHaveBeenCalled();
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 
     it('rejects with error on service failure', async () => {
@@ -552,9 +578,9 @@ describe('flowsheet.controller', () => {
     });
 
     // Sentry BACKEND-SERVICE-2T / BS#1864: getShowInfo shares the same
-    // unguarded `.map(transformToV2)` shape as getEntries — apply the same
-    // call-site guard for symmetry.
-    it('omits a nullish entry from the projected entries array without throwing', async () => {
+    // unguarded `.map(transformToV2)` shape as getEntries — the shared
+    // projectEntriesV2 guard drops the nullish slot and captures the anomaly.
+    it('omits a nullish entry from the projected entries array and captures the anomaly', async () => {
       const validEntry = createMockEntry(1);
       mockGetShowMetadata.mockResolvedValue(mockShowMetadata);
       mockGetEntriesByShow.mockResolvedValue([validEntry, undefined] as unknown[]);
@@ -569,6 +595,7 @@ describe('flowsheet.controller', () => {
         ...mockShowMetadata,
         entries: [{ ...validEntry, v2: true }],
       });
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 
     it('fetches show metadata and entries in parallel', async () => {

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -233,6 +233,32 @@ describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
     expect(entries[0].upcoming_show).toBeUndefined();
     expect(entries[1].upcoming_show).toBeUndefined();
   });
+
+  // Sentry BACKEND-SERVICE-2T / BS#1864: GET /flowsheet/latest 500'd once with
+  // `TypeError: Cannot read properties of undefined (reading 'entry_type')`.
+  // Every producer feeding this function should return a dense array, so this
+  // is defensive hardening against a transient bad element, not a reachable-
+  // by-design case. The `.some(...)` prefilter short-circuits on the first
+  // matching track and stops iterating, while the `for...of` body visits every
+  // slot — so a nullish element positioned AFTER a real track slips past the
+  // prefilter and trips the loop. This is the exact shape that must not throw.
+  it('tolerates a nullish array element positioned after a real track', async () => {
+    const concert = makeConcert({ headlining_artist_id: 4211 });
+    lookup.mockResolvedValueOnce(maps(new Map([[4211, concert]])));
+    const validEntry = createTrackEntry({ id: 1, artist_id: 4211, artist_name: 'Juana Molina' });
+    const entries = [validEntry, undefined] as IFSEntry[];
+
+    await expect(attachUpcomingShows(entries)).resolves.toBe(entries);
+
+    expect(validEntry.upcoming_show).toBe(concert);
+    expect(entries[1]).toBeUndefined();
+  });
+
+  it('skips the DB when the only entries are a nullish element and a non-matchable marker', async () => {
+    const entries = [undefined, createTrackEntry({ id: 2, entry_type: 'show_start' })] as IFSEntry[];
+    await expect(attachUpcomingShows(entries)).resolves.toBe(entries);
+    expect(lookup).not.toHaveBeenCalled();
+  });
 });
 
 describe('transformToV2 upcoming_show projection (BS#1607)', () => {


### PR DESCRIPTION
## What

Guards every V2 flowsheet read path against a transient nullish entry element that 500'd `GET /flowsheet/latest` once in production (Sentry [BACKEND-SERVICE-2T](https://wxyc.sentry.io/issues/7638909864), release `backend@v0.1.704`, 0 users impacted).

## Root cause

The minified stack pins the throw to `entry.entry_type` inside `attachUpcomingShows`'s `for...of` loop, reached via `getLatest`'s `await attachUpcomingShows(entries)`. Every producer that feeds this function builds its array via `.map(transformToIFSEntry)`, which always returns a dense, fully-populated array, so this reads as a transient anomaly rather than a reachable-by-design path - the fix is defensive hardening so this class of anomaly can never 500 a public read endpoint again.

The `.some(...)` prefilter at the top of `attachUpcomingShows` short-circuits on the first matching track and stops iterating, while the subsequent `for...of` loop visits every slot - so a nullish element positioned *after* a real track slips past the guard and trips the loop.

## Change

- `attachUpcomingShows`: the `.some(...)` prefilter and the `for...of` loop both skip a falsy entry (`entry?.entry_type` / `if (!entry) continue;`) instead of dereferencing it.
- `getLatest`: branches on `entries[0]` truthiness rather than `entries.length`, so a nullish head degrades to the same 204 the empty-array case already returns instead of throwing inside `transformToV2`. This guard is independently necessary - the `attachUpcomingShows` fix alone doesn't cover it, since `getLatest` calls `transformToV2(entries[0])` separately after enrichment.
- Every remaining `entries.map(transformToV2)` call site in the controller shares the same unguarded shape, so all of them now `filter(Boolean)` before projecting: the `getEntries` default paginated branch, the `getEntriesByRange` branch, the `getEntries` `shows_limit` branch, and `getShowInfo`. The guard lives at each call site rather than inside `transformToV2` itself, so no caller's wire shape changes for the normal dense-page case.
- Unit coverage: a `[validTrack, undefined]` array for `attachUpcomingShows` (the exact shape - `.some` short-circuits on the valid track, then the loop hits the undefined), a prefilter-tolerance case, a `getLatest -> 204` case, and one case per controller projection site asserting the nullish slot is omitted from the projected array without throwing.

## Verification

- `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, `npm run test:unit` (5470 passed) all green locally.

## Related

WXYC/Backend-Service#1863 is a narrower earlier-filed duplicate covering only the `attachUpcomingShows`/`getLatest` guards; an open PR (#1865) targets it. This PR is a self-contained superset built independently off `main` and fully satisfies #1864's acceptance criteria (including the `getEntries`/`getShowInfo` projection guards #1865 doesn't cover). Whichever of #1865/#1864 merges first, the other should be rebased - the overlapping hunks are near-identical and should resolve cleanly.

Closes #1864