### PR TITLE
feat: resolve catalog album by legacy_release_id (GET /library/info)

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -508,10 +508,37 @@ export const addGenre: RequestHandler = async (req, res) => {
   res.status(201).json(insertion);
 };
 
-export const getAlbum: RequestHandler<object, unknown, unknown, { album_id: string }> = async (req, res) => {
+export const getAlbum: RequestHandler<
+  object,
+  unknown,
+  unknown,
+  { album_id?: string; legacy_release_id?: string }
+> = async (req, res) => {
   const { query } = req;
+
+  // dj.wxyc.org per-release permalink front door (BS#1880): external callers
+  // (LML, wxyc.info, the request line) hold the tubafrenzy `legacy_release_id`,
+  // not the BS serial `library.id`. When given a legacy id, resolve it to the
+  // serial so a legacy-keyed permalink can reach the catalog. 404 when it maps
+  // to no catalog row (a `library.db` release not yet synced into BS Postgres).
+  if (query.legacy_release_id !== undefined) {
+    // Strict `Number()` (not `parseInt`) so trailing garbage ("65880xyz") and a
+    // repeated param (Express yields `string[]` → "1,2") both become NaN and are
+    // rejected, rather than silently parsing a partial/fabricated id.
+    const legacyId = Number(query.legacy_release_id);
+    if (!Number.isInteger(legacyId) || legacyId <= 0) {
+      throw new WxycError('Invalid legacy_release_id', 400);
+    }
+    const album = await libraryService.getAlbumByLegacyId(legacyId);
+    if (album === undefined) {
+      throw new WxycError('No catalog album for that legacy_release_id', 404);
+    }
+    res.status(200).json(album);
+    return;
+  }
+
   if (query.album_id === undefined) {
-    throw new WxycError('Bad Request, missing album identifier: album_id', 400);
+    throw new WxycError('Bad Request, missing album identifier: album_id or legacy_release_id', 400);
   }
 
   const album = await libraryService.getAlbumFromDB(parseInt(query.album_id));

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import * as Sentry from '@sentry/node';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
+import { getAlbumIdByLegacyId } from '../services/library.service.js';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import {
   mapProdEntryType,
@@ -489,16 +490,13 @@ const VALID_ROTATION_BINS = new Set(['S', 'L', 'M', 'H', 'N']);
 /**
  * Resolve a Backend-Service album_id from a tubafrenzy LIBRARY_RELEASE_ID.
  * Returns null if the library release ID is 0 or not found.
+ *
+ * Thin wrapper over `library.service.getAlbumIdByLegacyId` — the legacy→serial
+ * bridge now lives in one place (BS#1880). Kept so the inbound call sites below
+ * read unchanged.
  */
-async function resolveAlbumId(legacyLibraryReleaseId: number): Promise<number | null> {
-  if (!legacyLibraryReleaseId) return null;
-
-  const [row] = await db
-    .select({ id: library.id })
-    .from(library)
-    .where(eq(library.legacy_release_id, legacyLibraryReleaseId))
-    .limit(1);
-  return row?.id ?? null;
+function resolveAlbumId(legacyLibraryReleaseId: number): Promise<number | null> {
+  return getAlbumIdByLegacyId(legacyLibraryReleaseId);
 }
 
 /**

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1806,6 +1806,41 @@ export const getAlbumFromDB = async (album_id: number) => {
   return serializeReconciledIdentity(album[0]);
 };
 
+/**
+ * Resolve a Backend-Service catalog `library.id` (the serial PK) from a
+ * tubafrenzy `LIBRARY_RELEASE.ID`, which BS stores in the separate
+ * `library.legacy_release_id` column. Returns null for a 0/falsy legacy id or
+ * when no catalog row carries it.
+ *
+ * The two id spaces are distinct: external callers (LML `library.db.id`,
+ * `wxyc.info/libraryRelease?id=`, the request line) speak the legacy id, while
+ * every BS catalog read is keyed on the serial. This is the single home for the
+ * bridge — `routes/internal.route.ts` delegates here (BS#1880), matching the
+ * `libraryId === legacy_release_id` convention documented on the `/proxy/library`
+ * routes (`controllers/proxy.controller.ts`).
+ */
+export const getAlbumIdByLegacyId = async (legacyReleaseId: number): Promise<number | null> => {
+  if (!legacyReleaseId) return null;
+  const [row] = await db
+    .select({ id: library.id })
+    .from(library)
+    .where(eq(library.legacy_release_id, legacyReleaseId))
+    .limit(1);
+  return row?.id ?? null;
+};
+
+/**
+ * Fetch a catalog album by its tubafrenzy `legacy_release_id`, returning the
+ * same shape as {@link getAlbumFromDB}. Returns undefined when the legacy id
+ * resolves to no catalog row — e.g. a release present in the daily-rebuilt
+ * `library.db` but not yet synced into BS Postgres.
+ */
+export const getAlbumByLegacyId = async (legacyReleaseId: number) => {
+  const albumId = await getAlbumIdByLegacyId(legacyReleaseId);
+  if (albumId === null) return undefined;
+  return getAlbumFromDB(albumId);
+};
+
 export const markAlbumMissing = async (album_id: number) => {
   const result = await db
     .update(library)

--- a/tests/integration/library-legacy-info.spec.js
+++ b/tests/integration/library-legacy-info.spec.js
@@ -1,0 +1,54 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+/**
+ * Integration tests for GET /library/info?legacy_release_id=<id> (BS#1880).
+ *
+ * External callers (LML, wxyc.info, the request line) hold the tubafrenzy
+ * `LIBRARY_RELEASE.ID` (= BS `library.legacy_release_id`), not the BS serial
+ * `library.id`. This endpoint resolves the legacy id to the serial and returns
+ * the same album payload as `?album_id=`, so the dj-site legacy permalink front
+ * door can turn a legacy-keyed URL into the canonical `/dashboard/album/[serial]`.
+ *
+ * The seeded row (library.id=7100, legacy_release_id=65880, Autechre / Confield)
+ * comes from tests/fixtures/shape.sql. Pure BS PG — no mock LML required.
+ */
+
+const SHAPE_LIBRARY_ID = 7100;
+const SHAPE_LEGACY_ID = 65880;
+
+describe('GET /library/info?legacy_release_id= (BS#1880)', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  test('resolves a legacy_release_id to the serial-keyed album', async () => {
+    const res = await auth.get(`/library/info?legacy_release_id=${SHAPE_LEGACY_ID}`).expect(200);
+    expect(res.body.id).toBe(SHAPE_LIBRARY_ID);
+    expect(res.body.album_title).toBe('Confield');
+  });
+
+  test('returns the same album as the serial ?album_id= path', async () => {
+    const byLegacy = await auth.get(`/library/info?legacy_release_id=${SHAPE_LEGACY_ID}`).expect(200);
+    const bySerial = await auth.get(`/library/info?album_id=${SHAPE_LIBRARY_ID}`).expect(200);
+    expect(byLegacy.body.id).toBe(bySerial.body.id);
+    expect(byLegacy.body.album_title).toBe(bySerial.body.album_title);
+  });
+
+  test('returns 404 when the legacy_release_id maps to no catalog row', async () => {
+    const res = await auth.get('/library/info?legacy_release_id=999999999').expect(404);
+    expect(res.body.message ?? res.body.error ?? '').toMatch(/legacy_release_id/i);
+  });
+
+  test.each([['not-a-number'], ['0'], ['-5']])('returns 400 for an invalid legacy_release_id (%s)', async (bad) => {
+    const res = await auth.get(`/library/info?legacy_release_id=${bad}`).expect(400);
+    expect(res.body.message ?? res.body.error ?? '').toMatch(/legacy_release_id/i);
+  });
+
+  test('returns 400 when neither album_id nor legacy_release_id is provided', async () => {
+    const res = await auth.get('/library/info').expect(400);
+    expect(res.body.message ?? res.body.error ?? '').toMatch(/album identifier/i);
+  });
+});

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import type { Request, Response, NextFunction } from 'express';
 
 const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockGetAlbumByLegacyId = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
 const mockMarkAlbumMissing = jest.fn<() => Promise<{ id: number } | undefined>>();
 const mockMarkAlbumFound = jest.fn<() => Promise<{ id: number } | undefined>>();
 const mockFuzzySearchLibrary = jest.fn<() => Promise<unknown[]>>();
@@ -35,6 +36,7 @@ const mockSearchLibrary = jest.fn<() => Promise<{ results: unknown[]; total: num
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
+  getAlbumByLegacyId: mockGetAlbumByLegacyId,
   markAlbumMissing: mockMarkAlbumMissing,
   markAlbumFound: mockMarkAlbumFound,
   fuzzySearchLibrary: mockFuzzySearchLibrary,
@@ -118,6 +120,7 @@ import {
   markFound,
   searchForAlbum,
   addAlbum,
+  getAlbum,
   getRotationTracks,
   updateAlbum,
   searchLibraryQueryEndpoint,
@@ -893,6 +896,84 @@ describe('library.controller', () => {
 
       expect(mockSearchLibrary).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('getAlbum', () => {
+    it('returns 200 with the album when album_id is provided (serial path)', async () => {
+      mockGetAlbumFromDB.mockResolvedValue(fullAlbum);
+      const req = { query: { album_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getAlbum(req, res, next);
+
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(42);
+      expect(mockGetAlbumByLegacyId).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(fullAlbum);
+    });
+
+    it('returns 400 when neither album_id nor legacy_release_id is provided', async () => {
+      const req = { query: {} } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getAlbum(req, res, next)).rejects.toThrow('missing album identifier');
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    it('resolves legacy_release_id and returns 200 with the album (serial in id)', async () => {
+      mockGetAlbumByLegacyId.mockResolvedValue(fullAlbum);
+      const req = { query: { legacy_release_id: '65880' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getAlbum(req, res, next);
+
+      expect(mockGetAlbumByLegacyId).toHaveBeenCalledWith(65880);
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(fullAlbum);
+    });
+
+    it('prefers legacy_release_id over album_id when both are present', async () => {
+      mockGetAlbumByLegacyId.mockResolvedValue(fullAlbum);
+      const req = { query: { legacy_release_id: '65880', album_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getAlbum(req, res, next);
+
+      expect(mockGetAlbumByLegacyId).toHaveBeenCalledWith(65880);
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when legacy_release_id resolves to no catalog row', async () => {
+      mockGetAlbumByLegacyId.mockResolvedValue(undefined);
+      const req = { query: { legacy_release_id: '999999999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getAlbum(req, res, next)).rejects.toThrow('No catalog album for that legacy_release_id');
+    });
+
+    // '65880xyz' locks in strict Number() parsing (parseInt would have accepted
+    // the leading digits); '0'/'-5' are non-positive; 'not-a-number' is NaN.
+    it.each([['not-a-number'], ['0'], ['-5'], ['65880xyz']])(
+      'returns 400 for an invalid legacy_release_id (%s)',
+      async (bad) => {
+        const req = { query: { legacy_release_id: bad } } as unknown as Request;
+        const res = mockResponse();
+
+        await expect(getAlbum(req, res, next)).rejects.toThrow('Invalid legacy_release_id');
+        expect(mockGetAlbumByLegacyId).not.toHaveBeenCalled();
+      }
+    );
+
+    it('returns 400 for a repeated legacy_release_id (Express yields string[]) (#1553-style guard)', async () => {
+      // Number(['1','2']) → Number("1,2") → NaN, so a fabricated partial id is
+      // rejected rather than silently used.
+      const req = { query: { legacy_release_id: ['1', '2'] } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getAlbum(req, res, next)).rejects.toThrow('Invalid legacy_release_id');
+      expect(mockGetAlbumByLegacyId).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/library.getAlbumByLegacyId.test.ts
+++ b/tests/unit/services/library.getAlbumByLegacyId.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from '@jest/globals';
+import { db } from '@wxyc/database';
+import { getAlbumIdByLegacyId, getAlbumByLegacyId } from '../../../apps/backend/services/library.service';
+
+// The legacy→serial bridge (BS#1880). `getAlbumIdByLegacyId` is shaped
+// `await db.select({ id }).from(library).where(...).limit(1)` — `.limit()` is the
+// terminal step the await resolves, so we swap a thenable into that position via
+// the shared mock chain (`mockReturnValueOnce`), matching
+// library.catalogLastModifiedAt.test.ts. `getAlbumByLegacyId` composes this with
+// `getAlbumFromDB`; the happy path (a real join → serialized album) is covered by
+// tests/integration/library-legacy-info.spec.js, so here we pin only the cheap,
+// db-light branches the endpoint tests don't reach directly.
+
+const mockDb = db as unknown as {
+  _chain: Record<string, jest.Mock>;
+};
+
+describe('library.service: getAlbumIdByLegacyId / getAlbumByLegacyId', () => {
+  it('returns the serial library.id when a row carries the legacy_release_id', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([{ id: 7100 }]));
+    expect(await getAlbumIdByLegacyId(65880)).toBe(7100);
+  });
+
+  it('returns null when no row carries the legacy_release_id', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+    expect(await getAlbumIdByLegacyId(999999999)).toBeNull();
+  });
+
+  it('short-circuits to null for a 0/falsy legacy id without querying', async () => {
+    const before = mockDb._chain.limit.mock.calls.length;
+    expect(await getAlbumIdByLegacyId(0)).toBeNull();
+    expect(mockDb._chain.limit.mock.calls.length).toBe(before);
+  });
+
+  it('getAlbumByLegacyId resolves to undefined when the legacy id maps to no row', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+    expect(await getAlbumByLegacyId(999999999)).toBeUndefined();
+  });
+
+  it('getAlbumByLegacyId short-circuits to undefined for a 0/falsy legacy id', async () => {
+    expect(await getAlbumByLegacyId(0)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a legacy-keyed catalog lookup: `GET /library/info?legacy_release_id=<id>` resolves a tubafrenzy `LIBRARY_RELEASE.ID` (= LML `library.db.id`) to the Backend-Service serial `library.id` and returns the same album payload as the existing `?album_id=` path.

This is the Backend-Service half of the dj.wxyc.org per-release permalink work. External callers (LML, `wxyc.info`, the request line) only ever hold the tubafrenzy legacy id, while the dj-site card-catalog route (`/dashboard/album/[id]`) and `?album_id=` are keyed on the BS serial. The two id spaces are distinct and were previously bridged only by the private `resolveAlbumId()` behind the internal API. This exposes that bridge to the (authed) catalog read surface so a dj-site legacy permalink front door can turn a legacy-keyed URL into the canonical serial route.

## Changes

- `apps/backend/services/library.service.ts` — new `getAlbumIdByLegacyId(legacyReleaseId)` (the `legacy_release_id → library.id` query, lifted from `internal.route.ts`) and `getAlbumByLegacyId(legacyReleaseId)` (resolve then `getAlbumFromDB`, returns `undefined` when unresolved).
- `apps/backend/controllers/library.controller.ts` — `getAlbum` branches on `legacy_release_id` (preferred when present): `400` for missing/invalid/≤0, `404` when the legacy id maps to no catalog row, otherwise the album. Existing `?album_id=` behavior unchanged.
- `apps/backend/routes/internal.route.ts` — `resolveAlbumId` now delegates to `library.service.getAlbumIdByLegacyId`, so the bridge query lives in one place (inbound webhook call sites unchanged).
- Tests: new `getAlbum` unit coverage (the controller had none) + `tests/integration/library-legacy-info.spec.js` mirroring `library-tracks.spec.js` against the seeded `shape.sql` row (`library.id=7100 / legacy_release_id=65880`, Autechre / Confield).

## Auth

Same `catalog:read` as the existing `/library/info` — no new permission.

## Testing

- Unit: `tests/unit/controllers/library.controller.test.ts` — 61/61 green (8 new `getAlbum` cases).
- Lint + typecheck: clean.
- Integration: `library-legacy-info.spec.js` (resolve, serial-parity, 404 unresolved, 400 invalid/missing).

## Notes

- `404` on unresolved is deliberate: a release can exist in the daily-rebuilt `library.db` but not yet be synced into BS Postgres (the front door renders a "not in catalog yet" state rather than a cacheable redirect).
- **Intentional status asymmetry:** the new `legacy_release_id` miss returns `404`, while the pre-existing `album_id` miss returns `200` with an empty body (`getAlbumFromDB` → `undefined`). The new path is the more correct behavior; the `album_id` path is left unchanged here because the existing rightbar `AlbumDetailPanel` consumer relies on its current shape — normalizing it to `404` is a separate, wider-blast-radius change, not silent divergence.
- Surfaced but **out of scope**: `apps/backend/middleware/legacy/flowsheet.mirror.ts:274` writes the BS serial `album_id` into tubafrenzy's `LIBRARY_RELEASE_ID` column without reverse-mapping to `legacy_release_id` (the inbound path maps correctly) — filed separately.

Closes #1880
