### PR TITLE
Attach batched critic reviews to flowsheet feed assembly

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -7,6 +7,7 @@ import { NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ } from '@wxyc/datab
 type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
 import type { ConcertDTO } from '../services/concerts.service.js';
+import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import { projectFlowsheetEntry } from '../utils/flowsheet-projection.js';
 import { stashMirrorData } from '../middleware/legacy/mirror.middleware.js';
 import WxycError from '../utils/error.js';
@@ -85,6 +86,15 @@ export interface IFSEntry extends Omit<
   // `upcoming_show` on the V2 track wire shape (SSOT `FlowsheetV2TrackEntry`,
   // wxyc-shared api.yaml 1.16.0), reusing the `Concert` schema verbatim.
   upcoming_show?: ConcertDTO | null;
+  // Batched critic-review snippets (album-critic-reviews slice, ADR 0012;
+  // BS#1870), keyed strictly on this track's `album_id` — id-arm only, no
+  // name-arm fuzzy match (unlike `upcoming_show`'s BS#1613 hybrid). Populated
+  // only when `attachCriticReviews` found at least one seeded
+  // `album_critic_reviews` row for the entry's `album_id`, and only when the
+  // `CRITIC_REVIEWS_ENABLED` flag is on; absent/undefined otherwise.
+  // `transformToV2` emits it as `critic_reviews` on the V2 track wire shape,
+  // reusing the generated `CriticReviewItem` from `@wxyc/shared` verbatim.
+  critic_reviews?: CriticReviewItem[];
 }
 
 const MAX_ITEMS = 200;
@@ -133,7 +143,13 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     const entries = await flowsheet_service.getEntriesByShow(...recentShows.map((show) => show.id));
 
     if (entries.length) {
-      await flowsheet_service.attachUpcomingShows(entries);
+      // The two attaches are independent (they set different, disjoint
+      // fields on each entry), so run them concurrently rather than
+      // serializing two DB round trips.
+      await Promise.all([
+        flowsheet_service.attachUpcomingShows(entries),
+        flowsheet_service.attachCriticReviews(entries),
+      ]);
       res.status(200).json(projectEntriesV2(entries));
     } else {
       res.status(404).json({
@@ -162,7 +178,10 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     }
     const entries = await flowsheet_service.getEntriesByRange(startId, endId);
     if (entries.length) {
-      await flowsheet_service.attachUpcomingShows(entries);
+      await Promise.all([
+        flowsheet_service.attachUpcomingShows(entries),
+        flowsheet_service.attachCriticReviews(entries),
+      ]);
       res.status(200).json(projectEntriesV2(entries));
     } else {
       res.status(404).json({ message: 'No Tracks found' });
@@ -189,9 +208,11 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     }),
   ]);
 
-  // Attach the per-playcut upcoming-show enrichment (BS#1607) before
-  // projecting to V2 — one batched concerts query for the whole page.
-  await flowsheet_service.attachUpcomingShows(entries);
+  // Attach the per-playcut upcoming-show enrichment (BS#1607) and the
+  // batched critic-review snippets (BS#1870) before projecting to V2 — one
+  // batched concerts query plus one batched (flag-gated) reviews query for
+  // the whole page. Independent attaches, so run concurrently.
+  await Promise.all([flowsheet_service.attachUpcomingShows(entries), flowsheet_service.attachCriticReviews(entries)]);
 
   const totalPages = Math.ceil(total / limit);
 
