### PR TITLE
feat(playlist-proxy): serve the v=1 flat wire format + X-Last-Modified

### DIFF
--- a/apps/backend/controllers/playlist.controller.ts
+++ b/apps/backend/controllers/playlist.controller.ts
@@ -1,45 +1,86 @@
 /**
  * Playlist controller.
  *
- * GET /playlists/recentEntries — unauthenticated, returns the enriched
- * playlist in tubafrenzy's grouped format with artworkURL on playcuts.
+ * GET /playlists/recentEntries — unauthenticated. Serves both legacy
+ * tubafrenzy wire formats: the v=2 grouped object (iOS) and the v=1 flat
+ * array (Android). See playlist-proxy.service.ts.
  */
 import { RequestHandler } from 'express';
-import { getRecentEntries as getEntries } from '../services/playlist-proxy.service.js';
+import {
+  getRecentEntries as getGrouped,
+  getRecentEntriesFlat as getFlat,
+  lastModifiedFromTimestamps,
+} from '../services/playlist-proxy.service.js';
+
+// v=2 grouped (iOS): playcuts sliced to n from a 200-row window.
+const DEFAULT_GROUPED_N = 50;
+const MAX_GROUPED_N = 100;
+// v=1 flat (Android): n bounds TOTAL entries, matching tubafrenzy's
+// getNRecentFlowsheetEntries(n) and its 200-entry cache cap / default.
+const DEFAULT_FLAT_N = 200;
+const MAX_FLAT_N = 200;
+
+function parseN(raw: unknown, def: number, max: number): number {
+  let n = Number(raw);
+  if (!Number.isFinite(n)) {
+    n = def;
+  }
+  n = Math.round(n);
+  return Math.max(1, Math.min(n, max));
+}
 
 /**
  * GET /playlists/recentEntries
  *
  * Query params:
- *   v — API version (ignored, for compatibility)
- *   n — number of playcut entries to return (default 50, clamped [1, 100])
+ *   v — wire-format version. `v=2` → grouped `{playcuts, talksets,
+ *       breakpoints}` (iOS). Absent or any other value → v=1 flat array
+ *       (Android's contract — Android sends no `v`). BS#1866.
+ *   n — entry count. v=2: playcuts returned (default 50, clamped [1, 100]).
+ *       v=1: total entries returned (default 200, clamped [1, 200]).
  *
- * Returns the playlist grouped into `{playcuts, talksets, breakpoints}`,
- * queried live from Postgres (Phase 3 of the tubafrenzy decommission,
- * WXYC/wiki#88 — see playlist-proxy.service.ts). Playcuts are enriched with
- * `artworkURL` when album_metadata has a match.
+ * Queried live from Postgres (Phase 3 of the tubafrenzy decommission,
+ * WXYC/wiki#88). v=2 playcuts are enriched with `artworkURL`; v=1 is not
+ * (tubafrenzy's v=1 never carried artwork — Android resolves its own).
  *
- * Cache-Control: public, max-age=30 (30 seconds).
+ * Headers:
+ *   Cache-Control: public, max-age=30
+ *   X-Last-Modified: max entry `timeCreated` in the served window (BS#1866),
+ *     exposed via Access-Control-Expose-Headers for the browser page's
+ *     conditional-fetch parity.
  *
  * A DB failure is caught here and written as a DIRECT 503 response — it must
  * not be thrown into the error pipeline, because `sentryErrorFilter` captures
  * every >=500 and this unauthenticated endpoint is polled on a fixed interval
  * by every mobile client, so a transient DB blip would emit one Sentry event
- * per poll (the catalog-search 503 flood pattern). The direct write mirrors
- * the pre-Phase-3 code, which returned its "SSE not ready" 503 the same way,
- * uncaptured. A 503 (not 500) so clients read it as "try again shortly".
+ * per poll (the catalog-search 503 flood pattern). A 503 (not 500) so clients
+ * read it as "try again shortly".
  */
 export const getRecentEntries: RequestHandler = async (req, res) => {
-  let n = Number(req.query.n);
-  if (!Number.isFinite(n)) {
-    n = 50;
-  }
-  n = Math.round(n);
-  n = Math.max(1, Math.min(n, 100));
+  // Only a plain `?v=2` string selects the grouped shape; anything else
+  // (absent, v=1, an array/object from a malformed query) is the v=1 default.
+  const versionParam = req.query.v;
+  const grouped = (typeof versionParam === 'string' ? versionParam : '') === '2';
+  const n = grouped
+    ? parseN(req.query.n, DEFAULT_GROUPED_N, MAX_GROUPED_N)
+    : parseN(req.query.n, DEFAULT_FLAT_N, MAX_FLAT_N);
 
-  let result;
+  let payload: unknown;
+  let lastModified: number;
   try {
-    result = await getEntries(n);
+    if (grouped) {
+      const result = await getGrouped(n);
+      lastModified = lastModifiedFromTimestamps([
+        ...result.playcuts.map((p) => p.timeCreated),
+        ...result.talksets.map((t) => t.timeCreated),
+        ...result.breakpoints.map((b) => b.timeCreated),
+      ]);
+      payload = result;
+    } else {
+      const entries = await getFlat(n);
+      lastModified = lastModifiedFromTimestamps(entries.map((e) => e.timeCreated));
+      payload = entries;
+    }
   } catch (err) {
     console.error('[playlist] Failed to fetch recent entries:', err);
     res.status(503).json({ message: 'Playlist data temporarily unavailable' });
@@ -47,5 +88,9 @@ export const getRecentEntries: RequestHandler = async (req, res) => {
   }
 
   res.set('Cache-Control', 'public, max-age=30');
-  res.status(200).json(result);
+  res.set('X-Last-Modified', String(lastModified));
+  // Append, not set: the global CORS middleware already exposes X-Request-Id
+  // (app.ts), and res.set would clobber it. res.append preserves both.
+  res.append('Access-Control-Expose-Headers', 'X-Last-Modified');
+  res.status(200).json(payload);
 };

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -99,6 +99,12 @@ type RecentRow = {
   album_title: string | null;
   record_label: string | null;
   request_flag: boolean | null;
+  segue: boolean | null;
+  // Marker text: the label the v=1 flat format emits as `artistName` on
+  // breakpoint / showDelimiter entries (consumer-invisible — see the v=1
+  // serializer), and the source of tubafrenzy's own breakpoint/showDelimiter
+  // artistName via the mirror. Unused by the v=2 grouped output.
+  message: string | null;
   rotation_id: number | null;
   album_id: number | null;
   // FK-lane rotation_bin only (rotation.rotation_bin via the rotation_id
@@ -171,6 +177,41 @@ function toBaseEntry(row: RecentRow): BaseEntry {
   };
 }
 
+/**
+ * Fetch the most recent `limit` flowsheet rows (any entry_type, ordered by
+ * flowsheet.id DESC), with the FK-lane rotation_bin joined in. Shared by both
+ * the v=2 grouped path (`getRecentEntries`, limit = MAX_ENTRIES) and the v=1
+ * flat path (`getRecentEntriesFlat`, limit = the caller's n). The fallback
+ * rotation lane runs separately, post-classification (BS#1862).
+ */
+async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
+  return db
+    .select({
+      id: flowsheet.id,
+      entry_type: flowsheet.entry_type,
+      add_time: flowsheet.add_time,
+      radio_hour: flowsheet.radio_hour,
+      track_title: flowsheet.track_title,
+      artist_name: flowsheet.artist_name,
+      album_title: flowsheet.album_title,
+      record_label: flowsheet.record_label,
+      request_flag: flowsheet.request_flag,
+      segue: flowsheet.segue,
+      message: flowsheet.message,
+      rotation_id: flowsheet.rotation_id,
+      album_id: flowsheet.album_id,
+      // FK-lane rotation_bin only. The correlated fallback subquery this used
+      // to COALESCE with was removed (BS#1862) — it seq-scanned `library`
+      // for every window row and cost ~2.4s. The fallback runs post-slice in
+      // resolveFallbackRotation over the track rows that survive classification.
+      rotation_bin: rotation.rotation_bin,
+    })
+    .from(flowsheet)
+    .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .orderBy(desc(flowsheet.id))
+    .limit(limit);
+}
+
 // --- Public API ---
 
 /**
@@ -182,29 +223,7 @@ function toBaseEntry(row: RecentRow): BaseEntry {
  * the playcuts sub-array at read time.
  */
 export async function getRecentEntries(n: number): Promise<GroupedResponse> {
-  const rows: RecentRow[] = await db
-    .select({
-      id: flowsheet.id,
-      entry_type: flowsheet.entry_type,
-      add_time: flowsheet.add_time,
-      radio_hour: flowsheet.radio_hour,
-      track_title: flowsheet.track_title,
-      artist_name: flowsheet.artist_name,
-      album_title: flowsheet.album_title,
-      record_label: flowsheet.record_label,
-      request_flag: flowsheet.request_flag,
-      rotation_id: flowsheet.rotation_id,
-      album_id: flowsheet.album_id,
-      // FK-lane rotation_bin only. The correlated fallback subquery this used
-      // to COALESCE with was removed (BS#1862) — it seq-scanned `library`
-      // for every window row and cost ~2.4s. The fallback now runs post-slice
-      // in resolveFallbackRotation over the <= n sliced playcuts.
-      rotation_bin: rotation.rotation_bin,
-    })
-    .from(flowsheet)
-    .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .orderBy(desc(flowsheet.id))
-    .limit(MAX_ENTRIES);
+  const rows = await fetchRecentRows(MAX_ENTRIES);
 
   const playcutRows: RecentRow[] = [];
   const talksetRows: RecentRow[] = [];
@@ -260,6 +279,133 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
     talksets: talksetRows.map(toBaseEntry),
     breakpoints: breakpointRows.map(toBaseEntry),
   };
