### PR TITLE
fix(artwork): skip negative-caching on transient LML errors, not just confirmed absence

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -166,6 +166,17 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
   });
 
   if (!result.artworkUrl) {
+    if (result.errored) {
+      // BS#1089: every provider that came back empty did so by throwing
+      // (LML timeout/5xx/network blip), not by confirming there's no
+      // artwork. Skip the negative cache — writing here would strand up to
+      // 24h of cold artwork cells per container once LML recovers, since
+      // this cache is per-process (see the module doc above). Respond with
+      // a retryable upstream failure instead of a false "confirmed no
+      // artwork" 404.
+      res.status(502).json({ message: 'Artwork lookup temporarily unavailable' });
+      return;
+    }
     negativeCache.set(cacheKey, true);
     res.status(404).json({ message: 'No artwork found' });
     return;

--- a/apps/backend/services/artwork/finder.ts
+++ b/apps/backend/services/artwork/finder.ts
@@ -33,6 +33,17 @@ export class ArtworkFinder {
     }
 
     const allResults: ArtworkSearchResult[] = [];
+    // BS#1089: a provider that throws (LML timeout/5xx/network blip) hasn't
+    // confirmed "no artwork" — it just failed to answer. Track that
+    // separately from a provider that ran and genuinely found nothing, so a
+    // request where no provider found anything doesn't look the same
+    // whether every provider searched and came up empty or one of them
+    // never got to answer. This only matters when nothing was found at all
+    // — a later provider's real match still wins outright below, so a
+    // transient Discogs failure followed by a Last.fm hit is "found," not
+    // "errored" (don't infect a positive result from a partially-failing
+    // fallback chain).
+    let anyProviderErrored = false;
 
     for (const provider of this.providers) {
       try {
@@ -41,11 +52,16 @@ export class ArtworkFinder {
         console.log(`[ArtworkFinder] Provider ${provider.name} returned ${results.length} results`);
       } catch (error) {
         console.error(`[ArtworkFinder] Provider ${provider.name} failed:`, error);
+        anyProviderErrored = true;
         continue;
       }
     }
 
     if (allResults.length === 0) {
+      if (anyProviderErrored) {
+        console.log('[ArtworkFinder] No artwork found and at least one provider errored — not a confirmed absence');
+        return this.erroredResponse();
+      }
       console.log('[ArtworkFinder] No artwork found from any provider');
       return this.emptyResponse();
     }
@@ -70,7 +86,8 @@ export class ArtworkFinder {
   }
 
   /**
-   * Create an empty artwork response.
+   * Create an empty artwork response — a confirmed absence: every provider
+   * that was asked ran to completion and found nothing.
    */
   private emptyResponse(): ArtworkResponse {
     return {
@@ -81,6 +98,17 @@ export class ArtworkFinder {
       source: null,
       confidence: 0,
     };
+  }
+
+  /**
+   * Same empty shape as {@link emptyResponse}, tagged `errored: true`
+   * (BS#1089). Returned when nothing was found AND at least one provider
+   * never got to confirm an answer because it threw. Callers (the
+   * `/proxy/artwork/search` negative cache) must not treat this the same as
+   * a confirmed absence.
+   */
+  private erroredResponse(): ArtworkResponse {
+    return { ...this.emptyResponse(), errored: true };
   }
 }
 

--- a/apps/backend/services/artwork/providers/base.ts
+++ b/apps/backend/services/artwork/providers/base.ts
@@ -17,7 +17,13 @@ export interface ArtworkProvider {
    * Search for album artwork matching the request.
    *
    * @param request - The artwork request containing song/album/artist info
-   * @returns List of search results, ordered by relevance. Empty list if no results found.
+   * @returns List of search results, ordered by relevance. An empty list
+   *   means the search ran to completion and confirmed no match — a
+   *   provider backed by an external service that could not answer (e.g.
+   *   an upstream timeout/5xx) must throw rather than resolve empty, so
+   *   `ArtworkFinder.find` can tell "confirmed no artwork" apart from
+   *   "couldn't determine" (BS#1089). `DiscogsProvider.search` is the
+   *   reference implementation of this contract.
    */
   search(request: ArtworkRequest): Promise<ArtworkSearchResult[]>;
 }

--- a/apps/backend/services/artwork/providers/discogs.ts
+++ b/apps/backend/services/artwork/providers/discogs.ts
@@ -30,15 +30,19 @@ export class DiscogsProvider implements ArtworkProvider {
       return [];
     }
 
-    let lookupResponse;
-    try {
-      lookupResponse = await lmlLookupCoordinator.lookup(request.artist || '', request.album, request.song, {
-        caller: 'artwork-discogs-fallback',
-      });
-    } catch (error) {
-      console.warn('[DiscogsProvider] LML lookup failed:', error);
-      return [];
-    }
+    // BS#1089: let a lookup failure propagate instead of swallowing it to
+    // `[]`. `lmlLookupCoordinator.lookup` never caches errors and rethrows
+    // whatever `lookupMetadata` threw — in practice always an
+    // `LmlClientError` (timeout/5xx/network blip; see `@wxyc/lml-client`'s
+    // `lmlFetch`). Swallowing it here made a transient LML outage
+    // indistinguishable from "LML answered and found nothing," which is
+    // exactly what let a brief LML degradation get cached as "confirmed no
+    // artwork" for 24h. `ArtworkFinder.find` is the caller that now tells
+    // the two apart (a thrown error vs. an empty array) and tags its
+    // response accordingly.
+    const lookupResponse = await lmlLookupCoordinator.lookup(request.artist || '', request.album, request.song, {
+      caller: 'artwork-discogs-fallback',
+    });
 
     const results: ArtworkSearchResult[] = [];
     for (const item of lookupResponse.results ?? []) {

--- a/apps/backend/services/requestLine/types.ts
+++ b/apps/backend/services/requestLine/types.ts
@@ -237,6 +237,17 @@ export interface ArtworkResponse {
   artist: string | null;
   source: string | null;
   confidence: number;
+  /**
+   * BS#1089: true when every provider that came back with zero results did
+   * so by throwing (LML timeout/5xx/network blip, or another provider-side
+   * exception) rather than confirming an empty match. Distinguishes
+   * "couldn't determine" from "confirmed no artwork" so a caller like the
+   * `/proxy/artwork/search` negative cache doesn't treat a transient
+   * upstream failure as a durable negative result. Absent (falsy) on a
+   * genuine match or a confirmed-empty search — existing callers that don't
+   * read this field see unchanged behavior.
+   */
+  errored?: boolean;
 }
 
 /**

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -140,7 +140,18 @@ jest.mock('../../../apps/backend/services/artwork/finder', () => ({
   getArtworkFinder: () => ({ find: mockFind }),
 }));
 
-// LRU cache mock (proxy controller uses it for artwork caching)
+// LRU cache mock (proxy controller uses it for artwork caching).
+//
+// Note (BS#1089): this monorepo has a *second*, nested `lru-cache` install
+// under `apps/backend/node_modules/` (separate from the hoisted root copy),
+// so `proxy.controller.ts`'s `import { LRUCache } from 'lru-cache'` resolves
+// to a different physical module than this `jest.mock('lru-cache', ...)`
+// call does from this file's location — the mock below is never actually
+// substituted into proxy.controller.ts, which runs against the real
+// `lru-cache` package. That's harmless for the tests that only depend on a
+// cache starting empty, but it means the negative-cache tests below can't
+// assert on a mocked `.set`/`.has` — they instead assert on the REAL cache's
+// observable behavior (does a follow-up request re-hit the finder or not).
 jest.mock('lru-cache', () => ({
   LRUCache: jest.fn().mockImplementation(() => ({
     get: jest.fn(),
@@ -290,6 +301,113 @@ describe('proxy.controller', () => {
       const res = createMockRes();
 
       await expect(searchArtwork(req, res as Response, mockNext)).rejects.toThrow(error);
+    });
+
+    // --- BS#1089: negative-cache must not conflate a transient upstream
+    // error with a confirmed "no artwork" result. `artworkCache`/
+    // `negativeCache` are real module-level LRU singletons here (see the
+    // `jest.mock('lru-cache', ...)` note above — it isn't actually wired
+    // into proxy.controller.ts in this monorepo layout), so these tests
+    // assert on the cache's real, observable effect on a follow-up request
+    // rather than on a mocked `.set` call. Each test uses an artist/release
+    // pair not used by any other `searchArtwork` test in this file, since
+    // the cache persists across tests within this run.
+
+    it('does not negative-cache a transient upstream failure: returns 502, and a follow-up request re-attempts the lookup', async () => {
+      // Mirrors ArtworkFinder.find's `errored: true` tag: every provider
+      // came back empty because it threw (e.g. an LML timeout), not because
+      // it confirmed there's no artwork. A negative-cache write here would
+      // strand this key as "no artwork" for the full 24h TTL even after LML
+      // recovers — proven below by a second, identical request re-hitting
+      // the finder instead of short-circuiting to a cached 404.
+      //
+      // `mockReset()` (not just the outer `beforeEach`'s `clearAllMocks()`)
+      // because `clearMocks`/`clearAllMocks` don't drain a queued-but-
+      // unconsumed `mockResolvedValueOnce` — if this test's second call
+      // never reaches the finder (the bug this test guards against), that
+      // second queued value would otherwise leak into the next test.
+      mockFind.mockReset();
+      mockFind.mockResolvedValueOnce({
+        artworkUrl: null,
+        releaseUrl: null,
+        album: null,
+        artist: null,
+        source: null,
+        confidence: 0,
+        errored: true,
+      });
+      mockFind.mockResolvedValueOnce({
+        artworkUrl: 'https://i.discogs.com/edits.jpg',
+        releaseUrl: 'https://discogs.com/release/1',
+        album: 'Edits',
+        artist: 'Chuquimamani-Condori',
+        source: 'discogs',
+        confidence: 0.9,
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(Buffer.from('img').buffer),
+        headers: new Headers({ 'content-type': 'image/jpeg' }),
+      } as unknown as globalThis.Response);
+      mockClassifyNSFW.mockResolvedValue('sfw');
+
+      const req = { query: { artistName: 'Chuquimamani-Condori', releaseTitle: 'Edits' } } as unknown as Request;
+
+      const firstRes = createMockRes();
+      await searchArtwork(req, firstRes as Response, mockNext);
+      expect(firstRes.status).toHaveBeenCalledWith(502);
+
+      const secondRes = createMockRes();
+      await searchArtwork(req, secondRes as Response, mockNext);
+
+      // Nothing was cached, so the second request re-consults the finder
+      // (and this time gets a real match) instead of short-circuiting.
+      expect(mockFind).toHaveBeenCalledTimes(2);
+      expect(secondRes.status).toHaveBeenCalledWith(200);
+    });
+
+    it('negative-caches a confirmed absence: returns 404, and a follow-up request short-circuits without re-invoking the finder', async () => {
+      // Every provider ran to completion and confirmed no match — this IS
+      // the legitimate negative-cache case (albums genuinely absent from
+      // Discogs), so a subsequent identical request should be served from
+      // the cache rather than re-attempting the lookup for the rest of the
+      // TTL.
+      //
+      // `mockReset()` for the same reason as the previous test — guards
+      // against a queued-but-unconsumed `mockResolvedValueOnce` leaking in
+      // from a prior test (`clearMocks` doesn't drain that queue).
+      mockFind.mockReset();
+      mockFind.mockResolvedValueOnce({
+        artworkUrl: null,
+        releaseUrl: null,
+        album: null,
+        artist: null,
+        source: null,
+        confidence: 0,
+        errored: false,
+      });
+      // If the second request reached the finder again, this would resolve
+      // to a real match — the assertion below proves it never does.
+      mockFind.mockResolvedValueOnce({
+        artworkUrl: 'https://i.discogs.com/obscure.jpg',
+        releaseUrl: 'https://discogs.com/release/2',
+        album: 'Obscure Album',
+        artist: 'Obscure Artist',
+        source: 'discogs',
+        confidence: 0.9,
+      });
+
+      const req = { query: { artistName: 'Obscure Artist', releaseTitle: 'Obscure Album' } } as unknown as Request;
+
+      const firstRes = createMockRes();
+      await searchArtwork(req, firstRes as Response, mockNext);
+      expect(firstRes.status).toHaveBeenCalledWith(404);
+
+      const secondRes = createMockRes();
+      await searchArtwork(req, secondRes as Response, mockNext);
+
+      expect(mockFind).toHaveBeenCalledTimes(1);
+      expect(secondRes.status).toHaveBeenCalledWith(404);
     });
   });
 

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -136,12 +136,17 @@ describe('artwork DiscogsProvider', () => {
       expect(results).toHaveLength(0);
     });
 
-    it('returns empty on LML error', async () => {
-      mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+    it('propagates the error on LML failure (BS#1089) instead of swallowing it to empty', async () => {
+      // Pre-BS#1089 this resolved to `[]`, making a transient LML timeout/5xx
+      // indistinguishable from a confirmed "no match" — the bug that let a
+      // brief LML outage get negative-cached as "no artwork" for 24h at the
+      // proxy controller. `ArtworkFinder.find` is the caller that now
+      // depends on this throwing so it can tag the response `errored: true`
+      // instead of treating an all-empty sweep as a confirmed absence.
+      const lmlError = new Error('LML down');
+      mockLookupMetadata.mockRejectedValue(lmlError);
 
-      const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
-
-      expect(results).toEqual([]);
+      await expect(provider.search({ artist: 'Autechre', album: 'Confield' })).rejects.toThrow(lmlError);
     });
 
     it('uses song when album is not provided', async () => {

--- a/tests/unit/services/artwork.finder.test.ts
+++ b/tests/unit/services/artwork.finder.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for ArtworkFinder (BS#1089).
+ *
+ * Focus: the finder must distinguish "every provider ran and confirmed no
+ * match" from "at least one provider threw and never got to answer" — only
+ * the former is a confirmed absence. Fake providers are injected directly
+ * via the constructor (`new ArtworkFinder(providers)`), so these tests don't
+ * need to mock the LML client or any provider module.
+ */
+import { ArtworkFinder } from '../../../apps/backend/services/artwork/finder';
+import type { ArtworkProvider } from '../../../apps/backend/services/artwork/providers/base';
+import type { ArtworkRequest, ArtworkSearchResult } from '../../../apps/backend/services/requestLine/types';
+
+function confirmedEmptyProvider(name: string): ArtworkProvider {
+  return {
+    name,
+    search: (_request: ArtworkRequest) => Promise.resolve([]),
+  };
+}
+
+function throwingProvider(name: string, error: Error = new Error(`${name} down`)): ArtworkProvider {
+  return {
+    name,
+    search: (_request: ArtworkRequest) => Promise.reject<ArtworkSearchResult[]>(error),
+  };
+}
+
+function matchingProvider(name: string, result: ArtworkSearchResult): ArtworkProvider {
+  return {
+    name,
+    search: (_request: ArtworkRequest) => Promise.resolve([result]),
+  };
+}
+
+const sampleRequest: ArtworkRequest = { artist: 'Chuquimamani-Condori', album: 'Edits' };
+
+describe('ArtworkFinder', () => {
+  it('returns a confirmed-empty response (not errored) when every provider runs and finds nothing', async () => {
+    const finder = new ArtworkFinder([confirmedEmptyProvider('discogs'), confirmedEmptyProvider('lastfm')]);
+
+    const result = await finder.find(sampleRequest);
+
+    expect(result.artworkUrl).toBeNull();
+    expect(result.errored).toBeFalsy();
+  });
+
+  it('returns an errored response (not a confirmed absence) when a provider throws and nothing else is found', async () => {
+    // Mirrors the production failure mode: LML times out (DiscogsProvider
+    // throws), and the lower-confidence fallbacks genuinely have nothing —
+    // this must NOT look identical to "confirmed no artwork."
+    const finder = new ArtworkFinder([
+      throwingProvider('discogs'),
+      confirmedEmptyProvider('lastfm'),
+      confirmedEmptyProvider('itunes'),
+    ]);
+
+    const result = await finder.find(sampleRequest);
+
+    expect(result.artworkUrl).toBeNull();
+    expect(result.errored).toBe(true);
+  });
+
+  it('still tries every provider after one throws (Discogs failing must not skip Last.fm/iTunes)', async () => {
+    const lastFmSearch = jest.fn((_request: ArtworkRequest): Promise<ArtworkSearchResult[]> => Promise.resolve([]));
+    const finder = new ArtworkFinder([
+      throwingProvider('discogs'),
+      { name: 'lastfm', search: lastFmSearch },
+      confirmedEmptyProvider('itunes'),
+    ]);
+
+    await finder.find(sampleRequest);
+
+    expect(lastFmSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the match — not tagged errored — when a later provider succeeds after an earlier one threw', async () => {
+    // Constraint from the issue: "A successful Last.fm or iTunes match after
+    // a Discogs error is 'found, cache positive' — don't infect the
+    // negative cache from a partially-failing fallback chain."
+    const match: ArtworkSearchResult = {
+      artworkUrl: 'https://lastfm.example/edits.jpg',
+      releaseUrl: 'https://last.fm/music/Chuquimamani-Condori/Edits',
+      album: 'Edits',
+      artist: 'Chuquimamani-Condori',
+      source: 'lastfm',
+      confidence: 0.7,
+    };
+    const finder = new ArtworkFinder([throwingProvider('discogs'), matchingProvider('lastfm', match)]);
+
+    const result = await finder.find(sampleRequest);
+
+    expect(result.artworkUrl).toBe(match.artworkUrl);
+    expect(result.source).toBe('lastfm');
+    expect(result.errored).toBeFalsy();
+  });
+
+  it('returns a confirmed-empty response (not errored) for an empty request — no provider is even asked', async () => {
+    const discogsSearch = jest.fn((_request: ArtworkRequest): Promise<ArtworkSearchResult[]> => Promise.resolve([]));
+    const finder = new ArtworkFinder([{ name: 'discogs', search: discogsSearch }]);
+
+    const result = await finder.find({});
+
+    expect(result.artworkUrl).toBeNull();
+    expect(result.errored).toBeFalsy();
+    expect(discogsSearch).not.toHaveBeenCalled();
+  });
+
+  it('picks the highest-confidence result when multiple providers find matches', async () => {
+    const lowConfidence: ArtworkSearchResult = {
+      artworkUrl: 'https://itunes.example/edits.jpg',
+      releaseUrl: 'https://itunes.example/release',
+      album: 'Edits',
+      artist: 'Chuquimamani-Condori',
+      source: 'itunes',
+      confidence: 0.4,
+    };
+    const highConfidence: ArtworkSearchResult = {
+      artworkUrl: 'https://discogs.example/edits.jpg',
+      releaseUrl: 'https://discogs.com/release/1',
+      album: 'Edits',
+      artist: 'Chuquimamani-Condori',
+      source: 'discogs',
+      confidence: 0.95,
+    };
+    const finder = new ArtworkFinder([matchingProvider('itunes', lowConfidence), matchingProvider('discogs', highConfidence)]);
+
+    const result = await finder.find(sampleRequest);
+
+    expect(result.source).toBe('discogs');
+    expect(result.artworkUrl).toBe(highConfidence.artworkUrl);
+  });
+});

--- a/tests/unit/services/artwork.finder.test.ts
+++ b/tests/unit/services/artwork.finder.test.ts
@@ -122,7 +122,10 @@ describe('ArtworkFinder', () => {
       source: 'discogs',
       confidence: 0.95,
     };
-    const finder = new ArtworkFinder([matchingProvider('itunes', lowConfidence), matchingProvider('discogs', highConfidence)]);
+    const finder = new ArtworkFinder([
+      matchingProvider('itunes', lowConfidence),
+      matchingProvider('discogs', highConfidence),
+    ]);
 
     const result = await finder.find(sampleRequest);
 


### PR DESCRIPTION
## Summary

- `DiscogsProvider.search` caught every `lmlLookupCoordinator.lookup` failure and resolved to `[]`, so `ArtworkFinder.find` couldn't distinguish "LML timed out / 5xx / network blip" from "LML answered and found nothing." A brief LML degradation got negative-cached at the `/proxy/artwork/search` layer as "confirmed no artwork" for the full 24h per-process TTL, independently across each of Backend's containers.
- `DiscogsProvider.search` now lets a lookup failure propagate instead of swallowing it (`ArtworkProvider.search`'s contract doc updated accordingly).
- `ArtworkFinder.find` tracks whether any provider threw versus ran to completion and confirmed empty. An all-empty result is tagged `errored: true` only when at least one provider never got to answer — a later provider's real match after an earlier provider's error still returns positive and untagged, so a transient Discogs failure followed by a Last.fm hit is "found, cache positive," not infected by the earlier error.
- `proxy.controller.ts`'s `searchArtwork` skips the negative-cache write and responds `502` on an errored result instead of writing a false "confirmed no artwork" `404`. The two other pre-existing negative-cache write sites (image-download failure, NSFW classification) are unchanged — out of scope for this issue.

## Test plan

- [x] `tests/unit/services/artwork.discogs-provider.test.ts` — `DiscogsProvider.search` now rejects (propagates) on an LML lookup failure instead of resolving to `[]`.
- [x] `tests/unit/services/artwork.finder.test.ts` (new) — `ArtworkFinder.find`: confirmed-empty when every provider runs and finds nothing; `errored: true` when a provider throws and nothing else is found; every provider is still tried after one throws; a later provider's match after an earlier error returns positive and untagged; empty request stays a confirmed-empty non-error; highest-confidence match still wins among several matches.
- [x] `tests/unit/controllers/proxy.controller.test.ts` — `searchArtwork`: an errored finder result returns `502` and a follow-up identical request re-attempts the lookup (proving nothing was cached); a confirmed-absence finder result returns `404` and a follow-up identical request short-circuits without re-invoking the finder (proving the negative cache still works for the legitimate case).
- [x] `npm run lint` — clean (0 errors on the full run; pre-existing warnings elsewhere untouched).
- [x] `npm run typecheck` — clean across all workspaces.
- [x] `npm run test:unit` — 366/366 suites, 5593/5593 tests passing.
- [x] Confirmed red→green: stashed the source changes and re-ran the new/modified tests to verify they fail against the pre-fix code, then restored the fix and confirmed green.
- [ ] `npm run test:integration` / `ci:testmock` — not completed locally due to unrelated local-environment friction (a native Postgres already bound to the default port, and the plain `dev` profile running with rate limiting enabled by default causes a sign-in 429 avalanche across the integration suite's shared setup). No integration spec exercises the changed files (`proxy.controller.ts`'s `searchArtwork`, the artwork finder/provider), so this doesn't cover new ground; flagging for reviewer awareness rather than blocking on it.

Closes #1089