@@ -225,7 +246,7 @@ export const getLatest: RequestHandler = async (req, res) => {
   // same 204 the empty-array case already returns, not throw on transformToV2.
   const entry = entries[0];
   if (entry) {
-    await flowsheet_service.attachUpcomingShows(entries);
+    await Promise.all([flowsheet_service.attachUpcomingShows(entries), flowsheet_service.attachCriticReviews(entries)]);
     res.status(200).json(flowsheet_service.transformToV2(entry));
   } else {
     // A non-empty page whose head is nullish is the same unexplained anomaly
@@ -670,7 +691,7 @@ export const getShowInfo: RequestHandler<object, unknown, object, { show_id: str
     throw new WxycError(`Show ${showId} not found`, 404);
   }
 
-  await flowsheet_service.attachUpcomingShows(entries);
+  await Promise.all([flowsheet_service.attachUpcomingShows(entries), flowsheet_service.attachCriticReviews(entries)]);
 
   res.status(200).json({
     ...showMetadata,

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -4,7 +4,7 @@
  * (album-critic-reviews slice, ADR 0012). All read BS's own persisted state
  * so the steady-state serve path skips the LML cascade entirely.
  *
- * Four exported helpers, keyed on the `album_id` of a matching `flowsheet`
+ * Five exported helpers, keyed on the `album_id` of a matching `flowsheet`
  * row and staged so the handler resolves that id exactly once per request:
  *   - {@link selectLinkedFlowsheetRow} — normalized `(artist, release)` key →
  *     the matching linked flowsheet row (`album_id` plus the base,
@@ -29,6 +29,11 @@
  *   - {@link lookupCriticReviewsByAlbumId} — up to `CRITIC_REVIEWS_LIMIT`
  *     attributed snippets for a resolved id, independent of whether
  *     `album_metadata` enrichment has run.
+ *   - {@link lookupCriticReviewsByAlbumIds} — batched sibling of
+ *     {@link lookupCriticReviewsByAlbumId} for flowsheet feed-assembly
+ *     (`attachCriticReviews`, `apps/backend/services/flowsheet.service.ts`):
+ *     one indexed query for a whole page's `album_id`s instead of one per
+ *     row, capped and ordered identically per album.
  *
  * The `/proxy/metadata/album` handler calls {@link selectLinkedFlowsheetRow}
  * once and feeds the resolved `album_id` to both the metadata and reviews
@@ -43,7 +48,7 @@
  * linked-row cohort (the steady state for entries old enough to be of
  * interest to a detail-view fetch).
  */
-import { sql, eq, desc } from 'drizzle-orm';
+import { sql, eq, desc, inArray } from 'drizzle-orm';
 import { db, album_metadata, album_critic_reviews } from '@wxyc/database';
 import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
@@ -204,18 +209,109 @@ export async function lookupCriticReviewsByAlbumId(albumId: number): Promise<Cri
     .orderBy(sql`${album_critic_reviews.published_at} DESC NULLS LAST`, desc(album_critic_reviews.id))
     .limit(CRITIC_REVIEWS_LIMIT);
 
-  // Project to the wire shape, omitting optional fields when null so the
-  // response carries only present keys (matches the metadata handler's
-  // "assign only when present" convention).
-  return rows.map((row) => {
-    const item: CriticReviewItem = {
-      source: row.source,
-      url: row.source_url,
-      snippet: row.snippet,
-    };
-    if (row.author) item.author = row.author;
-    if (row.published_at) item.publishedDate = row.published_at;
-    if (row.rating) item.rating = row.rating;
-    return item;
-  });
+  return rows.map(projectCriticReviewRow);
+}
+
+/**
+ * Row shape shared by {@link lookupCriticReviewsByAlbumId} and
+ * {@link lookupCriticReviewsByAlbumIds} — the six `album_critic_reviews`
+ * columns both queries select (everything except the internal `id` /
+ * `album_id` / `discogs_release_id` / `source_key` / timestamps).
+ */
+type CriticReviewRow = {
+  source: string;
+  source_url: string;
+  snippet: string;
+  author: string | null;
+  published_at: string | null;
+  rating: string | null;
+};
+
+/**
+ * Project one `album_critic_reviews` row onto the wire shape, omitting
+ * optional fields when null so the response carries only present keys
+ * (matches the metadata handler's "assign only when present" convention).
+ * Extracted so the single-album and batched lookups can't drift on the
+ * projection (source → source, url ← source_url, publishedDate ←
+ * published_at).
+ */
+function projectCriticReviewRow(row: CriticReviewRow): CriticReviewItem {
+  const item: CriticReviewItem = {
+    source: row.source,
+    url: row.source_url,
+    snippet: row.snippet,
+  };
+  if (row.author) item.author = row.author;
+  if (row.published_at) item.publishedDate = row.published_at;
+  if (row.rating) item.rating = row.rating;
+  return item;
+}
+
+/**
+ * Batched sibling of {@link lookupCriticReviewsByAlbumId} for flowsheet
+ * feed-assembly (`attachCriticReviews`, album-critic-reviews slice / ADR
+ * 0012). ONE query for a whole page's worth of linked track rows — a
+ * `WHERE album_id = ANY(...)` scan against the same
+ * `album_critic_reviews_album_id_source_url_uq` index the single-album read
+ * uses — rather than one query per row (the no-N+1 guarantee `upcoming_show`
+ * / `attachUpcomingShows` documents; project #32 perf posture).
+ *
+ * Returns `[]` immediately without touching the DB when `albumIds` is empty
+ * (the caller's prefilter already short-circuits this in practice, but the
+ * guard makes the function safe to call directly).
+ *
+ * Per-album ordering and cap match the single-album read exactly
+ * (`published_at DESC NULLS LAST`, then `id DESC` as a stable tiebreak,
+ * capped at `CRITIC_REVIEWS_LIMIT`): the query orders globally by
+ * `(album_id, published_at DESC NULLS LAST, id DESC)` so every album's rows
+ * arrive already in the right order, then this function groups them by
+ * `album_id` in JS and stops appending once a bucket hits the cap — cheaper
+ * than a `ROW_NUMBER() OVER (PARTITION BY album_id ...)` window for the
+ * per-request row counts this endpoint sees, and it reuses
+ * {@link projectCriticReviewRow} so the wire projection can't drift from the
+ * single-album read.
+ *
+ * A key absent from the returned map means that album has no seeded
+ * snippets — the caller (`attachCriticReviews`) treats "absent" and "empty
+ * array" identically (both leave `critic_reviews` unset on the entry).
+ */
+export async function lookupCriticReviewsByAlbumIds(albumIds: number[]): Promise<Map<number, CriticReviewItem[]>> {
+  const result = new Map<number, CriticReviewItem[]>();
+  if (albumIds.length === 0) {
+    return result;
+  }
+
+  const rows = await db
+    .select({
+      album_id: album_critic_reviews.album_id,
+      source: album_critic_reviews.source,
+      source_url: album_critic_reviews.source_url,
+      snippet: album_critic_reviews.snippet,
+      author: album_critic_reviews.author,
+      published_at: album_critic_reviews.published_at,
+      rating: album_critic_reviews.rating,
+    })
+    .from(album_critic_reviews)
+    .where(inArray(album_critic_reviews.album_id, albumIds))
+    .orderBy(
+      album_critic_reviews.album_id,
+      sql`${album_critic_reviews.published_at} DESC NULLS LAST`,
+      desc(album_critic_reviews.id)
+    );
+
+  for (const row of rows) {
+    let bucket = result.get(row.album_id);
+    if (bucket === undefined) {
+      bucket = [];
+      result.set(row.album_id, bucket);
+    }
+    // Rows for a given album_id arrive already newest-first (the ORDER BY
+    // above), so capping here — rather than re-sorting per group — preserves
+    // that order and just stops once a bucket is full.
+    if (bucket.length < CRITIC_REVIEWS_LIMIT) {
+      bucket.push(projectCriticReviewRow(row));
+    }
+  }
+
+  return result;
 }

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -25,6 +25,8 @@ import {
 } from '@wxyc/database';
 import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
 import { getUpcomingShowsMapsCached } from './concerts.service.js';
+import { lookupCriticReviewsByAlbumIds } from './album-metadata-lookup.service.js';
+import { getConfig as getCriticReviewsConfig } from '../config/criticReviews.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
@@ -1229,6 +1231,85 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   return entries;
 };
 
+/**
+ * Attach batched critic-review snippets to a feed page of entries
+ * (album-critic-reviews slice, ADR 0012; BS#1870). Modeled directly on
+ * {@link attachUpcomingShows} — same "batch a page, mutate in place" shape —
+ * but deliberately narrower in two ways:
+ *
+ *   1. **Id-arm only.** Keys strictly on the track's resolved `album_id`
+ *      (`flowsheet.album_id`, populated only for library-linked plays) via
+ *      {@link lookupCriticReviewsByAlbumIds}. There is NO name-arm fallback
+ *      like `attachUpcomingShows`'s BS#1613 hybrid — a review must never
+ *      attach by fuzzy artist-name match, only by the exact linked album,
+ *      mirroring the `album-critic-reviews-etl` writer's own exact-match
+ *      ceiling (it never guesses an album for a review either).
+ *   2. **Flag-gated.** Early-returns without touching the DB when
+ *      `getCriticReviewsConfig().enabled` is false — the same
+ *      `CRITIC_REVIEWS_ENABLED` gate `proxy.controller.ts`'s
+ *      `/proxy/metadata/album` handler uses. Default off, so this attach adds
+ *      zero queries to the hot public flowsheet path until an operator opts
+ *      in (Post-launch service hardening / project #32 posture).
+ *
+ * Batched — ONE indexed `album_critic_reviews` query for the whole page via
+ * `lookupCriticReviewsByAlbumIds`, never one per row (the same no-N+1
+ * guarantee `attachUpcomingShows` documents). Unlike the concerts maps, this
+ * is NOT memoized: the key set (the page's distinct `album_id`s) varies per
+ * page and the query is a plain indexed lookup, so a short-TTL cache would
+ * mostly miss while adding bookkeeping for no real savings.
+ *
+ * Watermark/staleness note (document, don't engineer): `GET /flowsheet` and
+ * `GET /flowsheet/latest` 304 on the flowsheet watermark (`conditionalGet`,
+ * BS#902/BS#1689). The weekly `album-critic-reviews-etl` (BS#1830) writes
+ * only `album_critic_reviews` and does not advance that watermark, so a
+ * freshly-written review can stay masked behind a stale 304 until the next
+ * ordinary flowsheet mutation — potentially minutes during a live broadcast.
+ * This is accepted: unlike the concerts ET-midnight fold (which corrects a
+ * genuine correctness cliff — a past show's CTA would otherwise render
+ * indefinitely), a late-surfacing review is a freshness lag with no
+ * incorrect state, so it is not worth folding into the watermark.
+ *
+ * Returns the same array reference with matched entries mutated in place;
+ * the caller maps the result through `transformToV2`, which reads
+ * `entry.critic_reviews`.
+ */
+export const attachCriticReviews = async (entries: IFSEntry[]): Promise<IFSEntry[]> => {
+  if (!getCriticReviewsConfig().enabled) {
+    return entries;
+  }
+
+  // Same defensive `entry?.` guard as attachUpcomingShows's prefilter
+  // (Sentry BACKEND-SERVICE-2T / BS#1864): a transient nullish array element
+  // must not throw here either.
+  const hasLinkedTrack = entries.some((entry) => entry?.entry_type === 'track' && entry.album_id !== null);
+  if (!hasLinkedTrack) {
+    return entries;
+  }
+
+  const albumIds = [
+    ...new Set(
+      entries
+        .filter((entry): entry is IFSEntry & { album_id: number } => {
+          return !!entry && entry.entry_type === 'track' && entry.album_id !== null;
+        })
+        .map((entry) => entry.album_id)
+    ),
+  ];
+
+  const reviewsByAlbumId = await lookupCriticReviewsByAlbumIds(albumIds);
+
+  for (const entry of entries) {
+    if (!entry || entry.entry_type !== 'track' || entry.album_id === null) {
+      continue;
+    }
+    const reviews = reviewsByAlbumId.get(entry.album_id);
+    if (reviews !== undefined && reviews.length > 0) {
+      entry.critic_reviews = reviews;
+    }
+  }
+  return entries;
+};
+
 export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
   const baseFields = {
     id: entry.id,
@@ -1296,6 +1377,13 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         // absent field as "no touring CTA". The SSOT field is optional +
         // nullable, so this present-or-absent projection is spec-conformant.
         ...(entry.upcoming_show ? { upcoming_show: entry.upcoming_show } : {}),
+        // Batched critic-review snippets (BS#1870). Emitted ONLY when
+        // `attachCriticReviews` found at least one seeded review for this
+        // track's `album_id` (flag on + a linked album with reviews) — absent
+        // otherwise, so a no-match or flag-off track row is byte-identical to
+        // its pre-1870 shape. Mirrors the `upcoming_show` present-or-absent
+        // projection above.
+        ...(entry.critic_reviews && entry.critic_reviews.length > 0 ? { critic_reviews: entry.critic_reviews } : {}),
       };
 
     case 'show_start':

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1250,6 +1250,16 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
  *      `/proxy/metadata/album` handler uses. Default off, so this attach adds
  *      zero queries to the hot public flowsheet path until an operator opts
  *      in (Post-launch service hardening / project #32 posture).
+ *   3. **Fails open.** The lookup + fan-out runs inside its own try/catch:
+ *      a DB error is reported via `Sentry.captureException` and swallowed,
+ *      returning `entries` unmodified (no `critic_reviews` attached) rather
+ *      than rejecting. This is called `Promise.all`'d with
+ *      `attachUpcomingShows` at every `GET /flowsheet` call site, and
+ *      `CRITIC_REVIEWS_ENABLED` is already on in prod, so an unguarded
+ *      rejection here would 500 the hottest public endpoint on a mere
+ *      `album_critic_reviews` blip — the same "strictly additive, must never
+ *      break the response" contract `proxy.controller.ts` applies to this
+ *      identical lookup on the metadata-proxy serve path.
  *
  * Batched — ONE indexed `album_critic_reviews` query for the whole page via
  * `lookupCriticReviewsByAlbumIds`, never one per row (the same no-N+1
@@ -1296,16 +1306,31 @@ export const attachCriticReviews = async (entries: IFSEntry[]): Promise<IFSEntry
     ),
   ];
 
-  const reviewsByAlbumId = await lookupCriticReviewsByAlbumIds(albumIds);
+  // Same "strictly additive, must never break the response" contract
+  // proxy.controller.ts's `/proxy/metadata/album` handler applies to this
+  // exact lookup (see its comment there). Here the stakes are higher: this
+  // runs Promise.all'd with attachUpcomingShows at all 5 GET /flowsheet call
+  // sites, and CRITIC_REVIEWS_ENABLED is already true in prod, so an
+  // unguarded rejection here would 500 the hottest public endpoint on a mere
+  // album_critic_reviews DB blip. Degrade to "no cards" instead: report to
+  // Sentry and hand the page back untouched.
+  try {
+    const reviewsByAlbumId = await lookupCriticReviewsByAlbumIds(albumIds);
 
-  for (const entry of entries) {
-    if (!entry || entry.entry_type !== 'track' || entry.album_id === null) {
-      continue;
+    for (const entry of entries) {
+      if (!entry || entry.entry_type !== 'track' || entry.album_id === null) {
+        continue;
+      }
+      const reviews = reviewsByAlbumId.get(entry.album_id);
+      if (reviews !== undefined && reviews.length > 0) {
+        entry.critic_reviews = reviews;
+      }
     }
-    const reviews = reviewsByAlbumId.get(entry.album_id);
-    if (reviews !== undefined && reviews.length > 0) {
-      entry.critic_reviews = reviews;
-    }
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { subsystem: 'attach-critic-reviews' },
+      extra: { album_id_count: albumIds.length },
+    });
   }
   return entries;
 };

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -19,6 +19,12 @@ const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<str
 // tests/unit/services/flowsheet.attachUpcomingShows.test.ts); returning the
 // same array keeps these controller tests focused on the HTTP wiring.
 const mockAttachUpcomingShows = jest.fn((entries: unknown[]) => Promise.resolve(entries));
+// BS#1870: the same feed paths also call attachCriticReviews (batched
+// critic-review attach, album-critic-reviews slice / ADR 0012), wired at the
+// same 5 call sites as attachUpcomingShows. No-op passthrough for the same
+// reason — the enrichment logic itself is unit-tested in
+// tests/unit/services/flowsheet.attachCriticReviews.test.ts.
+const mockAttachCriticReviews = jest.fn((entries: unknown[]) => Promise.resolve(entries));
 const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
 const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
@@ -42,6 +48,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getShowMetadata: mockGetShowMetadata,
   transformToV2: mockTransformToV2,
   attachUpcomingShows: mockAttachUpcomingShows,
+  attachCriticReviews: mockAttachCriticReviews,
   addTrack: mockAddTrack,
   getLatestShow: mockGetLatestShow,
   getOnAirDJName: mockGetOnAirDJName,
@@ -203,6 +210,21 @@ describe('flowsheet.controller', () => {
       expect(Array.isArray(body)).toBe(true);
     });
 
+    // BS#1870: the shows_limit branch is one of the 5 attachCriticReviews
+    // call sites (mirrors attachUpcomingShows's BS#1607 wiring).
+    it('attaches critic reviews on the shows_limit branch', async () => {
+      const entries = [createMockEntry(1)];
+      mockGetNShows.mockResolvedValue([{ id: 1 }]);
+      mockGetEntriesByShow.mockResolvedValue(entries);
+
+      const req = createMockReq({ shows_limit: '1' });
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(mockAttachCriticReviews).toHaveBeenCalledWith(entries);
+    });
+
     // Sentry BACKEND-SERVICE-2T / BS#1864: the shows_limit branch shares the
     // same unguarded `.map(transformToV2)` shape as the other getEntries
     // branches — the shared projectEntriesV2 guard drops the nullish slot and
@@ -277,6 +299,19 @@ describe('flowsheet.controller', () => {
         expect(res.status).toHaveBeenCalledWith(200);
       });
 
+      // BS#1870: the range branch is one of the 5 attachCriticReviews call sites.
+      it('attaches critic reviews on the range branch', async () => {
+        const entries = [createMockEntry(100)];
+        mockGetEntriesByRange.mockResolvedValue(entries);
+
+        const req = createMockReq({ start_id: '100', end_id: '105' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(mockAttachCriticReviews).toHaveBeenCalledWith(entries);
+      });
+
       // Sentry BACKEND-SERVICE-2T / BS#1864: the range branch shares the same
       // unguarded `.map(transformToV2)` shape as the default branch — the
       // shared projectEntriesV2 guard drops the nullish slot and captures it.
@@ -345,6 +380,22 @@ describe('flowsheet.controller', () => {
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[0], 0, entries);
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[1], 1, entries);
       expect(mockTransformToV2).toHaveBeenCalledWith(entries[2], 2, entries);
+    });
+
+    // BS#1870: the default paginated branch (the one the iOS app polls) must
+    // attach critic reviews alongside upcoming shows before projecting to V2.
+    it('attaches critic reviews before projecting to V2', async () => {
+      const entries = [createMockEntry(1)];
+      mockGetEntriesByPage.mockResolvedValue(entries);
+      mockGetEntryCount.mockResolvedValue(1);
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(mockAttachCriticReviews).toHaveBeenCalledWith(entries);
     });
 
     // Sentry BACKEND-SERVICE-2T / BS#1864: this is the higher-traffic branch
@@ -472,6 +523,8 @@ describe('flowsheet.controller', () => {
       expect(mockTransformToV2).toHaveBeenCalledWith(entry);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ ...entry, v2: true });
+      // BS#1870: getLatest is one of the 5 attachCriticReviews call sites.
+      expect(mockAttachCriticReviews).toHaveBeenCalledWith([entry]);
     });
 
     it('returns 204 with no body when no entries exist', async () => {
@@ -509,6 +562,7 @@ describe('flowsheet.controller', () => {
       expect(res.json).not.toHaveBeenCalled();
       expect(mockTransformToV2).not.toHaveBeenCalled();
       expect(mockAttachUpcomingShows).not.toHaveBeenCalled();
+      expect(mockAttachCriticReviews).not.toHaveBeenCalled();
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 
@@ -575,6 +629,8 @@ describe('flowsheet.controller', () => {
         ...mockShowMetadata,
         entries: entries.map((e) => ({ ...e, v2: true })),
       });
+      // BS#1870: getShowInfo is one of the 5 attachCriticReviews call sites.
+      expect(mockAttachCriticReviews).toHaveBeenCalledWith(entries);
     });
 
     // Sentry BACKEND-SERVICE-2T / BS#1864: getShowInfo shares the same

--- a/tests/unit/routes/flowsheet.singleValidator.route.test.ts
+++ b/tests/unit/routes/flowsheet.singleValidator.route.test.ts
@@ -13,6 +13,11 @@ const mockGetEntriesByPage = jest.fn<() => Promise<unknown[]>>().mockResolvedVal
 const mockGetEntryCount = jest.fn<() => Promise<number>>().mockResolvedValue(0);
 const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>().mockResolvedValue(null);
 const mockAttachUpcomingShows = jest.fn((entries: unknown[]) => Promise.resolve(entries));
+// BS#1870: getEntries/getLatest also call attachCriticReviews (batched
+// critic-review attach) alongside attachUpcomingShows — no-op passthrough
+// here, same as the upcoming-shows mock; this file only pins the watermark
+// header wiring, not the attach behavior itself.
+const mockAttachCriticReviews = jest.fn((entries: unknown[]) => Promise.resolve(entries));
 const mockTransformToV2 = jest.fn((entry: unknown) => entry);
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
@@ -21,6 +26,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntryCount: mockGetEntryCount,
   getOnAirDJName: mockGetOnAirDJName,
   attachUpcomingShows: mockAttachUpcomingShows,
+  attachCriticReviews: mockAttachCriticReviews,
   transformToV2: mockTransformToV2,
 }));
 