+}
+
+// --- v=1 flat contract (Android; tubafrenzy's FlowsheetEntryJsonSerializer.toJson) ---
+
+/** Playcut fields nested under `playcut` in the v=1 flat wire format. */
+interface FlatPlaycutFields {
+  artistName: string;
+  songTitle: string;
+  releaseTitle: string;
+  labelName: string;
+  rotation: string;
+  request: string;
+  segue: string;
+}
+
+/**
+ * One entry in the v=1 flat array (see §2.2 of the tubafrenzy decommission
+ * plan / tubafrenzy's `FlowsheetEntryJsonSerializer.toJson`). Every entry
+ * carries the base fields + an `entryType` discriminator. Playcuts nest their
+ * typed fields under `playcut`; breakpoints and showDelimiters carry an
+ * `artistName` label (consumer-invisible — the Android DTO has no top-level
+ * artistName and reads the breakpoint hour from `hour`; iOS consumes the v=2
+ * grouped shape, not this one — but emitted for byte-faithfulness).
+ */
+export interface FlatEntry {
+  id: number;
+  chronOrderID: number;
+  hour: number;
+  timeCreated: number;
+  entryType: 'playcut' | 'talkset' | 'breakpoint' | 'showDelimiter';
+  playcut?: FlatPlaycutFields;
+  artistName?: string;
+}
+
+type FlatBucket = 'playcut' | 'talkset' | 'breakpoint' | 'showDelimiter';
+
+/**
+ * Flat-format entry_type classification. Unlike `classifyEntryType` (v=2),
+ * this never drops a row: show_start/show_end map to `showDelimiter` (v=1
+ * includes them). Unknown types fall to `talkset`, the benign non-track
+ * bucket — the BS entry_type enum is closed, so this is defensive only.
+ */
+function classifyFlatEntryType(entryType: string): FlatBucket {
+  switch (entryType) {
+    case 'track':
+      return 'playcut';
+    case 'breakpoint':
+      return 'breakpoint';
+    case 'show_start':
+    case 'show_end':
+      return 'showDelimiter';
+    case 'talkset':
+    case 'dj_join':
+    case 'dj_leave':
+    case 'message':
+    default:
+      return 'talkset';
+  }
+}
+
+function toFlatEntry(row: RecentRow, fallbackRotationMap: Map<number, string>): FlatEntry {
+  const base = {
+    id: row.id,
+    chronOrderID: row.id,
+    hour: computeHourMs(row),
+    timeCreated: row.add_time.getTime(),
+  };
+  switch (classifyFlatEntryType(row.entry_type)) {
+    case 'playcut': {
+      // Same COALESCE(FK, fallback) rotation semantics as the v=2 path.
+      const rotationBin = row.rotation_bin ?? fallbackRotationMap.get(row.id) ?? null;
+      return {
+        ...base,
+        entryType: 'playcut',
+        playcut: {
+          artistName: row.artist_name ?? '',
+          songTitle: row.track_title ?? '',
+          releaseTitle: row.album_title ?? '',
+          labelName: row.record_label ?? '',
+          rotation: rotationBin !== null ? 'true' : 'false',
+          request: row.request_flag ? 'true' : 'false',
+          segue: row.segue ? 'true' : 'false',
+        },
+      };
+    }
+    case 'talkset':
+      return { ...base, entryType: 'talkset' };
+    case 'breakpoint':
+      // tubafrenzy stored the breakpoint label as the uppercased message (the
+      // mirror's `message.toUpperCase() || 'BREAKPOINT'`); reproduce it.
+      return { ...base, entryType: 'breakpoint', artistName: (row.message ?? '').trim().toUpperCase() || 'BREAKPOINT' };
+    case 'showDelimiter':
+      // The mirror sent the show marker's `message` as tubafrenzy's artistName.
+      return { ...base, entryType: 'showDelimiter', artistName: row.message ?? '' };
+  }
+}
+
+/**
+ * Query Postgres for the current playlist as the v=1 flat array (the Android
+ * contract; BS#1866). Returns the most recent min(n, MAX_ENTRIES) rows of ANY
+ * type — matching tubafrenzy's `getNRecentFlowsheetEntries(n)` semantic where
+ * `n` bounds total entries, not playcuts — serialized flat with the
+ * `entryType` discriminator. showDelimiter (show_start/show_end) entries are
+ * INCLUDED, unlike the v=2 grouped path. No artwork enrichment (v=1 never
+ * carried it — Android does its own artwork lookup client-side).
+ */
+export async function getRecentEntriesFlat(n: number): Promise<FlatEntry[]> {
+  const rows = await fetchRecentRows(Math.min(n, MAX_ENTRIES));
+
+  // Rotation fallback only needs the track rows (the playcut candidates).
+  const trackRows = rows.filter((row) => classifyFlatEntryType(row.entry_type) === 'playcut');
+  const fallbackRotationMap = await resolveFallbackRotation(trackRows);
+
+  return rows.map((row) => toFlatEntry(row, fallbackRotationMap));
+}
+
+/**
+ * The `X-Last-Modified` value for a window: the max `timeCreated` (add_time
+ * epoch ms) across the given entries, or 0 for an empty window. tubafrenzy's
+ * header is its cache's last-modified instant; the plan (§2.4) specifies the
+ * max timeCreated of the served window, which increases whenever a newer entry
+ * appears. Computed from the served payload, so the v=2 value can miss a
+ * showDelimiter that the grouped shape drops — inconsequential, since v=2
+ * (iOS) never sends `?since`, and the bridge's `?since` path stays on legacy.
+ */
+export function lastModifiedFromTimestamps(timestamps: number[]): number {
+  return timestamps.length > 0 ? Math.max(...timestamps) : 0;
 }
 
 // --- Enrichment ---

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -304,7 +304,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('groups playcuts/talksets/breakpoints and omits show_start/show_end', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     expect(res.headers['cache-control']).toBe('public, max-age=30');
 
@@ -323,7 +323,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('resolves both split-format plays to the lower album_id artwork (BS#1105 tie-break, end to end)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const cdEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[0]);
     const lpEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[1]);
@@ -338,7 +338,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('emits request as a "true"/"false" string, not a boolean', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const cdEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[0]);
     const lpEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[1]);
