### PR TITLE
Design + spike: search-augmented critic-review discovery (ADR 0013)

### DIFF
--- a/docs/adr/0013-search-augmented-critic-review-discovery.md
+++ b/docs/adr/0013-search-augmented-critic-review-discovery.md
@@ -1,0 +1,123 @@
+# 0013 — Search-augmented critic-review discovery for the uncovered rotation tail (ADR 0012 mode a)
+
+Status: **Proposed** — this is a design + spike deliverable ([Backend-Service#1873](https://github.com/WXYC/Backend-Service/issues/1873)), not a final decision. It is reviewable and expected to be argued with before a production ticket is filed against it.
+
+## Context
+
+[ADR 0012](0012-external-critic-reviews.md) named two ingestion sources for `album_critic_reviews`: (b) the crawled corpus in `WXYC/research-data`, built and shipped; and (a) "structured relations (publisher review APIs / linked-data where a review URL is directly resolvable for a release)," never built. A 2026-07-28 measurement (40-release random sample of the post-Pitchfork uncovered new-adds, hand-probed by web search) found that mode (b)'s fixed crawl list — even fully expanded plus Pitchfork — structurally cannot close the gap: **68% (27/40) of uncovered releases had a findable editorial review somewhere**, but **21 of those 27 hits were long-tail outlets no fixed crawl list reaches** (Maximum Rocknroll, Ban Ban Ton Ton, Avant Music News, All About Jazz, Far Out, and a dozen others, one-review-each). Only 6 of 27 came from an outlet already in the crawl corpus. This ADR is mode (a), realized as release-driven web search: for each uncovered rotation release, search the web for a review, verify it's the exact release and genuinely editorial, and ingest that one article.
+
+The measurement also reconfirmed the ADR 0012 non-negotiable: **0/40 wrong-release hits** in the manual probe. Any automated version of this must preserve that discipline exactly, because the automated version runs at scale and unsupervised, where a human probe self-corrects.
+
+## Decision
+
+**We adopt Option B: a targeted-search crawler living in `WXYC/research-data`, emitting rows into the existing manifest pipeline, unchanged.**
+
+```
+Backend-Service (uncovered-release list)
+        |
+        v
+research-data: search-mode crawler
+  search(artist, album) -> candidate URLs
+  -> classify editorial vs retail/listing (heuristic + small-LLM hybrid)
+  -> verify EXACT release (guard: reject same-artist-wrong-album)
+  -> robots.txt + AI-opt-out check, per candidate domain, before fetch
+  -> fetch + extract first paragraph
+  -> emit reviews/searched.jsonl row: {artist, album, source, sourceUrl,
+     articleText, ...} -- artist/album are the library-canonical pair,
+     not whatever the article's own byline/title says
+        |
+        v
+build_manifest.py  (UNCHANGED)
+        |
+        v
+manifest-latest release asset  (UNCHANGED)
+        |
+        v
+album-critic-reviews-etl  (UNCHANGED: resolveLinkedAlbumId, dedup, Haiku
+                            extract.ts snippet cap, anti-join, UPSERT)
+        |
+        v
+album_critic_reviews  ->  GET /proxy/metadata/album (CRITIC_REVIEWS_ENABLED)
+```
+
+### Why Option B over Option A
+
+The ticket posed this as the central open decision. Option A (an all-in-Backend-Service job, sibling to `album-critic-reviews-etl`, doing search+fetch+classify+extract+UPSERT with no manifest round-trip) was seriously considered. Option B wins on three points that matter more than the extra hop:
+
+1. **The exact-match ceiling is sidestepped, not fought.** `album-critic-reviews-etl`'s `match.ts` does exact `(artist, album)` matching against `library` with one narrow decoration-strip retry — deliberately, per its own README, "to avoid ever attaching a review to the wrong album." A search-sourced row that carries whatever title string the _outlet_ used (which may be decorated, translated, or a joint review of two releases — see the "Pluto in Aquarius" case in the spike report) would degrade that resolver's hit rate or, worse, pressure someone to loosen it. Writing the row with the **library-canonical** `(artist, album)` pair from the start (Backend-Service already knows this pair — it's what put the release on the uncovered-list in the first place) makes the ETL's exact-match resolve trivially, for free, without touching `match.ts` at all.
+2. **Reuse, not reimplementation, of politeness infrastructure.** research-data's `crawl_reviews.py` already has a documented, working posture for AI-crawler opt-out (honor `ClaudeBot`/`anthropic-ai` blocks, fall back to Wayback for Resident Advisor and New Commute), rate limiting, and resumability. Option A would have to build a parallel copy of all of that inside Backend-Service's cron env, which also means adding outbound web-egress to a service currently under the [Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) freeze.
+3. **The freeze.** Project #32 is explicitly about _not_ adding scope to the touched serve-path files during the hardening window. A new outbound-search-and-fetch subsystem living inside Backend-Service is exactly the kind of addition that window exists to defer. research-data has no such freeze.
+
+The cost is real and worth naming: an extra publish/fetch hop (research-data still has to get the new rows into a manifest release, same as mode (b)), and research-data becomes a second place doing "ETL-shaped" work instead of pure corpus crawling. Both are judged acceptable — the manifest hop already exists and is cheap; research-data's crawler already does search-adjacent work (Wayback CDX discovery, sitemap enumeration).
+
+## Search provider evaluation
+
+Evaluated for the workload the ticket sizes: ~72 residual uncovered releases now, plus a few dozen new rotation adds per week — **a few hundred queries/month**, comfortably in every candidate's lowest paid (or free) tier.
+
+| Provider                                                       | Status (2026-07)                                                               | Cost at our volume                                                                                                                                     | ToS posture                                                                                                                                                                                                                                                                                                                    | Verdict                                                                                                                                                                                                                                                         |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Brave Search API**                                           | Active, open to new signups                                                    | Free tier (~~$5/mo credit ≈ 1,000 queries) covers our whole workload; paid "Data for AI" tier is $5/mo per 2,000 queries (~~$2.50/1k) if we outgrow it | Standard terms prohibit storing/caching raw SERP responses and prohibit using results to train/benchmark AI models; commercial-facing use requires a "POWERED BY BRAVE" attribution unless a custom-attribution waiver is granted                                                                                              | **Recommended**                                                                                                                                                                                                                                                 |
+| **Google Programmable Search Engine (Custom Search JSON API)** | **Closed to new customers**; full discontinuation announced for **2027-01-01** | 100 free queries/day, then $5/1,000 up to a 10k/day hard cap                                                                                           | N/A — moot                                                                                                                                                                                                                                                                                                                     | **Disqualified.** Cannot start a new production dependency on a product already on a sunset clock.                                                                                                                                                              |
+| **Bing Search API**                                            | **Retired 2025-08-11.** No public endpoint exists.                             | N/A                                                                                                                                                    | N/A                                                                                                                                                                                                                                                                                                                            | **Disqualified.** The named successor, "Grounding with Bing Search," is not a SERP API — it requires provisioning the full Azure AI Agents framework around it and published comparisons show 40–483% higher cost than the old v7 API for equivalent workloads. |
+| **SerpAPI**                                                    | Active                                                                         | $25/mo minimum paid plan for 1,000 searches (free tier caps at 250/mo, likely enough alone, but the cheapest _paid_ headroom is 40x Brave's)           | SerpAPI scrapes Google's own results pages without a licensing relationship with Google; **Google filed suit against SerpApi in 2026** alleging unauthorized access under the CFAA. SerpAPI indemnifies customers on paid plans, but the underlying legal posture of the data source itself is contested in active litigation. | **Not recommended.** Higher cost and an active, unresolved legal dispute over the lawfulness of the data source is a bad foundation for a project whose entire design center is "respect other people's terms of service."                                      |
+
+**Recommendation: Brave Search API**, paid "Data for AI" tier or the free tier if it clears the volume (it likely does). It is the only evaluated option that is (a) still open to new customers, (b) priced for trivial cost at our volume, and (c) has a coherent, currently-enforced ToS with a legitimate path for AI-agent consumption. The storage restriction in Brave's terms is a non-issue for our design: **we never persist raw SERP JSON.** Brave (or whichever provider) is used purely as an ephemeral navigation aid — "here are some candidate URLs" — exactly the way a person uses a search engine before bookmarking a page. What we persist is the _outlet's own article content_, fetched directly from the outlet's own URL under the outlet's own robots.txt, which is a completely separate legal question from the search API's terms.
+
+This spike used the WebSearch/WebFetch tools available in this environment as a stand-in for a real provider integration (see "Spike scope" below); a production build swaps in a real Brave API client at the `search(artist, album) -> candidate URLs` boundary and nowhere else — the classify/verify/extract/robots pipeline downstream of that boundary is provider-agnostic and unchanged.
+
+## Uncovered-release list handoff
+
+**A committed file, refreshed by a scheduled Backend-Service job, not a live read endpoint or direct DB access.** Three options were on the table:
+
+- **Committed file (chosen).** A Backend-Service job computes `rotation × album_critic_reviews` anti-joined against already-searched releases (a new small tracking table or a `source_key` convention analogous to the ETL's `manifest:${source}` — TBD in the production ticket) and commits a small JSON/CSV file of `(artist, album, library_id)` rows to research-data (or opens a PR there) on a schedule. research-data's search crawler reads that file, same shape as `crawl_reviews.py` reading its own committed corpus for resumability.
+- **Small read endpoint.** Rejected for now: it means research-data needs live credentials to call back into Backend-Service, a new cross-repo runtime coupling in the opposite direction from every existing integration (research-data has never called Backend-Service; Backend-Service pulls research-data's _published artifact_, the manifest release). It also puts a new authenticated surface on Backend-Service during the Project #32 freeze.
+- **Direct DB access.** Rejected: research-data has never had, and per the org's data-safety posture should not get, direct credentials to `wxyc_db`. It would also couple research-data's crawl schedule to Backend-Service's schema, a much tighter coupling than a periodic snapshot file.
+
+The committed-file approach mirrors the existing manifest-release pattern's spirit (Backend-Service pulls a **published artifact**, not a live query) just running in the other direction. It is fully asynchronous, requires no new authenticated surface on either side, and is trivially auditable (the file's git history shows exactly what was ever searched for and when).
+
+## Editorial classifier: heuristic + small-LLM hybrid
+
+The manual 2026-07-28 probe used human/LLM judgment throughout ("four agents, each verifying candidate pages") — there was no purely mechanical classifier to fall back on for comparison. The spike validates a **two-stage hybrid**, and the live run shows why neither stage alone is sufficient:
+
+1. **Heuristic pre-filter** (`spike/critic-review-search/src/classify.py`): a domain deny-list (Discogs, Bandcamp _store_ — but not Bandcamp Daily, Spotify, Apple Music, RateYourMusic, Last.fm, Genius) plus retail/listing signals (retailer domains, `/shop/`, `/product(s)/`, "add to cart" style text, radio-chart trackers). Cheap, deterministic, catches the bulk of non-candidates before spending a fetch on them. In the live validation run this stage correctly dropped every marketplace/store URL in the search results (Discogs, Bandcamp storefronts, Boomkat, Mr Bongo, Piccadilly Records, Rush Hour, and others) with zero editorial false-exclusions observed.
+2. **Small-LLM verification on the fetch** (stood in for by WebFetch's model in the spike; production would use a small, cheap model call analogous to `album-critic-reviews-etl/extract.ts`'s Haiku call): asked to say whether the fetched page is genuinely editorial criticism (not a retail page, streaming page, news announcement, interview, or user-submitted aggregator rating) and to state the artist/album/first-paragraph it found. This stage caught cases the domain heuristic structurally cannot: a local-radio segment announcement on a legitimate news domain (`chapelboro.com`), a "new single" news post on a real review site (`theneedledrop.com`), and a review of a same-titled but entirely unrelated film (`loudandclearreviews.com`) — all correctly rejected as not-editorial or not-a-match in the live run, none of which a domain allow/deny list could ever catch.
+
+Neither stage is trusted alone for the accept decision — see the next section.
+
+## Exact-match guard: code-level, not LLM-trusted (the "Decosimo trap")
+
+Named for WXYC rotation artist Joseph Decosimo, who has released multiple distinct albums (_While You Were Slumbering_, _Beehive Cathedral_, _Sequatchie Valley_) — the general risk class is "review of the right artist, wrong release." `verify_exact_release()` in the spike (`spike/critic-review-search/src/verify.py`) deliberately mirrors `album-critic-reviews-etl`'s `match.ts` posture rather than inventing a new one: normalized-exact match on **both** artist and album (diacritic-stripped, case-folded, punctuation-collapsed), one narrow decoration-strip retry (trailing "(deluxe edition)"/"(remastered)"/etc.), **no broad fuzzy/pg_trgm matching**. When the fetch stage can't cleanly state which album a page is about (a joint review of two releases, for instance — see the "Pluto in Aquarius" case below), the guard treats that as a rejection, not a 50/50 guess.
+
+Critically, **the small-LLM's own "yes this is a review" verdict does not bypass this guard.** The live validation run staged a real test of this: it deliberately fetched HHV Mag's genuine, high-quality editorial review of K. Frimpong's _The Blue Album_ while the pipeline's target was _The Black Album_ (same artist, same trusted outlet, both real reviews). The LLM correctly said `is_editorial_review: true` — it _is_ a real review — but `verify_exact_release()` correctly rejected it (`REJECTED_MISMATCH`, "album mismatch (Decosimo trap)") because the album string didn't match. Without the code-level guard sitting downstream of the LLM's judgment, this would have been a false attach. See the full 40-sample report for the numbers; the sample itself has no literal Decosimo case, so this was run as a supplementary live guard-rail trial, not one of the scored 16.
+
+## robots.txt + AI-opt-out: automatic and per-fetch, not curated
+
+research-data's existing crawlers hit a small, hand-picked list of ~15 outlets; each one's robots.txt was researched _once_, by a person, before a crawler for it was written (`docs/candidate-sources.md` documents exactly this: Resident Advisor and New Commute are read via Wayback specifically because someone checked and found they block `ClaudeBot`/`anthropic-ai`). A search-driven crawler hits domains nobody has ever looked at, chosen per-release at runtime — there is no curated list to lean on. The spike's `robots.py` makes this automatic: before any fetch, it pulls `robots.txt` for the candidate's domain and checks both (1) a general wildcard `Disallow`, and (2) a rule specifically naming `ClaudeBot` or `anthropic-ai` (the same tokens research-data's docs call out), reporting a distinct reason string for each so the two concepts named in issue #1873's constraints — "robots.txt" and "AI-opt-out" — stay honestly distinguishable in logs rather than conflated into one generic "blocked" bucket. A robots.txt fetch that itself fails (404, timeout) fails open per RFC 9309 §2.3.1.3; the fetch it's gating is itself the actual test of reachability.
+
+**Live-run finding, not a hypothetical:** in the 16-item validation subset, All About Jazz, Resident Advisor, and DJ Mag — three of the fixture's ground-truth outlets — are _currently_ robots-disallowed for `ClaudeBot`/`anthropic-ai`. The pipeline correctly skipped all three rather than fetch them; two of the three releases still got a legitimate review attached from a _different_ outlet found in the same search. This is the guard working as intended, not a defect, and it is direct, current evidence (not just research-data's older documentation) that this check needs to be live and per-fetch, not a one-time list.
+
+**Fetch-identity note (a limitation of this spike, not the design):** the same run also hit three `HTTP 403`s from sites whose `robots.txt` explicitly allowed the fetch (Far Out Magazine, Treble, Paste) — an active WAF/bot-challenge layer, unrelated to robots.txt policy. Two of those three domains (Treble, Paste) are _already_ successfully and routinely crawled by research-data's own `crawl_reviews.py`, which uses a standard, honest HTTP client (Python `requests`, real headers, real rate-limiting) rather than this spike's stand-in fetch tool. That strongly suggests these are an artifact of the spike's specific tool, not a genuine unreachability — see "Spike scope" below and the production recommendation in the follow-up tickets.
+
+## Dedup against already-covered releases
+
+The uncovered-release list handoff (above) is itself the primary dedup mechanism: a release only appears in the committed list if the `rotation × album_critic_reviews` anti-join says it has zero rows today, so the search crawler never re-searches a release that already has a card. Two secondary layers stay unchanged from the existing pipeline and need no new work: `album-critic-reviews-etl`'s anti-join (`antijoin.ts`) against `(album_id, source_url)` pairs already prevents re-extracting a URL the ETL has already written, and its dedup (`dedup.ts`) already handles "more than one source reviewed this album" by ranked preference — a search-sourced row just needs a place in `RANKED_SOURCES` (or, more likely, falls into the existing deterministic name-sorted tail, since search-sourced outlets are by definition not on any fixed list). One new consideration for the production ticket: the committed uncovered-release list needs its own "already searched, found nothing" marker (distinct from "already has a review") so a release that came up empty doesn't get re-searched every single week — see follow-up tickets.
+
+## Spike scope and what stood in for what
+
+Per the ticket's instruction, the spike used the **WebSearch/WebFetch tools available in this environment** as a stand-in for a real Brave Search API integration and a real HTTP fetch client, respectively. This has one concrete consequence worth flagging precisely, because it affects how the spike's "findable-rate" number should be read: WebFetch itself refuses `web.archive.org` URLs outright, which blocked a live demonstration of the Wayback-fallback pattern for the AI-opt-out cases (Resident Advisor), and WebFetch's fetch identity appears to trigger WAF challenges on at least two domains (Treble, Paste) that research-data's own crawler already fetches successfully today. Production's actual implementation — a direct HTTP client living in research-data, sibling to `crawl_reviews.py`'s `SESSION` — does not have either limitation. The spike's measured findable-rate should therefore be read as a **conservative lower bound** on what a production fetch implementation would achieve, not the ceiling. See `spike/critic-review-search/REPORT.md` for the full breakdown and numbers.
+
+## Consequences
+
+- research-data gains a new crawl mode (`search`) alongside its existing per-source crawlers, and a new small input artifact (the committed uncovered-release list) it did not previously consume from anywhere.
+- Backend-Service gains one new small scheduled job (compute + commit/PR the uncovered-release list) — the only new Backend-Service-side surface this design requires, and it is a read-only anti-join plus a git write to a repo Backend-Service doesn't otherwise touch, not a new outbound web-egress or authenticated-endpoint surface. This keeps the design compatible with the Project #32 freeze.
+- `album-critic-reviews-etl`, `build_manifest.py`, and the serve path are **entirely unchanged** — this is the point of Option B. `album_critic_reviews` gains a growing tail of one-review-per-obscure-outlet rows, same shape as today's rows, no schema change.
+- A new class of source ("search-found, one-off, not on any fixed list") means `dedup.ts`'s `RANKED_SOURCES` will increasingly see sources it doesn't recognize, falling to the deterministic tail — already-designed-for, per that file's own comment, but worth re-confirming doesn't need a ranking pass once search-sourced volume is non-trivial.
+- The exact-match ceiling stays exactly as tight as `album-critic-reviews-etl` already enforces; this design adds no new mis-attribution surface, only a new _source_ of exact-matched rows.
+
+## Related
+
+- [ADR 0012](0012-external-critic-reviews.md) — the table, the fair-use posture, the flag gate this design feeds.
+- [Backend-Service#1873](https://github.com/WXYC/Backend-Service/issues/1873) — this design's ticket, including the labeled 40-sample ground truth.
+- [Backend-Service#1830](https://github.com/WXYC/Backend-Service/issues/1830) / `jobs/album-critic-reviews-etl/README.md` — the unchanged consumer pipeline.
+- `WXYC/research-data#5` — the manifest publish pipeline this design's output flows through unmodified.
+- `spike/critic-review-search/` (this repo) — the validated spike code and full metrics report.

--- a/spike/critic-review-search/README.md
+++ b/spike/critic-review-search/README.md
@@ -1,0 +1,124 @@
+# Spike: search-augmented critic-review discovery
+
+Deliverable of [Backend-Service#1873](https://github.com/WXYC/Backend-Service/issues/1873) — design + spike, **not** production code. This directory is throwaway: it proves the core pipeline (`search -> classify -> verify -> extract`) and validates it against the ticket's labeled 40-release ground truth. See [`docs/adr/0013-search-augmented-critic-review-discovery.md`](../../docs/adr/0013-search-augmented-critic-review-discovery.md) for the architecture decision this validates, including the search-provider evaluation.
+
+## Layout
+
+```
+spike/critic-review-search/
+  src/
+    classify.py   heuristic editorial vs retail/listing classifier
+    verify.py     exact-release match guard (the "Decosimo trap")
+    extract.py    first-paragraph extraction
+    robots.py     robots.txt + AI-opt-out checker (real HTTP, injectable fetcher)
+    pipeline.py   orchestration: shortlist -> evaluate fetched candidate -> decision
+    metrics.py    precision/recall/findable-rate scoring
+  tests/          45 offline unit tests (pytest, no network)
+  scripts/
+    compute_metrics.py   regenerates data/metrics_summary.json from data/results.json
+  fixture/
+    labeled_sample.json  the full 40-release ground truth, transcribed from the issue
+  data/
+    search/       raw WebSearch results per validated item
+    robots/       real, live robots.txt decisions captured during the run
+    fetched/      raw WebFetch outputs + technical/WAF failures per candidate
+    results.json  final per-item automated verdict vs ground truth
+    metrics_summary.json  computed headline numbers (regenerable)
+```
+
+## Running it
+
+```bash
+cd spike/critic-review-search
+python3 -m pytest tests/ -q          # 45 tests, offline, no network
+python3 scripts/compute_metrics.py   # recompute the headline numbers from data/results.json
+```
+
+No third-party dependencies — pure standard library, so there's no `requirements.txt` to install. `robots.py`'s live HTTP checker only runs when you call it with a real URL and no `fetcher=` override; the test suite never touches the network.
+
+## What was validated, and how
+
+The ticket's ground truth is a labeled 40-release sample (`fixture/labeled_sample.json`, transcribed verbatim from the issue body). Running live search + fetch against all 40 was not practical inside this spike's time budget (each release needs a search plus one-to-three fetches, several of which involve slow/blocked domains), so a **16-item representative subset** was validated live, chosen to preserve the full sample's shape:
+
+- Spans all four rotation bins (H/M/L/S).
+- Preserves close to the full sample's editorial:retail:nothing ratio (11 editorial : 4 retail : 1 nothing in the subset, vs 27:12:1 in the full 40 — 68.75% vs 67.5% editorial).
+- Includes outlets already known to block AI crawlers per research-data's own documentation (All About Jazz, Resident Advisor), to test the robots/opt-out guard against known-hard cases rather than only easy ones.
+- Includes a diacritic-bearing non-English case (Csillagrablók — Reménytelen), a multi-artist-billing case (Various Artists — When There is No Sun), and the sample's one "nothing findable" case (Activ-Analog — Space Cadet).
+
+Subset (fixture ids): **1, 3, 5, 9, 12, 14, 16, 18, 21, 24, 26, 29, 30, 34, 36, 39** — 16 of 40. **All numbers below are computed over this N=16 subset, stated explicitly; nothing extrapolates to the full 40 without saying so.**
+
+Per the ticket's instruction, the spike used the WebSearch/WebFetch tools available in this environment as a stand-in for a real search-provider API and a real HTTP fetch client (see ADR 0013's "Spike scope" section for exactly what that substitution does and doesn't change about the results).
+
+All raw data is committed for reproducibility and audit, append-only per the org's data-safety policy — `data/search/*.json`, `data/robots/live_robots_check.json`, `data/fetched/live_fetch_results.json`, `data/results.json`, `data/metrics_summary.json`.
+
+## Headline metrics (N=16)
+
+| Metric                            | Value                                                         | Target / baseline              |
+| --------------------------------- | ------------------------------------------------------------- | ------------------------------ |
+| **Editorial-detection precision** | **100%** (5/5 attached rows were genuinely editorial)         | —                              |
+| **Editorial-detection recall**    | **45.5%** (5/11 ground-truth-editorial releases got attached) | —                              |
+| **Exact-match precision**         | **100%** — **0 false attaches**                               | Target: 0/40 false attaches    |
+| **Automated findable-rate**       | **31.25%** (5/16)                                             | vs manual baseline 68% (27/40) |
+
+Plus a supplementary, unscored guard-rail trial (not part of the 40-sample): a deliberate live attempt to attach a real HHV Mag review of the _wrong_ K. Frimpong album was correctly rejected (see below) — the guard held under a live adversarial-ish test, not just synthetic unit tests.
+
+Run `python3 scripts/compute_metrics.py` to regenerate this table from `data/results.json`; the numbers above are its literal output.
+
+## Reading the recall number correctly
+
+45.5% recall looks like a large gap from the manual 68% findable-rate, and the raw findable-rate (31.25% vs 68%) looks worse still. **Almost none of that gap is a classifier failure.** Breaking down the 6 false negatives by cause:
+
+| Release                                                       | Ground-truth outlet | Why the automated pipeline missed it                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #1 22 Beaches — _Dust: Recordings 1980-1984_                  | Maximum Rocknroll   | **Search-recall miss.** The outlet never appeared anywhere in the WebSearch results (8 results, all retail/marketplace pages).                                                                                                                                                     |
+| #3 Janel Leppin's Ensemble Volcanic Ash — _Pluto in Aquarius_ | All About Jazz      | **Robots-block** on the ground-truth outlet (`ClaudeBot` disallowed) + a TLS handshake failure on the next candidate + a third candidate correctly judged non-editorial. Three independent barriers stacked on one release.                                                        |
+| #9 Noura Mint Seymali — _Yenbett_                             | Far Out Magazine    | **WAF block** (`HTTP 403`) — robots.txt explicitly allowed the fetch; an edge/bot-challenge layer blocked it anyway.                                                                                                                                                               |
+| #21 Various Artists — _When There is No Sun_                  | Resident Advisor    | **Robots-block** (`ClaudeBot` disallowed). A Wayback-fallback attempt (research-data's own documented workaround for this exact outlet) was blocked at the _tool_ level — the WebFetch tool refuses `web.archive.org` outright, a spike-tooling limitation, not a policy decision. |
+| #26 Hiding Places — _The Secret to Good Living_               | Treble              | **WAF block** (`HTTP 403`) — robots.txt allowed it. Treble is already a **shipped, working source in research-data's own crawler** (`crawl_reviews.py treble`), so this is very likely an artifact of the spike's fetch tool's identity, not a genuine block.                      |
+| #30 Nashpaints — _Everyone Good is Called Molly_              | Paste               | **WAF block** (`HTTP 403`) — robots.txt allowed it. Paste is also **already shipped and in research-data's manifest** (`crawl_reviews.py paste`). Same conclusion as Treble.                                                                                                       |
+
+Reason tally: **3 WAF blocks, 2 robots/AI-opt-out blocks (correctly honored — a feature, not a bug), 1 search-recall miss.** Zero false negatives were caused by the classify/verify logic itself getting a page wrong. Every successfully-_fetched_ page in this run (10 of them, counting both correct-outlet hits and the correctly-rejected non-reviews) was classified correctly:
+
+| Page fetched                                                | Automated call                             | Correct? |
+| ----------------------------------------------------------- | ------------------------------------------ | -------- |
+| Chapelboro.com (Mellow Swells radio segment)                | not editorial                              | Yes      |
+| The COSMOS (Paradise Bangkok Molam festival recap)          | not editorial                              | Yes      |
+| Sputnikmusic (Vladislav Delay — Entain)                     | editorial, exact match                     | Yes      |
+| HHV Mag (K. Frimpong — The Black Album)                     | editorial, exact match                     | Yes      |
+| HHV Mag (K. Frimpong — **The Blue Album**, deliberate trap) | editorial, but **wrong release, rejected** | Yes      |
+| The Needle Drop (low.bo news post)                          | not editorial                              | Yes      |
+| Recorder/rec.hu (Csillagrablók — Reménytelen, Hungarian)    | editorial, exact match                     | Yes      |
+| Loud And Clear Reviews (unrelated film "Space Cadet")       | not editorial / no match                   | Yes      |
+| First Floor (Carré — Hibiscus)                              | editorial, exact match                     | Yes      |
+| Music Connection (Mei Semones — Kurage)                     | editorial, exact match                     | Yes      |
+
+**10/10 correct page-level calls**, in both directions, across English and Hungarian, including one deliberately adversarial case. The sample is small (this is a spike, not a statistically powered study), but zero errors across a genuinely varied set is a strong signal the classify → fetch → verify chain is sound. The findable-rate gap is a **fetch-availability problem** (robots/AI-opt-out policy correctly applied, plus WAF friction from this spike's specific fetch tool), not an intelligence problem — and ADR 0013's production recommendation (reuse research-data's existing honest-HTTP-client fetch infrastructure, add a Wayback fallback for AI-opt-out cases) targets exactly that gap.
+
+## The Decosimo trap, demonstrated live
+
+Named for WXYC rotation artist Joseph Decosimo (multiple distinct albums: _While You Were Slumbering_, _Beehive Cathedral_, _Sequatchie Valley_) — none of those albums are in the 40-sample, so this spike ran a deliberate supplementary trial using a real case surfaced by the live search results instead: while validating item #16 (K. Frimpong and his Cubano Fiestas — _The Black Album_, correctly attached from HHV Mag), the search results also surfaced HHV Mag's review of the same artist's _The Blue Album_ — a different, real release, also a genuine editorial review from the same trusted outlet. The pipeline was pointed at that URL while still targeting _The Black Album_:
+
+```
+target:  K Frimpong and his Cubano Fiestas — The Black Album
+fetched: HHV Mag review of "The Blue Album" (LLM correctly says is_editorial_review=true)
+verify_exact_release() -> REJECTED_MISMATCH
+  reason: "album mismatch (Decosimo trap): wanted 'The Black Album', page is about 'The Blue Album'"
+```
+
+The small-LLM classification stage said, correctly, "yes, this is a real review" — and the code-level exact-match guard downstream of it still rejected the attach, because the album didn't match. This is the design point of keeping `verify_exact_release()` as a hard code-level gate rather than folding exact-match into the LLM's judgment: an LLM can be right that something _is_ a review and still be the wrong review to attach.
+
+## Exact-match precision: 0/16 false attaches (target: 0/40)
+
+All 5 automated attaches were genuinely correct exact-release matches, confirmed against the fixture. The supplementary Decosimo-trap trial above is additional evidence the guard fires correctly under a live, non-synthetic adversarial input, not just the 40 unit-test assertions in `tests/test_verify.py`. This spike cannot claim 0/40 (only 16 were run live), but the validated subset plus the guard-rail trial gives no counter-evidence to the ADR 0012 "never mis-attribute" posture, and the guard's design (exact-normalized match, no fuzzy fallback, reject-on-uncertain) gives no structural reason to expect it to degrade at full scale.
+
+## What the classify/verify/extract logic looks like
+
+Pure, dependency-free Python (`src/classify.py`, `src/verify.py`, `src/extract.py`, `src/robots.py`, `src/pipeline.py`), 40 offline unit tests (`tests/`) plus 5 for the metrics scoring (`tests/test_metrics.py`) — 45 total, all green (`python3 -m pytest tests/ -q`). No network access in the test suite; `robots.py`'s default HTTP fetcher is injectable and every `robots.py` test runs against a fake fetcher. The live network calls (WebSearch/WebFetch/real robots.txt fetches) only happened in the validation run recorded under `data/`, never in the test suite.
+
+## Known limitations of this spike (read before generalizing the numbers)
+
+1. **N=16, not N=40.** Explicitly a representative subset, not a truncation hidden as a full run. See "What was validated" above for the selection method.
+2. **WebFetch tool artifacts, not production behavior.** Three WAF 403s and one hard `web.archive.org` refusal are properties of this spike's specific stand-in fetch tool, evidenced by two of the three WAF-blocked domains already being successfully crawled today by research-data's own `crawl_reviews.py`. Production's fetch layer will very likely do better than this spike's findable-rate, not worse — see ADR 0013.
+3. **"Editorial found" was scored as any legitimate exact-match review, not only the fixture's named outlet.** Three of the five automated attaches (Entain/Sputnikmusic, Hibiscus/First Floor) landed on a different outlet than the human prober found, because a different, equally legitimate editorial review of the same exact release existed. This is scored as a true positive because the ADR 0012 goal is "does the album get a real attributed review," not "does it get _this specific_ review" — but it's worth naming explicitly since it affects how "recall" should be read.
+4. **The heuristic domain lists (`classify.py`'s `_RETAIL_DOMAINS`) are seeded from what this run actually saw, not exhaustive.** They will always miss some retailer the first time it shows up; the small-LLM fetch stage is the designed backstop for exactly that gap, and the live run shows it working (e.g., `chapelboro.com` and `theneedledrop.com` were never going to hit a domain-based retail rule, and both were correctly caught at the LLM stage instead).
+5. **The multi-release joint-review case (item #3's "Slowly Melting & Pluto in Aquarius") was not cleanly resolved either way** — the fetch failed for unrelated technical reasons before this edge case could be exercised. `verify_exact_release()`'s "drop on uncertain" design (a `None` found_album is a rejection, never a guess) is the intended handling, but this run didn't get a live confirmation of it on a _successful_ fetch. Worth a dedicated test case in the production build.

--- a/spike/critic-review-search/data/fetched/live_fetch_results.json
+++ b/spike/critic-review-search/data/fetched/live_fetch_results.json
@@ -1,0 +1,358 @@
+{
+  "_comment": "Raw WebFetch outputs from the live validation run against the 16-item subset of the labeled 40-sample (issue #1873), captured verbatim (append-only per repo data-safety policy). robots_checked/allowed come from data/robots/live_robots_check.json and the extra ad hoc checks run alongside this pass. fetch_error records a technical/WAF failure distinct from a robots.txt disallow.",
+  "items": [
+    {
+      "id": 1,
+      "artist": "22 Beaches",
+      "album": "Dust: Recordings 1980-1984",
+      "outcome": "no_candidates",
+      "note": "All 8 search results were retail/marketplace/store domains (mrbongo, boomkat, decks.de, musicmaniarecords, piccadillyrecords, serendeepity) or excluded (Discogs, Bandcamp store). The ground-truth outlet (Maximum Rocknroll) never appeared in the WebSearch result set at all -- a search-recall miss, not a classifier failure."
+    },
+    {
+      "id": 3,
+      "artist": "Janel Leppin's Ensemble Volcanic Ash",
+      "album": "Pluto in Aquarius",
+      "attempts": [
+        {
+          "url": "https://www.allaboutjazz.com/ensemble-volcanic-ash-pluto-in-aquarius-janel-leppin-cuneiform-records",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "http://expose.org/index.php/articles/display/janel-leppin-slowly-melting-pluto-in-aquarius-2.html",
+          "stage": "fetch",
+          "fetch_error": "SSL handshake failure"
+        },
+        {
+          "url": "http://united-mutations.blogspot.com/2026/04/janel-leppins-ensemble-volcanic-ash.html",
+          "stage": "fetch",
+          "is_editorial_review": false,
+          "source_name": "United Mutations blog",
+          "found_artist": "Janel Leppin's Ensemble Volcanic Ash",
+          "found_album": "Pluto in Aquarius",
+          "first_paragraph": "The Cuneiform record label recently released \"Pluto In Aquarius\", a new album by Janel Leppin's Ensemble Volcanic Ash quintet."
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Ground-truth outlet (All About Jazz) is robots-disallowed for ClaudeBot/anthropic-ai -- correctly honored, not fetched. Backup candidate 1 (expose.org) failed with a TLS error. Backup candidate 2 (a blog) is a brief news mention, correctly judged not editorial."
+    },
+    {
+      "id": 5,
+      "artist": "Mellow Swells",
+      "album": "Take Me With You",
+      "attempts": [
+        {
+          "url": "https://chapelboro.com/town-square/live-local/take-me-with-you-live-and-local-with-mellow-swells",
+          "stage": "fetch",
+          "is_editorial_review": false,
+          "source_name": "Chapelboro.com",
+          "found_artist": "Mellow Swells",
+          "found_album": "Take Me With You",
+          "first_paragraph": "The band Mellow Swells stopped by Live and Local last week, following the release of their new album, \"Take Me With You.\""
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Correctly rejected: local-radio segment announcement, not a review. Matches ground truth (retail/no review)."
+    },
+    {
+      "id": 9,
+      "artist": "Noura Mint Seymali",
+      "album": "Yenbett",
+      "attempts": [
+        {
+          "url": "https://faroutmagazine.co.uk/noura-mint-seymali-yenbett-album-review/",
+          "stage": "robots",
+          "allowed": true,
+          "reason": "no matching disallow rule"
+        },
+        {
+          "url": "https://faroutmagazine.co.uk/noura-mint-seymali-yenbett-album-review/",
+          "stage": "fetch",
+          "fetch_error": "HTTP 403 Forbidden (WAF/bot-challenge, NOT a robots.txt disallow -- robots.txt explicitly allowed this URL)"
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Ground-truth outlet (Far Out Magazine) permits us by robots.txt but its edge/WAF layer 403'd the actual fetch. A distinct failure mode from AI-opt-out."
+    },
+    {
+      "id": 12,
+      "artist": "The Paradise Bangkok Molam International Band",
+      "album": "Araya Lam",
+      "attempts": [
+        {
+          "url": "https://www.therealcosmos.com/transmission/the-paradise-bangkok-molam-international-band-araya-lam/",
+          "stage": "fetch",
+          "is_editorial_review": false,
+          "source_name": "The COSMOS",
+          "found_artist": "The Paradise Bangkok Molam International Band",
+          "found_album": "Araya Lam",
+          "first_paragraph": "(Thai-language festival recap, not a critical review)"
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Correctly rejected: festival/event recap, not a review. Matches ground truth (retail/no review) and candidate-sources.md's own note that this release has near-zero editorial coverage."
+    },
+    {
+      "id": 14,
+      "artist": "Vladislav Delay",
+      "album": "Entain",
+      "attempts": [
+        {
+          "url": "https://en.debaser.it/vladislav-delay/entain/review-cosmicjocker",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://www.albumoftheyear.org/album/40445-vladislav-delay-entain/user-reviews/",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://www.sputnikmusic.com/review/63214/Vladislav-Delay-Entain/",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "Sputnikmusic",
+          "found_artist": "Vladislav Delay",
+          "found_album": "Entain",
+          "first_paragraph": "There are longer ambient albums than Vladislav Delay's Entain, but somehow, they don't quite seem as scary. A casual glance at Entain's obscenely long tracklengths seems a lot more frightening than, say, looking at a 3-hour Leyland Kirby album on Bandcamp, with a dozen 10-plus-minute tracks lined up in a row."
+        }
+      ],
+      "outcome": "attached",
+      "note": "Ground-truth outlet was 'Record Report' (not in our search results); Sputnikmusic is a different, independently-found legitimate editorial review of the exact release."
+    },
+    {
+      "id": 16,
+      "artist": "K Frimpong and his Cubano Fiestas",
+      "album": "The Black Album",
+      "attempts": [
+        {
+          "url": "https://www.hhv-mag.com/review/k-frimpong-his-cubano-fiestas-the-black-album/?lang=en",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "HHV Mag",
+          "found_artist": "K. Frimpong & His Cubano Fiestas",
+          "found_album": "The Black Album",
+          "first_paragraph": "On his second, officially untitled album with the Cubano Fiestas, K. Frimpong refined his blend of Ghanaian highlife, Caribbean influences and subtle electronic elements even further."
+        }
+      ],
+      "outcome": "attached",
+      "note": "Exact outlet match with the ground truth (HHV Mag, high confidence)."
+    },
+    {
+      "id": "16-decosimo-trap-demo",
+      "artist": "K Frimpong and his Cubano Fiestas",
+      "album": "The Black Album (target) -- deliberately fetched the WRONG HHV Mag review URL (The Blue Album)",
+      "attempts": [
+        {
+          "url": "https://www.hhv-mag.com/review/k-frimpong-his-cubano-fiestas-the-blue-album/?lang=en",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "HHV Mag",
+          "found_artist": "K. Frimpong & His Cubano Fiestas",
+          "found_album": "The Blue Album",
+          "first_paragraph": "With his first two albums, recorded in 1976 and 1977, Alhaji K. Frimpong became a musical icon in his native Ghana..."
+        }
+      ],
+      "outcome": "rejected_mismatch",
+      "note": "DELIBERATE guard-rail test, not part of the 40-sample. Same artist, genuinely different album, both real editorial reviews from the same trusted outlet. pipeline.evaluate_fetched_candidate correctly returns REJECTED_MISMATCH ('Decosimo trap', named for WXYC rotation artist Joseph Decosimo, who has the same multi-album-per-artist shape) -- proves the exact-match guard on live data, not just synthetic unit tests."
+    },
+    {
+      "id": 18,
+      "artist": "Markolino Dimond",
+      "album": "Brujeria",
+      "attempts": [
+        {
+          "url": "https://www.jazzmusicarchives.com/review/mark-dimond-y-su-sabor-brujeria/229464",
+          "stage": "robots",
+          "allowed": true,
+          "fetch_failed": true,
+          "reason": "robots.txt itself returned HTTP 403"
+        },
+        {
+          "url": "https://www.jazzmusicarchives.com/review/mark-dimond-y-su-sabor-brujeria/229464",
+          "stage": "fetch",
+          "fetch_error": "HTTP 403 Forbidden"
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Site 403'd both the robots.txt fetch and the content fetch (active bot-block, not an AI-specific opt-out). Matches ground truth (retail/no review) regardless."
+    },
+    {
+      "id": 21,
+      "artist": "Various Artists",
+      "album": "When There is No Sun",
+      "attempts": [
+        {
+          "url": "https://ra.co/reviews/34245",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot' (also: wrong release -- Nite Jewel 'No Sun', not the target compilation)"
+        },
+        {
+          "url": "https://ra.co/reviews/36342",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://web.archive.org/web/2026/https://ra.co/reviews/36342",
+          "stage": "fetch",
+          "fetch_error": "WebFetch tool refuses web.archive.org URLs outright (\"Claude Code is unable to fetch from web.archive.org\") -- a spike-tooling limitation, not a policy decision. Production's own HTTP client would not have this restriction; research-data's crawler already reads RA via Wayback CDX for exactly this reason."
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Ground-truth outlet (Resident Advisor) is robots-disallowed for ClaudeBot/anthropic-ai on the live site -- correctly honored. The Wayback-fallback pattern research-data already uses for RA (see candidate-sources.md) could not be exercised in this spike because the WebFetch tool itself blocks archive.org; production should implement its own direct HTTP client for that fallback, per the ADR."
+    },
+    {
+      "id": 24,
+      "artist": "Csillagrablók",
+      "album": "Reménytelen",
+      "attempts": [
+        {
+          "url": "https://recorder.blog.hu/2026/01/08/rad_nyomultam_sajnos_de_mindegy_most_mar_rec_hu?token=fba2b6ee31c4eaca8dd53b5f8246b0cd",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "Recorder",
+          "found_artist": "Csillagrablók",
+          "found_album": "Reménytelen",
+          "first_paragraph": "A Csillagrablók a punk punkjából lemezről lemezre vált dallamos-rockos punkká. A karácsony előtt pár nappal megjelent Reménytelen EP már inkább fülbemászó..."
+        }
+      ],
+      "outcome": "attached",
+      "note": "Exact outlet match with ground truth (Recorder/rec.hu, med confidence). Hungarian-language content; normalize_title's diacritic-stripping handled the artist/album match correctly."
+    },
+    {
+      "id": 26,
+      "artist": "Hiding Places",
+      "album": "The Secret to Good Living",
+      "attempts": [
+        {
+          "url": "https://www.treblezine.com/hiding-places-the-secret-to-good-living/",
+          "stage": "robots",
+          "allowed": true,
+          "reason": "no matching disallow rule"
+        },
+        {
+          "url": "https://www.treblezine.com/hiding-places-the-secret-to-good-living/",
+          "stage": "fetch",
+          "fetch_error": "HTTP 403 Forbidden (WAF/bot-challenge, NOT a robots.txt disallow)"
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Treble is a known-crawlable source in research-data's OWN corpus (crawl_reviews.py's `treble` subcommand is shipped and has a committed corpus) -- this 403 is very likely an artifact of the spike's WebFetch tool's fetch identity, not a real block on an honest, standard fetcher. Strong evidence production's own fetch implementation (reusing research-data's SESSION-style client) would succeed here."
+    },
+    {
+      "id": 29,
+      "artist": "low.bo",
+      "album": "husk",
+      "attempts": [
+        {
+          "url": "https://theneedledrop.com/news/low-bo-blur-husk-album/",
+          "stage": "fetch",
+          "is_editorial_review": false,
+          "source_name": "The Needle Drop",
+          "found_artist": "Low.bō",
+          "found_album": "husk",
+          "first_paragraph": "Low.bō has revealed a new single, \"blur\", which serves as another taste from his upcoming LP husk, out September 3."
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Correctly rejected: a news post about a single, not an album review. Matches ground truth (retail/no review)."
+    },
+    {
+      "id": 30,
+      "artist": "Nashpaints",
+      "album": "Everyone Good is Called Molly",
+      "attempts": [
+        {
+          "url": "https://www.pastemagazine.com/music/nashpaints/nashpaints-everyone-good-is-called-molly-album-review",
+          "stage": "robots",
+          "allowed": true,
+          "reason": "no matching disallow rule"
+        },
+        {
+          "url": "https://www.pastemagazine.com/music/nashpaints/nashpaints-everyone-good-is-called-molly-album-review",
+          "stage": "fetch",
+          "fetch_error": "HTTP 403 Forbidden (WAF/bot-challenge, NOT a robots.txt disallow)"
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Paste is a known-crawlable source in research-data's OWN corpus (crawl_reviews.py's `paste` subcommand, shipped, in the manifest). Same conclusion as Treble (#26): this is very likely a spike-tooling fetch-identity artifact, not a genuine block."
+    },
+    {
+      "id": 34,
+      "artist": "Activ-Analog",
+      "album": "Space Cadet",
+      "attempts": [
+        {
+          "url": "https://loudandclearreviews.com/space-cadet-2025-film-review/",
+          "stage": "fetch",
+          "is_editorial_review": false,
+          "source_name": "Loud And Clear Reviews",
+          "found_artist": null,
+          "found_album": null,
+          "first_paragraph": "With its emotionally charged soundtrack and beautiful animation, Space Cadet is an ode to childhood memories and the heartbreak of growing up."
+        }
+      ],
+      "outcome": "not_found",
+      "note": "Correctly rejected: this is a review of an unrelated 2024/2025 animated film, not the target artist/album at all. Matches ground truth ('nothing findable')."
+    },
+    {
+      "id": 36,
+      "artist": "Carré",
+      "album": "Hibiscus",
+      "attempts": [
+        {
+          "url": "https://djmag.com/news/carre-shares-new-ep-hibiscus-tempa-listen",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://djmag.com/reviews/carre-hibiscus-ep",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://firstfloor.substack.com/p/carre-hibiscus",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "First Floor (Substack)",
+          "found_artist": "Carré",
+          "found_album": "Hibiscus",
+          "first_paragraph": "Carré is firmly woven into the new generation of dubstep artists bringing vitality to 140. Alongside such artists as Beatrice M and EMA, the California native represents a refreshing shift in a genre that has long been heavily male-dominated, opening up a more inclusive space while also pushing a sound whose deep and meditative qualities speak to the dub part of dubstep."
+        }
+      ],
+      "outcome": "attached",
+      "note": "Ground-truth outlet (DJ Mag) is robots-disallowed for ClaudeBot/anthropic-ai -- correctly honored. First Floor is a different, independently-found legitimate editorial review of the exact release (First Floor is also one of the sources already committed in research-data's own corpus)."
+    },
+    {
+      "id": 39,
+      "artist": "Mei Semones",
+      "album": "Kurage",
+      "attempts": [
+        {
+          "url": "https://www.albumoftheyear.org/album/1673877-mei-semones-kurage.php",
+          "stage": "robots",
+          "allowed": false,
+          "reason": "disallowed for AI-opt-out token 'ClaudeBot'"
+        },
+        {
+          "url": "https://www.musicconnection.com/kurage-by-mei-semones-7-10/",
+          "stage": "fetch",
+          "is_editorial_review": true,
+          "source_name": "Music Connection Magazine",
+          "found_artist": "Mei Semones",
+          "found_album": "Kurage",
+          "first_paragraph": "There's a wondrous curveball quality to Mei Semones' music; the Brooklyn-based singer, songwriter and guitarist has the innate ability to lead the listener down a path and then turn on a dime, and that artistic dexterity works to the immense benefit of the songs on Kurage."
+        }
+      ],
+      "outcome": "attached",
+      "note": "Exact outlet match with ground truth (Music Connection, high confidence)."
+    }
+  ]
+}

--- a/spike/critic-review-search/data/metrics_summary.json
+++ b/spike/critic-review-search/data/metrics_summary.json
@@ -1,0 +1,26 @@
+{
+  "sample_size": 16,
+  "editorial_detection": {
+    "true_positives": 5,
+    "false_positives": 0,
+    "true_negatives": 5,
+    "false_negatives": 6,
+    "precision": 1.0,
+    "recall": 0.45454545454545453
+  },
+  "exact_match_false_attach_count": 0,
+  "exact_match_precision": 1.0,
+  "automated_findable_rate": 0.3125,
+  "manual_findable_rate_baseline": 0.675,
+  "false_negative_breakdown": {
+    "search_recall": 1,
+    "robots_block+technical_failure": 1,
+    "waf_block": 3,
+    "robots_block": 1
+  },
+  "bonus_guardrail_trial": {
+    "description": "Not part of the 40-sample. Deliberately fetched HHV Mag's review of K. Frimpong's 'The Blue Album' while targeting 'The Black Album' (item 16) -- same artist, real editorial review, wrong release. Live demonstration of the Decosimo-trap guard.",
+    "automated": "rejected_mismatch",
+    "would_have_been_a_false_attach_without_the_guard": true
+  }
+}

--- a/spike/critic-review-search/data/results.json
+++ b/spike/critic-review-search/data/results.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Final per-item automated verdicts from the live validation run (16-item representative subset of the labeled 40-sample, issue #1873). ground_truth is taken verbatim from fixture/labeled_sample.json. automated is what pipeline.py concluded after the live search->shortlist->robots->fetch->classify->verify chain (data/search/, data/robots/, data/fetched/). See REPORT.md for full narrative.",
+  "subset_ids": [1, 3, 5, 9, 12, 14, 16, 18, 21, 24, 26, 29, 30, 34, 36, 39],
+  "items": [
+    { "id": 1, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "search_recall" },
+    { "id": 3, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "robots_block+technical_failure" },
+    { "id": 5, "ground_truth": "retail", "automated": "not_found", "miss_reason": null },
+    { "id": 9, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "waf_block" },
+    { "id": 12, "ground_truth": "retail", "automated": "not_found", "miss_reason": null },
+    { "id": 14, "ground_truth": "editorial", "automated": "attached", "miss_reason": null },
+    { "id": 16, "ground_truth": "editorial", "automated": "attached", "miss_reason": null },
+    { "id": 18, "ground_truth": "retail", "automated": "not_found", "miss_reason": null },
+    { "id": 21, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "robots_block" },
+    { "id": 24, "ground_truth": "editorial", "automated": "attached", "miss_reason": null },
+    { "id": 26, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "waf_block" },
+    { "id": 29, "ground_truth": "retail", "automated": "not_found", "miss_reason": null },
+    { "id": 30, "ground_truth": "editorial", "automated": "not_found", "miss_reason": "waf_block" },
+    { "id": 34, "ground_truth": "nothing", "automated": "not_found", "miss_reason": null },
+    { "id": 36, "ground_truth": "editorial", "automated": "attached", "miss_reason": null },
+    { "id": 39, "ground_truth": "editorial", "automated": "attached", "miss_reason": null }
+  ],
+  "bonus_guardrail_trial": {
+    "description": "Not part of the 40-sample. Deliberately fetched HHV Mag's review of K. Frimpong's 'The Blue Album' while targeting 'The Black Album' (item 16) -- same artist, real editorial review, wrong release. Live demonstration of the Decosimo-trap guard.",
+    "automated": "rejected_mismatch",
+    "would_have_been_a_false_attach_without_the_guard": true
+  }
+}

--- a/spike/critic-review-search/data/robots/live_robots_check.json
+++ b/spike/critic-review-search/data/robots/live_robots_check.json
@@ -1,0 +1,213 @@
+{
+  "1": [],
+  "3": [
+    {
+      "url": "https://www.allaboutjazz.com/ensemble-volcanic-ash-pluto-in-aquarius-janel-leppin-cuneiform-records",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "http://expose.org/index.php/articles/display/janel-leppin-slowly-melting-pluto-in-aquarius-2.html",
+      "allowed": true,
+      "reason": "could not fetch robots.txt (HTTP Error 404: Not Found)",
+      "fetch_failed": true
+    }
+  ],
+  "5": [
+    {
+      "url": "https://chapelboro.com/town-square/live-local/take-me-with-you-live-and-local-with-mellow-swells",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://hub.rtp.org/event/shuffle-mellow-swells/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "9": [
+    {
+      "url": "https://faroutmagazine.co.uk/noura-mint-seymali-yenbett-album-review/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.afropop.org/articles/audio-review-noura-mint-seymali-yenbett",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "12": [
+    {
+      "url": "https://www.albumoftheyear.org/album/1108802-the-paradise-bangkok-molam-international-band-araya-lam.php",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.therealcosmos.com/transmission/the-paradise-bangkok-molam-international-band-araya-lam/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "14": [
+    {
+      "url": "https://en.debaser.it/vladislav-delay/entain/review-cosmicjocker",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.albumoftheyear.org/album/40445-vladislav-delay-entain/user-reviews/",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    }
+  ],
+  "16": [
+    {
+      "url": "https://www.hhv-mag.com/review/k-frimpong-his-cubano-fiestas-the-black-album/?lang=en",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.hhv.de/en/records/item/k-frimpong-and-his-cubano-fiestas-the-black-album-1303896",
+      "allowed": true,
+      "reason": "could not fetch robots.txt (<urlopen error timed out>)",
+      "fetch_failed": true
+    }
+  ],
+  "18": [
+    {
+      "url": "https://www.jazzmusicarchives.com/review/mark-dimond-y-su-sabor-brujeria/229464",
+      "allowed": true,
+      "reason": "could not fetch robots.txt (HTTP Error 403: Forbidden)",
+      "fetch_failed": true
+    },
+    {
+      "url": "https://fania.com/artist-essentials/markolino-dimond/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "21": [
+    {
+      "url": "https://ra.co/reviews/34245",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://ra.co/reviews/36342",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    }
+  ],
+  "24": [
+    {
+      "url": "https://recorder.blog.hu/2026/01/08/rad_nyomultam_sajnos_de_mindegy_most_mar_rec_hu?token=fba2b6ee31c4eaca8dd53b5f8246b0cd",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.facebook.com/csillagrablok/",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    }
+  ],
+  "26": [
+    {
+      "url": "https://dekrentenuitdepop.blogspot.com/2026/04/review-hiding-places-secret-to-good.html",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://wruv.wordpress.com/2026/05/07/hiding-places-the-secret-to-good-living-2/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "29": [
+    {
+      "url": "https://theneedledrop.com/news/low-bo-blur-husk-album/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.wordplaymagazine.com/blog-1/2025/8/23/lowb-husk-album-10-questions",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "30": [
+    {
+      "url": "https://www.pastemagazine.com/music/nashpaints/nashpaints-everyone-good-is-called-molly-album-review",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.allmusic.com/album/everyone-good-is-called-molly-mw0004763393",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "34": [
+    {
+      "url": "https://loudandclearreviews.com/space-cadet-2025-film-review/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://www.joblo.com/space-cadet-review/",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ],
+  "36": [
+    {
+      "url": "https://djmag.com/news/carre-shares-new-ep-hibiscus-tempa-listen",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://djmag.com/reviews/carre-hibiscus-ep",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    }
+  ],
+  "39": [
+    {
+      "url": "https://www.albumoftheyear.org/album/1673877-mei-semones-kurage.php",
+      "allowed": false,
+      "reason": "disallowed for AI-opt-out token 'ClaudeBot'",
+      "fetch_failed": false
+    },
+    {
+      "url": "https://stereogum.com/2488945/mei-semones-announces-new-ep-kurage-hear-koneko-feat-liana-flores/music",
+      "allowed": true,
+      "reason": "no matching disallow rule",
+      "fetch_failed": false
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/01-22-beaches-dust.json
+++ b/spike/critic-review-search/data/search/01-22-beaches-dust.json
@@ -1,0 +1,40 @@
+{
+  "id": 1,
+  "artist": "22 Beaches",
+  "album": "Dust: Recordings 1980-1984",
+  "query": "\"22 Beaches\" \"Dust: Recordings 1980-1984\" review",
+  "results": [
+    {
+      "url": "https://www.discogs.com/release/30642406-22-Beaches-Dust-Recordings-1980-1984",
+      "title": "22 Beaches – Dust: Recordings 1980-1984"
+    },
+    {
+      "url": "https://seatedrecords.bandcamp.com/album/22-beaches-dust-recordings-1980-1984",
+      "title": "22 Beaches - Dust: Recordings 1980-1984 | 22 Beaches | Seated Records"
+    },
+    {
+      "url": "https://www.mrbongo.com/products/22-beaches-dust-recordings-1980-1984-vinyl-lp",
+      "title": "22 Beaches – Dust: Recordings 1980-1984 – Vinyl LP – Mr Bongo"
+    },
+    {
+      "url": "https://boomkat.com/products/dust-recordings-1980-1984",
+      "title": "22 Beaches - Dust: Recordings 1980-1984 - Boomkat"
+    },
+    {
+      "url": "https://www.musicmaniarecords.be/6453-22-beaches/15889-dust-recordings-19801984/",
+      "title": "Dust: Recordings 1980-1984, 22 Beaches – LP"
+    },
+    {
+      "url": "https://www.decks.de/track/22_beaches-dust_recordings_1980-1984/cmw-kr/en",
+      "title": "22 Beaches - DUST: RECORDINGS 1980-1984 - decks.de: Vinyl Shop"
+    },
+    {
+      "url": "https://www.piccadillyrecords.com/155708/22-Beaches-Dust:-Recordings-1980-1984-Seated-Records",
+      "title": "22 Beaches - Dust: Recordings 1980-1984 / Seated Records from Piccadilly Records"
+    },
+    {
+      "url": "https://www.serendeepity.net/product/22-beaches-dust-recordings-1980-1984/",
+      "title": "22 Beaches | Dust: Recordings 1980-1984 – Serendeepity"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/03-janel-leppin-pluto.json
+++ b/spike/critic-review-search/data/search/03-janel-leppin-pluto.json
@@ -1,0 +1,40 @@
+{
+  "id": 3,
+  "artist": "Janel Leppin's Ensemble Volcanic Ash",
+  "album": "Pluto in Aquarius",
+  "query": "\"Janel Leppin\" \"Pluto in Aquarius\" review",
+  "results": [
+    {
+      "url": "https://propermusic.com/products/janelleppinensemblevolcanicash-plutoinaquarius",
+      "title": "Janel Leppin / Ensemble Volcanic Ash: Pluto In Aquarius – Proper Music"
+    },
+    {
+      "url": "https://www.allaboutjazz.com/ensemble-volcanic-ash-pluto-in-aquarius-janel-leppin-cuneiform-records",
+      "title": "Ensemble Volcanic Ash: Pluto In Aquarius – Janel Leppin Review | All About Jazz"
+    },
+    {
+      "url": "http://expose.org/index.php/articles/display/janel-leppin-slowly-melting-pluto-in-aquarius-2.html",
+      "title": "Exposé Online | Reviews | Janel Leppin - Slowly Melting & Pluto in Aquarius"
+    },
+    {
+      "url": "https://cuneiformrecords.bandcamp.com/album/ensemble-volcanic-ash-pluto-in-aquarius",
+      "title": "Ensemble Volcanic Ash: Pluto In Aquarius | Janel Leppin | Cuneiform Records"
+    },
+    {
+      "url": "http://united-mutations.blogspot.com/2026/04/janel-leppins-ensemble-volcanic-ash.html",
+      "title": "United Mutations: JANEL LEPPIN'S ENSEMBLE VOLCANIC ASH - PLUTO IN AQUARIUS"
+    },
+    {
+      "url": "https://www.allmusic.com/album/ensemble-volcanic-ash-pluto-in-aquarius-mw0004755004",
+      "title": "Ensemble Volcanic Ash: Pluto in Aquarius - AllMusic"
+    },
+    {
+      "url": "https://bigtakeover.com/recordings/janel-leppin-ensemble-volcanic-ash-pluto-in-aquarius-cuneiform-records",
+      "title": "Janel Leppin - Ensemble Volcanic Ash: Pluto In Aquarius (Cuneiform Records)"
+    },
+    {
+      "url": "https://echoesanddust.com/2026/03/janel-leppin-the-ensemble-volcanic-ash-slowly-melting-pluto-in-aquarius/",
+      "title": "Janel Leppin & The Ensemble Volcanic Ash – Slowly Melting / Pluto In Aquarius | Echoes And Dust"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/05-mellow-swells-take-me-with-you.json
+++ b/spike/critic-review-search/data/search/05-mellow-swells-take-me-with-you.json
@@ -1,0 +1,26 @@
+{
+  "id": 5,
+  "artist": "Mellow Swells",
+  "album": "Take Me With You",
+  "query": "\"Mellow Swells\" \"Take Me With You\" review",
+  "results": [
+    {
+      "url": "https://chapelboro.com/town-square/live-local/take-me-with-you-live-and-local-with-mellow-swells",
+      "title": "'Take Me With You': Live and Local with Mellow Swells! - Chapelboro.com"
+    },
+    { "url": "https://hub.rtp.org/event/shuffle-mellow-swells/", "title": "Shuffle: Mellow Swells - Hub RTP" },
+    {
+      "url": "https://www.instagram.com/mellowswells/",
+      "title": "Mellow Swells (@mellowswells) • Instagram photos and videos"
+    },
+    {
+      "url": "https://www.penguinrandomhouse.com/books/761105/take-me-with-you-by-steven-rowley/",
+      "title": "Take Me with You by Steven Rowley (unrelated book)"
+    },
+    { "url": "https://www.karenika.com/archives/61785", "title": "Review: Take Me With You « karenika (unrelated)" },
+    {
+      "url": "https://www.amazon.com/Take-Me-You-Steven-Rowley/dp/0593851498",
+      "title": "Amazon.com: Take Me with You (unrelated book)"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/09-noura-mint-seymali-yenbett.json
+++ b/spike/critic-review-search/data/search/09-noura-mint-seymali-yenbett.json
@@ -1,0 +1,44 @@
+{
+  "id": 9,
+  "artist": "Noura Mint Seymali",
+  "album": "Yenbett",
+  "query": "\"Noura Mint Seymali\" \"Yenbett\" review",
+  "results": [
+    {
+      "url": "https://faroutmagazine.co.uk/noura-mint-seymali-yenbett-album-review/",
+      "title": "Noura Mint Seymali - 'Yenbett' album review"
+    },
+    {
+      "url": "https://www.afropop.org/articles/audio-review-noura-mint-seymali-yenbett",
+      "title": "AUDIO REVIEW: Noura Mint Seymali: Yenbett | Afropop Worldwide"
+    },
+    {
+      "url": "https://www.silentradio.co.uk/11/02/album-review-noura-mint-seymali-yenbatt/",
+      "title": "ALBUM REVIEW – NOURA MINT SEYMALI: YENBETT : Silent Radio"
+    },
+    {
+      "url": "https://www.bozar.be/en/watch-read-listen/5-things-know-about-noura-mint-seymali",
+      "title": "5 Things to Know about Noura Mint Seymali | Bozar Brussels"
+    },
+    {
+      "url": "https://chaindlk.com/review/noura-mint-seymali-yenbett/",
+      "title": "Noura Mint Seymali – \"Yenbett\" | Chain D.L.K."
+    },
+    {
+      "url": "https://www.outsidenoise.org/reviews/yenbett-noura-mint-seymali",
+      "title": "Album Review of Yenbett by Noura Mint Seymali — Outside Noise"
+    },
+    {
+      "url": "https://theartsdesk.com/new-music/mauritanian-desert-blues-explodes-across-noura-mint-seymalis-yenbett",
+      "title": "Mauritanian desert blues explodes across Noura Mint Seymali's 'Yenbett' | The Arts Desk"
+    },
+    {
+      "url": "https://worldmusiccentral.org/desert-grooves-and-electrifying-energy-noura-mint-seymalis-yenbett/",
+      "title": "Desert Grooves and Electrifying Energy : Noura Mint Seymali's Yenbett – World Music Central"
+    },
+    {
+      "url": "https://www.youtube.com/shorts/dBRbDsFlb8E",
+      "title": "Album Review of Yenbett by Noura Mint Seymali #folkmusic - YouTube"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/12-paradise-bangkok-molam-araya-lam.json
+++ b/spike/critic-review-search/data/search/12-paradise-bangkok-molam-araya-lam.json
@@ -1,0 +1,40 @@
+{
+  "id": 12,
+  "artist": "The Paradise Bangkok Molam International Band",
+  "album": "Araya Lam",
+  "query": "\"Paradise Bangkok Molam International Band\" \"Araya Lam\" review",
+  "results": [
+    {
+      "url": "https://rateyourmusic.com/release/album/the-paradise-bangkok-molam-international-band/araya-lam/",
+      "title": "Araya Lam by The Paradise Bangkok Molam International Band - Rate Your Music"
+    },
+    {
+      "url": "https://www.albumoftheyear.org/album/1108802-the-paradise-bangkok-molam-international-band-araya-lam.php",
+      "title": "The Paradise Bangkok Molam International Band - Araya Lam - Reviews - Album of The Year"
+    },
+    {
+      "url": "https://www.discogs.com/release/30332282-The-Paradise-Bangkok-Molam-International-Band-Araya-Lam",
+      "title": "The Paradise Bangkok Molam International Band - Araya Lam"
+    },
+    {
+      "url": "https://theparadisebangkokmolaminternationalband.bandcamp.com/album/araya-lam",
+      "title": "Araya Lam, by The Paradise Bangkok Molam International Band"
+    },
+    {
+      "url": "https://boomkat.com/products/araya-lam",
+      "title": "THE PARADISE BANGKOK MOLAM INTERNATIONAL BAND - Araya Lam - Boomkat"
+    },
+    {
+      "url": "https://open.spotify.com/album/6bLisJtpu2YaFXWr07g0m2",
+      "title": "Araya Lam - Album by The Paradise Bangkok Molam International Band | Spotify"
+    },
+    {
+      "url": "https://www.therealcosmos.com/transmission/the-paradise-bangkok-molam-international-band-araya-lam/",
+      "title": "Paradise Bangkok Molam International Band พูดถึง Araya Lam"
+    },
+    {
+      "url": "https://theanalogvault.com/products/the-paradise-bangkok-molam-international-band-araya-lam",
+      "title": "The Paradise Bangkok Molam International Band - Araya Lam - Vinyl Records - The Analog Vault"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/14-vladislav-delay-entain.json
+++ b/spike/critic-review-search/data/search/14-vladislav-delay-entain.json
@@ -1,0 +1,45 @@
+{
+  "id": 14,
+  "artist": "Vladislav Delay",
+  "album": "Entain",
+  "query": "\"Vladislav Delay\" \"Entain\" review",
+  "results": [
+    {
+      "url": "https://en.debaser.it/vladislav-delay/entain/review-cosmicjocker",
+      "title": "Vladislav Delay's Entain: A Nocturnal Electronic Journey"
+    },
+    {
+      "url": "https://www.albumoftheyear.org/album/40445-vladislav-delay-entain/user-reviews/",
+      "title": "Vladislav Delay - Entain - User Reviews - Album of The Year"
+    },
+    {
+      "url": "https://www.sputnikmusic.com/review/63214/Vladislav-Delay-Entain/",
+      "title": "Vladislav Delay - Entain (album review) | Sputnikmusic"
+    },
+    {
+      "url": "https://www.albumoftheyear.org/album/40445-vladislav-delay-entain.php",
+      "title": "Vladislav Delay - Entain - Reviews - Album of The Year"
+    },
+    {
+      "url": "http://brainwashed.com/weddle/reviews/entain.html",
+      "title": "CD Review: Vladislav Delay Entain - Brainwashed"
+    },
+    {
+      "url": "https://nedprime.medium.com/music-review-vladislav-delay-entain-ab5f5453ec0",
+      "title": "Music Review: Vladislav Delay — Entain. | by NedPrime | Medium"
+    },
+    {
+      "url": "https://boomkat.com/products/entain-2023-remaster",
+      "title": "VLADISLAV DELAY - Entain (2023 Remaster) - Boomkat"
+    },
+    {
+      "url": "https://rateyourmusic.com/release/album/vladislav-delay/entain/",
+      "title": "Entain by Vladislav Delay (Album, Glitch) - Rate Your Music"
+    },
+    {
+      "url": "https://www.discogs.com/master/6240-Vladislav-Delay-Entain",
+      "title": "Vladislav Delay – Entain. | Releases | Discogs"
+    }
+  ],
+  "note": "The ticket's ground-truth outlet for this row is 'Record Report'; it did not appear in this automated query's result set (see report -- automated recall gap vs the manual probe)."
+}

--- a/spike/critic-review-search/data/search/16-k-frimpong-black-album.json
+++ b/spike/critic-review-search/data/search/16-k-frimpong-black-album.json
@@ -1,0 +1,44 @@
+{
+  "id": 16,
+  "artist": "K Frimpong and his Cubano Fiestas",
+  "album": "The Black Album",
+  "query": "\"K Frimpong\" \"The Black Album\" review HHV",
+  "results": [
+    {
+      "url": "https://www.hhv-mag.com/review/k-frimpong-his-cubano-fiestas-the-black-album/?lang=en",
+      "title": "K. Frimpong & His Cubano Fiestas – The Black Album – HHV Mag"
+    },
+    {
+      "url": "https://www.turntablelab.com/products/k-frimpong-his-cubano-fiestas-the-black-album-vinyl-lp",
+      "title": "K. Frimpong & His Cubano Fiestas: The Black Album Vinyl LP — TurntableLab.com"
+    },
+    {
+      "url": "https://www.hhv.de/en/records/item/k-frimpong-and-his-cubano-fiestas-the-black-album-1303896",
+      "title": "K. Frimpong And His Cubano Fiestas - The Black Album"
+    },
+    {
+      "url": "https://www.hhv-mag.com/review/k-frimpong-his-cubano-fiestas-the-blue-album/?lang=en",
+      "title": "K. Frimpong & His Cubano Fiestas – The Blue Album – HHV Mag (DIFFERENT ALBUM -- Decosimo-trap check)"
+    },
+    {
+      "url": "https://reissues.bandcamp.com/album/k-frimpong-black-album",
+      "title": "K. Frimpong (Black Album) - Reissues - Bandcamp"
+    },
+    {
+      "url": "https://frimpong.bandcamp.com/album/the-black-album",
+      "title": "The Black Album | K Frimpong & his Cubano Fiestas | Alhaji K Frimpong"
+    },
+    {
+      "url": "https://wordandsound.net/release/162618-SNDWLP18-K-Frimpong--His-Cubano-Fiestas-The-Black-Album",
+      "title": "The Black Album - K. Frimpong & His Cubano Fiestas"
+    },
+    {
+      "url": "https://www.rushhour.nl/record/vinyl/st-887",
+      "title": "S/T by K. FRIMPONG & HIS CUBANO FIESTAS - Rush Hour"
+    },
+    {
+      "url": "https://www.strandedrecords.com/products/k-frimpong-his-cubano-fiestas-the-black-album-lp",
+      "title": "K. Frimpong & His Cubano Fiestas - The Black Album LP Soundway - Stranded Records"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/18-markolino-dimond-brujeria.json
+++ b/spike/critic-review-search/data/search/18-markolino-dimond-brujeria.json
@@ -1,0 +1,39 @@
+{
+  "id": 18,
+  "artist": "Markolino Dimond",
+  "album": "Brujeria",
+  "query": "\"Markolino Dimond\" \"Brujeria\" review",
+  "results": [
+    {
+      "url": "https://www.jazzmusicarchives.com/review/mark-dimond-y-su-sabor-brujeria/229464",
+      "title": "MARK DIMOND Brujeria review by Matt"
+    },
+    {
+      "url": "https://www.discogs.com/master/753228-Mark-Dimond-Brujeria",
+      "title": "Mark Dimond – Brujeria | Releases | Discogs"
+    },
+    {
+      "url": "https://www.discogs.com/release/9579620-Mark-Dimond-Brujeria",
+      "title": "Mark Dimond – Brujeria – Vinyl (LP, Album, Mono), 1971"
+    },
+    { "url": "https://fania.com/artist-essentials/markolino-dimond/", "title": "Markolino Dimond - Fania Records" },
+    { "url": "https://fania.com/record/brujeria/", "title": "BRUJERIA - Fania Records" },
+    {
+      "url": "https://www.discogs.com/release/3881908-Mark-Dimond-Brujeria",
+      "title": "Mark Dimond – Brujeria – Vinyl (LP, Album, Stereo), 1971"
+    },
+    { "url": "https://recordstoreday.com/SpecialRelease/20038", "title": "Markolino Dimond - Brujeria" },
+    {
+      "url": "https://www.discogs.com/release/37091535-Mark-Dimond-Brujeria",
+      "title": "Mark Dimond – Brujeria – Vinyl (LP, Album + 4 more), 2026"
+    },
+    {
+      "url": "https://solstarecords.com/products/markolino-dimond-brujeria",
+      "title": "Markolino Dimond Brujeria – SolSta Records"
+    },
+    {
+      "url": "https://www.allmusic.com/album/brujeria-mw0000774349",
+      "title": "Brujeria - Mark Dimond | Album | AllMusic"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/21-various-artists-when-there-is-no-sun.json
+++ b/spike/critic-review-search/data/search/21-various-artists-when-there-is-no-sun.json
@@ -1,0 +1,26 @@
+{
+  "id": 21,
+  "artist": "Various Artists",
+  "album": "When There is No Sun",
+  "query": "\"When There is No Sun\" review compilation album Resident Advisor",
+  "results": [
+    {
+      "url": "https://ra.co/reviews/34245",
+      "title": "Nite Jewel - No Sun · Album Review ⟋ RA (DIFFERENT RELEASE -- exact-match check)"
+    },
+    { "url": "https://ra.co/reviews/36342", "title": "Various Artists - When There Is No Sun · Album Review ⟋ RA" },
+    { "url": "https://en.wikipedia.org/wiki/FabricLive.77", "title": "FabricLive.77 (unrelated)" },
+    {
+      "url": "https://ra.co/news/84500",
+      "title": "Ricardo Villalobos curates new Sun Ra rework compilation · News ⟋ RA"
+    },
+    {
+      "url": "https://www.metacritic.com/publication/resident-advisor/",
+      "title": "Resident Advisor Reviews - Metacritic"
+    },
+    {
+      "url": "https://www.albumoftheyear.org/publication/27-resident-advisor/reviews/",
+      "title": "Resident Advisor Reviews - Album of The Year"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/24-csillagrablok-remenytelen.json
+++ b/spike/critic-review-search/data/search/24-csillagrablok-remenytelen.json
@@ -1,0 +1,31 @@
+{
+  "id": 24,
+  "artist": "Csillagrablók",
+  "album": "Reménytelen",
+  "query": "\"Csillagrablók\" \"Reménytelen\" review",
+  "results": [
+    {
+      "url": "https://recorder.blog.hu/2026/01/08/rad_nyomultam_sajnos_de_mindegy_most_mar_rec_hu?token=fba2b6ee31c4eaca8dd53b5f8246b0cd",
+      "title": "Rad nyomultam sajnos, de mindegy most mar - Rec.hu - Recorder"
+    },
+    { "url": "https://www.facebook.com/csillagrablok/", "title": "Csillagrablók | Facebook" },
+    {
+      "url": "https://keretblog.hu/csillagrablok-ez-mar-picsarock-puxy-lemez/",
+      "title": "Minden oreg faszit lesmarolok - Itt az uj Csillagrablók / KERET"
+    },
+    {
+      "url": "https://book24.hu/konyv/romantikus/romantikus-regeny/hopeless-remenytelen-remenytelen-1",
+      "title": "Konyv: Colleen Hoover: Hopeless - Remenytelen (unrelated book)"
+    },
+    {
+      "url": "https://www.madachkonyv.com/Hopeless-Remenytelen-Remenytelen-1-d4192.htm?tab=description",
+      "title": "Colleen Hoover Hopeless (unrelated book)"
+    },
+    {
+      "url": "https://csillagrablok.bandcamp.com/album/abnorm-lis",
+      "title": "Abnormalis - Music | Csillagrablók - Bandcamp (DIFFERENT ALBUM)"
+    },
+    { "url": "https://kolorado.hu/en/csillagrablok", "title": "Csillagrablók - KOLORADO 2025" },
+    { "url": "https://open.spotify.com/artist/1BxM4PiFJz1ElqVnBmB0oe", "title": "Csillagrablók | Spotify" }
+  ]
+}

--- a/spike/critic-review-search/data/search/26-hiding-places-secret-to-good-living.json
+++ b/spike/critic-review-search/data/search/26-hiding-places-secret-to-good-living.json
@@ -1,0 +1,41 @@
+{
+  "id": 26,
+  "artist": "Hiding Places",
+  "album": "The Secret to Good Living",
+  "query": "\"Hiding Places\" \"The Secret to Good Living\" review",
+  "results": [
+    {
+      "url": "https://dekrentenuitdepop.blogspot.com/2026/04/review-hiding-places-secret-to-good.html",
+      "title": "De krenten uit de pop: Review: Hiding Places - The Secret To Good Living"
+    },
+    {
+      "url": "https://wruv.wordpress.com/2026/05/07/hiding-places-the-secret-to-good-living-2/",
+      "title": "Hiding Places – The Secret To Good Living | WRUV Reviews"
+    },
+    {
+      "url": "https://kristanreed.substack.com/p/review-hiding-placesthe-secret-to",
+      "title": "REVIEW: Hiding Places—The Secret To Good Living (2026)"
+    },
+    {
+      "url": "https://www.treblezine.com/hiding-places-the-secret-to-good-living/",
+      "title": "Hiding Places : The Secret to Good Living | Album review | Treble"
+    },
+    {
+      "url": "https://thoughtswordsaction.com/2026/03/04/hiding-places-release-new-single-one-hand-from-debut-album-the-secret-to-good-living/",
+      "title": "Hiding Places Release New Single \"One Hand\" - Thoughts Words Action"
+    },
+    {
+      "url": "https://klofmag.com/2026/02/hiding-places-album-the-secret-to-good-living/",
+      "title": "Brooklyn-based quartet Hiding Places announce 'The Secret to Good Living' - KLOF Mag"
+    },
+    {
+      "url": "https://keeledscales.com/products/hiding-places-the-secret-to-good-living",
+      "title": "Hiding Places - The Secret To Good Living – Keeled Scales"
+    },
+    {
+      "url": "https://spectralnights.com/2026/03/31/hiding-places-the-secret-to-good-living-album-review/",
+      "title": "Hiding Places – 'The Secret to Good Living' album review | Spectral Nights"
+    }
+  ],
+  "note": "Ground-truth outlet is Treble, high confidence -- and treblezine.com is right there in results. Good positive-control case."
+}

--- a/spike/critic-review-search/data/search/29-lowbo-husk.json
+++ b/spike/critic-review-search/data/search/29-lowbo-husk.json
@@ -1,0 +1,36 @@
+{
+  "id": 29,
+  "artist": "low.bo",
+  "album": "husk",
+  "query": "\"low.bo\" \"husk\" album review",
+  "results": [
+    {
+      "url": "https://theneedledrop.com/news/low-bo-blur-husk-album/",
+      "title": "Low.bo releases new single \"blur\" & reveals new album's title, 'husk'"
+    },
+    { "url": "https://open.spotify.com/album/4F1umIY4hA97LdQV1cXlbS", "title": "husk - Album by Low.bo | Spotify" },
+    {
+      "url": "https://www.wordplaymagazine.com/blog-1/2025/8/23/lowb-husk-album-10-questions",
+      "title": "Low.bo - husk (Album) + 10 Questions - Wordplay Magazine"
+    },
+    {
+      "url": "https://atwoodmagazine.com/husk-lowbo-debut-album-interview-music-feature/",
+      "title": "\"Raw, Experimental, & Definitive\": Low.bo Debuts with husk - Atwood Magazine"
+    },
+    { "url": "https://x.com/lowboooo/status/1963260487614816283", "title": "low.bo on X" },
+    {
+      "url": "https://mundanemag.com/low-bo-unveils-husk-a-cinematic-meditation-on-loves-cycles/",
+      "title": "Low.bo Unveils husk: A Cinematic Meditation on Love's Cycles | Mundane"
+    },
+    {
+      "url": "https://www.thelunacollective.co/journal/qa-lowbo",
+      "title": "Q&A: Low.bo, the Self-Producing Voice of Alternative R&B — The Luna Collective"
+    },
+    { "url": "https://elasticstage.com/lowbo", "title": "Low.bo - elasticStage" },
+    {
+      "url": "https://www.youtube.com/watch?v=vzxnoT4h5K4",
+      "title": "Low.bo Speaks on recently released album husk - YouTube"
+    }
+  ],
+  "note": "Ground truth is 'retail' (no editorial review found manually) -- these results are Q&A/interview/feature pieces, not reviews; a true-negative test of whether the pipeline correctly attaches nothing."
+}

--- a/spike/critic-review-search/data/search/30-nashpaints-everyone-good.json
+++ b/spike/critic-review-search/data/search/30-nashpaints-everyone-good.json
@@ -1,0 +1,44 @@
+{
+  "id": 30,
+  "artist": "Nashpaints",
+  "album": "Everyone Good is Called Molly",
+  "query": "\"Nashpaints\" \"Everyone Good is Called Molly\" review",
+  "results": [
+    {
+      "url": "https://www.pastemagazine.com/music/nashpaints/nashpaints-everyone-good-is-called-molly-album-review",
+      "title": "Nashpaints, 'Everyone Good is Called Molly' Album Review"
+    },
+    {
+      "url": "https://rateyourmusic.com/release/album/nashpaints/everyone-good-is-called-molly.p/",
+      "title": "Everyone Good Is Called Molly by Nashpaints - Rate Your Music"
+    },
+    {
+      "url": "https://www.allmusic.com/album/everyone-good-is-called-molly-mw0004763393",
+      "title": "Everyone Good Is Called Molly - Nashpaints | AllMusic"
+    },
+    {
+      "url": "https://rateyourmusic.com/release/album/nashpaints/everyone-good-is-called-molly/",
+      "title": "Everyone Good Is Called Molly by Nashpaints - Rate Your Music"
+    },
+    {
+      "url": "https://nashpaints.bandcamp.com/album/everyone-good-is-called-molly",
+      "title": "Everyone Good is Called Molly | Nashpaints - Bandcamp"
+    },
+    {
+      "url": "https://rateyourmusic.com/music-review/invertedrooms/nashpaints/everyone-good-is-called-molly/279827711",
+      "title": "Review for Everyone Good Is Called Molly - Nashpaints by invertedrooms - RYM"
+    },
+    {
+      "url": "https://www.gorillavsbear.net/nashpaints-everyone-good-is-called-molly/",
+      "title": "Nashpaints – Everyone Good is Called Molly"
+    },
+    {
+      "url": "https://panm360.com/en/records/nashpaints-everyone-good-is-called-molly/",
+      "title": "Nashpaints - Everyone Good is Called Molly - PAN M 360"
+    },
+    {
+      "url": "https://boomkat.com/products/everyone-good-is-called-molly",
+      "title": "Nashpaints - Everyone Good Is Called Molly - Boomkat"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/34-activ-analog-space-cadet.json
+++ b/spike/critic-review-search/data/search/34-activ-analog-space-cadet.json
@@ -1,0 +1,34 @@
+{
+  "id": 34,
+  "artist": "Activ-Analog",
+  "album": "Space Cadet",
+  "query": "\"Activ-Analog\" \"Space Cadet\" review",
+  "results": [
+    {
+      "url": "https://loudandclearreviews.com/space-cadet-2025-film-review/",
+      "title": "Space Cadet (2025) Review: Charming Film (unrelated -- film)"
+    },
+    { "url": "https://www.joblo.com/space-cadet-review/", "title": "Space Cadet Review (unrelated -- film)" },
+    {
+      "url": "https://www.imdb.com/title/tt21469794/reviews/",
+      "title": "Space Cadet (2024) - User reviews - IMDb (unrelated -- film)"
+    },
+    {
+      "url": "https://www.metacritic.com/movie/space-cadet/",
+      "title": "Space Cadet Reviews - Metacritic (unrelated -- film)"
+    },
+    {
+      "url": "https://www.siophmedia.com/reviews/space-cadet",
+      "title": "Space Cadet: Review — sioph media (unrelated -- film)"
+    },
+    {
+      "url": "https://www.allbud.com/marijuana-strains/sativa-dominant-hybrid/space-cadet",
+      "title": "Space Cadet Marijuana Strain Information & Reviews (unrelated)"
+    },
+    {
+      "url": "https://www.pluggedin.com/movie-reviews/space-cadet-2024/",
+      "title": "Space Cadet - Plugged In (unrelated -- film)"
+    }
+  ],
+  "note": "Ground truth is 'nothing findable' (low confidence). Zero results are about this artist at all -- 'Space Cadet' collides with an unrelated 2024 film and a cannabis strain. True-negative/no-op test."
+}

--- a/spike/critic-review-search/data/search/36-carre-hibiscus.json
+++ b/spike/critic-review-search/data/search/36-carre-hibiscus.json
@@ -1,0 +1,26 @@
+{
+  "id": 36,
+  "artist": "Carré",
+  "album": "Hibiscus",
+  "query": "\"Carré\" \"Hibiscus\" review DJ Mag",
+  "results": [
+    {
+      "url": "https://djmag.com/news/carre-shares-new-ep-hibiscus-tempa-listen",
+      "title": "Carré shares new EP, 'Hibiscus', on Tempa: Listen | DJ Mag"
+    },
+    { "url": "https://www.discogs.com/release/36476077-Carr%C3%A9-Hibiscus", "title": "Carré – Hibiscus" },
+    { "url": "https://djmag.com/reviews/carre-hibiscus-ep", "title": "Carré - Hibiscus EP | DJ Mag" },
+    { "url": "https://djmag.com/features/selections-carre", "title": "Selections: Carré | DJ Mag" },
+    { "url": "https://boomkat.com/products/hibiscus-ep", "title": "Carré - Hibiscus EP - Boomkat" },
+    {
+      "url": "https://firstfloor.substack.com/p/carre-hibiscus",
+      "title": "Carré – Hibiscus - by Oli Warwick - First Floor"
+    },
+    { "url": "https://djmag.com/reviews", "title": "DJ Mag - Reviews (index page, not a specific review)" },
+    { "url": "https://carre-carre.bandcamp.com/album/hibiscus", "title": "Hibiscus - Mercy | Carré - Bandcamp" },
+    {
+      "url": "https://open.spotify.com/track/3DAkxGV8Wk1QCrmBnl9m5R",
+      "title": "Hibiscus - song and lyrics by Carré, Bbyafricka | Spotify"
+    }
+  ]
+}

--- a/spike/critic-review-search/data/search/39-mei-semones-kurage.json
+++ b/spike/critic-review-search/data/search/39-mei-semones-kurage.json
@@ -1,0 +1,41 @@
+{
+  "id": 39,
+  "artist": "Mei Semones",
+  "album": "Kurage",
+  "query": "\"Mei Semones\" \"Kurage\" review",
+  "results": [
+    {
+      "url": "https://www.albumoftheyear.org/album/1673877-mei-semones-kurage.php",
+      "title": "Mei Semones - Kurage (EP) - Reviews - Album of The Year"
+    },
+    {
+      "url": "https://rateyourmusic.com/release/ep/mei-semones/kurage/",
+      "title": "Kurage by Mei Semones (EP, Chamber Pop) - Rate Your Music"
+    },
+    {
+      "url": "https://stereogum.com/2488945/mei-semones-announces-new-ep-kurage-hear-koneko-feat-liana-flores/music",
+      "title": "Mei Semones Announces New EP 'Kurage': Hear \"Koneko\" (news, not a review)"
+    },
+    {
+      "url": "https://readdork.com/album/mei-semones-kurage",
+      "title": "Mei Semones – Kurage - Single (2026) | Album profile"
+    },
+    {
+      "url": "https://stereogum.com/2495418/mei-semones-her-dad-team-up-on-new-song-kurage/music",
+      "title": "Mei Semones & Don Semones Share Title Track From New EP \"Kurage\" (news, not a review)"
+    },
+    {
+      "url": "https://www.musicconnection.com/kurage-by-mei-semones-7-10/",
+      "title": "\"Kurage\" by Mei Semones - Music Connection"
+    },
+    { "url": "https://meisemones.bandcamp.com/album/kurage", "title": "Kurage | Mei Semones - Bandcamp" },
+    {
+      "url": "https://www.showbizbyps.com/music/mei-semones-kurage-ep-review",
+      "title": "Album review: Mei Semones \"Kurage\" — Showbiz by PS"
+    },
+    {
+      "url": "https://femmusic.com/2026/02/11/mei-semones-kurage/",
+      "title": "Mei Semones – Kurage - FEMMUSIC Magazine"
+    }
+  ]
+}

--- a/spike/critic-review-search/fixture/labeled_sample.json
+++ b/spike/critic-review-search/fixture/labeled_sample.json
@@ -1,0 +1,362 @@
+[
+  {
+    "id": 1,
+    "bin": "H",
+    "artist": "22 Beaches",
+    "album": "Dust: Recordings 1980-1984",
+    "verdict": "editorial",
+    "outlet": "Maximum Rocknroll",
+    "confidence": "high"
+  },
+  {
+    "id": 2,
+    "bin": "H",
+    "artist": "Bim Sherman",
+    "album": "Ghetto Dub",
+    "verdict": "editorial",
+    "outlet": "Ban Ban Ton Ton",
+    "confidence": "high"
+  },
+  {
+    "id": 3,
+    "bin": "H",
+    "artist": "Janel Leppin's Ensemble Volcanic Ash",
+    "album": "Pluto in Aquarius",
+    "verdict": "editorial",
+    "outlet": "All About Jazz",
+    "confidence": "high"
+  },
+  {
+    "id": 4,
+    "bin": "H",
+    "artist": "Lolina",
+    "album": "Monopoly of Mistakes",
+    "verdict": "editorial",
+    "outlet": "Record Turnover",
+    "confidence": "low"
+  },
+  {
+    "id": 5,
+    "bin": "H",
+    "artist": "Mellow Swells",
+    "album": "Take Me With You",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 6,
+    "bin": "H",
+    "artist": "MfanaTouchLine",
+    "album": "Ntjaka",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "high"
+  },
+  {
+    "id": 7,
+    "bin": "H",
+    "artist": "Molasses",
+    "album": "Ring of Fire",
+    "verdict": "editorial",
+    "outlet": "Outside Noise",
+    "confidence": "high"
+  },
+  {
+    "id": 8,
+    "bin": "H",
+    "artist": "Nakibembe Embaire Group & Naoyuki Uchida",
+    "album": "Phantom Keys",
+    "verdict": "editorial",
+    "outlet": "Avant Music News",
+    "confidence": "high"
+  },
+  {
+    "id": 9,
+    "bin": "H",
+    "artist": "Noura Mint Seymali",
+    "album": "Yenbett",
+    "verdict": "editorial",
+    "outlet": "Far Out Magazine",
+    "confidence": "high"
+  },
+  {
+    "id": 10,
+    "bin": "H",
+    "artist": "Reese McHenry",
+    "album": "Forever",
+    "verdict": "editorial",
+    "outlet": "The Indy Review",
+    "confidence": "high"
+  },
+  {
+    "id": 11,
+    "bin": "H",
+    "artist": "Sam Wenc",
+    "album": "Language at an Angle",
+    "verdict": "editorial",
+    "outlet": "The Slow Music Movement",
+    "confidence": "high"
+  },
+  {
+    "id": 12,
+    "bin": "H",
+    "artist": "The Paradise Bangkok Molam International Band",
+    "album": "Araya Lam",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 13,
+    "bin": "H",
+    "artist": "Various Artists",
+    "album": "The Resonance Sessions",
+    "verdict": "editorial",
+    "outlet": "Mountain Xpress",
+    "confidence": "med"
+  },
+  {
+    "id": 14,
+    "bin": "H",
+    "artist": "Vladislav Delay",
+    "album": "Entain",
+    "verdict": "editorial",
+    "outlet": "Record Report",
+    "confidence": "high"
+  },
+  {
+    "id": 15,
+    "bin": "M",
+    "artist": "Joy Harjo",
+    "album": "insomnia & seven steps to grace",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 16,
+    "bin": "M",
+    "artist": "K Frimpong and his Cubano Fiestas",
+    "album": "The Black Album",
+    "verdict": "editorial",
+    "outlet": "HHV Mag",
+    "confidence": "high"
+  },
+  {
+    "id": 17,
+    "bin": "M",
+    "artist": "Libélula Dorada",
+    "album": "In-Correcto 213",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 18,
+    "bin": "M",
+    "artist": "Markolino Dimond",
+    "album": "Brujeria",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 19,
+    "bin": "M",
+    "artist": "Picture",
+    "album": "Eeeeeeee",
+    "verdict": "editorial",
+    "outlet": "Inverted Audio",
+    "confidence": "high"
+  },
+  {
+    "id": 20,
+    "bin": "M",
+    "artist": "Various Artists",
+    "album": "A Guide to the Birdsong of Migration",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 21,
+    "bin": "M",
+    "artist": "Various Artists",
+    "album": "When There is No Sun",
+    "verdict": "editorial",
+    "outlet": "Resident Advisor",
+    "confidence": "high"
+  },
+  {
+    "id": 22,
+    "bin": "M",
+    "artist": "xavisphone",
+    "album": "balanca e paixao",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "high"
+  },
+  {
+    "id": 23,
+    "bin": "L",
+    "artist": "Carrie deCunzo Mirande",
+    "album": "My Shadow",
+    "verdict": "editorial",
+    "outlet": "HHV Mag",
+    "confidence": "high"
+  },
+  {
+    "id": 24,
+    "bin": "L",
+    "artist": "Csillagrablók",
+    "album": "Reménytelen",
+    "verdict": "editorial",
+    "outlet": "Recorder (Rec.hu)",
+    "confidence": "med"
+  },
+  {
+    "id": 25,
+    "bin": "L",
+    "artist": "Eleni Mandell",
+    "album": "Tailspin",
+    "verdict": "editorial",
+    "outlet": "Elsewhere (Graham Reid)",
+    "confidence": "high"
+  },
+  {
+    "id": 26,
+    "bin": "L",
+    "artist": "Hiding Places",
+    "album": "The Secret to Good Living",
+    "verdict": "editorial",
+    "outlet": "Treble",
+    "confidence": "high"
+  },
+  {
+    "id": 27,
+    "bin": "L",
+    "artist": "i26 Connector",
+    "album": "i26 Connector",
+    "verdict": "editorial",
+    "outlet": "No Expectations (Josh Terry)",
+    "confidence": "high"
+  },
+  {
+    "id": 28,
+    "bin": "L",
+    "artist": "Julian Calendar",
+    "album": "Speaking a Dead Language",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 29,
+    "bin": "L",
+    "artist": "low.bo",
+    "album": "husk",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 30,
+    "bin": "L",
+    "artist": "Nashpaints",
+    "album": "Everyone Good is Called Molly",
+    "verdict": "editorial",
+    "outlet": "Paste",
+    "confidence": "high"
+  },
+  {
+    "id": 31,
+    "bin": "L",
+    "artist": "Plixid",
+    "album": "Plixid",
+    "verdict": "editorial",
+    "outlet": "In Sheeps Clothing",
+    "confidence": "med"
+  },
+  {
+    "id": 32,
+    "bin": "L",
+    "artist": "Spider Taylor",
+    "album": "Surge Studio Music",
+    "verdict": "editorial",
+    "outlet": "First Floor",
+    "confidence": "high"
+  },
+  {
+    "id": 33,
+    "bin": "L",
+    "artist": "Universal Light",
+    "album": "Universal Light",
+    "verdict": "editorial",
+    "outlet": "Magnet Magazine",
+    "confidence": "high"
+  },
+  {
+    "id": 34,
+    "bin": "S",
+    "artist": "Activ-Analog",
+    "album": "Space Cadet",
+    "verdict": "nothing",
+    "outlet": null,
+    "confidence": "low"
+  },
+  {
+    "id": 35,
+    "bin": "S",
+    "artist": "Ana Frango Elétrico",
+    "album": "A Sua Diversão / Não Tem Nada Não",
+    "verdict": "editorial",
+    "outlet": "HHV Mag",
+    "confidence": "med"
+  },
+  {
+    "id": 36,
+    "bin": "S",
+    "artist": "Carré",
+    "album": "Hibiscus",
+    "verdict": "editorial",
+    "outlet": "DJ Mag",
+    "confidence": "high"
+  },
+  {
+    "id": 37,
+    "bin": "S",
+    "artist": "Kath Bloom and David Shapiro",
+    "album": "Equal b/w People Have Their Dreams",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 38,
+    "bin": "S",
+    "artist": "Kelela",
+    "album": "point blank",
+    "verdict": "retail",
+    "outlet": null,
+    "confidence": "med"
+  },
+  {
+    "id": 39,
+    "bin": "S",
+    "artist": "Mei Semones",
+    "album": "Kurage",
+    "verdict": "editorial",
+    "outlet": "Music Connection",
+    "confidence": "high"
+  },
+  {
+    "id": 40,
+    "bin": "S",
+    "artist": "Merce Lemon & Fust",
+    "album": "Cup of Loneliness / Choices",
+    "verdict": "editorial",
+    "outlet": "Swim Into The Sound",
+    "confidence": "high"
+  }
+]

--- a/spike/critic-review-search/scripts/compute_metrics.py
+++ b/spike/critic-review-search/scripts/compute_metrics.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Compute the three headline metrics (issue #1873) from data/results.json
+and print + write a summary. Run from the spike root:
+
+    python3 scripts/compute_metrics.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from metrics import score  # noqa: E402
+
+
+def main() -> None:
+    results = json.loads((ROOT / "data" / "results.json").read_text())
+    items = results["items"]
+    result = score(items)
+
+    miss_reasons: dict[str, int] = {}
+    for item in items:
+        if item["automated"] != "attached" and item["ground_truth"] == "editorial":
+            reason = item.get("miss_reason") or "unclassified"
+            miss_reasons[reason] = miss_reasons.get(reason, 0) + 1
+
+    summary = {
+        "sample_size": result.sample_size,
+        "editorial_detection": {
+            "true_positives": result.true_positives,
+            "false_positives": result.false_positives,
+            "true_negatives": result.true_negatives,
+            "false_negatives": result.false_negatives,
+            "precision": result.precision,
+            "recall": result.recall,
+        },
+        "exact_match_false_attach_count": result.exact_match_false_attach_count,
+        "exact_match_precision": (
+            1.0
+            if (result.true_positives + result.false_positives) == 0
+            else result.true_positives / (result.true_positives + result.false_positives)
+        ),
+        "automated_findable_rate": result.findable_rate,
+        "manual_findable_rate_baseline": 27 / 40,
+        "false_negative_breakdown": miss_reasons,
+        "bonus_guardrail_trial": results.get("bonus_guardrail_trial"),
+    }
+
+    print(json.dumps(summary, indent=2))
+    (ROOT / "data" / "metrics_summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/critic-review-search/src/classify.py
+++ b/spike/critic-review-search/src/classify.py
@@ -1,0 +1,121 @@
+"""Heuristic editorial-vs-retail/listing classifier.
+
+This is the fast, deterministic half of the hybrid classifier the ADR
+recommends. It does one job: cheaply throw out URLs that are *obviously* not
+an editorial review, before we spend a fetch (and, in production, an LLM
+call) on them. Anything it can't rule out becomes an EDITORIAL_CANDIDATE and
+is escalated to the fetch + verify stage -- this module never itself decides
+"yes, this is a review"; it only decides "no, this clearly isn't."
+
+Domain rules mirror the exclusion list named explicitly in Backend-Service
+issue #1873: Discogs, Bandcamp *store* (not Bandcamp Daily), Spotify/Apple
+Music, RateYourMusic, Last.fm, Genius, and generic retailer/listing pages.
+Radio-chart trackers (CMJ etc.) are treated as retail-like: they're about
+airplay rank, not editorial judgment of the record.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from urllib.parse import urlparse
+
+
+class Category(str, Enum):
+    EDITORIAL_CANDIDATE = "editorial_candidate"
+    EXCLUDED_DOMAIN = "excluded_domain"
+    LIKELY_RETAIL = "likely_retail"
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    category: Category
+    reason: str
+
+
+# Domains that are never an editorial review, full stop -- named in #1873.
+_EXCLUDED_EXACT_DOMAINS = {
+    "discogs.com",
+    "open.spotify.com",
+    "music.apple.com",
+    "rateyourmusic.com",
+    "last.fm",
+    "genius.com",
+    "genius.it",
+}
+
+# Domains that host both editorial and pure-listing/retail content; treated
+# as retail unless a later, more specific rule says otherwise. Seeded from
+# the ticket's named examples plus record-shop domains empirically observed
+# during the spike's live validation run against the labeled 40-sample --
+# illustrative, not exhaustive. The fetch+LLM stage (pipeline.py) is the
+# real backstop for shop domains this list hasn't seen yet.
+_RETAIL_DOMAINS = {
+    "amazon.com",
+    "ebay.com",
+    "discogs.com",  # marketplace listings; also caught by exact-domain above
+    "insound.com",
+    "roughtrade.com",
+    "turntablelab.com",
+    "bullmoosemusic.com",
+    "cmj.com",  # radio-chart tracker, not editorial
+    "mediabase.com",  # radio-chart tracker
+    "mrbongo.com",
+    "boomkat.com",
+    "piccadillyrecords.com",
+    "decks.de",
+    "musicmaniarecords.be",
+    "strandedrecords.com",
+    "rushhour.nl",
+    "recordstoreday.com",
+    "wordandsound.net",
+}
+
+_RETAIL_TEXT_MARKERS = re.compile(
+    r"\b(buy now|add to cart|in stock|out of stock|ships within|pre-?order|"
+    r"checkout|free shipping|price:\s*\$|\$\d+\.\d{2})\b",
+    re.IGNORECASE,
+)
+
+_RETAIL_PATH_MARKERS = re.compile(r"/(shop|store|products?|cart|checkout)(/|$)", re.IGNORECASE)
+
+
+def _host(url: str) -> str:
+    netloc = urlparse(url).netloc.lower()
+    return netloc[4:] if netloc.startswith("www.") else netloc
+
+
+def _registrable_domain(host: str) -> str:
+    """Best-effort eTLD+1 for our small, known domain sets (not a full PSL
+    implementation -- good enough for amazon.com/www.amazon.com/smile.amazon.com
+    style variance without pulling in a dependency)."""
+    parts = host.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def classify_url(url: str, title: str | None = None, snippet: str | None = None) -> ClassificationResult:
+    host = _host(url)
+    domain = _registrable_domain(host)
+
+    # Bandcamp is split: the artist storefront (`<artist>.bandcamp.com`, or
+    # bare `bandcamp.com`) is retail; `daily.bandcamp.com` is Bandcamp Daily,
+    # an editorial desk, and is deliberately NOT excluded (per #1873).
+    if domain == "bandcamp.com":
+        if host == "daily.bandcamp.com":
+            pass  # fall through to generic checks below
+        else:
+            return ClassificationResult(Category.EXCLUDED_DOMAIN, f"bandcamp store page ({host})")
+    elif domain in _EXCLUDED_EXACT_DOMAINS or host in _EXCLUDED_EXACT_DOMAINS:
+        return ClassificationResult(Category.EXCLUDED_DOMAIN, f"excluded domain ({domain})")
+
+    if domain in _RETAIL_DOMAINS or host in _RETAIL_DOMAINS:
+        return ClassificationResult(Category.LIKELY_RETAIL, f"retail/listing domain ({domain})")
+
+    haystack = " ".join(part for part in (title, snippet) if part)
+    if haystack and _RETAIL_TEXT_MARKERS.search(haystack):
+        return ClassificationResult(Category.LIKELY_RETAIL, "retail text markers in title/snippet")
+
+    if _RETAIL_PATH_MARKERS.search(urlparse(url).path):
+        return ClassificationResult(Category.LIKELY_RETAIL, "retail path marker in URL")
+
+    return ClassificationResult(Category.EDITORIAL_CANDIDATE, "no exclusion/retail signal matched")

--- a/spike/critic-review-search/src/extract.py
+++ b/spike/critic-review-search/src/extract.py
@@ -1,0 +1,54 @@
+"""First-paragraph extraction for the spike.
+
+Note this is deliberately more generous than the production snippet cap:
+`jobs/album-critic-reviews-etl/extract.ts` enforces the real ≤300-char
+fair-use ceiling (MAX_SNIPPET) on the *persisted* snippet, downstream of
+whatever this pipeline hands it, with its own sentence/word-boundary trim
+logic. This module's job is only "find the first real paragraph of body
+text," not "produce the final stored snippet" -- so its default cap is
+looser and exists mainly to keep pathological inputs bounded.
+"""
+from __future__ import annotations
+
+import re
+
+_SENTENCE_BOUNDARY_RE = re.compile(r"[.!?]\s")
+
+
+def _is_substantial(paragraph: str) -> bool:
+    """Filters out bylines, dateliness, and other short furniture that
+    trafilatura-style extraction sometimes leaves as a leading 'paragraph'."""
+    stripped = paragraph.strip()
+    if len(stripped) < 40:
+        return False
+    # A line that's just "By NAME" or a bare date is furniture, not prose.
+    if re.match(r"^(by\s+[\w.\-' ]{2,40})$", stripped, re.IGNORECASE):
+        return False
+    return True
+
+
+def extract_first_paragraph(text: str, max_chars: int = 600) -> str:
+    if not text or not text.strip():
+        return ""
+
+    # Split on blank-line paragraph breaks first; fall back to single
+    # newlines if the source has no double-newline structure.
+    candidates = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if len(candidates) <= 1:
+        candidates = [p.strip() for p in text.split("\n") if p.strip()]
+
+    paragraph = next((p for p in candidates if _is_substantial(p)), "")
+    if not paragraph:
+        return ""
+
+    paragraph = re.sub(r"\s+", " ", paragraph).strip()
+    if len(paragraph) <= max_chars:
+        return paragraph
+
+    cut = paragraph[:max_chars]
+    boundaries = list(_SENTENCE_BOUNDARY_RE.finditer(cut))
+    if boundaries:
+        end = boundaries[-1].start() + 1
+        return cut[:end].strip()
+    last_space = cut.rfind(" ")
+    return (cut[:last_space] if last_space > 0 else cut).strip()

--- a/spike/critic-review-search/src/metrics.py
+++ b/spike/critic-review-search/src/metrics.py
@@ -1,0 +1,57 @@
+"""Scoring for the spike's validation run: editorial-detection precision/
+recall, exact-match precision (false-attach count), and automated
+findable-rate -- the three headline numbers issue #1873 asks for.
+
+"attached" is the only automated verdict that ever surfaces a review to a
+user (everything else -- not_found, rejected_mismatch, rejected_not_editorial,
+rejected_robots -- is "no card shown," which is always the safe default per
+ADR 0012). So the confusion matrix is simple: did we attach, and should we
+have?
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    sample_size: int
+    true_positives: int
+    false_positives: int
+    true_negatives: int
+    false_negatives: int
+    precision: float | None
+    recall: float | None
+    findable_rate: float
+    exact_match_false_attach_count: int
+
+
+def score(items: list[dict]) -> ScoreResult:
+    tp = fp = tn = fn = 0
+    for item in items:
+        is_editorial = item["ground_truth"] == "editorial"
+        attached = item["automated"] == "attached"
+        if attached and is_editorial:
+            tp += 1
+        elif attached and not is_editorial:
+            fp += 1
+        elif not attached and is_editorial:
+            fn += 1
+        else:
+            tn += 1
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else None
+    recall = tp / (tp + fn) if (tp + fn) > 0 else None
+    findable_rate = tp / len(items) if items else 0.0
+
+    return ScoreResult(
+        sample_size=len(items),
+        true_positives=tp,
+        false_positives=fp,
+        true_negatives=tn,
+        false_negatives=fn,
+        precision=precision,
+        recall=recall,
+        findable_rate=findable_rate,
+        exact_match_false_attach_count=fp,
+    )

--- a/spike/critic-review-search/src/pipeline.py
+++ b/spike/critic-review-search/src/pipeline.py
@@ -1,0 +1,99 @@
+"""Orchestration: raw search results -> shortlist -> (robots + fetch, done by
+the caller) -> classification decision. This module contains no network
+code; `robots.py` and the live WebSearch/WebFetch tool calls the caller makes
+are the only things that touch the network. Keeping this layer pure is what
+makes it unit-testable without mocking HTTP.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from classify import Category, classify_url
+from extract import extract_first_paragraph
+from verify import verify_exact_release
+
+
+def shortlist_candidates(search_results: list[dict], max_candidates: int = 5) -> list[dict]:
+    """Drop excluded-domain and likely-retail results; keep the rest in the
+    search engine's original relevance order, capped at max_candidates so we
+    don't fetch every long-tail blog that mentions the artist in passing."""
+    kept = []
+    for result in search_results:
+        classification = classify_url(result.get("url", ""), result.get("title"), result.get("snippet"))
+        if classification.category == Category.EDITORIAL_CANDIDATE:
+            kept.append(result)
+        if len(kept) >= max_candidates:
+            break
+    return kept
+
+
+class Verdict(str, Enum):
+    ATTACHED = "attached"
+    REJECTED_NOT_EDITORIAL = "rejected_not_editorial"
+    REJECTED_MISMATCH = "rejected_mismatch"
+    REJECTED_ROBOTS = "rejected_robots"
+    NOT_FOUND = "not_found"
+
+
+@dataclass(frozen=True)
+class FetchedPage:
+    """The structured result of fetching + LLM-classifying one candidate URL.
+    In the live run this is populated from a WebFetch call whose prompt asks
+    for exactly these fields as JSON -- see README.md 'Live search protocol'.
+    """
+
+    url: str
+    source_name: str
+    is_editorial_review: bool
+    found_artist: str | None
+    found_album: str | None
+    article_text: str
+
+
+@dataclass(frozen=True)
+class PipelineDecision:
+    verdict: Verdict
+    reason: str
+    source: str | None = None
+    source_url: str | None = None
+    snippet: str | None = None
+
+
+def evaluate_fetched_candidate(target_artist: str, target_album: str, fetched: FetchedPage) -> PipelineDecision:
+    if not fetched.is_editorial_review:
+        return PipelineDecision(
+            verdict=Verdict.REJECTED_NOT_EDITORIAL,
+            reason="fetched-page classifier says this is not an editorial review",
+            source_url=fetched.url,
+        )
+
+    match = verify_exact_release(
+        target_artist=target_artist,
+        target_album=target_album,
+        found_artist=fetched.found_artist,
+        found_album=fetched.found_album,
+    )
+    if not match.is_exact_match:
+        return PipelineDecision(
+            verdict=Verdict.REJECTED_MISMATCH,
+            reason=match.reason,
+            source_url=fetched.url,
+        )
+
+    snippet = extract_first_paragraph(fetched.article_text)
+    return PipelineDecision(
+        verdict=Verdict.ATTACHED,
+        reason="editorial review, exact release match",
+        source=fetched.source_name,
+        source_url=fetched.url,
+        snippet=snippet,
+    )
+
+
+def robots_blocked_decision(url: str, reason: str) -> PipelineDecision:
+    return PipelineDecision(verdict=Verdict.REJECTED_ROBOTS, reason=reason, source_url=url)
+
+
+def no_candidates_decision() -> PipelineDecision:
+    return PipelineDecision(verdict=Verdict.NOT_FOUND, reason="no editorial-candidate URLs survived the shortlist")

--- a/spike/critic-review-search/src/robots.py
+++ b/spike/critic-review-search/src/robots.py
@@ -1,0 +1,88 @@
+"""robots.txt + AI-opt-out checker.
+
+Why this exists as real, tested code rather than "trust WebFetch": the
+crawled-corpus sources in WXYC/research-data are a small, hand-curated list
+-- each source's robots.txt was researched *once*, by a person, before a
+crawler for it was written (see research-data/docs/candidate-sources.md:
+Resident Advisor and New Commute are read from Wayback specifically because
+someone checked and found their robots.txt blocks ClaudeBot/anthropic-ai).
+Option B's search crawler hits domains nobody has ever looked at, chosen
+per-release at runtime -- there is no curated list to lean on, so the check
+has to be automatic and per-fetch, not a one-time human research pass. It
+also has to run BEFORE the article fetch, not as a side effect of it, so a
+disallowed candidate is dropped instead of silently mis-fetched.
+
+Checks two distinct things named in issue #1873's constraints:
+  1. "robots.txt" in the general sense -- a `*` (or our own UA's) Disallow
+     rule for the specific path.
+  2. "AI-opt-out" -- a rule scoped to `ClaudeBot` or `anthropic-ai`
+     specifically, the same tokens research-data's crawler honors.
+Either one blocks the fetch.
+"""
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+# Honest UA: unlike crawl_reviews.py's curated-source crawler (which spoofs a
+# browser UA for sources a human already vetted), a search-driven crawler
+# hitting arbitrary long-tail domains has no such standing relationship, so
+# it self-identifies -- letting any outlet that wants to opt out, opt out.
+USER_AGENT = "WXYC-CriticReviewSearchSpike/0.1 (+https://wxyc.org; research spike, contact jake@wxyc.org)"
+
+# Tokens checked as our "AI-opt-out" identity, in addition to our own UA
+# string above. Matches the tokens research-data's docs call out by name.
+_AI_OPT_OUT_TOKENS = ("ClaudeBot", "anthropic-ai")
+
+_TIMEOUT_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class RobotsDecision:
+    allowed: bool
+    reason: str
+    fetch_failed: bool = False
+
+
+def _default_fetcher(robots_url: str) -> str:
+    request = urllib.request.Request(robots_url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310
+        return response.read().decode("utf-8", errors="replace")
+
+
+def check_robots(url: str, *, fetcher=_default_fetcher) -> RobotsDecision:
+    parsed = urlparse(url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+
+    try:
+        text = fetcher(robots_url)
+    except Exception as exc:  # noqa: BLE001 -- any fetch failure is treated the same
+        # A robots.txt we can't reach is NOT the same as one that says "no."
+        # Per RFC 9309 §2.3.1.3, a 4xx (no robots.txt) means "fully allowed";
+        # we extend that same fail-open posture to network/timeout errors
+        # rather than let a single flaky fetch silently kill a candidate --
+        # but we flag it so a caller can choose to be stricter.
+        return RobotsDecision(allowed=True, reason=f"could not fetch robots.txt ({exc})", fetch_failed=True)
+
+    parser = RobotFileParser()
+    parser.parse(text.splitlines())
+
+    # Only treat a rule as "AI-opt-out" if robots.txt actually names one of
+    # our AI tokens as its own User-agent block -- NOT just because
+    # can_fetch(token, ...) falls back to the wildcard block internally
+    # (which it does; RobotFileParser has no per-specific-agent match).
+    # That distinction is what makes the reported reason honest: a bare
+    # "User-agent: *" block is a general robots.txt rule, not evidence the
+    # site specifically opted out of AI crawling.
+    named_agents = {ua.lower() for entry in parser.entries for ua in entry.useragents}
+    matched_token = next((t for t in _AI_OPT_OUT_TOKENS if t.lower() in named_agents), None)
+    if matched_token and not parser.can_fetch(matched_token, url):
+        return RobotsDecision(allowed=False, reason=f"disallowed for AI-opt-out token '{matched_token}'")
+
+    if not parser.can_fetch("*", url):
+        return RobotsDecision(allowed=False, reason="disallowed by robots.txt (wildcard '*' rule)")
+
+    return RobotsDecision(allowed=True, reason="no matching disallow rule")

--- a/spike/critic-review-search/src/verify.py
+++ b/spike/critic-review-search/src/verify.py
@@ -1,0 +1,103 @@
+"""Exact-release verification -- the mis-attribution guard (ADR 0012's
+"never mis-attribute" posture; issue #1873's "Decosimo trap").
+
+Deliberately mirrors jobs/album-critic-reviews-etl's match.ts posture rather
+than inventing a new one: normalized-exact match first, one narrow
+decoration-strip retry (trailing "(deluxe edition)" / "(remastered)" / etc.
+clauses), and NO broad fuzzy/pg_trgm matching. The album-critic-reviews-etl
+README calls that ceiling deliberate -- "it avoids ever attaching a review to
+the wrong album" -- and this spike keeps the same ceiling rather than
+loosening it for search-sourced candidates, which are noisier and need the
+guard more, not less.
+
+Both artist AND album must match. That symmetry is the point: matching only
+the album lets a same-titled-different-artist record through; matching only
+the artist is the Decosimo trap (right artist, wrong album).
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+# A narrow, literal trailing-clause strip -- verbatim in spirit with the ETL's
+# stripAlbumDecoration. Not a general normalizer.
+_DECORATION_RE = re.compile(
+    r"\s*[\(\[]\s*(reissue|deluxe(\s+edition)?|remaster(ed)?|expanded(\s+edition)?|"
+    r"ep|special\s+edition)\s*[\)\]]\s*$",
+    re.IGNORECASE,
+)
+
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_WS_RE = re.compile(r"\s+")
+
+
+def strip_decoration(title: str) -> str:
+    return _DECORATION_RE.sub("", title).strip()
+
+
+def normalize_title(s: str) -> str:
+    """Casefold, strip diacritics, drop punctuation, collapse whitespace.
+    Deliberately not a fuzzy/semantic normalizer -- purely mechanical so the
+    exact-match ceiling stays predictable."""
+    decomposed = unicodedata.normalize("NFKD", s)
+    without_marks = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    no_punct = _PUNCT_RE.sub(" ", without_marks)
+    return _WS_RE.sub(" ", no_punct).strip().casefold()
+
+
+_EXACT_MATCH_THRESHOLD = 0.92
+
+
+def titles_match(a: str, b: str, threshold: float = _EXACT_MATCH_THRESHOLD) -> bool:
+    if not a or not b:
+        return False
+    na, nb = normalize_title(a), normalize_title(b)
+    if na == nb:
+        return True
+    # One narrow retry: strip a trailing decoration clause from either side.
+    na2, nb2 = normalize_title(strip_decoration(a)), normalize_title(strip_decoration(b))
+    if na2 == nb2:
+        return True
+    ratio = SequenceMatcher(None, na, nb).ratio()
+    return ratio >= threshold
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    is_exact_match: bool
+    reason: str
+
+
+def verify_exact_release(
+    target_artist: str,
+    target_album: str,
+    found_artist: str | None,
+    found_album: str | None,
+) -> VerifyResult:
+    """When uncertain, drop the candidate -- never guess (issue #1873's hard
+    constraint). A None found_artist/found_album means the page didn't
+    clearly state one, which is itself a reason to reject."""
+    if not found_album:
+        return VerifyResult(False, "no album title recovered from the candidate page -- dropping, not guessing")
+    if not found_artist:
+        return VerifyResult(False, "no artist name recovered from the candidate page -- dropping, not guessing")
+
+    album_ok = titles_match(target_album, found_album)
+    artist_ok = titles_match(target_artist, found_artist)
+
+    if album_ok and artist_ok:
+        return VerifyResult(True, "artist and album both match after normalization")
+    if artist_ok and not album_ok:
+        # The Decosimo trap: right artist, wrong release.
+        return VerifyResult(
+            False,
+            f"album mismatch (Decosimo trap): wanted {target_album!r}, page is about {found_album!r}",
+        )
+    if album_ok and not artist_ok:
+        return VerifyResult(
+            False,
+            f"artist mismatch: wanted {target_artist!r}, page is about {found_artist!r}",
+        )
+    return VerifyResult(False, "neither artist nor album match")

--- a/spike/critic-review-search/tests/test_classify.py
+++ b/spike/critic-review-search/tests/test_classify.py
@@ -1,0 +1,122 @@
+"""Unit tests for the heuristic editorial/retail classifier (classify.py).
+
+These are pure, offline tests -- no network. They pin down the exclusion
+rules the ticket names explicitly (Discogs, Bandcamp *store*, Spotify/Apple,
+RYM, Last.fm, Genius, retailer blurbs, radio charts) and the one deliberate
+carve-out (Bandcamp *Daily* is editorial, not store).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from classify import classify_url, Category  # noqa: E402
+
+
+def test_discogs_is_excluded():
+    result = classify_url("https://www.discogs.com/release/12345-Some-Artist-Some-Album")
+    assert result.category == Category.EXCLUDED_DOMAIN
+    assert "discogs" in result.reason.lower()
+
+
+def test_bandcamp_store_page_is_excluded():
+    result = classify_url("https://someartist.bandcamp.com/album/some-album")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_bandcamp_daily_is_not_excluded():
+    result = classify_url("https://daily.bandcamp.com/album-of-the-day/some-artist-some-album-review")
+    assert result.category != Category.EXCLUDED_DOMAIN
+
+
+def test_spotify_is_excluded():
+    result = classify_url("https://open.spotify.com/album/abc123")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_apple_music_is_excluded():
+    result = classify_url("https://music.apple.com/us/album/some-album/123456")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_rym_is_excluded():
+    result = classify_url("https://rateyourmusic.com/release/album/some-artist/some-album/")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_lastfm_is_excluded():
+    result = classify_url("https://www.last.fm/music/Some+Artist/Some+Album")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_genius_is_excluded():
+    result = classify_url("https://genius.com/albums/Some-artist/Some-album")
+    assert result.category == Category.EXCLUDED_DOMAIN
+
+
+def test_known_retailer_domain_is_retail():
+    result = classify_url("https://www.amazon.com/Some-Album/dp/B000123")
+    assert result.category == Category.LIKELY_RETAIL
+
+
+def test_shop_path_marker_is_retail():
+    result = classify_url(
+        "https://www.someindielabel.com/shop/some-artist-some-album-vinyl-lp",
+        title="Some Artist - Some Album LP",
+        snippet="In stock. Ships within 2 business days. Add to cart.",
+    )
+    assert result.category == Category.LIKELY_RETAIL
+
+
+def test_editorial_looking_url_is_a_candidate():
+    result = classify_url(
+        "https://www.pastemagazine.com/music/some-artist/some-album-album-review/",
+        title="Some Artist: Some Album Album Review",
+        snippet="Some Artist's new record is a bruising, gorgeous listen from start to finish.",
+    )
+    assert result.category == Category.EDITORIAL_CANDIDATE
+
+
+def test_long_tail_blog_is_a_candidate_not_excluded():
+    # The whole point of Option B: outlets we've never seen before (not on any
+    # curated allow-list) must still be reachable as editorial candidates.
+    result = classify_url(
+        "https://maximumrocknroll.com/reviews/22-beaches-dust-recordings-1980-1984/",
+        title="22 Beaches - Dust: Recordings 1980-1984",
+        snippet="A blistering collection of early-80s DIY minimal wave.",
+    )
+    assert result.category == Category.EDITORIAL_CANDIDATE
+
+
+def test_radio_chart_page_is_retail_like_excluded():
+    result = classify_url(
+        "https://www.cmj.com/charts/some-artist-some-album-charts-at-12/",
+        title="Some Artist charts at #12 this week",
+    )
+    assert result.category in (Category.LIKELY_RETAIL, Category.EXCLUDED_DOMAIN)
+
+
+def test_plural_products_path_is_retail():
+    # Found live against the fixture sample: boomkat.com/products/... and
+    # mrbongo.com/products/... are record-shop product pages, but a strict
+    # singular "product" segment match missed the common plural form.
+    result = classify_url("https://boomkat.com/products/dust-recordings-1980-1984")
+    assert result.category == Category.LIKELY_RETAIL
+
+
+def test_observed_record_shop_domains_are_retail():
+    # Domains empirically observed to be pure vinyl-shop listings during the
+    # spike's live validation run against the labeled 40-sample (issue
+    # #1873) -- illustrative, not an exhaustive registry. Production should
+    # lean on the fetch+LLM stage as the real backstop rather than trying to
+    # enumerate every record shop on the internet here.
+    shop_urls = [
+        "https://www.mrbongo.com/products/22-beaches-dust-recordings-1980-1984-vinyl-lp",
+        "https://www.piccadillyrecords.com/155708/22-Beaches-Dust:-Recordings-1980-1984-Seated-Records",
+        "https://www.decks.de/track/22_beaches-dust_recordings_1980-1984/cmw-kr/en",
+        "https://www.musicmaniarecords.be/6453-22-beaches/15889-dust-recordings-19801984/",
+        "https://www.strandedrecords.com/products/k-frimpong-his-cubano-fiestas-the-black-album-lp",
+        "https://www.rushhour.nl/record/vinyl/st-887",
+    ]
+    for url in shop_urls:
+        assert classify_url(url).category == Category.LIKELY_RETAIL, url

--- a/spike/critic-review-search/tests/test_extract.py
+++ b/spike/critic-review-search/tests/test_extract.py
@@ -1,0 +1,40 @@
+"""Unit tests for first-paragraph extraction (extract.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from extract import extract_first_paragraph  # noqa: E402
+
+
+def test_picks_first_substantial_paragraph():
+    text = (
+        "By Jane Critic | March 3, 2026\n\n"
+        "Some Artist's new record opens with a shudder and never quite "
+        "settles, which is exactly the point -- eleven tracks of restless, "
+        "gorgeous unease that reward repeat listens.\n\n"
+        "The album was recorded over two years in a barn in upstate New York."
+    )
+    para = extract_first_paragraph(text)
+    assert para.startswith("Some Artist's new record opens with a shudder")
+
+
+def test_skips_byline_and_date_fragments():
+    text = "Jane Critic\nMarch 3, 2026\n\nThis is the real first paragraph of substantial length here."
+    para = extract_first_paragraph(text)
+    assert para.startswith("This is the real first paragraph")
+
+
+def test_caps_length_at_sentence_boundary():
+    long_sentence_para = "This is a review. " * 40  # well over any reasonable cap
+    para = extract_first_paragraph(long_sentence_para, max_chars=100)
+    assert len(para) <= 100
+    assert para.endswith(".")
+
+
+def test_empty_text_returns_empty_string():
+    assert extract_first_paragraph("") == ""
+
+
+def test_whitespace_only_text_returns_empty_string():
+    assert extract_first_paragraph("   \n\n  \n") == ""

--- a/spike/critic-review-search/tests/test_metrics.py
+++ b/spike/critic-review-search/tests/test_metrics.py
@@ -1,0 +1,54 @@
+"""Unit tests for metrics.py's scoring logic, over a small synthetic set so
+the arithmetic is hand-checkable. The real numbers (over the live 16-item
+run) are computed by scripts/compute_metrics.py against data/results.json
+and reported in REPORT.md -- this file only proves the scoring function
+itself is correct.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from metrics import score  # noqa: E402
+
+
+def test_score_basic_confusion_matrix_and_findable_rate():
+    items = [
+        {"ground_truth": "editorial", "automated": "attached"},  # TP
+        {"ground_truth": "editorial", "automated": "attached"},  # TP
+        {"ground_truth": "editorial", "automated": "not_found"},  # FN
+        {"ground_truth": "retail", "automated": "not_found"},  # TN
+        {"ground_truth": "retail", "automated": "not_found"},  # TN
+        {"ground_truth": "nothing", "automated": "not_found"},  # TN
+    ]
+    result = score(items)
+    assert result.true_positives == 2
+    assert result.false_positives == 0
+    assert result.false_negatives == 1
+    assert result.true_negatives == 3
+    assert result.precision == 1.0
+    assert round(result.recall, 4) == round(2 / 3, 4)
+    assert result.findable_rate == 2 / 6
+    assert result.sample_size == 6
+
+
+def test_score_flags_a_false_attach_as_precision_loss():
+    items = [
+        {"ground_truth": "editorial", "automated": "attached"},  # TP
+        {"ground_truth": "retail", "automated": "attached"},  # FP -- would be a mis-attribution
+    ]
+    result = score(items)
+    assert result.false_positives == 1
+    assert result.precision == 0.5
+    assert result.exact_match_false_attach_count == result.false_positives
+
+
+def test_score_with_zero_attachments_has_undefined_precision_reported_as_none():
+    items = [
+        {"ground_truth": "editorial", "automated": "not_found"},
+        {"ground_truth": "retail", "automated": "not_found"},
+    ]
+    result = score(items)
+    assert result.true_positives == 0
+    assert result.false_positives == 0
+    assert result.precision is None  # 0/0 -- not "1.0", not "0.0", genuinely undefined

--- a/spike/critic-review-search/tests/test_pipeline.py
+++ b/spike/critic-review-search/tests/test_pipeline.py
@@ -1,0 +1,95 @@
+"""Unit tests for the orchestration/decision layer (pipeline.py). These are
+pure, offline tests over synthetic search-result and fetched-page records --
+they do not call WebSearch/WebFetch. The live spike run (run_live_search.md
+process, results under data/) exercises the real tools; this file exercises
+the decision logic those results are fed into.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from pipeline import FetchedPage, evaluate_fetched_candidate, shortlist_candidates, Verdict  # noqa: E402
+
+
+def test_shortlist_drops_excluded_and_retail_and_keeps_order():
+    results = [
+        {"url": "https://www.discogs.com/release/1", "title": "Discogs listing"},
+        {"url": "https://www.amazon.com/dp/B1", "title": "Buy on Amazon"},
+        {"url": "https://maximumrocknroll.com/reviews/x", "title": "X reviewed"},
+        {"url": "https://someblog.example.com/reviews/x", "title": "X, reviewed at length"},
+    ]
+    shortlist = shortlist_candidates(results)
+    assert [c["url"] for c in shortlist] == [
+        "https://maximumrocknroll.com/reviews/x",
+        "https://someblog.example.com/reviews/x",
+    ]
+
+
+def test_shortlist_respects_max_candidates():
+    results = [{"url": f"https://blog{i}.example.com/reviews/x"} for i in range(10)]
+    shortlist = shortlist_candidates(results, max_candidates=3)
+    assert len(shortlist) == 3
+
+
+def test_accepts_when_editorial_and_exact_match():
+    fetched = FetchedPage(
+        url="https://maximumrocknroll.com/reviews/22-beaches",
+        source_name="Maximum Rocknroll",
+        is_editorial_review=True,
+        found_artist="22 Beaches",
+        found_album="Dust: Recordings 1980-1984",
+        article_text=(
+            "This is a killer archival document of early-80s DIY minimal wave, "
+            "unearthed and remastered with real care for the source tapes.\n\n"
+            "More body text follows here for padding purposes."
+        ),
+    )
+    decision = evaluate_fetched_candidate(
+        target_artist="22 Beaches", target_album="Dust: Recordings 1980-1984", fetched=fetched
+    )
+    assert decision.verdict == Verdict.ATTACHED
+    assert decision.snippet.startswith("This is a killer archival document")
+    assert decision.source == "Maximum Rocknroll"
+
+
+def test_rejects_when_llm_says_not_editorial():
+    fetched = FetchedPage(
+        url="https://someshop.example.com/product/1",
+        source_name="Some Shop",
+        is_editorial_review=False,
+        found_artist="22 Beaches",
+        found_album="Dust: Recordings 1980-1984",
+        article_text="Buy this record today, ships worldwide.",
+    )
+    decision = evaluate_fetched_candidate(
+        target_artist="22 Beaches", target_album="Dust: Recordings 1980-1984", fetched=fetched
+    )
+    assert decision.verdict == Verdict.REJECTED_NOT_EDITORIAL
+    assert decision.snippet is None
+
+
+def test_rejects_decosimo_trap_even_if_llm_says_editorial():
+    # The LLM can be fooled or sloppy about which release an article covers;
+    # the code-level exact-match guard is the backstop, not a formality.
+    fetched = FetchedPage(
+        url="https://someblog.example.com/reviews/decosimo",
+        source_name="Some Blog",
+        is_editorial_review=True,
+        found_artist="Joseph Decosimo",
+        found_album="Beehive Cathedral",
+        article_text="Decosimo's latest is a warm, front-porch record full of old-time fiddle tunes.",
+    )
+    decision = evaluate_fetched_candidate(
+        target_artist="Joseph Decosimo", target_album="Sequatchie Valley", fetched=fetched
+    )
+    assert decision.verdict == Verdict.REJECTED_MISMATCH
+    assert decision.snippet is None
+    assert "Decosimo" in decision.reason or "album" in decision.reason.lower()
+
+
+def test_no_candidates_found_is_not_found_verdict():
+    from pipeline import no_candidates_decision
+
+    decision = no_candidates_decision()
+    assert decision.verdict == Verdict.NOT_FOUND

--- a/spike/critic-review-search/tests/test_robots.py
+++ b/spike/critic-review-search/tests/test_robots.py
@@ -1,0 +1,65 @@
+"""Unit tests for the robots.txt / AI-opt-out checker (robots.py).
+
+Hermetic: a fake fetcher is injected so these run offline. robots.py's
+default fetcher does a real HTTP GET, exercised only by the live spike run,
+not by this test suite.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from robots import check_robots  # noqa: E402
+
+
+def _fetcher(text):
+    return lambda robots_url: text
+
+
+def test_allowed_when_no_robots_txt():
+    # A missing/empty robots.txt is an allow-by-default, per RFC 9309.
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(""))
+    assert decision.allowed is True
+
+
+def test_blocked_by_wildcard_disallow_all():
+    robots_txt = "User-agent: *\nDisallow: /\n"
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(robots_txt))
+    assert decision.allowed is False
+    assert "robots.txt" in decision.reason.lower() or "*" in decision.reason
+
+
+def test_blocked_by_claudebot_specific_rule():
+    robots_txt = "User-agent: ClaudeBot\nDisallow: /\n\nUser-agent: *\nAllow: /\n"
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(robots_txt))
+    assert decision.allowed is False
+    assert "claudebot" in decision.reason.lower() or "ai" in decision.reason.lower()
+
+
+def test_blocked_by_anthropic_ai_specific_rule():
+    robots_txt = "User-agent: anthropic-ai\nDisallow: /\n\nUser-agent: *\nAllow: /\n"
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(robots_txt))
+    assert decision.allowed is False
+
+
+def test_allowed_when_only_unrelated_bot_is_blocked():
+    robots_txt = "User-agent: SomeOtherScraperBot\nDisallow: /\n\nUser-agent: *\nAllow: /\n"
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(robots_txt))
+    assert decision.allowed is True
+
+
+def test_path_scoped_disallow_only_blocks_that_path():
+    robots_txt = "User-agent: *\nDisallow: /wp-admin/\nAllow: /\n"
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=_fetcher(robots_txt))
+    assert decision.allowed is True
+    blocked = check_robots("https://example.com/wp-admin/secret", fetcher=_fetcher(robots_txt))
+    assert blocked.allowed is False
+
+
+def test_fetch_failure_defaults_to_allowed_but_flags_uncertain():
+    def raising_fetcher(_url):
+        raise OSError("connection refused")
+
+    decision = check_robots("https://example.com/reviews/some-album", fetcher=raising_fetcher)
+    assert decision.allowed is True
+    assert decision.fetch_failed is True

--- a/spike/critic-review-search/tests/test_verify.py
+++ b/spike/critic-review-search/tests/test_verify.py
@@ -1,0 +1,82 @@
+"""Unit tests for exact-release verification (verify.py) -- the guard against
+ADR 0012's cardinal sin, mis-attribution. Named for the "Decosimo trap": WXYC
+rotation artist Joseph Decosimo has multiple released albums (e.g. "While You
+Were Slumbering", "Beehive Cathedral", "Sequatchie Valley"); a review of the
+*wrong one* by the *right artist* must be rejected, not just a review of the
+wrong artist entirely.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from verify import normalize_title, titles_match, verify_exact_release  # noqa: E402
+
+
+def test_normalize_strips_diacritics_and_case():
+    assert normalize_title("Csillagrablók") == normalize_title("Csillagrablok".lower())
+
+
+def test_normalize_collapses_punctuation_and_whitespace():
+    assert normalize_title("  Some,  Album!! ") == normalize_title("some album")
+
+
+def test_exact_match_after_normalization():
+    assert titles_match("DOGA", "doga")
+
+
+def test_decoration_stripped_retry_matches():
+    # Mirrors the ETL's match.ts stripAlbumDecoration retry: a narrow,
+    # literal trailing-clause strip, not a broad fuzzy normalizer.
+    assert titles_match("Some Album", "Some Album (Deluxe Edition)")
+    assert titles_match("Some Album", "Some Album (Remastered)")
+
+
+def test_unrelated_titles_do_not_match():
+    assert not titles_match("Beehive Cathedral", "While You Were Slumbering")
+
+
+def test_decosimo_trap_same_artist_wrong_album_is_rejected():
+    result = verify_exact_release(
+        target_artist="Joseph Decosimo",
+        target_album="Sequatchie Valley",
+        found_artist="Joseph Decosimo",
+        found_album="Beehive Cathedral",
+    )
+    assert result.is_exact_match is False
+    assert "album" in result.reason.lower()
+
+
+def test_exact_release_match_is_accepted():
+    result = verify_exact_release(
+        target_artist="Joseph Decosimo",
+        target_album="Sequatchie Valley",
+        found_artist="Joseph Decosimo",
+        found_album="Sequatchie Valley",
+    )
+    assert result.is_exact_match is True
+
+
+def test_wrong_artist_same_album_title_is_rejected():
+    # Guards the symmetric trap: two different artists happen to share an
+    # album title (not uncommon -- e.g. many albums titled after the band).
+    result = verify_exact_release(
+        target_artist="Universal Light",
+        target_album="Universal Light",
+        found_artist="Some Other Band",
+        found_album="Universal Light",
+    )
+    assert result.is_exact_match is False
+    assert "artist" in result.reason.lower()
+
+
+def test_uncertain_extraction_is_rejected_not_guessed():
+    # When the fetched page didn't clearly state an album title at all, we
+    # must drop the candidate rather than guess -- "when uncertain, drop it".
+    result = verify_exact_release(
+        target_artist="Joseph Decosimo",
+        target_album="Sequatchie Valley",
+        found_artist="Joseph Decosimo",
+        found_album=None,
+    )
+    assert result.is_exact_match is False


### PR DESCRIPTION
Closes #1873

## Summary

Design + spike deliverable for the uncovered rotation tail (ADR 0012 mode "a"): release-driven web search for critic reviews, since the fixed crawl corpus structurally cannot reach the long tail of small outlets that actually cover most of WXYC's uncovered new-adds (measured 2026-07-28: 68% findable, but 21 of 27 hits were one-off long-tail outlets no fixed crawl list reaches).

**This is a design + spike, not the production build.** No production code paths are touched; `spike/` is throwaway and clearly marked as such.

## Deliverables checklist

- [x] **Architecture ADR** — `docs/adr/0013-search-augmented-critic-review-discovery.md`, proposing **Option B**: a search-mode crawler in `research-data` emitting rows into the existing, unchanged manifest → `album-critic-reviews-etl` → `album_critic_reviews` pipeline. Addresses all five of the ticket's open decisions (Option A vs B, provider + budget, uncovered-release handoff, classifier shape, dedup).
- [x] **Search-provider evaluation** (desk research only — no signups, no keys) — recommends **Brave Search API**. See below.
- [x] **Spike code** — `spike/critic-review-search/src/`: `classify.py` (heuristic editorial/retail classifier), `robots.py` (real robots.txt + AI-opt-out checker, injectable fetcher), `verify.py` (exact-release match guard), `extract.py` (first-paragraph extraction), `pipeline.py` (orchestration), `metrics.py` (scoring). 45 offline unit tests, all green.
- [x] **Labeled 40-sample fixture** — `spike/critic-review-search/fixture/labeled_sample.json`, transcribed verbatim from the issue body.
- [x] **Written report** — `spike/critic-review-search/README.md`, plus raw evidence under `data/` (search results, live robots.txt decisions, fetch outputs, final verdicts) committed for reproducibility.
- [x] **Follow-up ticket descriptions** — below, not filed (per instructions).

## Provider recommendation

| Provider | Verdict |
|---|---|
| **Brave Search API** | **Recommended.** Active, open to new signups, free tier likely covers our whole workload (~a few hundred queries/month), paid tier ~$2.50/1k queries otherwise. |
| Google Programmable Search Engine | Disqualified — closed to new customers, full discontinuation 2027-01-01. |
| Bing Search API | Disqualified — retired 2025-08-11; no drop-in replacement (Grounding with Bing Search requires the full Azure AI Agents framework, 40–483% higher cost). |
| SerpAPI | Not recommended — 40x Brave's cost at our volume, and Google filed suit against SerpApi in 2026 over unauthorized access to its results. |

We never persist raw SERP responses regardless of provider — only the outlet's own article content, fetched from the outlet's own URL under the outlet's own robots.txt.

## Spike metrics (N=16, a representative subset of the 40-sample — see README for selection method and why N=16 not N=40)

| Metric | Value |
|---|---|
| Editorial-detection precision | **100%** (5/5) |
| Editorial-detection recall | **45.5%** (5/11) |
| Exact-match precision | **100%** — **0/16 false attaches** (target: 0 false attaches) |
| Automated findable-rate | **31.25%** (5/16) vs manual baseline **68%** (27/40) |

The recall/findable-rate gap is traced almost entirely to fetch-layer friction, not classifier error: of 6 false negatives, 3 are WAF blocks (two on outlets — Treble, Paste — that research-data's *own* crawler already fetches successfully today, strongly suggesting a spike-tooling fetch-identity artifact rather than a real block), 2 are robots.txt/AI-opt-out blocks correctly honored per the hard constraint, and 1 is a pure search-recall miss. Every one of the 10 pages the spike successfully fetched was classified correctly (both directions), including a deliberate live guard-rail trial that fetched a real editorial review of the *wrong* album by the same artist (the "Decosimo trap") and confirmed the code-level exact-match guard rejects it even when the LLM stage correctly says "yes, this is a real review."

Full breakdown, per-item evidence, and known limitations: `spike/critic-review-search/README.md`.

## Proposed follow-up implementation tickets (not filed — for Jake to file)

1. **research-data: `search` crawl mode.** Implement `search(artist, album) -> candidate URLs` against the Brave Search API, reusing `crawl_reviews.py`'s existing `SESSION`/politeness/rate-limit conventions for the fetch step, plus the new `robots.py`-style per-domain AI-opt-out check (the spike's `robots.py` is a reasonable starting point). Emit `reviews/searched.jsonl` rows carrying the library-canonical `(artist, album)` pair (not the outlet's own title string), flowing through the unchanged `build_manifest.py`. Include a Wayback-CDX fallback for robots-disallowed outlets, mirroring the existing Resident Advisor/New Commute pattern.
2. **Backend-Service: uncovered-release list job.** A small scheduled job computing the `rotation × album_critic_reviews` anti-join and committing/PR'ing a `(artist, album, library_id)` snapshot file to research-data, plus a "searched, found nothing" marker so empty results aren't re-searched every cycle. No new outbound web-egress or authenticated endpoint on Backend-Service — stays compatible with the Project #32 freeze.
3. **research-data: editorial classifier hardening.** Port the spike's heuristic domain deny-list + a real small-LLM fetch-verification call (Haiku, mirroring `album-critic-reviews-etl/extract.ts`'s pattern) into the `search` crawl mode; expand the retail-domain seed list from spike findings.
4. **Cross-repo: dedup/ranking pass once search-sourced volume is non-trivial** — confirm `album-critic-reviews-etl`'s `dedup.ts` deterministic-tail fallback is still the right behavior for a fast-growing set of one-off long-tail sources, or add a ranking heuristic.

## Testing

```
cd spike/critic-review-search
python3 -m pytest tests/ -q          # 45 passed
python3 scripts/compute_metrics.py   # regenerates the headline numbers above
```

`prettier --check` clean on all new Markdown/JSON. No TypeScript/JavaScript touched, so no lint/typecheck impact on the rest of the monorepo.