--- a/tests/unit/services/album-metadata-lookup.service.test.ts
+++ b/tests/unit/services/album-metadata-lookup.service.test.ts
@@ -64,6 +64,13 @@ function makeChain() {
       chainSpy.limit(...args);
       return Promise.resolve(resolveValue);
     },
+    // The batched critic-reviews query (lookupCriticReviewsByAlbumIds) has no
+    // terminal `.limit(...)` — it caps per-album in JS — so the chain itself
+    // must be awaitable at the `.orderBy(...)` step, mirroring the real
+    // drizzle query builder (every step is thenable, not just the one after
+    // an explicit `.limit()`).
+    then: (resolve: (value: Array<Record<string, unknown>>) => void, reject?: (reason?: unknown) => void) =>
+      Promise.resolve(resolveValue).then(resolve, reject),
   };
   resolveValue = mockRowsQueue.shift() ?? [];
   return chain;
@@ -118,6 +125,7 @@ jest.mock('@wxyc/database', () => ({
 import {
   lookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId,
+  lookupCriticReviewsByAlbumIds,
 } from '../../../apps/backend/services/album-metadata-lookup.service';
 
 describe('album-metadata-lookup.service', () => {
@@ -312,6 +320,100 @@ describe('album-metadata-lookup.service', () => {
       // Pin that the reviews query carries an ORDER BY (the newest-first +
       // stable-tiebreak contract) rather than relying on insertion order.
       expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('lookupCriticReviewsByAlbumIds (batched, BS#1870)', () => {
+    // Batched sibling backing flowsheet feed-assembly's attachCriticReviews:
+    // one query for a whole page's album_ids, grouped + capped in JS, reusing
+    // the same wire projection as the single-album lookup above.
+
+    it('returns an empty map and never touches the DB when albumIds is empty', async () => {
+      const result = await lookupCriticReviewsByAlbumIds([]);
+      expect(result).toEqual(new Map());
+      expect(mockSelect).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty map when no rows match any requested album_id', async () => {
+      mockRowsQueue.push([]);
+      const result = await lookupCriticReviewsByAlbumIds([42, 99]);
+      expect(result).toEqual(new Map());
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+      // Single indexed query for the whole batch — the no-N+1 guarantee.
+      expect(chainSpy.where).toHaveBeenCalledTimes(1);
+    });
+
+    it('groups rows by album_id and projects each onto the wire shape', async () => {
+      mockRowsQueue.push([
+        {
+          album_id: 501,
+          source: 'The Quietus',
+          source_url: 'https://thequietus.com/articles/juana-molina-doga',
+          snippet: 'A record that dissolves the line between song and texture.',
+          author: 'A. Critic',
+          published_at: '2024-03-15',
+          rating: '8.0',
+        },
+        {
+          album_id: 777,
+          source: 'Pitchfork',
+          source_url: 'https://pitchfork.com/reviews/albums/example',
+          snippet: 'The most quietly radical thing she has made.',
+          author: null,
+          published_at: null,
+          rating: null,
+        },
+      ]);
+      const result = await lookupCriticReviewsByAlbumIds([501, 777]);
+
+      expect(result.get(501)).toEqual([
+        {
+          source: 'The Quietus',
+          url: 'https://thequietus.com/articles/juana-molina-doga',
+          snippet: 'A record that dissolves the line between song and texture.',
+          author: 'A. Critic',
+          publishedDate: '2024-03-15',
+          rating: '8.0',
+        },
+      ]);
+      expect(result.get(777)).toEqual([
+        {
+          source: 'Pitchfork',
+          url: 'https://pitchfork.com/reviews/albums/example',
+          snippet: 'The most quietly radical thing she has made.',
+        },
+      ]);
+      // An album with no matching rows is absent from the map entirely (not
+      // present with an empty array) — the caller treats the two identically.
+      expect(result.has(999)).toBe(false);
+    });
+
+    it('caps each album at CRITIC_REVIEWS_LIMIT (5), keeping the newest-first rows', async () => {
+      // Rows arrive pre-ordered by the query's ORDER BY (album_id, then
+      // published_at DESC NULLS LAST, id DESC) — six rows for one album, the
+      // 6th (oldest) must be dropped by the per-bucket cap.
+      const rows = Array.from({ length: 6 }, (_, i) => ({
+        album_id: 501,
+        source: `Source ${i}`,
+        source_url: `https://example.com/${i}`,
+        snippet: `Snippet ${i}`,
+        author: null,
+        published_at: `2024-01-${String(10 - i).padStart(2, '0')}`, // descending
+        rating: null,
+      }));
+      mockRowsQueue.push(rows);
+
+      const result = await lookupCriticReviewsByAlbumIds([501]);
+      const bucket = result.get(501);
+      expect(bucket).toHaveLength(5);
+      expect(bucket?.map((r) => r.source)).toEqual(['Source 0', 'Source 1', 'Source 2', 'Source 3', 'Source 4']);
+    });
+
+    it('pins the (album_id, published_at DESC NULLS LAST, id DESC) ORDER BY contract', async () => {
+      mockRowsQueue.push([]);
+      await lookupCriticReviewsByAlbumIds([501]);
+      expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+      expect(chainSpy.orderBy).toHaveBeenCalledWith('album_id', expect.anything(), expect.anything());
     });
   });
 });

--- a/tests/unit/services/flowsheet.attachCriticReviews.test.ts
+++ b/tests/unit/services/flowsheet.attachCriticReviews.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for the batched critic-review attach (album-critic-reviews
+ * slice, ADR 0012; BS#1870). Modeled on
+ * `tests/unit/services/flowsheet.attachUpcomingShows.test.ts`:
+ *   - `attachCriticReviews` does exactly ONE `lookupCriticReviewsByAlbumIds`
+ *     call for a feed page (the no-N+1 guarantee), then fans each album's
+ *     reviews onto every track row carrying that `album_id` — id-arm only,
+ *     no name-arm fallback (unlike `attachUpcomingShows`'s BS#1613 hybrid);
+ *   - flag off (`CRITIC_REVIEWS_ENABLED` via `getConfig().enabled`) short-
+ *     circuits before the DB, mirroring the `proxy.controller.test.ts`
+ *     `criticReviews attach (ADR 0012)` suite's flag-mocking style;
+ *   - `transformToV2` emits `critic_reviews` only when present, so a
+ *     no-match or flag-off track row is byte-identical to its pre-1870 shape.
+ *
+ * `@wxyc/database` resolves to tests/mocks/database.mock.ts (see
+ * jest.unit.config.ts), so these pin the pure batching + fan-out logic
+ * without PostgreSQL. The `album-metadata-lookup.service`'s own SQL-shape
+ * tests (ORDER BY, cap, wire projection) live in
+ * tests/unit/services/album-metadata-lookup.service.test.ts.
+ */
+// Type-only: erased at compile time, so these are safe alongside the
+// jest.mock(...) of runtime exports below.
+import type { IFSEntry, IFSEntryMetadata } from '../../../apps/backend/controllers/flowsheet.controller';
+import type { CriticReviewItem } from '@wxyc/shared/dtos';
+
+const mockCriticReviewsConfig = jest.fn<() => { enabled: boolean }>(() => ({ enabled: false }));
+jest.mock('../../../apps/backend/config/criticReviews', () => ({
+  getConfig: mockCriticReviewsConfig,
+}));
+
+import { attachCriticReviews, transformToV2 } from '../../../apps/backend/services/flowsheet.service';
+import * as albumMetadataLookupService from '../../../apps/backend/services/album-metadata-lookup.service';
+
+const nullMetadata: IFSEntryMetadata = {
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+};
+
+const createTrackEntry = (overrides: Partial<IFSEntry> = {}): IFSEntry => ({
+  id: 1,
+  show_id: 100,
+  album_id: 501,
+  rotation_id: null,
+  entry_type: 'track',
+  track_title: 'la paradoja',
+  track_position: null,
+  album_title: 'DOGA',
+  artist_name: 'Juana Molina',
+  record_label: 'Sonamos',
+  label_id: null,
+  play_order: 1,
+  request_flag: false,
+  segue: false,
+  message: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  rotation_bin: null,
+  on_streaming: null,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  metadata_status: 'pending',
+  enriching_since: null,
+  radio_hour: null,
+  metadata: nullMetadata,
+  artist_id: 4211,
+  ...overrides,
+});
+
+const makeReview = (overrides: Partial<CriticReviewItem> = {}): CriticReviewItem => ({
+  source: 'The Quietus',
+  url: 'https://thequietus.com/articles/juana-molina-doga',
+  snippet: 'A record that dissolves the line between song and texture.',
+  ...overrides,
+});
+
+describe('attachCriticReviews (BS#1870, id-arm only)', () => {
+  let lookup: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockCriticReviewsConfig.mockReturnValue({ enabled: false });
+    lookup = jest.spyOn(albumMetadataLookupService, 'lookupCriticReviewsByAlbumIds');
+  });
+
+  it('flag off: leaves every entry untouched and never touches the DB', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: false });
+    const entries = [createTrackEntry({ id: 1, album_id: 501 })];
+    const result = await attachCriticReviews(entries);
+    expect(result).toBe(entries);
+    expect(lookup).not.toHaveBeenCalled();
+    expect(entries[0].critic_reviews).toBeUndefined();
+  });
+
+  it('flag on, no linked track rows (all album_id null or non-track): skips the DB', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const entries = [
+      createTrackEntry({ id: 1, entry_type: 'show_start', album_id: 501 }), // marker
+      createTrackEntry({ id: 2, album_id: null }), // free-text track, no linked album
+    ];
+    await attachCriticReviews(entries);
+    expect(lookup).not.toHaveBeenCalled();
+    expect(entries[1].critic_reviews).toBeUndefined();
+  });
+
+  it('flag on: does exactly ONE lookupCriticReviewsByAlbumIds call for an N-row page, deduped by album_id', async () => {
+    lookup.mockResolvedValueOnce(new Map());
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const entries = [
+      createTrackEntry({ id: 1, album_id: 501 }),
+      createTrackEntry({ id: 2, album_id: 501 }), // duplicate album_id
+      createTrackEntry({ id: 3, album_id: 777 }),
+      createTrackEntry({ id: 4, album_id: null }), // no linked album
+      createTrackEntry({ id: 5, entry_type: 'talkset', album_id: 999 }), // non-track
+    ];
+    await attachCriticReviews(entries);
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    const [albumIds] = lookup.mock.calls[0];
+    expect(new Set(albumIds)).toEqual(new Set([501, 777]));
+  });
+
+  it('attaches reviews only to entries whose album_id matches, absent elsewhere', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const review = makeReview();
+    lookup.mockResolvedValueOnce(new Map([[501, [review]]]));
+    const entries = [
+      createTrackEntry({ id: 1, album_id: 501 }),
+      createTrackEntry({ id: 2, album_id: 501 }), // same album, also matches
+      createTrackEntry({ id: 3, album_id: 777 }), // no reviews for this album
+      createTrackEntry({ id: 4, album_id: null }), // free-text, no album
+    ];
+    await attachCriticReviews(entries);
+
+    expect(entries[0].critic_reviews).toEqual([review]);
+    expect(entries[1].critic_reviews).toEqual([review]);
+    expect(entries[2].critic_reviews).toBeUndefined();
+    expect(entries[3].critic_reviews).toBeUndefined();
+  });
+
+  it('never attaches by artist name — only album_id is consulted (id-arm only, no name-arm)', async () => {
+    // Even though this free-text track shares the artist name of a
+    // reviewed album, it carries no album_id (unlinked play) and must not
+    // pick up the review via any fuzzy name match.
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    lookup.mockResolvedValueOnce(new Map([[501, [makeReview()]]]));
+    const entries = [createTrackEntry({ id: 1, album_id: null, artist_name: 'Juana Molina', album_title: 'DOGA' })];
+    await attachCriticReviews(entries);
+    expect(lookup).not.toHaveBeenCalled(); // no linked track row at all
+    expect(entries[0].critic_reviews).toBeUndefined();
+  });
+
+  it('leaves an entry untouched when the lookup returns an empty array for its album', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    lookup.mockResolvedValueOnce(new Map([[501, []]]));
+    const entries = [createTrackEntry({ id: 1, album_id: 501 })];
+    await attachCriticReviews(entries);
+    expect(entries[0].critic_reviews).toBeUndefined();
+  });
+
+  it('leaves an entry untouched when its album_id is absent from the returned map', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    lookup.mockResolvedValueOnce(new Map());
+    const entries = [createTrackEntry({ id: 1, album_id: 501 })];
+    await attachCriticReviews(entries);
+    expect(entries[0].critic_reviews).toBeUndefined();
+  });
+
+  // Sentry BACKEND-SERVICE-2T / BS#1864: mirrors attachUpcomingShows's
+  // defensive guard against a transient nullish array element.
+  it('tolerates a nullish array element positioned after a real linked track', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const review = makeReview();
+    lookup.mockResolvedValueOnce(new Map([[501, [review]]]));
+    const validEntry = createTrackEntry({ id: 1, album_id: 501 });
+    const entries = [validEntry, undefined] as IFSEntry[];
+
+    await expect(attachCriticReviews(entries)).resolves.toBe(entries);
+
+    expect(validEntry.critic_reviews).toEqual([review]);
+    expect(entries[1]).toBeUndefined();
+  });
+
+  it('skips the DB when the only entries are a nullish element and a non-matchable marker', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const entries = [undefined, createTrackEntry({ id: 2, entry_type: 'show_start' })] as IFSEntry[];
+    await expect(attachCriticReviews(entries)).resolves.toBe(entries);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});
+
+describe('transformToV2 critic_reviews projection (BS#1870)', () => {
+  it('emits critic_reviews on a track row when the attach matched', () => {
+    const reviews = [makeReview()];
+    const entry = createTrackEntry({ critic_reviews: reviews });
+    const result = transformToV2(entry);
+    expect(result.critic_reviews).toBe(reviews);
+  });
+
+  it('omits the key entirely on a no-match track row (parity with pre-1870)', () => {
+    const entry = createTrackEntry(); // critic_reviews undefined
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('critic_reviews');
+  });
+
+  it('omits the key on an empty critic_reviews array (defensive)', () => {
+    const entry = createTrackEntry({ critic_reviews: [] });
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('critic_reviews');
+  });
+
+  it('never emits critic_reviews on a non-track (marker) row', () => {
+    const reviews = [makeReview()];
+    const entry = createTrackEntry({
+      entry_type: 'show_start',
+      critic_reviews: reviews,
+    });
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('critic_reviews');
+  });
+});