@@ -349,7 +349,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('emits rotation as "true" via the fallback text-match query for a hand-typed entry with no rotation_id (branch b)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const rotationMatchEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[2]);
     expect(rotationMatchEntry).toBeDefined();
@@ -361,7 +361,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('emits rotation as "true" via the album_id branch for a hand-typed entry whose text matches no rotation (branch a, BS#1862)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const albumIdMatchEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[8]);
     expect(albumIdMatchEntry).toBeDefined();
@@ -371,7 +371,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('emits rotation as "true" via the rotation->library->artists branch for a hand-typed entry with no album_id (branch c, BS#1862)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const libraryLinkedEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[9]);
     expect(libraryLinkedEntry).toBeDefined();
@@ -382,7 +382,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('does NOT badge a rotation-text match whose artist has a trailing newline (JS-vs-SQL trim parity, BS#1862)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const newlineEntry = res.body.playcuts.find((p) => p.id === flowsheetIds[10]);
     expect(newlineEntry).toBeDefined();
@@ -394,16 +394,74 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   });
 
   test('breakpoint hour uses radio_hour verbatim, not floor(add_time)', async () => {
-    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+    const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const breakpointEntry = res.body.breakpoints.find((b) => b.id === flowsheetIds[5]);
     expect(breakpointEntry).toBeDefined();
     expect(breakpointEntry.hour).toBe(new Date('2026-07-28T20:00:00.000Z').getTime());
   });
 
-  test('clamps n and returns 200 for the default/no-param case', async () => {
-    const res = await request.get('/playlists/recentEntries').expect(200);
+  test('v=2 defaults to <=50 playcuts and returns the grouped object', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ v: 2 }).expect(200);
     expect(Array.isArray(res.body.playcuts)).toBe(true);
     expect(res.body.playcuts.length).toBeLessThanOrEqual(50);
+  });
+
+  // --- v=1 flat wire format (Android; BS#1866) ---
+
+  test('v absent -> flat ARRAY (Android contract), with X-Last-Modified exposed', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ n: 100 }).expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.headers['x-last-modified']).toMatch(/^\d+$/);
+    expect(Number(res.headers['x-last-modified'])).toBeGreaterThan(0);
+    expect(res.headers['access-control-expose-headers']).toContain('X-Last-Modified');
+  });
+
+  test('flat: a track is a playcut entry with a nested playcut object', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ v: 1, n: 100 }).expect(200);
+
+    const cd = res.body.find((e) => e.id === flowsheetIds[0]);
+    expect(cd).toBeDefined();
+    expect(cd.entryType).toBe('playcut');
+    expect(cd.playcut).toMatchObject({
+      artistName: ARTIST_NAME,
+      songTitle: 'Probe Track (CD press)',
+      releaseTitle: ALBUM_TITLE,
+      rotation: 'false',
+      request: 'false',
+      segue: 'false',
+    });
+  });
+
+  test('flat: INCLUDES show_start/show_end as showDelimiter entries (unlike v=2)', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ v: 1, n: 100 }).expect(200);
+
+    const showStart = res.body.find((e) => e.id === flowsheetIds[6]);
+    const showEnd = res.body.find((e) => e.id === flowsheetIds[7]);
+    expect(showStart).toBeDefined();
+    expect(showEnd).toBeDefined();
+    expect(showStart.entryType).toBe('showDelimiter');
+    expect(showEnd.entryType).toBe('showDelimiter');
+    expect(showStart.playcut).toBeUndefined();
+  });
+
+  test('flat: breakpoint carries entryType "breakpoint"; talkset/dj_join carry "talkset"', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ v: 1, n: 100 }).expect(200);
+
+    const bp = res.body.find((e) => e.id === flowsheetIds[5]);
+    const talkset = res.body.find((e) => e.id === flowsheetIds[3]);
+    const djJoin = res.body.find((e) => e.id === flowsheetIds[4]);
+    expect(bp.entryType).toBe('breakpoint');
+    expect(talkset.entryType).toBe('talkset');
+    expect(djJoin.entryType).toBe('talkset');
+  });
+
+  test('flat: rotation badge resolves the same as v=2 (hand-typed branch-b match)', async () => {
+    const res = await request.get('/playlists/recentEntries').query({ v: 1, n: 100 }).expect(200);
+
+    const rotationMatch = res.body.find((e) => e.id === flowsheetIds[2]);
+    expect(rotationMatch.entryType).toBe('playcut');
+    expect(rotationMatch.playcut.rotation).toBe('true');
   });
 });

