### PR TITLE
perf(playlist-proxy): batch the recentEntries rotation fallback post-slice

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -27,6 +27,18 @@
  * tubafrenzy-flowsheetEntryType mapping (flowsheetEntryType 7 covers both
  * real talksets and dj_join/dj_leave; 9/10 are show_start/show_end).
  *
+ * Rotation-badge resolution runs in two lanes (BS#1862). The primary source
+ * is the FK join (`leftJoin(rotation, rotation.id = flowsheet.rotation_id)`),
+ * computed cheaply in the main window query. The fallback — a text/album_id
+ * match against active rotations for entries a DJ typed by hand instead of
+ * picking from rotation (`rotation_id IS NULL`) — is deferred to a single
+ * batched query over the SLICED (<= n) playcuts only, run post-slice
+ * alongside artwork enrichment. It used to be a correlated subquery in the
+ * SELECT list evaluated for every one of the 200 window rows, which
+ * seq-scanned the 64k-row `library` table per row and cost ~2.4s
+ * server-side regardless of `n` (BS#1862); batching it drops the cost to
+ * ~10-30ms while preserving the exact COALESCE(FK, fallback) semantics.
+ *
  * Exported API:
  *   getRecentEntries(n) — query Postgres for the current playlist grouped
  *                         by entry type, sliced to n playcuts. Async (was
@@ -38,6 +50,7 @@ import { sql, inArray, and, isNotNull, eq, desc } from 'drizzle-orm';
 
 const MAX_ENTRIES = 200;
 const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
 
 /** Compute a normalized lookup key from artist and album for matching against flowsheet rows. */
 function lookupKey(artist: string, album: string): string {
@@ -46,54 +59,6 @@ function lookupKey(artist: string, album: string): string {
 
 /** SQL expression that computes the same lookup key from flowsheet columns. */
 const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
-
-/**
- * Whether a flowsheet row actively matches a rotation record, expressed as
- * the `rotation.rotation_bin` letter or NULL. Structurally identical to
- * `FSEntryFieldsRaw.rotation_bin` in `apps/backend/services/flowsheet.service.ts`
- * (kept in sync at the expression level, not literally imported/shared —
- * same convention `shared/legacy-mirror/src/rotation-match.ts`'s
- * `isActiveRotationMatch` already documents for this same three-cohort
- * match). Primary source is the FK join (`leftJoin(rotation, rotation.id =
- * flowsheet.rotation_id)`); the fallback subquery only fires when that join
- * misses and the entry looks like a real track (non-empty artist + album),
- * covering DJs who typed an entry by hand instead of using the rotation
- * picker. This is also the exact classification
- * `shared/legacy-mirror/src/http-mirror.ts`'s `mapEntryToTubafrenzy` used
- * to decide tubafrenzy's flowsheetEntryType=2 (rotation) at mirror time, so
- * reusing it here is the most faithful available reconstruction of what
- * tubafrenzy's own recentStream would have reported.
- */
-const rotationBinExpr = sql<string | null>`
-  COALESCE(
-    ${rotation.rotation_bin},
-    CASE WHEN ${flowsheet.rotation_id} IS NULL
-      AND coalesce(${flowsheet.artist_name}, '') <> ''
-      AND coalesce(${flowsheet.album_title}, '') <> ''
-    THEN (
-      SELECT r2.rotation_bin
-      FROM ${rotation} r2
-      LEFT JOIN ${library} l2 ON l2.id = r2.album_id
-      LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
-      WHERE r2.add_date <= ${flowsheet.add_time}::date
-        AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
-        AND (
-          (${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id})
-          OR (
-            lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
-            AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
-          )
-          OR (
-            lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
-            AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
-          )
-        )
-      ORDER BY r2.id
-      LIMIT 1
-    )
-    END
-  )
-`;
 
 // --- Types ---
 
@@ -134,6 +99,12 @@ type RecentRow = {
   album_title: string | null;
   record_label: string | null;
   request_flag: boolean | null;
+  rotation_id: number | null;
+  album_id: number | null;
+  // FK-lane rotation_bin only (rotation.rotation_bin via the rotation_id
+  // join). NULL here does NOT mean "not in rotation" — a hand-typed entry
+  // with rotation_id NULL can still match an active rotation via the
+  // post-slice fallback lane. See resolveFallbackRotation.
   rotation_bin: string | null;
 };
 
@@ -222,7 +193,13 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
       album_title: flowsheet.album_title,
       record_label: flowsheet.record_label,
       request_flag: flowsheet.request_flag,
-      rotation_bin: rotationBinExpr,
+      rotation_id: flowsheet.rotation_id,
+      album_id: flowsheet.album_id,
+      // FK-lane rotation_bin only. The correlated fallback subquery this used
+      // to COALESCE with was removed (BS#1862) — it seq-scanned `library`
+      // for every window row and cost ~2.4s. The fallback now runs post-slice
+      // in resolveFallbackRotation over the <= n sliced playcuts.
+      rotation_bin: rotation.rotation_bin,
     })
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
@@ -249,9 +226,16 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
   }
 
   const slicedPlaycuts = playcutRows.slice(0, n);
-  const artworkMap = await enrichPlaycuts(slicedPlaycuts);
+  const [artworkMap, fallbackRotationMap] = await Promise.all([
+    enrichPlaycuts(slicedPlaycuts),
+    resolveFallbackRotation(slicedPlaycuts),
+  ]);
 
   const playcuts: GroupedPlaycut[] = slicedPlaycuts.map((row) => {
+    // COALESCE(FK rotation_bin, fallback rotation_bin) — the exact semantics
+    // the old inline COALESCE(rotation.rotation_bin, <correlated subquery>)
+    // produced, now split across two lanes for performance (BS#1862).
+    const rotationBin = row.rotation_bin ?? fallbackRotationMap.get(row.id) ?? null;
     const grouped: GroupedPlaycut = {
       id: row.id,
       chronOrderID: row.id,
@@ -261,7 +245,7 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
       artistName: row.artist_name ?? '',
       releaseTitle: row.album_title ?? '',
       labelName: row.record_label ?? '',
-      rotation: row.rotation_bin !== null ? 'true' : 'false',
+      rotation: rotationBin !== null ? 'true' : 'false',
       request: row.request_flag ? 'true' : 'false',
     };
     const artwork = artworkMap.get(row.id);
@@ -350,6 +334,135 @@ async function enrichPlaycuts(candidates: PlaycutCandidate[]): Promise<Map<numbe
     return map;
   } catch (err) {
     console.error('[playlist-proxy] artwork enrichment failed:', err);
+    return new Map();
+  }
+}
+
+interface FallbackCandidate {
+  id: number;
+  rotation_id: number | null;
+  album_id: number | null;
+  artist_name: string | null;
+  album_title: string | null;
+  add_time: Date;
+}
+
+/**
+ * Resolve the rotation-badge FALLBACK for hand-typed playcuts, batched
+ * (BS#1862).
+ *
+ * The primary rotation source is the FK join in `getRecentEntries`'s window
+ * query (`rotation.rotation_bin` via `flowsheet.rotation_id`). This fallback
+ * covers only the cohort that join can't reach: track entries a DJ typed by
+ * hand instead of picking from the rotation UI (`rotation_id IS NULL`) that
+ * nonetheless match an active rotation record. It reconstructs the exact
+ * match tubafrenzy's own flowsheetEntryType=2 (rotation) classification
+ * used, three branches:
+ *   (a) direct album_id match (`flowsheet.album_id = rotation.album_id`);
+ *   (b) rotation's own denormalized artist/album text;
+ *   (c) rotation -> library -> artists text (rotations added via the picker
+ *       carry an album_id link but may have NULL artist_name/album_title).
+ * As in the original, a row must have a non-empty artist AND album to be a
+ * candidate, and the lowest `rotation.id` match wins.
+ *
+ * Why batched instead of the original per-row correlated subquery: that
+ * subquery was evaluated for every one of the 200 window rows (before the
+ * slice), and branch (c) forced a full seq scan of the 64k-row `library`
+ * table per row — ~2.4s server-side, constant in `n` (BS#1862). Here the
+ * active-rotation set is materialized ONCE (an index nested-loop into
+ * library, not a per-row seq scan) and matched against the <= n sliced
+ * candidates, dropping the cost to ~10-30ms.
+ *
+ * The `active_rot` date bounds are a padded superset of the candidate batch's
+ * play dates (min-1d .. max+1d) so a single materialized scan covers every
+ * candidate; the final join re-applies the exact per-candidate active-window
+ * predicate (`add_date <= play_date < kill_date`), so correctness does not
+ * depend on the bound padding. Degrades to an empty map on query failure
+ * (badge shows 'false' rather than 500-ing the endpoint), mirroring
+ * enrichPlaycuts.
+ *
+ * @returns Map of flowsheet.id -> rotation_bin for the candidates that
+ *          matched an active rotation. Absent ids had no fallback match.
+ */
+async function resolveFallbackRotation(candidates: FallbackCandidate[]): Promise<Map<number, string>> {
+  // Only hand-typed track rows with a non-null, non-empty artist AND album,
+  // and no FK rotation link, are fallback candidates — the exact gate the
+  // original CASE used (`flowsheet.rotation_id IS NULL AND
+  // coalesce(artist_name,'') <> '' AND coalesce(album_title,'') <> ''`). NOT
+  // trimmed: the original SQL gate is untrimmed, and trimming here would drop a
+  // whitespace-only-artist linked row that the album_id branch could still
+  // badge (SQL `trim()` collapses it to '' downstream, matching the original).
+  const eligible = candidates.filter(
+    (c) => c.rotation_id == null && (c.artist_name ?? '') !== '' && (c.album_title ?? '') !== ''
+  );
+  if (eligible.length === 0) return new Map();
+
+  // Padded (±1 day) UTC date bounds spanning the batch, so the materialized
+  // active-rotation set is a superset of every candidate's per-day active
+  // window. The DB session is UTC (RDS default) and `add_time::date` casts in
+  // session TZ, so a UTC date bound matches; the ±1d padding is cheap
+  // insurance against any session-TZ skew. The final join re-checks each
+  // candidate's exact window regardless, so the padding only affects how many
+  // rotation rows are materialized, never the result.
+  const times = eligible.map((c) => c.add_time.getTime());
+  const boundLo = new Date(Math.min(...times) - DAY_MS).toISOString().slice(0, 10);
+  const boundHi = new Date(Math.max(...times) + DAY_MS).toISOString().slice(0, 10);
+
+  // One VALUES row per candidate: (flowsheet id, album_id, normalized artist,
+  // normalized album, play date). Normalization is done IN SQL — the same
+  // `lower(trim(coalesce(...)))` the active_rot side uses — so both sides of
+  // the equality join share Postgres semantics. Normalizing the candidate
+  // side in JS instead (`.toLowerCase().trim()`) would desync the join: JS
+  // `.trim()` strips all whitespace, but Postgres `trim()` strips only spaces,
+  // so an artist/album with an edge tab or newline would normalize differently
+  // on the two sides and match (or miss) differently than the original query.
+  const candRows = eligible.map(
+    (c) =>
+      sql`(${c.id}::int, ${c.album_id}::int, lower(trim(coalesce(${c.artist_name}::text, ''))), lower(trim(coalesce(${c.album_title}::text, ''))), ${c.add_time.toISOString()}::timestamptz::date)`
+  );
+
+  try {
+    const result = await db.execute(sql`
+      WITH cand(fid, album_id, norm_artist, norm_album, play_date) AS (
+        VALUES ${sql.join(candRows, sql`, `)}
+      ),
+      active_rot AS MATERIALIZED (
+        SELECT
+          r2.id,
+          r2.rotation_bin,
+          r2.album_id,
+          r2.add_date,
+          r2.kill_date,
+          lower(trim(coalesce(r2.artist_name, ''))) AS r_artist,
+          lower(trim(coalesce(r2.album_title, ''))) AS r_album,
+          lower(trim(coalesce(a2.artist_name, ''))) AS lib_artist,
+          lower(trim(coalesce(l2.album_title, ''))) AS lib_album
+        FROM ${rotation} r2
+        LEFT JOIN ${library} l2 ON l2.id = r2.album_id
+        LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
+        WHERE r2.add_date <= ${boundHi}::date
+          AND (r2.kill_date IS NULL OR r2.kill_date > ${boundLo}::date)
+      )
+      SELECT DISTINCT ON (cand.fid) cand.fid AS fid, ar.rotation_bin AS rotation_bin
+      FROM cand
+      JOIN active_rot ar
+        ON ar.add_date <= cand.play_date
+       AND (ar.kill_date IS NULL OR ar.kill_date > cand.play_date)
+      WHERE (cand.album_id IS NOT NULL AND ar.album_id = cand.album_id)
+         OR (ar.r_artist = cand.norm_artist AND ar.r_album = cand.norm_album)
+         OR (ar.lib_artist = cand.norm_artist AND ar.lib_album = cand.norm_album)
+      ORDER BY cand.fid, ar.id
+    `);
+
+    const map = new Map<number, string>();
+    for (const row of result as unknown as Array<{ fid: number; rotation_bin: string | null }>) {
+      if (row.rotation_bin != null) {
+        map.set(Number(row.fid), row.rotation_bin);
+      }
+    }
+    return map;
+  } catch (err) {
+    console.error('[playlist-proxy] rotation fallback resolution failed:', err);
     return new Map();
   }
 }

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -50,6 +50,28 @@ const ROTATION_ALBUM_TITLE = 'BS88 Phase3 Rotation Album';
 // PRESS_CD/PRESS_LP above.
 const ROTATION_ID = 7170;
 
+// Branch (a) probe (BS#1862): a rotation linked purely by album_id, matched by
+// a hand-typed play whose artist/album text does NOT match any rotation — so
+// only `flowsheet.album_id = rotation.album_id` can classify it as rotation.
+const ROTATION_ID_BRANCH_A = 7171;
+// Dedicated album for the branch-(a) probe — distinct from PRESS_CD/PRESS_LP so
+// the split-format probes (which link PRESS_CD) don't accidentally match this
+// rotation via album_id and flip their expected rotation='false'.
+const BRANCHA_LIB_ID = 7162;
+const BRANCHA_ARTIST = 'BS88 BranchA Artist';
+const BRANCHA_ALBUM = 'BS88 BranchA Album';
+
+// Branch (c) probe (BS#1862): a rotation linked by album_id to a library row
+// whose artist comes from the `artists` join — matched by a hand-typed play
+// whose album_id is NULL (so branch a can't fire) and whose text matches the
+// rotation row's OWN columns not at all (they're NULL, so branch b can't
+// fire), leaving only rotation -> library -> artists text as the match path.
+const ROTATION_ID_BRANCH_C = 7172;
+const BRANCHC_ARTIST_ID = 7300;
+const BRANCHC_LIB_ID = 7301;
+const BRANCHC_ARTIST = 'BS88 BranchC Artist';
+const BRANCHC_ALBUM = 'BS88 BranchC Album';
+
 function makeSql() {
   return postgres({
     host: process.env.DB_HOST || 'localhost',
@@ -65,8 +87,8 @@ function makeSql() {
 describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#88)', () => {
   let sql;
   const flowsheetIds = [];
-  const libraryIds = [PRESS_CD, PRESS_LP];
-  let rotationId;
+  const libraryIds = [PRESS_CD, PRESS_LP, BRANCHA_LIB_ID, BRANCHC_LIB_ID];
+  const rotationIds = [];
 
   beforeAll(async () => {
     sql = makeSql();
@@ -110,7 +132,59 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
         artist_name = EXCLUDED.artist_name,
         album_title = EXCLUDED.album_title
     `;
-    rotationId = ROTATION_ID;
+    rotationIds.push(ROTATION_ID);
+
+    // Branch (a): a dedicated library album + a rotation linked to it by
+    // album_id only (no denormalized artist/album text). Distinct from the
+    // split-format probes so they don't match this rotation.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+      VALUES (${BRANCHA_LIB_ID}, ${ART}, ${GEN}, ${FMT}, ${BRANCHA_ALBUM}, 1162, ${BRANCHA_ARTIST})
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation
+        (id, rotation_bin, add_date, kill_date, album_id)
+      VALUES (${ROTATION_ID_BRANCH_A}, 'H', CURRENT_DATE - INTERVAL '30 days', NULL, ${BRANCHA_LIB_ID})
+      ON CONFLICT (id) DO UPDATE SET
+        rotation_bin = EXCLUDED.rotation_bin,
+        add_date = EXCLUDED.add_date,
+        kill_date = EXCLUDED.kill_date,
+        album_id = EXCLUDED.album_id,
+        artist_name = NULL,
+        album_title = NULL
+    `;
+    rotationIds.push(ROTATION_ID_BRANCH_A);
+
+    // Branch (c): a dedicated artist + library row, and a rotation linked to
+    // that library row with NO denormalized artist/album text of its own — so
+    // the only path from a hand-typed play to a badge is via the
+    // rotation -> library -> artists join text.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.artists (id, artist_name, alphabetical_name, code_letters)
+      VALUES (${BRANCHC_ARTIST_ID}, ${BRANCHC_ARTIST}, ${BRANCHC_ARTIST}, 'XC')
+      ON CONFLICT (id) DO UPDATE SET artist_name = EXCLUDED.artist_name
+    `;
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+      VALUES (${BRANCHC_LIB_ID}, ${BRANCHC_ARTIST_ID}, ${GEN}, ${FMT}, ${BRANCHC_ALBUM}, 1301, ${BRANCHC_ARTIST})
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation
+        (id, rotation_bin, add_date, kill_date, album_id)
+      VALUES (${ROTATION_ID_BRANCH_C}, 'L', CURRENT_DATE - INTERVAL '30 days', NULL, ${BRANCHC_LIB_ID})
+      ON CONFLICT (id) DO UPDATE SET
+        rotation_bin = EXCLUDED.rotation_bin,
+        add_date = EXCLUDED.add_date,
+        kill_date = EXCLUDED.kill_date,
+        album_id = EXCLUDED.album_id,
+        artist_name = NULL,
+        album_title = NULL
+    `;
+    rotationIds.push(ROTATION_ID_BRANCH_C);
 
     // Two split-format plays of the same artist+album (tie-break probe).
     const cdPlay = await sql`
@@ -132,6 +206,40 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
       INSERT INTO ${sql(SCHEMA)}.flowsheet
         (entry_type, play_order, artist_name, album_title, track_title, request_flag)
       VALUES ('track', 91602, ${ROTATION_ARTIST_NAME}, ${ROTATION_ALBUM_TITLE}, 'Probe Track (hand-typed rotation match)', false)
+      RETURNING id
+    `;
+
+    // Branch (a): links album_id = BRANCHA_LIB_ID (the album ROTATION_ID_BRANCH_A
+    // is in rotation on), rotation_id NULL. Its artist/album text also matches
+    // the linked library row here, but the point is the album_id path fires —
+    // branch (c) is exercised separately below with a text-only match.
+    const albumIdRotationPlay = await sql`
+      INSERT INTO ${sql(SCHEMA)}.flowsheet
+        (entry_type, play_order, artist_name, album_title, track_title, album_id, request_flag)
+      VALUES ('track', 91608, ${BRANCHA_ARTIST}, ${BRANCHA_ALBUM}, 'Probe Track (album_id rotation match)', ${BRANCHA_LIB_ID}, false)
+      RETURNING id
+    `;
+
+    // Branch (c): album_id NULL (so branch a can't fire), artist/album text
+    // matching the rotation ONLY through its library->artists link.
+    const libraryLinkedRotationPlay = await sql`
+      INSERT INTO ${sql(SCHEMA)}.flowsheet
+        (entry_type, play_order, artist_name, album_title, track_title, request_flag)
+      VALUES ('track', 91609, ${BRANCHC_ARTIST}, ${BRANCHC_ALBUM}, 'Probe Track (library-linked rotation match)', false)
+      RETURNING id
+    `;
+
+    // Normalization-parity guard: same artist/album text as the branch-(b)
+    // rotation but with a TRAILING NEWLINE in the artist. Postgres `trim()`
+    // strips only spaces (not newlines), on BOTH the candidate and rotation
+    // sides — so this must NOT match (rotation='false'), identical to the
+    // original correlated subquery. A candidate normalized in JS (`.trim()`,
+    // which strips the newline) would wrongly badge it 'true'. rotation_id +
+    // album_id NULL so only the branch-(b) text path could ever fire.
+    const newlineArtistPlay = await sql`
+      INSERT INTO ${sql(SCHEMA)}.flowsheet
+        (entry_type, play_order, artist_name, album_title, track_title, request_flag)
+      VALUES ('track', 91610, ${`${ROTATION_ARTIST_NAME}\n`}, ${ROTATION_ALBUM_TITLE}, 'Probe Track (newline artist, no match)', false)
       RETURNING id
     `;
 
@@ -166,14 +274,17 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     `;
 
     flowsheetIds.push(
-      cdPlay[0].id,
-      lpPlay[0].id,
-      rotationMatchPlay[0].id,
-      talksetRow[0].id,
-      djJoinRow[0].id,
-      breakpointRow[0].id,
-      showStartRow[0].id,
-      showEndRow[0].id
+      cdPlay[0].id, // [0]
+      lpPlay[0].id, // [1]
+      rotationMatchPlay[0].id, // [2]
+      talksetRow[0].id, // [3]
+      djJoinRow[0].id, // [4]
+      breakpointRow[0].id, // [5]
+      showStartRow[0].id, // [6]
+      showEndRow[0].id, // [7]
+      albumIdRotationPlay[0].id, // [8]
+      libraryLinkedRotationPlay[0].id, // [9]
+      newlineArtistPlay[0].id // [10]
     );
   });
 
@@ -182,11 +293,13 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     if (flowsheetIds.length > 0) {
       await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${flowsheetIds})`;
     }
-    if (rotationId != null) {
-      await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id = ${rotationId}`;
+    if (rotationIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id = ANY(${rotationIds})`;
     }
     await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${libraryIds})`;
     await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+    // Delete the branch-(c) artist AFTER its library row (library.artist_id FK).
+    await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${BRANCHC_ARTIST_ID}`;
     await sql.end();
   });
 
@@ -235,7 +348,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     expect(typeof cdEntry.request).toBe('string');
   });
 
-  test('emits rotation as "true" via the fallback text-match subquery for a hand-typed entry with no rotation_id', async () => {
+  test('emits rotation as "true" via the fallback text-match query for a hand-typed entry with no rotation_id (branch b)', async () => {
     const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
 
     const rotationMatchEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[2]);
@@ -245,6 +358,39 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // The split-format probes are NOT in rotation.
     const cdEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[0]);
     expect(cdEntry.rotation).toBe('false');
+  });
+
+  test('emits rotation as "true" via the album_id branch for a hand-typed entry whose text matches no rotation (branch a, BS#1862)', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+
+    const albumIdMatchEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[8]);
+    expect(albumIdMatchEntry).toBeDefined();
+    // rotation_id is NULL and the artist/album text matches no rotation row —
+    // the only path to a badge is `flowsheet.album_id = rotation.album_id`.
+    expect(albumIdMatchEntry.rotation).toBe('true');
+  });
+
+  test('emits rotation as "true" via the rotation->library->artists branch for a hand-typed entry with no album_id (branch c, BS#1862)', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+
+    const libraryLinkedEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[9]);
+    expect(libraryLinkedEntry).toBeDefined();
+    // album_id is NULL (no branch a) and the rotation row's own artist/album
+    // are NULL (no branch b) — the match can only come from the rotation's
+    // linked library row joined to its artist.
+    expect(libraryLinkedEntry.rotation).toBe('true');
+  });
+
+  test('does NOT badge a rotation-text match whose artist has a trailing newline (JS-vs-SQL trim parity, BS#1862)', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+
+    const newlineEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[10]);
+    expect(newlineEntry).toBeDefined();
+    // Postgres trim() keeps the newline on both the candidate and rotation
+    // sides, so 'bs88 phase3 rotation artist\n' != 'bs88 phase3 rotation artist'
+    // -> no branch-b match, exactly as the original subquery. Would be 'true'
+    // if the candidate side were normalized in JS (`.trim()` strips newlines).
+    expect(newlineEntry.rotation).toBe('false');
   });
 
   test('breakpoint hour uses radio_hour verbatim, not floor(add_time)', async () => {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -27,6 +27,8 @@ const mockWhere = jest.fn();
 const mockGroupBy = jest.fn();
 const mockOrderBy = jest.fn();
 const mockLimit = jest.fn();
+// db.execute(sql`...`) resolves the batched rotation-fallback query (BS#1862).
+const mockExecute = jest.fn();
 
 const mockDbChain = {
   select: mockSelect,
@@ -46,6 +48,7 @@ mockWhere.mockReturnValue(mockDbChain);
 mockGroupBy.mockResolvedValue([]);
 mockOrderBy.mockReturnValue(mockDbChain);
 mockLimit.mockResolvedValue([]);
+mockExecute.mockResolvedValue([]); // rotation fallback: no matches by default
 
 jest.mock('@wxyc/database', () => ({
   db: {
@@ -57,6 +60,7 @@ jest.mock('@wxyc/database', () => ({
     groupBy: (...args: unknown[]) => mockGroupBy(...args),
     orderBy: (...args: unknown[]) => mockOrderBy(...args),
     limit: (...args: unknown[]) => mockLimit(...args),
+    execute: (...args: unknown[]) => mockExecute(...args),
   },
   flowsheet: {
     id: 'id',
@@ -96,7 +100,7 @@ jest.mock('@wxyc/database', () => ({
 }));
 
 jest.mock('drizzle-orm', () => ({
-  sql: Object.assign(jest.fn(), { raw: jest.fn() }),
+  sql: Object.assign(jest.fn(), { raw: jest.fn(), join: jest.fn() }),
   inArray: jest.fn(),
   isNotNull: jest.fn(),
   and: jest.fn(),
@@ -124,6 +128,12 @@ const jessicaPrattRow = {
   album_title: 'On Your Own Love Again',
   record_label: 'Drag City',
   request_flag: false,
+  // No FK rotation link and no fallback match -> not in rotation. As a
+  // hand-typed track (rotation_id null, artist+album present) it IS a
+  // fallback candidate, so getRecentEntries runs the batched fallback query
+  // for it — which the mock resolves to no match by default.
+  rotation_id: null,
+  album_id: 7001,
   rotation_bin: null,
 };
 
@@ -137,7 +147,29 @@ const juanaMolinaRow = {
   album_title: 'DOGA',
   record_label: 'Sonamos',
   request_flag: true,
+  // FK rotation hit: rotation_id set, so rotation.rotation_bin comes back from
+  // the window join and this row is NOT a fallback candidate.
+  rotation_id: 940,
+  album_id: 8001,
   rotation_bin: 'M',
+};
+
+// Hand-typed play that matches an active rotation only through the fallback
+// lane (rotation_id null, so no FK badge; the batched fallback query resolves
+// it). BS#1862.
+const handTypedRotationRow = {
+  id: 2602251,
+  entry_type: 'track',
+  add_time: new Date('2026-07-28T20:50:00.000Z'),
+  radio_hour: null,
+  track_title: 'Call Your Name',
+  artist_name: 'Chuquimamani-Condori',
+  album_title: 'Edits',
+  record_label: 'self-released',
+  request_flag: false,
+  rotation_id: null,
+  album_id: null,
+  rotation_bin: null,
 };
 
 const talksetRow = {
@@ -217,6 +249,7 @@ describe('playlist-proxy.service', () => {
     mockOrderBy.mockReturnValue(mockDbChain);
     mockGroupBy.mockResolvedValue([]); // artwork query default: no matches
     mockLimit.mockResolvedValue([]); // main entries query default: empty
+    mockExecute.mockResolvedValue([]); // rotation fallback default: no matches
   });
 
   describe('getRecentEntries — grouping and entry_type mapping', () => {
@@ -396,6 +429,88 @@ describe('playlist-proxy.service', () => {
       expect(juana?.request).toBe('true');
       expect(typeof juana?.request).toBe('string');
       expect(jessica?.request).toBe('false');
+    });
+  });
+
+  describe('getRecentEntries — rotation fallback lane (BS#1862)', () => {
+    // The FK join supplies rotation_bin for picker-added rotation plays in the
+    // window query; the batched db.execute fallback resolves only the
+    // hand-typed cohort (rotation_id NULL) post-slice. These tests exercise
+    // that split and the batched-not-per-row invariant that motivated BS#1862.
+    it('resolves rotation "true" for a hand-typed entry via the batched fallback query', async () => {
+      mockLimit.mockResolvedValue([handTypedRotationRow]);
+      mockExecute.mockResolvedValue([{ fid: handTypedRotationRow.id, rotation_bin: 'H' }]);
+
+      const result = await getRecentEntries(50);
+
+      const entry = result.playcuts.find((p) => p.id === handTypedRotationRow.id);
+      expect(entry?.rotation).toBe('true');
+    });
+
+    it('resolves rotation "false" for a hand-typed entry the fallback query does not match', async () => {
+      mockLimit.mockResolvedValue([handTypedRotationRow]);
+      mockExecute.mockResolvedValue([]); // no active rotation matched
+
+      const result = await getRecentEntries(50);
+
+      const entry = result.playcuts.find((p) => p.id === handTypedRotationRow.id);
+      expect(entry?.rotation).toBe('false');
+    });
+
+    it('prefers the FK rotation_bin without consulting the fallback for a picker-added rotation play', async () => {
+      // juanaMolinaRow has rotation_id set: the window join supplies its
+      // rotation_bin, so it is not an eligible fallback candidate.
+      mockLimit.mockResolvedValue([juanaMolinaRow]);
+
+      const result = await getRecentEntries(50);
+
+      expect(result.playcuts[0].rotation).toBe('true');
+      // No eligible candidates -> the batched fallback query never runs.
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('runs the batched fallback query exactly once for a mix of eligible hand-typed playcuts', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, handTypedRotationRow, juanaMolinaRow]);
+
+      await getRecentEntries(50);
+
+      // One batched query covers every eligible candidate (jessica + hand-typed),
+      // never one-query-per-row (the BS#1862 regression guard).
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not run the fallback query when there are no playcuts', async () => {
+      mockLimit.mockResolvedValue([talksetRow, breakpointRow]);
+
+      await getRecentEntries(50);
+
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('resolves only the sliced playcuts and runs the fallback once regardless of window size', async () => {
+      const manyPlaycuts = Array.from({ length: 10 }, (_, i) => ({
+        ...handTypedRotationRow,
+        id: 5000 + i,
+      }));
+      mockLimit.mockResolvedValue(manyPlaycuts);
+      mockExecute.mockResolvedValue([{ fid: 5000, rotation_bin: 'H' }]);
+
+      const result = await getRecentEntries(3);
+
+      expect(result.playcuts).toHaveLength(3);
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      expect(result.playcuts.find((p) => p.id === 5000)?.rotation).toBe('true');
+      expect(result.playcuts.find((p) => p.id === 5001)?.rotation).toBe('false');
+    });
+
+    it('degrades to rotation "false" (rather than throwing) when the fallback query fails', async () => {
+      mockLimit.mockResolvedValue([handTypedRotationRow]);
+      mockExecute.mockRejectedValue(new Error('DB connection lost'));
+
+      const result = await getRecentEntries(50);
+
+      const entry = result.playcuts.find((p) => p.id === handTypedRotationRow.id);
+      expect(entry?.rotation).toBe('false');
     });
   });
 


### PR DESCRIPTION
## Summary

`GET /playlists/recentEntries` had ~2.0–3.6s warm server-side TTFB, constant in `n` ([#1862](https://github.com/WXYC/Backend-Service/issues/1862)). `EXPLAIN (ANALYZE, BUFFERS)` on prod pinned the entire cost to the `rotation_bin` **fallback correlated subquery**:

- Same recent-200 window **with** the subquery: **2424 ms**
- Same window **without** it (FK join only): **0.48 ms**

The subquery ran in the SELECT list for all 200 window rows *before* the `n`-slice (hence constant in `n`), firing on the 85 hand-typed track rows; its branch (c) seq-scanned the 64k-row `library` table **per row** (278k shared buffers), and returned 0 matches — 2.4s spent finding nothing.

## Fix

Split rotation-badge resolution into two lanes, preserving the exact `COALESCE(FK, fallback)` semantics:

1. **FK lane** — `rotation.rotation_bin` via the existing `leftJoin(rotation, rotation.id = flowsheet.rotation_id)` stays in the window query (0.48 ms).
2. **Fallback lane** — the hand-typed cohort (`rotation_id IS NULL`) moves to a single **batched** query over only the sliced `<= n` playcuts, run post-slice alongside artwork enrichment. The active-rotation set is materialized **once** (`AS MATERIALIZED` → index nested-loop into `library`, not a per-row seq scan), matched against the small candidate set. **~10–30 ms** on prod (1.3k buffers).

All three original match branches — (a) `album_id`, (b) rotation's own artist/album text, (c) `rotation → library → artists` text — and the lowest-`rotation.id` tie-break are preserved verbatim.

## Verification

- **Prod differential (byte-parity):** ran the old `COALESCE(FK, correlated-subquery)` and the new two-lane logic over the same data and diffed. **0 mismatches** over the live 200-row window (56 badge rows) **and** over a 300-row hand-typed linked sample. The refactor is byte-identical to the original on real data.
- **`EXPLAIN (ANALYZE, BUFFERS)`** of the new batched query on prod: **9.9 ms**, index nested-loop into `library` (buffers 278k → 1.4k).
- Unit: new coverage for the fallback lane (batched-not-per-row invariant, FK-preferred, degrade-on-failure, slice-bounded). Full suite 5470/5470 green.
- Integration: added positive-match coverage for branches **(a)** (`album_id`) and **(c)** (`rotation → library → artists`); branch (b) was already covered.
- Local: typecheck, eslint, prettier all clean.

No response-shape change — the byte-shape parity AC from #1860 still holds.

Closes #1862