--- a/tests/unit/services/flowsheet.attachCriticReviews.test.ts
+++ b/tests/unit/services/flowsheet.attachCriticReviews.test.ts
@@ -28,6 +28,11 @@ jest.mock('../../../apps/backend/config/criticReviews', () => ({
   getConfig: mockCriticReviewsConfig,
 }));
 
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 import { attachCriticReviews, transformToV2 } from '../../../apps/backend/services/flowsheet.service';
 import * as albumMetadataLookupService from '../../../apps/backend/services/album-metadata-lookup.service';
 
@@ -198,6 +203,26 @@ describe('attachCriticReviews (BS#1870, id-arm only)', () => {
     const entries = [undefined, createTrackEntry({ id: 2, entry_type: 'show_start' })] as IFSEntry[];
     await expect(attachCriticReviews(entries)).resolves.toBe(entries);
     expect(lookup).not.toHaveBeenCalled();
+  });
+
+  // BS#1872 review-bounce: attachCriticReviews is Promise.all'd with
+  // attachUpcomingShows at all 5 GET /flowsheet call sites, and
+  // CRITIC_REVIEWS_ENABLED is already true in prod, so a rejection here
+  // must not propagate — that would 500 the hottest public endpoint on a
+  // mere album_critic_reviews DB blip. Mirrors proxy.controller.ts's
+  // "strictly additive, must never break the response" contract for the
+  // same lookup on the metadata-proxy serve path.
+  it('degrades to no cards and reports to Sentry when the batched lookup rejects, instead of rejecting itself', async () => {
+    mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+    const dbError = new Error('connection terminated unexpectedly');
+    lookup.mockRejectedValueOnce(dbError);
+    const entries = [createTrackEntry({ id: 1, album_id: 501 })];
+
+    await expect(attachCriticReviews(entries)).resolves.toBe(entries);
+
+    expect(entries[0].critic_reviews).toBeUndefined();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][0]).toBe(dbError);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `critic_reviews` to the V2 flowsheet track wire shape, populated at feed-assembly time (mirrors the existing `upcoming_show` concert-embed donor).
- New batched `lookupCriticReviewsByAlbumIds(albumIds)` in `album-metadata-lookup.service.ts` — one indexed `album_critic_reviews` query per page (`WHERE album_id = ANY(...)`), grouped and capped at `CRITIC_REVIEWS_LIMIT` (5) per album in JS, ordered `published_at DESC NULLS LAST, id DESC`. Extracted `projectCriticReviewRow` so it and the existing single-album `lookupCriticReviewsByAlbumId` can't drift on the wire projection.
- New `attachCriticReviews(entries)` in `flowsheet.service.ts`, gated on `CRITIC_REVIEWS_ENABLED` (`getCriticReviewsConfig().enabled`) — **id-arm only**, keyed strictly on the track's linked `album_id`, with no name-arm fuzzy match (unlike the concerts hybrid, BS#1613). Flag off or no linked track rows ⇒ zero DB calls.
- `transformToV2` emits `critic_reviews` on the track case only when present, so a no-match or flag-off row stays byte-identical to its pre-1870 shape.
- Wired at the same 5 call sites `attachUpcomingShows` uses in `flowsheet.controller.ts` (`getEntries`'s three branches, `getLatest`, `getShowInfo`), run concurrently with `attachUpcomingShows` via `Promise.all` since the two attaches touch disjoint fields.
- Documents (rather than engineers around) the watermark-staleness note: the weekly `album-critic-reviews-etl` doesn't advance the flowsheet watermark, so a freshly-written review can stay behind a stale 304 for a few minutes.

## Test plan

- [x] `tests/unit/services/flowsheet.attachCriticReviews.test.ts` (new): flag off → untouched + zero DB calls; no linked track rows → zero DB calls; reviews land only on matching `album_id`, absent elsewhere; id-arm only (no name-arm); `transformToV2` emits `critic_reviews` only when present.
- [x] `tests/unit/services/album-metadata-lookup.service.test.ts`: new `lookupCriticReviewsByAlbumIds` suite — empty input, no-match, per-album grouping + wire projection, cap-at-5 ordering, ORDER BY contract.
- [x] `tests/unit/controllers/flowsheet.controller.test.ts`: wiring assertions at all 5 call sites; nullish-anomaly case asserts `attachCriticReviews` is not called.
- [x] `tests/unit/routes/flowsheet.singleValidator.route.test.ts`: updated the whole-module `flowsheet.service` mock to include the new export.
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run test:unit` — 5492/5492 passing

Closes #1870