--- a/tests/unit/controllers/playlist.controller.test.ts
+++ b/tests/unit/controllers/playlist.controller.test.ts
@@ -2,25 +2,29 @@
  * Unit tests for the playlist controller.
  *
  * The playlist proxy service is mocked; tests verify the HTTP handler
- * correctly reads query params, sets headers, and delegates to the service.
+ * correctly reads query params, routes v=1 (flat) vs v=2 (grouped), sets
+ * headers (incl. X-Last-Modified, BS#1866), and delegates to the service.
  *
  * Phase 3 of the tubafrenzy decommission (WXYC/wiki#88): `getRecentEntries`
- * is now async (a live Postgres query, not an in-memory read), so the
- * controller awaits it and there is no more `isConnected()` SSE gate. A
- * DB error is surfaced as a DIRECT 503 response — never thrown through the
- * error pipeline, whose Sentry filter captures every >=500. This is an
- * unauthenticated endpoint mobile clients poll on a fixed interval, so a
- * captured 503 would mean one Sentry event per poll during a DB blip.
+ * is now async (a live Postgres query). A DB error is surfaced as a DIRECT
+ * 503 response — never thrown through the error pipeline, whose Sentry filter
+ * captures every >=500. This is an unauthenticated endpoint mobile clients
+ * poll on a fixed interval, so a captured 503 would mean one Sentry event per
+ * poll during a DB blip.
  */
 import { jest } from '@jest/globals';
 import type { Request, Response, NextFunction } from 'express';
 
 // --- Mocks ---
 
-const mockGetRecentEntries = jest.fn();
+const mockGetGrouped = jest.fn();
+const mockGetFlat = jest.fn();
 
 jest.mock('../../../apps/backend/services/playlist-proxy.service', () => ({
-  getRecentEntries: (...args: unknown[]) => mockGetRecentEntries(...args),
+  getRecentEntries: (...args: unknown[]) => mockGetGrouped(...args),
+  getRecentEntriesFlat: (...args: unknown[]) => mockGetFlat(...args),
+  // Real logic so header-value assertions are meaningful.
+  lastModifiedFromTimestamps: (ts: number[]) => (ts.length > 0 ? Math.max(...ts) : 0),
 }));
 
 import { getRecentEntries } from '../../../apps/backend/controllers/playlist.controller';
@@ -32,14 +36,18 @@ const createMockRes = () => {
   res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
   res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
   res.set = jest.fn().mockReturnValue(res) as unknown as Response['set'];
+  res.append = jest.fn().mockReturnValue(res) as unknown as Response['append'];
   return res;
 };
 
 const noopNext: NextFunction = jest.fn();
 
+const setCalls = (res: Partial<Response>) => (res.set as jest.Mock).mock.calls as [string, string][];
+const headerValue = (res: Partial<Response>, name: string) => setCalls(res).find(([k]) => k === name)?.[1];
+
 // --- Fixture data: representative WXYC entries ---
 
-const sampleResponse = {
+const sampleGrouped = {
   playcuts: [
     {
       id: 2602250,
@@ -67,35 +75,52 @@ const sampleResponse = {
       rotation: 'true',
     },
   ],
-  talksets: [
-    {
-      id: 2602247,
-      chronOrderID: 2602247,
-      hour: 1775080800000,
-      timeCreated: 1775082820391,
-    },
-  ],
-  breakpoints: [
-    {
-      id: 2602238,
-      chronOrderID: 2602238,
-      hour: 1775077200000,
-      timeCreated: 1775076979166,
-    },
-  ],
+  talksets: [{ id: 2602247, chronOrderID: 2602247, hour: 1775080800000, timeCreated: 1775082820391 }],
+  breakpoints: [{ id: 2602238, chronOrderID: 2602238, hour: 1775077200000, timeCreated: 1775076979166 }],
 };
+// Max timeCreated across all grouped entries.
+const GROUPED_MAX_TS = 1775082999000;
+
+const sampleFlat = [
+  {
+    id: 2602250,
+    chronOrderID: 2602250,
+    hour: 1775080800000,
+    timeCreated: 1775082908948,
+    entryType: 'playcut',
+    playcut: {
+      artistName: 'Jessica Pratt',
+      songTitle: 'Back, Baby',
+      releaseTitle: 'On Your Own Love Again',
+      labelName: 'Drag City',
+      rotation: 'false',
+      request: 'false',
+      segue: 'false',
+    },
+  },
+  { id: 2602247, chronOrderID: 2602247, hour: 1775080800000, timeCreated: 1775082820391, entryType: 'talkset' },
+  {
+    id: 2602238,
+    chronOrderID: 2602238,
+    hour: 1775077200000,
+    timeCreated: 1775076979166,
+    entryType: 'breakpoint',
+    artistName: 'BREAKPOINT',
+  },
+];
+const FLAT_MAX_TS = 1775082908948;
 
 // --- Tests ---
 
 describe('playlist.controller', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetGrouped.mockResolvedValue(sampleGrouped);
+    mockGetFlat.mockResolvedValue(sampleFlat);
   });
 
-  describe('getRecentEntries', () => {
+  describe('v=2 grouped path (iOS)', () => {
     it('returns enriched playcuts with artworkURL', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
       const req = { query: { v: '2', n: '50' } } as unknown as Request;
       const res = createMockRes();
 
@@ -105,66 +130,103 @@ describe('playlist.controller', () => {
       const body = (res.json as jest.Mock).mock.calls[0][0];
       expect(body.playcuts[0].artworkURL).toBe('https://i.discogs.com/jessica.jpg');
       expect(body.playcuts[1].artworkURL).toBeUndefined();
+      expect(mockGetFlat).not.toHaveBeenCalled();
     });
 
-    it('sets Cache-Control: public, max-age=30', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
+    it('sets Cache-Control, X-Last-Modified (max timeCreated), and Access-Control-Expose-Headers', async () => {
       const req = { query: { v: '2' } } as unknown as Request;
       const res = createMockRes();
 
       await getRecentEntries(req, res as Response, noopNext);
 
       expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=30');
+      expect(headerValue(res, 'X-Last-Modified')).toBe(String(GROUPED_MAX_TS));
+      // Appended (not set) so the CORS-exposed X-Request-Id survives.
+      expect(res.append).toHaveBeenCalledWith('Access-Control-Expose-Headers', 'X-Last-Modified');
     });
 
-    it('passes n param to service (slices entries)', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
-      const req = { query: { v: '2', n: '5' } } as unknown as Request;
-      const res = createMockRes();
-
-      await getRecentEntries(req, res as Response, noopNext);
-
-      expect(mockGetRecentEntries).toHaveBeenCalledWith(5);
+    it('passes n to the grouped service; defaults to 50; clamps [1, 100]', async () => {
+      const cases: [string | undefined, number][] = [
+        ['5', 5],
+        [undefined, 50],
+        ['500', 100],
+        ['0', 1],
+        ['abc', 50],
+      ];
+      for (const [n, expected] of cases) {
+        jest.clearAllMocks();
+        mockGetGrouped.mockResolvedValue(sampleGrouped);
+        const req = { query: n === undefined ? { v: '2' } : { v: '2', n } } as unknown as Request;
+        await getRecentEntries(req, createMockRes() as Response, noopNext);
+        expect(mockGetGrouped).toHaveBeenCalledWith(expected);
+      }
     });
 
-    it('defaults n to 50 when not provided', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
+    it('preserves talksets and breakpoints unchanged', async () => {
       const req = { query: { v: '2' } } as unknown as Request;
       const res = createMockRes();
 
       await getRecentEntries(req, res as Response, noopNext);
 
-      expect(mockGetRecentEntries).toHaveBeenCalledWith(50);
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(body.talksets).toEqual(sampleGrouped.talksets);
+      expect(body.breakpoints).toEqual(sampleGrouped.breakpoints);
     });
+  });
 
-    it('clamps n to 100 when n exceeds maximum', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
-      const req = { query: { v: '2', n: '500' } } as unknown as Request;
+  describe('v=1 flat path (Android; default when v absent)', () => {
+    it('routes to the flat service when v is absent (the Android contract)', async () => {
+      const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
       await getRecentEntries(req, res as Response, noopNext);
 
-      expect(mockGetRecentEntries).toHaveBeenCalledWith(100);
+      expect(mockGetFlat).toHaveBeenCalled();
+      expect(mockGetGrouped).not.toHaveBeenCalled();
+      expect((res.json as jest.Mock).mock.calls[0][0]).toBe(sampleFlat);
     });
 
-    it('clamps n to 1 when n is zero or negative', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
-      const req = { query: { v: '2', n: '0' } } as unknown as Request;
+    it('routes to the flat service for v=1', async () => {
+      const req = { query: { v: '1' } } as unknown as Request;
       const res = createMockRes();
 
       await getRecentEntries(req, res as Response, noopNext);
 
-      expect(mockGetRecentEntries).toHaveBeenCalledWith(1);
+      expect(mockGetFlat).toHaveBeenCalled();
+      expect(mockGetGrouped).not.toHaveBeenCalled();
     });
 
-    it('returns a direct 503 when the service rejects (DB failure), without throwing into the error pipeline', async () => {
-      mockGetRecentEntries.mockRejectedValue(new Error('connection terminated'));
+    it('defaults n to 200 and clamps [1, 200] (tubafrenzy total-entries semantic)', async () => {
+      const cases: [string | undefined, number][] = [
+        [undefined, 200],
+        ['35', 35],
+        ['999', 200],
+        ['0', 1],
+      ];
+      for (const [n, expected] of cases) {
+        jest.clearAllMocks();
+        mockGetFlat.mockResolvedValue(sampleFlat);
+        const req = { query: n === undefined ? {} : { n } } as unknown as Request;
+        await getRecentEntries(req, createMockRes() as Response, noopNext);
+        expect(mockGetFlat).toHaveBeenCalledWith(expected);
+      }
+    });
 
+    it('sets X-Last-Modified from the flat window and Access-Control-Expose-Headers', async () => {
+      const req = { query: {} } as unknown as Request;
+      const res = createMockRes();
+
+      await getRecentEntries(req, res as Response, noopNext);
+
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=30');
+      expect(headerValue(res, 'X-Last-Modified')).toBe(String(FLAT_MAX_TS));
+      expect(res.append).toHaveBeenCalledWith('Access-Control-Expose-Headers', 'X-Last-Modified');
+    });
+  });
+
+  describe('DB failure', () => {
+    it('returns a direct 503 (grouped) without setting headers or calling next', async () => {
+      mockGetGrouped.mockRejectedValue(new Error('connection terminated'));
       const req = { query: { v: '2' } } as unknown as Request;
       const res = createMockRes();
 
@@ -176,28 +238,15 @@ describe('playlist.controller', () => {
       expect(noopNext).not.toHaveBeenCalled();
     });
 
-    it('preserves talksets and breakpoints unchanged', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
-      const req = { query: { v: '2' } } as unknown as Request;
+    it('returns a direct 503 (flat) without setting headers', async () => {
+      mockGetFlat.mockRejectedValue(new Error('connection terminated'));
+      const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
       await getRecentEntries(req, res as Response, noopNext);
 
-      const body = (res.json as jest.Mock).mock.calls[0][0];
-      expect(body.talksets).toEqual(sampleResponse.talksets);
-      expect(body.breakpoints).toEqual(sampleResponse.breakpoints);
-    });
-
-    it('handles non-numeric n param gracefully (defaults to 50)', async () => {
-      mockGetRecentEntries.mockResolvedValue(sampleResponse);
-
-      const req = { query: { v: '2', n: 'abc' } } as unknown as Request;
-      const res = createMockRes();
-
-      await getRecentEntries(req, res as Response, noopNext);
-
-      expect(mockGetRecentEntries).toHaveBeenCalledWith(50);
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.set).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -72,6 +72,8 @@ jest.mock('@wxyc/database', () => ({
     album_title: 'album_title',
     record_label: 'record_label',
     request_flag: 'request_flag',
+    segue: 'segue',
+    message: 'message',
     rotation_id: 'rotation_id',
     album_id: 'album_id',
   },
@@ -113,7 +115,11 @@ jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.spyOn(console, 'error').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-import { getRecentEntries } from '../../../apps/backend/services/playlist-proxy.service';
+import {
+  getRecentEntries,
+  getRecentEntriesFlat,
+  lastModifiedFromTimestamps,
+} from '../../../apps/backend/services/playlist-proxy.service';
 
 // --- Fixtures: representative WXYC data ---
 // (see the org CLAUDE.md "Example Music Data" section for the canonical pool)
@@ -128,6 +134,8 @@ const jessicaPrattRow = {
   album_title: 'On Your Own Love Again',
   record_label: 'Drag City',
   request_flag: false,
+  segue: false,
+  message: null,
   // No FK rotation link and no fallback match -> not in rotation. As a
   // hand-typed track (rotation_id null, artist+album present) it IS a
   // fallback candidate, so getRecentEntries runs the batched fallback query
@@ -147,6 +155,8 @@ const juanaMolinaRow = {
   album_title: 'DOGA',
   record_label: 'Sonamos',
   request_flag: true,
+  segue: true,
+  message: null,
   // FK rotation hit: rotation_id set, so rotation.rotation_bin comes back from
   // the window join and this row is NOT a fallback candidate.
   rotation_id: 940,
@@ -167,6 +177,8 @@ const handTypedRotationRow = {
   album_title: 'Edits',
   record_label: 'self-released',
   request_flag: false,
+  segue: false,
+  message: null,
   rotation_id: null,
   album_id: null,
   rotation_bin: null,
@@ -212,6 +224,8 @@ const breakpointRow = {
   album_title: null,
   record_label: null,
   request_flag: null,
+  segue: null,
+  message: 'BREAKPOINT',
   rotation_bin: null,
 };
 
@@ -231,10 +245,17 @@ const showStartRow = {
   album_title: null,
   record_label: null,
   request_flag: null,
+  segue: null,
+  message: 'Start of Show: DJ Probe joined the set',
   rotation_bin: null,
 };
 
-const showEndRow = { ...showStartRow, id: 2602199, entry_type: 'show_end' };
+const showEndRow = {
+  ...showStartRow,
+  id: 2602199,
+  entry_type: 'show_end',
+  message: 'End of Show: DJ Probe left the set',
+};
 
 // --- Tests ---
 
@@ -659,6 +680,207 @@ describe('playlist-proxy.service', () => {
       const result = await getRecentEntries(50);
 
       expect(result.playcuts[0].artworkURL).toBe('https://i.discogs.com/lowest-album-id.jpg');
+    });
+  });
+
+  describe('getRecentEntriesFlat — v=1 flat wire format (BS#1866)', () => {
+    it('returns a flat array, not the grouped object', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, talksetRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(2);
+    });
+
+    it('serializes a track as a playcut entry with a nested playcut object', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      expect(entry).toMatchObject({
+        id: jessicaPrattRow.id,
+        chronOrderID: jessicaPrattRow.id,
+        entryType: 'playcut',
+        timeCreated: jessicaPrattRow.add_time.getTime(),
+      });
+      expect(entry.playcut).toEqual({
+        artistName: 'Jessica Pratt',
+        songTitle: 'Back, Baby',
+        releaseTitle: 'On Your Own Love Again',
+        labelName: 'Drag City',
+        rotation: 'false',
+        request: 'false',
+        segue: 'false',
+      });
+    });
+
+    it('INCLUDES show_start/show_end as showDelimiter entries (unlike v=2 grouped)', async () => {
+      mockLimit.mockResolvedValue([showStartRow, jessicaPrattRow, showEndRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      const delimiters = result.filter((e) => e.entryType === 'showDelimiter');
+      expect(delimiters.map((d) => d.id)).toEqual([showStartRow.id, showEndRow.id]);
+      // showDelimiter carries the marker message as artistName (consumer-invisible).
+      expect(delimiters[0].artistName).toBe('Start of Show: DJ Probe joined the set');
+      expect(delimiters[1].artistName).toBe('End of Show: DJ Probe left the set');
+      expect(delimiters[0].playcut).toBeUndefined();
+    });
+
+    it('maps breakpoint to entryType "breakpoint" with the uppercased message as artistName', async () => {
+      mockLimit.mockResolvedValue([breakpointRow]);
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      expect(entry.entryType).toBe('breakpoint');
+      expect(entry.artistName).toBe('BREAKPOINT');
+      // breakpoint hour uses radio_hour verbatim (shared with v=2).
+      expect(entry.hour).toBe(breakpointRow.radio_hour.getTime());
+    });
+
+    it('maps talkset/dj_join/dj_leave/message to entryType "talkset"', async () => {
+      mockLimit.mockResolvedValue([talksetRow, djJoinRow, djLeaveRow, messageRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      expect(result.every((e) => e.entryType === 'talkset')).toBe(true);
+      expect(result.every((e) => e.playcut === undefined && e.artistName === undefined)).toBe(true);
+    });
+
+    it('emits segue as a "true"/"false" string in the nested playcut', async () => {
+      mockLimit.mockResolvedValue([juanaMolinaRow, jessicaPrattRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      const juana = result.find((e) => e.playcut?.artistName === 'Juana Molina');
+      const jessica = result.find((e) => e.playcut?.artistName === 'Jessica Pratt');
+      expect(juana?.playcut?.segue).toBe('true');
+      expect(jessica?.playcut?.segue).toBe('false');
+    });
+
+    it('resolves the rotation fallback for a hand-typed playcut', async () => {
+      mockLimit.mockResolvedValue([handTypedRotationRow]);
+      mockExecute.mockResolvedValue([{ fid: handTypedRotationRow.id, rotation_bin: 'H' }]);
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      expect(entry.playcut?.rotation).toBe('true');
+    });
+
+    it('does not enrich artwork (v=1 carries none)', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      expect('artworkURL' in entry).toBe(false);
+      expect(entry.playcut).not.toHaveProperty('imageURL');
+      expect(mockGroupBy).not.toHaveBeenCalled();
+    });
+
+    it('bounds the window to n TOTAL entries (min(n, 200)), not n playcuts', async () => {
+      await getRecentEntriesFlat(35);
+      expect(mockLimit).toHaveBeenCalledWith(35);
+
+      await getRecentEntriesFlat(500);
+      expect(mockLimit).toHaveBeenCalledWith(200);
+    });
+
+    it('carries the base fields on every entry type', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, talksetRow, breakpointRow, showStartRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      for (const e of result) {
+        expect(typeof e.id).toBe('number');
+        expect(typeof e.chronOrderID).toBe('number');
+        expect(typeof e.hour).toBe('number');
+        expect(typeof e.timeCreated).toBe('number');
+        expect(typeof e.entryType).toBe('string');
+      }
+    });
+  });
+
+  describe('X-Last-Modified (lastModifiedFromTimestamps)', () => {
+    it('returns the max timestamp of the window', () => {
+      expect(lastModifiedFromTimestamps([100, 500, 300])).toBe(500);
+    });
+
+    it('returns 0 for an empty window', () => {
+      expect(lastModifiedFromTimestamps([])).toBe(0);
+    });
+  });
+
+  describe('client-contract parity (BS#1866)', () => {
+    // A diacritic-bearing name (from wxyc-shared/test-utils) exercises the iOS
+    // repairingMojibake() no-op path: the emitted bytes must be clean UTF-8.
+    const niluferRow = {
+      ...jessicaPrattRow,
+      id: 2602260,
+      track_title: 'Midnight Sun',
+      artist_name: 'Nilüfer Yanya',
+      album_title: 'PAINLESS',
+      record_label: 'ATO Records',
+    };
+
+    it('v=1 flat playcut matches the Android PlaylistResponseDto shape', async () => {
+      mockLimit.mockResolvedValue([niluferRow]);
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      // PlaylistResponseDto: id:Int, entryType:String, playcut:?, hour:Long, chronOrderID:Int
+      expect(Number.isInteger(entry.id)).toBe(true);
+      expect(typeof entry.entryType).toBe('string');
+      expect(Number.isInteger(entry.hour)).toBe(true);
+      expect(Number.isInteger(entry.chronOrderID)).toBe(true);
+      // PlayCutDetailsDto: rotation/request/songTitle/labelName/artistName/releaseTitle (all String)
+      const pc = entry.playcut;
+      expect(pc).toBeDefined();
+      for (const key of ['rotation', 'request', 'songTitle', 'labelName', 'artistName', 'releaseTitle'] as const) {
+        expect(typeof pc?.[key]).toBe('string');
+      }
+      // Diacritic preserved byte-for-byte (no mojibake).
+      expect(pc?.artistName).toBe('Nilüfer Yanya');
+    });
+
+    it('v=1 flat marker entries deserialize cleanly (Android renders by entryType)', async () => {
+      mockLimit.mockResolvedValue([talksetRow, breakpointRow, showStartRow]);
+
+      const result = await getRecentEntriesFlat(50);
+
+      for (const e of result) {
+        expect(['talkset', 'breakpoint', 'showDelimiter']).toContain(e.entryType);
+        expect(e.playcut).toBeUndefined();
+      }
+    });
+
+    it('v=2 grouped playcut matches the iOS Playcut decoder shape', async () => {
+      mockLimit.mockResolvedValue([niluferRow]);
+
+      const result = await getRecentEntries(50);
+      const pc = result.playcuts[0];
+
+      // iOS Playcut: id/hour/chronOrderID/timeCreated (UInt64), songTitle/artistName (String),
+      // rotation decoded as Bool-or-String (here the "true"/"false" string).
+      expect(Number.isInteger(pc.id)).toBe(true);
+      expect(Number.isInteger(pc.hour)).toBe(true);
+      expect(Number.isInteger(pc.chronOrderID)).toBe(true);
+      expect(Number.isInteger(pc.timeCreated)).toBe(true);
+      expect(typeof pc.songTitle).toBe('string');
+      expect(typeof pc.artistName).toBe('string');
+      expect(typeof pc.rotation).toBe('string');
+      expect(pc.artistName).toBe('Nilüfer Yanya');
+    });
+
+    it('v=2 grouped exposes the iOS Playlist keys (playcuts/talksets/breakpoints)', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, talksetRow, breakpointRow]);
+
+      const result = await getRecentEntries(50);
+
+      expect(result).toHaveProperty('playcuts');
+      expect(result).toHaveProperty('talksets');
+      expect(result).toHaveProperty('breakpoints');
+      // iOS reads showMarkers/onAir via decodeIfPresent — their absence is tolerated.
     });
   });
 });


### PR DESCRIPTION
## Summary

`GET /playlists/recentEntries` ignored `v` and always returned the **v=2 grouped** object — which would break the Android client, whose DTO expects the **v=1 flat** array. This adds native v=1 support so Backend serves both legacy tubafrenzy wire formats itself (tubafrenzy turndown Phase 4 / [WXYC/wiki#88](https://github.com/WXYC/wiki/issues/88) §2.4 Piece 1).

- **`v=2`** → grouped `{playcuts, talksets, breakpoints}` (iOS). Byte-shape unchanged.
- **absent or `v=1`** → flat array (Android sends no `v`).

## v=1 flat contract (matches tubafrenzy's `FlowsheetEntryJsonSerializer.toJson`)

- Each entry: base fields + `entryType` discriminator.
- **playcut**: typed fields nested under a `playcut` object, incl. `segue`.
- **breakpoint / showDelimiter**: carry an `artistName` label. v=1 **includes** `showDelimiter` (show_start/show_end) — the v=2 grouped path drops them.
- `n` bounds **total** entries (tubafrenzy's `getNRecentFlowsheetEntries(n)`; default 200, clamp [1, 200]). v=2 keeps its playcut-slice semantics (default 50, clamp [1, 100]).
- **No artwork enrichment** (tubafrenzy's v=1 never carried it — Android resolves its own).

## X-Last-Modified

Both versions emit `X-Last-Modified` (max entry `timeCreated` of the served window), **appended** to `Access-Control-Expose-Headers` so the global CORS-exposed `X-Request-Id` (app.ts) isn't clobbered.

## Structure

- `fetchRecentRows(limit)` is now shared by both paths (adds `segue`/`message` to the window select).
- v=1 reuses the BS#1862 two-lane rotation resolution (FK + batched fallback) verbatim.
- Marker labels source from `flowsheet.message` (breakpoint uppercased or `BREAKPOINT`), the same field the legacy mirror mapped to tubafrenzy's `artistName` — consumer-invisible (Android's DTO has no top-level `artistName`; iOS reads the v=2 grouped shape).

## Tests

- Service: flat shape, showDelimiter inclusion, nested `playcut`, `segue` string, rotation fallback in the flat lane, no-artwork, `n`-total-entries bound, base-fields-on-every-type.
- Controller: v routing (v=2 grouped / absent+v=1 flat), per-version n defaults/clamps, X-Last-Modified value, append-not-clobber, direct-503 on both paths.
- **Parity**: v=1 flat against the Android `PlaylistResponseDto`; v=2 grouped against the iOS `Playcut` decoder; a diacritic-bearing name (Nilüfer Yanya) to confirm clean UTF-8 (iOS `repairingMojibake()` no-op).
- Integration: v=1 flat array end-to-end (showDelimiter present, nested playcut, entryType per type, rotation parity with v=2, X-Last-Modified exposed).
- Full unit suite green (5487); typecheck / lint / prettier clean.

## Notes

- **Chained on #1868** (BS#1862) — they overlap in `playlist-proxy.service.ts`. Base retargets to `main` when #1868 merges. Review #1868 first.
- `recentEntries` is a legacy-compat endpoint, not in the `api.yaml` SSOT — the v=1/v=2 shapes are documented in the plan (§2.2/§2.4), not codegen sources.

Closes #1866