### PR TITLE
feat(proxy): add server-side LRU caching to album/artist/entity/spotify endpoints

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -689,6 +689,7 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
         if (criticReviews.length > 0) metadata.criticReviews = criticReviews;
       } catch (reviewsError) {
         console.warn('[ProxyController] critic-reviews lookup failed; omitting criticReviews:', reviewsError);
+        cacheable = false;
       }
     }
 

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -8,6 +8,16 @@
  *
  * All handlers require `requirePermissions({})` + `trackActivity` +
  * `proxyRateLimit` middleware applied at the route level.
+ *
+ * Every handler that fans out to an upstream (LML or Spotify) sits behind an
+ * in-process LRU cache (BS#988, following BS#1089's negative-cache rule): a
+ * confirmed absence (a definitive 404 from the upstream) is cached, but a
+ * transient failure (timeout/5xx/network) never is — caching a transient
+ * failure would strand a degraded response for the full TTL even after the
+ * upstream recovers. `searchArtwork`'s `artworkCache`/`negativeCache` pair
+ * originated the pattern; `getAlbumMetadata`, `getArtistMetadata`,
+ * `resolveEntity`, and `getSpotifyTrack` each declare their own cache
+ * immediately above their handler.
  */
 import { RequestHandler } from 'express';
 import * as Sentry from '@sentry/node';
@@ -439,10 +449,60 @@ function parseDiscogsReleaseIdFromUrl(url: string): number | undefined {
   return Number.isFinite(id) && id > 0 ? id : undefined;
 }
 
+// --- Album metadata cache (BS#988) ---
+//
+// Positive-only server-side memo of the assembled `/proxy/metadata/album`
+// enrichment (everything except the request-echoed `artistName`/
+// `releaseTitle`/`trackTitle` base fields — see `albumMetadataCacheKey` and
+// the write site in the handler below). Keeping the base fields out of the
+// cached value means a hit never echoes back a different caller's exact
+// request casing; those three are always assembled fresh from the CURRENT
+// request, cache hit or miss.
+//
+// Never written on a transient failure (BS#1089 rule, mirrored here): a
+// local DB blip or an LML timeout/5xx/network error leaves the assembled
+// response only partially resolved, and caching that degraded shape would
+// strand it for the full TTL even after the upstream recovers. Only a
+// fully-resolved attempt — a persisted-state hit, or a completed (matched
+// or definitively empty) LML round-trip — is cached.
+
+const albumMetadataCache = new LRUCache<string, Record<string, unknown>>({
+  max: 2000,
+  ttl: 1000 * 60 * 60, // 1h (BS#988)
+});
+
+/** Test-only: drop cached entries between cases. */
+export function __resetAlbumMetadataCacheForTests(): void {
+  albumMetadataCache.clear();
+}
+
+/** Base fields excluded from the cached value — see the cache's doc comment above. */
+const ALBUM_METADATA_BASE_FIELDS = new Set(['artistName', 'releaseTitle', 'trackTitle']);
+
+function extractAlbumMetadataEnrichment(metadata: Record<string, unknown>): Record<string, unknown> {
+  const enrichment: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!ALBUM_METADATA_BASE_FIELDS.has(key)) enrichment[key] = value;
+  }
+  return enrichment;
+}
+
+/**
+ * CRITIC_REVIEWS_ENABLED is the one feature flag that changes this
+ * response's shape (adds `criticReviews`) — folded into the key so a flag
+ * flip can't serve a stale shape out of the TTL window. Mirrors
+ * `trackSearchCacheKey` in `library.service.ts`.
+ */
+function albumMetadataCacheKey(artistName: string, releaseTitle?: string, trackTitle?: string): string {
+  const flagBit = getCriticReviewsConfig().enabled ? '1' : '0';
+  const norm = (s?: string) => (s || '').toLowerCase().trim();
+  return `${norm(artistName)}|${norm(releaseTitle)}|${norm(trackTitle)}:${flagBit}`;
+}
+
 /**
  * GET /proxy/metadata/album
  *
- * Cache-first (BS#1331). The handler consults persisted state — the
+ * Cache-first (BS#1331; server-side response memo BS#988). The handler consults persisted state — the
  * `album_metadata` JOIN to `flowsheet` via the normalized `(artist,
  * album)` lookup key, partial-indexed by `flowsheet_album_link_lookup_idx`
  * — before going to LML. On a local hit it serves what BS already knows,
@@ -489,143 +549,195 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   if (!artistName) throw new WxycError('artistName query parameter is required', 400);
 
   // Base identity fields (BS#1827): exactly what the caller already asked
-  // about, so assembled unconditionally before any lookup below — nothing
-  // that happens next (a DB blip, an LML timeout) can ever erase these.
+  // about, so assembled unconditionally before any lookup or cache check
+  // below — nothing that happens next (a DB blip, an LML timeout, a cache
+  // hit populated by a differently-cased prior request) can ever erase or
+  // relabel these.
   const metadata: Record<string, unknown> = { artistName };
   if (releaseTitle) metadata.releaseTitle = releaseTitle;
   if (trackTitle) metadata.trackTitle = trackTitle;
 
-  // Cache-first: consult BS's own persisted state before going to LML.
-  // Catch-arm-shape rows (YT/BC/SC populated, Apple/Spotify/artwork null)
-  // count as hits; the persisted nulls are served, then `searchUrlProvider`
-  // fills missing streaming URLs at the bottom of the handler. iOS sees
-  // the same shape it would on the LML-fallthrough path.
-  //
-  // Resolve the linked flowsheet row from the normalized `(artist, album)`
-  // lookup key ONCE (BS#1827: album_id plus the base catalog fields, one
-  // query), then feed the album_id to both the persisted-metadata read and
-  // (below) the critic-reviews read. Resolving per-read would let a
-  // flowsheet insert land between the calls and make them describe
-  // different albums for the same request.
-  //
-  // A thrown DB error here would propagate as 500 and regress availability
-  // versus the LML-fallthrough path (which catches LML errors and degrades
-  // to synthesized search URLs). Treat any DB failure as a cache miss and
-  // fall through to LML — the caller's worst-case latency goes up, but the
-  // request still completes with a 200. Because album_id and the base
-  // fields now come from the SAME query, a failure here can no longer
-  // "partially" fail — it drops both together, which is the correct model:
-  // there's nothing left to partially succeed at.
-  let albumId: number | null = null;
-  let persisted: PersistedAlbumMetadata | null = null;
-  try {
-    const linkedRow = await selectLinkedFlowsheetRow(artistName, releaseTitle);
-    albumId = linkedRow?.album_id ?? null;
-    // Base catalog fields BS wrote at play time (BS#1827): sourced from the
-    // SAME row album_id came from. A free-text row that has never linked to
-    // an album_id has no efficient local source for these three (see
-    // selectLinkedFlowsheetRow's doc comment) — its artist/release/track
-    // identity above still survives via the request echo.
-    if (linkedRow?.record_label) metadata.recordLabel = linkedRow.record_label;
-    if (linkedRow?.label_id != null) metadata.labelId = linkedRow.label_id;
-    if (linkedRow?.metadata_status) metadata.metadataStatus = linkedRow.metadata_status;
-    if (albumId !== null) persisted = await lookupAlbumMetadataById(albumId);
-  } catch (lookupError) {
-    console.warn('[ProxyController] local metadata lookup failed; falling through to LML:', lookupError);
-  }
+  // BS#988: server-side cache in front of the persisted-state read + LML
+  // round-trip below. A hit short-circuits both entirely — see
+  // `albumMetadataCache`'s doc comment above for what is (and isn't) cached.
+  const cacheKey = albumMetadataCacheKey(artistName, releaseTitle, trackTitle);
+  const cachedEnrichment = albumMetadataCache.get(cacheKey);
+  const cacheHit = cachedEnrichment !== undefined;
 
-  if (persisted) Object.assign(metadata, buildLocalMetadataResponse(persisted));
   let upstreamCalls = 0;
+  let albumId: number | null = null;
 
-  if (!persisted) {
-    // Count the LML attempt before awaiting it — counting on success only
-    // would conflate the LML-failure cohort with the local-hit cohort on
-    // the trace explorer's `upstream_calls=0` split, masking LML incidents
-    // as healthy cache-hit growth.
-    upstreamCalls += 1;
-    let artwork: DiscogsMatchResult | undefined;
+  if (cacheHit) {
+    Object.assign(metadata, cachedEnrichment);
+  } else {
+    // Cache-first: consult BS's own persisted state before going to LML.
+    // Catch-arm-shape rows (YT/BC/SC populated, Apple/Spotify/artwork null)
+    // count as hits; the persisted nulls are served, then `searchUrlProvider`
+    // fills missing streaming URLs at the bottom of the handler. iOS sees
+    // the same shape it would on the LML-fallthrough path.
+    //
+    // Resolve the linked flowsheet row from the normalized `(artist, album)`
+    // lookup key ONCE (BS#1827: album_id plus the base catalog fields, one
+    // query), then feed the album_id to both the persisted-metadata read and
+    // (below) the critic-reviews read. Resolving per-read would let a
+    // flowsheet insert land between the calls and make them describe
+    // different albums for the same request.
+    //
+    // A thrown DB error here would propagate as 500 and regress availability
+    // versus the LML-fallthrough path (which catches LML errors and degrades
+    // to synthesized search URLs). Treat any DB failure as a cache miss and
+    // fall through to LML — the caller's worst-case latency goes up, but the
+    // request still completes with a 200. Because album_id and the base
+    // fields now come from the SAME query, a failure here can no longer
+    // "partially" fail — it drops both together, which is the correct model:
+    // there's nothing left to partially succeed at.
+    let persisted: PersistedAlbumMetadata | null = null;
+    // BS#988: gates the cache write below. A degraded response — a local DB
+    // blip or a transient (timeout/5xx/network) LML failure — must never be
+    // memoized for the full TTL; mirrors the #1089 rule for the artwork
+    // negative cache (only a fully-resolved attempt is cacheable).
+    let cacheable = true;
     try {
-      const lookupResponse: LookupResponse = await lmlLookupCoordinator.lookup(artistName, releaseTitle, trackTitle, {
-        caller: 'proxy-album-metadata',
-      });
-      artwork = lookupResponse.results?.[0]?.artwork;
-    } catch (searchError) {
-      console.warn('[ProxyController] LML lookup failed:', searchError);
+      const linkedRow = await selectLinkedFlowsheetRow(artistName, releaseTitle);
+      albumId = linkedRow?.album_id ?? null;
+      // Base catalog fields BS wrote at play time (BS#1827): sourced from the
+      // SAME row album_id came from. A free-text row that has never linked to
+      // an album_id has no efficient local source for these three (see
+      // selectLinkedFlowsheetRow's doc comment) — its artist/release/track
+      // identity above still survives via the request echo.
+      if (linkedRow?.record_label) metadata.recordLabel = linkedRow.record_label;
+      if (linkedRow?.label_id != null) metadata.labelId = linkedRow.label_id;
+      if (linkedRow?.metadata_status) metadata.metadataStatus = linkedRow.metadata_status;
+      if (albumId !== null) persisted = await lookupAlbumMetadataById(albumId);
+    } catch (lookupError) {
+      console.warn('[ProxyController] local metadata lookup failed; falling through to LML:', lookupError);
+      cacheable = false;
     }
 
-    if (artwork) {
-      populateCommonMetadataFields(metadata, artwork);
-      populateReleaseMetadata(metadata, {
-        year: artwork.release_year,
-        genres: artwork.genres,
-        styles: artwork.styles,
-        label: artwork.label,
-        artist_id: artwork.discogs_artist_id,
-        released: artwork.full_release_date,
-        tracklist: artwork.tracklist,
-        artwork_url: artwork.artwork_url,
-      });
+    if (persisted) Object.assign(metadata, buildLocalMetadataResponse(persisted));
+
+    if (!persisted) {
+      // Count the LML attempt before awaiting it — counting on success only
+      // would conflate the LML-failure cohort with the local-hit cohort on
+      // the trace explorer's `upstream_calls=0` split, masking LML incidents
+      // as healthy cache-hit growth.
+      upstreamCalls += 1;
+      let artwork: DiscogsMatchResult | undefined;
+      try {
+        const lookupResponse: LookupResponse = await lmlLookupCoordinator.lookup(artistName, releaseTitle, trackTitle, {
+          caller: 'proxy-album-metadata',
+        });
+        artwork = lookupResponse.results?.[0]?.artwork;
+      } catch (searchError) {
+        console.warn('[ProxyController] LML lookup failed:', searchError);
+        cacheable = false;
+      }
+
+      if (artwork) {
+        populateCommonMetadataFields(metadata, artwork);
+        populateReleaseMetadata(metadata, {
+          year: artwork.release_year,
+          genres: artwork.genres,
+          styles: artwork.styles,
+          label: artwork.label,
+          artist_id: artwork.discogs_artist_id,
+          released: artwork.full_release_date,
+          tracklist: artwork.tracklist,
+          artwork_url: artwork.artwork_url,
+        });
+      }
+    }
+
+    // Fallback: construct search URLs for services without persisted/LML URLs.
+    // Per-service semantics live in `SearchUrlProvider` (BS#889) — each
+    // service uses a different field-fallback order, so the URLs are no
+    // longer guaranteed to share a query string. Old behavior was a single
+    // combined `${artistName} ${searchTerm}` for all three; the new behavior
+    // matches the runtime path and the recurring backfill so iOS gets
+    // identical search URLs regardless of which BS path produced them.
+    //
+    // Post-BS#1185: Spotify and Apple Music also have search-URL fallbacks so
+    // iOS doesn't show greyed buttons when LML fails or returns zero results.
+    //
+    // BS#1192's verified-rejection invariant is a *write-path* concern (don't
+    // persist synth URLs in album_metadata). Synthesizing at request time
+    // doesn't poison persisted state, and both the local-hit and LML
+    // branches synthesize here so iOS sees identical degradation behavior
+    // regardless of which branch served the request.
+    const fallbackUrls = searchUrlProvider.getAllSearchUrls(artistName, releaseTitle, trackTitle);
+    if (!metadata.spotifyUrl) metadata.spotifyUrl = fallbackUrls.spotifyUrl;
+    if (!metadata.appleMusicUrl) metadata.appleMusicUrl = fallbackUrls.appleMusicUrl;
+    if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = fallbackUrls.youtubeMusicUrl;
+    if (!metadata.bandcampUrl) metadata.bandcampUrl = fallbackUrls.bandcampUrl;
+    if (!metadata.soundcloudUrl) metadata.soundcloudUrl = fallbackUrls.soundcloudUrl;
+
+    // External critic-review snippets (album-critic-reviews slice, ADR 0012).
+    // Flag-gated (`CRITIC_REVIEWS_ENABLED`, default off) so prod behavior — the
+    // response shape and the serve-path query plan — is unchanged until an
+    // operator opts in, keeping this compatible with the #32 hardening freeze
+    // on the album-metadata serve path. Reuses the `album_id` resolved for the
+    // metadata read above (one extra indexed read, not a second key resolve),
+    // and runs whenever the key resolved to a linked album — independent of
+    // whether `album_metadata` enrichment has landed, so a linked album with
+    // reviews but no metadata row still surfaces its reviews. Attached only when
+    // non-empty so an un-seeded album's response is byte-identical to before.
+    // Wrapped in try/catch: the reviews read is strictly additive and must never
+    // break the metadata response, so a DB failure degrades to omitting the field.
+    if (getCriticReviewsConfig().enabled && albumId !== null) {
+      try {
+        const criticReviews = await lookupCriticReviewsByAlbumId(albumId);
+        if (criticReviews.length > 0) metadata.criticReviews = criticReviews;
+      } catch (reviewsError) {
+        console.warn('[ProxyController] critic-reviews lookup failed; omitting criticReviews:', reviewsError);
+      }
+    }
+
+    if (cacheable) {
+      albumMetadataCache.set(cacheKey, extractAlbumMetadataEnrichment(metadata));
     }
   }
 
-  // Fallback: construct search URLs for services without persisted/LML URLs.
-  // Per-service semantics live in `SearchUrlProvider` (BS#889) — each
-  // service uses a different field-fallback order, so the URLs are no
-  // longer guaranteed to share a query string. Old behavior was a single
-  // combined `${artistName} ${searchTerm}` for all three; the new behavior
-  // matches the runtime path and the recurring backfill so iOS gets
-  // identical search URLs regardless of which BS path produced them.
-  //
-  // Post-BS#1185: Spotify and Apple Music also have search-URL fallbacks so
-  // iOS doesn't show greyed buttons when LML fails or returns zero results.
-  //
-  // BS#1192's verified-rejection invariant is a *write-path* concern (don't
-  // persist synth URLs in album_metadata). Synthesizing at request time
-  // doesn't poison persisted state, and both the local-hit and LML
-  // branches synthesize here so iOS sees identical degradation behavior
-  // regardless of which branch served the request.
-  const fallbackUrls = searchUrlProvider.getAllSearchUrls(artistName, releaseTitle, trackTitle);
-  if (!metadata.spotifyUrl) metadata.spotifyUrl = fallbackUrls.spotifyUrl;
-  if (!metadata.appleMusicUrl) metadata.appleMusicUrl = fallbackUrls.appleMusicUrl;
-  if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = fallbackUrls.youtubeMusicUrl;
-  if (!metadata.bandcampUrl) metadata.bandcampUrl = fallbackUrls.bandcampUrl;
-  if (!metadata.soundcloudUrl) metadata.soundcloudUrl = fallbackUrls.soundcloudUrl;
-
-  // Project the upstream-call count onto the active Sentry span so we can
-  // split p50/p95 by cohort in the trace explorer. Wrap in a try/except —
-  // observability must never break the request path.
+  // Project the upstream-call count + cache result onto the active Sentry
+  // span so we can split p50/p95 by cohort in the trace explorer. Wrap in
+  // try/except — observability must never break the request path. Two
+  // separate calls (not one merged object) so each attribute name is
+  // independently greppable in the trace explorer.
   try {
     Sentry.getActiveSpan()?.setAttributes({
       'proxy.metadata.album.upstream_calls': upstreamCalls,
+    });
+    Sentry.getActiveSpan()?.setAttributes({
+      'proxy.metadata.album.cache_hit': cacheHit,
     });
   } catch (err) {
     console.warn('[ProxyController] failed to project Sentry attrs', err);
   }
 
-  // External critic-review snippets (album-critic-reviews slice, ADR 0012).
-  // Flag-gated (`CRITIC_REVIEWS_ENABLED`, default off) so prod behavior — the
-  // response shape and the serve-path query plan — is unchanged until an
-  // operator opts in, keeping this compatible with the #32 hardening freeze
-  // on the album-metadata serve path. Reuses the `album_id` resolved for the
-  // metadata read above (one extra indexed read, not a second key resolve),
-  // and runs whenever the key resolved to a linked album — independent of
-  // whether `album_metadata` enrichment has landed, so a linked album with
-  // reviews but no metadata row still surfaces its reviews. Attached only when
-  // non-empty so an un-seeded album's response is byte-identical to before.
-  // Wrapped in try/catch: the reviews read is strictly additive and must never
-  // break the metadata response, so a DB failure degrades to omitting the field.
-  if (getCriticReviewsConfig().enabled && albumId !== null) {
-    try {
-      const criticReviews = await lookupCriticReviewsByAlbumId(albumId);
-      if (criticReviews.length > 0) metadata.criticReviews = criticReviews;
-    } catch (reviewsError) {
-      console.warn('[ProxyController] critic-reviews lookup failed; omitting criticReviews:', reviewsError);
-    }
-  }
-
   res.set('Cache-Control', 'private, max-age=600');
   res.status(200).json(metadata);
 };
+
+// --- Artist metadata cache (BS#988) ---
+//
+// Single cache holding either the assembled response body (a hit) or `body:
+// null` (a confirmed absence — LML resolved the id and definitively found
+// no artist). The `{ body }` wrapper is required because `LRUCache`'s value
+// type must extend `{}` — a bare `Record<string, unknown> | null` value
+// type doesn't typecheck, since `null` isn't assignable to `{}`. Mirrors
+// `tracklistCache`/`libraryTracks`'s shape below: a transient failure
+// (timeout/5xx/network — anything but a 404) is never written here, only
+// rethrown, so a repeat request keeps retrying LML for the rest of the TTL
+// (BS#1089 rule).
+
+const artistMetadataCache = new LRUCache<number, { body: Record<string, unknown> | null }>({
+  max: 2000,
+  ttl: 1000 * 60 * 60, // 1h (BS#988)
+});
+
+/** Test-only: drop cached entries between cases. */
+export function __resetArtistMetadataCacheForTests(): void {
+  artistMetadataCache.clear();
+}
 
 /**
  * GET /proxy/metadata/artist
@@ -633,6 +745,9 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
  * Fetches artist metadata (bio, Wikipedia URL, image) from LML by artist ID.
  * Bio is available as both raw Discogs markup (`bio`) and pre-parsed structured
  * tokens (`bioTokens`) for direct rendering by clients.
+ *
+ * Cache-first (BS#988): a hit (positive or confirmed-negative) short-circuits
+ * before any LML call.
  */
 export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistMetadataQuery> = async (req, res) => {
   const { artistId } = req.query;
@@ -642,25 +757,85 @@ export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistM
   const id = parseInt(artistId, 10);
   if (isNaN(id)) throw new WxycError('artistId must be an integer', 400);
 
-  const artist = await getArtistDetails(id);
+  let cacheHit = true;
+  let cached = artistMetadataCache.get(id);
 
-  const wikipediaUrl = artist.urls.find((url) => url.includes('wikipedia.org')) ?? null;
+  if (cached === undefined) {
+    cacheHit = false;
+    try {
+      const artist = await getArtistDetails(id);
+      const wikipediaUrl = artist.urls.find((url) => url.includes('wikipedia.org')) ?? null;
+      cached = {
+        body: {
+          discogsArtistId: artist.artist_id,
+          bio: artist.profile ?? null,
+          bioTokens: artist.profile_tokens ?? null,
+          wikipediaUrl,
+          imageUrl: artist.image_url ?? null,
+        },
+      };
+      artistMetadataCache.set(id, cached);
+    } catch (err) {
+      if (err instanceof LmlClientError && err.statusCode === 404) {
+        // BS#988: confirmed absence — cache the negative so a repeat
+        // request for the same id doesn't re-hit LML for the rest of the
+        // TTL. Any other status (502/504/...) is a transient failure and
+        // is deliberately NOT cached — the original error still propagates
+        // below so the response shape on a miss is unchanged.
+        artistMetadataCache.set(id, { body: null });
+      }
+      throw err;
+    }
+  }
+
+  try {
+    Sentry.getActiveSpan()?.setAttributes({ 'proxy.metadata.artist.cache_hit': cacheHit });
+  } catch (err) {
+    console.warn('[ProxyController] failed to project Sentry attrs', err);
+  }
+
+  if (cached.body === null) {
+    // Cache hit on a confirmed absence recorded by a prior miss above.
+    throw new WxycError('Artist not found', 404);
+  }
 
   res.set('Cache-Control', 'private, max-age=3600');
-  res.status(200).json({
-    discogsArtistId: artist.artist_id,
-    bio: artist.profile ?? null,
-    bioTokens: artist.profile_tokens ?? null,
-    wikipediaUrl,
-    imageUrl: artist.image_url ?? null,
-  });
+  res.status(200).json(cached.body);
 };
+
+// --- Entity resolve cache (BS#988) ---
+//
+// Same `{ body }`-wrapped shape as `artistMetadataCache` above (required
+// because `LRUCache`'s value type must extend `{}`, so a bare nullable
+// value type doesn't typecheck): the cached value is either the response
+// body (a hit) or `body: null` (a confirmed absence — LML resolved type+id
+// and definitively found nothing). A transient failure is never cached,
+// only rethrown (BS#1089 rule). 24h TTL matches the client Cache-Control
+// max-age already set below — resolved Discogs entity identities are
+// effectively immutable once minted.
+
+const entityResolveCache = new LRUCache<string, { body: Record<string, unknown> | null }>({
+  max: 2000,
+  ttl: 1000 * 60 * 60 * 24, // 24h (BS#988)
+});
+
+/** Test-only: drop cached entries between cases. */
+export function __resetEntityResolveCacheForTests(): void {
+  entityResolveCache.clear();
+}
+
+function entityResolveCacheKey(type: string, id: number): string {
+  return `${type}:${id}`;
+}
 
 /**
  * GET /proxy/entity/resolve
  *
  * Resolves a Discogs entity (artist, release, master) by type and ID via LML.
  * Returns the entity's name and basic info.
+ *
+ * Cache-first (BS#988): a hit (positive or confirmed-negative) short-circuits
+ * before any LML call.
  */
 export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResolveQuery> = async (req, res) => {
   const { type, id } = req.query;
@@ -675,74 +850,155 @@ export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResol
   const entityId = parseInt(id, 10);
   if (isNaN(entityId)) throw new WxycError('id must be an integer', 400);
 
-  const result = await lmlResolveEntity(type as 'artist' | 'release' | 'master', entityId);
+  const cacheKey = entityResolveCacheKey(type, entityId);
+  let cacheHit = true;
+  let cached = entityResolveCache.get(cacheKey);
+
+  if (cached === undefined) {
+    cacheHit = false;
+    try {
+      const result = await lmlResolveEntity(type as 'artist' | 'release' | 'master', entityId);
+      cached = { body: { name: result.name, type: result.type, id: result.id } };
+      entityResolveCache.set(cacheKey, cached);
+    } catch (err) {
+      if (err instanceof LmlClientError && err.statusCode === 404) {
+        // BS#988: confirmed absence — cache the negative so a repeat
+        // request for the same type+id doesn't re-hit LML for the rest of
+        // the TTL. Any other status is a transient failure and is
+        // deliberately NOT cached; the original error still propagates.
+        entityResolveCache.set(cacheKey, { body: null });
+      }
+      throw err;
+    }
+  }
+
+  try {
+    Sentry.getActiveSpan()?.setAttributes({ 'proxy.entity.resolve.cache_hit': cacheHit });
+  } catch (err) {
+    console.warn('[ProxyController] failed to project Sentry attrs', err);
+  }
+
+  if (cached.body === null) {
+    // Cache hit on a confirmed absence recorded by a prior miss above.
+    throw new WxycError('Entity not found', 404);
+  }
 
   res.set('Cache-Control', 'private, max-age=86400');
-  res.status(200).json({ name: result.name, type: result.type, id: result.id });
+  res.status(200).json(cached.body);
 };
+
+// --- Spotify track cache (BS#988) ---
+//
+// Same `{ body }`-wrapped shape as `artistMetadataCache`/`entityResolveCache`
+// above (required because `LRUCache`'s value type must extend `{}`): the
+// cached value is either the response body (a hit) or `body: null` (a
+// confirmed absence — Spotify returned a definitive 404 for the track id).
+// A transient failure (token/auth failure, non-404 fetch failure) is never
+// cached (BS#1089 rule), and neither is the "Spotify isn't configured at
+// all" 503 — that's an environment-wide condition, not a per-track fact.
+
+const spotifyTrackCache = new LRUCache<string, { body: Record<string, unknown> | null }>({
+  max: 2000,
+  ttl: 1000 * 60 * 60, // 1h (BS#988) — same tier as album/artist metadata.
+});
+
+/** Test-only: drop cached entries between cases. */
+export function __resetSpotifyTrackCacheForTests(): void {
+  spotifyTrackCache.clear();
+}
 
 /**
  * GET /proxy/spotify/track/:id
  *
  * Fetches Spotify track metadata using backend credentials.
+ *
+ * Cache-first (BS#988): a hit (positive or confirmed-negative) short-circuits
+ * before any Spotify call (token fetch included).
  */
 export const getSpotifyTrack: RequestHandler<SpotifyTrackParams> = async (req, res) => {
   const { id } = req.params;
 
   if (!id) throw new WxycError('Track ID is required', 400);
 
-  // Use the SpotifyProvider's internal auth to call the Spotify API
-  const spotifyClientId = process.env.SPOTIFY_CLIENT_ID;
-  const spotifyClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  let cacheHit = true;
+  let cached = spotifyTrackCache.get(id);
 
-  if (!spotifyClientId || !spotifyClientSecret) {
-    res.status(503).json({ message: 'Spotify integration not configured' });
-    return;
-  }
+  if (cached === undefined) {
+    cacheHit = false;
 
-  // Get or refresh Spotify access token
-  const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${spotifyClientId}:${spotifyClientSecret}`).toString('base64')}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: 'grant_type=client_credentials',
-  });
+    // Use the SpotifyProvider's internal auth to call the Spotify API
+    const spotifyClientId = process.env.SPOTIFY_CLIENT_ID;
+    const spotifyClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 
-  if (!tokenResponse.ok) {
-    console.error(`[ProxyController] Spotify auth failed: ${tokenResponse.status}`);
-    res.status(502).json({ message: 'Spotify authentication failed' });
-    return;
-  }
-
-  const tokenData: SpotifyTokenResponse = (await tokenResponse.json()) as SpotifyTokenResponse;
-
-  const trackResponse = await fetch(`https://api.spotify.com/v1/tracks/${encodeURIComponent(id)}`, {
-    headers: {
-      Authorization: `Bearer ${tokenData.access_token}`,
-    },
-  });
-
-  if (!trackResponse.ok) {
-    if (trackResponse.status === 404) {
-      res.status(404).json({ message: 'Track not found' });
+    if (!spotifyClientId || !spotifyClientSecret) {
+      res.status(503).json({ message: 'Spotify integration not configured' });
       return;
     }
-    console.error(`[ProxyController] Spotify track fetch failed: ${trackResponse.status}`);
-    res.status(502).json({ message: 'Failed to fetch track from Spotify' });
+
+    // Get or refresh Spotify access token
+    const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${spotifyClientId}:${spotifyClientSecret}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+
+    if (!tokenResponse.ok) {
+      console.error(`[ProxyController] Spotify auth failed: ${tokenResponse.status}`);
+      res.status(502).json({ message: 'Spotify authentication failed' });
+      return;
+    }
+
+    const tokenData: SpotifyTokenResponse = (await tokenResponse.json()) as SpotifyTokenResponse;
+
+    const trackResponse = await fetch(`https://api.spotify.com/v1/tracks/${encodeURIComponent(id)}`, {
+      headers: {
+        Authorization: `Bearer ${tokenData.access_token}`,
+      },
+    });
+
+    if (!trackResponse.ok) {
+      if (trackResponse.status === 404) {
+        // BS#988: confirmed absence — cache the negative so a repeat
+        // request for the same id doesn't re-hit Spotify for the rest of
+        // the TTL.
+        spotifyTrackCache.set(id, { body: null });
+        res.status(404).json({ message: 'Track not found' });
+        return;
+      }
+      console.error(`[ProxyController] Spotify track fetch failed: ${trackResponse.status}`);
+      res.status(502).json({ message: 'Failed to fetch track from Spotify' });
+      return;
+    }
+
+    const track: SpotifyTrackApiResponse = (await trackResponse.json()) as SpotifyTrackApiResponse;
+    cached = {
+      body: {
+        title: track.name,
+        artist: track.artists?.[0]?.name || '',
+        album: track.album?.name || '',
+        artworkUrl: track.album?.images?.[0]?.url || null,
+      },
+    };
+    spotifyTrackCache.set(id, cached);
+  }
+
+  try {
+    Sentry.getActiveSpan()?.setAttributes({ 'proxy.spotify.track.cache_hit': cacheHit });
+  } catch (err) {
+    console.warn('[ProxyController] failed to project Sentry attrs', err);
+  }
+
+  if (cached.body === null) {
+    // Cache hit on a confirmed absence recorded by a prior miss above.
+    res.status(404).json({ message: 'Track not found' });
     return;
   }
 
-  const track: SpotifyTrackApiResponse = (await trackResponse.json()) as SpotifyTrackApiResponse;
-
   res.set('Cache-Control', 'private, max-age=600');
-  res.status(200).json({
-    title: track.name,
-    artist: track.artists?.[0]?.name || '',
-    album: track.album?.name || '',
-    artworkUrl: track.album?.images?.[0]?.url || null,
-  });
+  res.status(200).json(cached.body);
 };
 
 /**

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -179,6 +179,10 @@ import {
   librarySearch,
   libraryTracks,
   __resetLibraryTracksCacheForTests,
+  __resetAlbumMetadataCacheForTests,
+  __resetArtistMetadataCacheForTests,
+  __resetEntityResolveCacheForTests,
+  __resetSpotifyTrackCacheForTests,
 } from '../../../apps/backend/controllers/proxy.controller';
 
 // --- Helpers ---
@@ -426,6 +430,15 @@ describe('proxy.controller', () => {
       // BS#1331 / BS#1827.
       mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
       mockLookupAlbumMetadataById.mockResolvedValue(null);
+      // BS#988: this suite reuses artist/release names across many
+      // independent `it()`s (e.g. "Autechre"/"Confield", "Jessica Pratt"/"On
+      // Your Own Love Again"). Without a reset, the new response cache
+      // introduced by BS#988 would make a later test's identical request
+      // silently short-circuit to an earlier test's cached response instead
+      // of exercising its own mocks — reset before every test so each one
+      // starts cold, same discipline as `__resetLibraryTracksCacheForTests`
+      // below in the `libraryTracks` suite.
+      __resetAlbumMetadataCacheForTests();
     });
 
     // ADR 0012: attach external critic-review snippets, flag-gated. These run
@@ -1737,11 +1750,165 @@ describe('proxy.controller', () => {
         expect('discogsUrl' in result).toBe(false);
       });
     });
+
+    // --- Server-side response cache (BS#988) ---
+    //
+    // The cache-first local-lookup suite above proves BS's own persisted
+    // state short-circuits LML. This suite proves the NEW layer in front of
+    // BOTH the persisted-state read and the LML round-trip: an identical
+    // repeat request is served from an in-process cache without touching
+    // either, and — mirroring the #1089 negative-cache rule for
+    // `searchArtwork` — a transient failure (a local DB blip or an LML
+    // timeout/5xx/network error) is never memoized, so a repeat request
+    // after a transient failure keeps retrying.
+    describe('server-side response cache (BS#988)', () => {
+      it('serves an identical repeat request from cache without a second LML round-trip', async () => {
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [
+            {
+              library_item: { id: 1, title: 'Ege Bamyasi', artist: 'Can', call_number: '', library_url: '' },
+              artwork: {
+                release_id: 555,
+                release_url: 'https://www.discogs.com/release/555',
+                artwork_url: 'https://i.discogs.com/can.jpg',
+                album: 'Ege Bamyasi',
+                artist: 'Can',
+                confidence: 0.9,
+              },
+            },
+          ],
+          search_type: 'direct',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = { query: { artistName: 'Can', releaseTitle: 'Ege Bamyasi' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await getAlbumMetadata(req, firstRes as Response, mockNext);
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+        const firstResult = (firstRes.json as jest.Mock).mock.calls[0][0];
+        expect(firstResult.discogsReleaseId).toBe(555);
+
+        const secondRes = createMockRes();
+        await getAlbumMetadata(req, secondRes as Response, mockNext);
+
+        // Neither the local lookup nor LML is re-consulted.
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(1);
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+        const secondResult = (secondRes.json as jest.Mock).mock.calls[0][0];
+        expect(secondResult.discogsReleaseId).toBe(555);
+        // Base identity fields are still assembled fresh from THIS request.
+        expect(secondResult.artistName).toBe('Can');
+      });
+
+      it('projects cache_hit=true onto the Sentry span on a repeat request, cache_hit=false on the first', async () => {
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Cache Hit Artist', releaseTitle: 'Cache Hit Album' },
+        } as unknown as Request;
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.album.cache_hit': false });
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.album.cache_hit': true });
+        // A cache hit makes zero upstream calls, same as a local hit.
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.album.upstream_calls': 0 });
+      });
+
+      it('does not cache a transient LML failure: a repeat request re-attempts the lookup', async () => {
+        // Mirrors the #1089 artwork negative-cache test: an LML timeout/5xx/
+        // network blip must never strand a degraded response in the cache
+        // for the full TTL.
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(null);
+        mockLookupMetadata.mockRejectedValue(new Error('LML timeout'));
+
+        const req = {
+          query: { artistName: 'Flaky LML Artist', releaseTitle: 'Flaky LML Album' },
+        } as unknown as Request;
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not cache a local-lookup DB failure: a repeat request re-attempts the local read', async () => {
+        mockSelectLinkedFlowsheetRow.mockRejectedValue(new Error('db blip'));
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Flaky DB Artist', releaseTitle: 'Flaky DB Album' },
+        } as unknown as Request;
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(2);
+      });
+
+      it('keys the cache on the CRITIC_REVIEWS_ENABLED flag state so a flag flip is not served a stale shape', async () => {
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        mockLookupAlbumMetadataById.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+        mockLookupCriticReviewsByAlbumId.mockResolvedValue([
+          { source: 'The Quietus', url: 'https://thequietus.com/x', snippet: 'snippet' },
+        ]);
+
+        const req = {
+          query: { artistName: 'Flag Split Artist', releaseTitle: 'Flag Split Album' },
+        } as unknown as Request;
+
+        // Flag off: cached without criticReviews.
+        mockCriticReviewsConfig.mockReturnValue({ enabled: false });
+        const offRes = createMockRes();
+        await getAlbumMetadata(req, offRes as Response, mockNext);
+        expect((offRes.json as jest.Mock).mock.calls[0][0]).not.toHaveProperty('criticReviews');
+
+        // Flag on: a DIFFERENT cache key, so the response is computed fresh
+        // (not served from the flag-off entry) and carries criticReviews.
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        const onRes = createMockRes();
+        await getAlbumMetadata(req, onRes as Response, mockNext);
+        expect((onRes.json as jest.Mock).mock.calls[0][0].criticReviews).toEqual([
+          { source: 'The Quietus', url: 'https://thequietus.com/x', snippet: 'snippet' },
+        ]);
+
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 
   // --- getArtistMetadata ---
 
   describe('getArtistMetadata', () => {
+    beforeEach(() => {
+      // BS#988: reset the response cache between tests — several tests below
+      // reuse the same artistId (e.g. `3840`) for both a success case and a
+      // rejection case, which would otherwise short-circuit on a cached hit
+      // from an earlier test.
+      __resetArtistMetadataCacheForTests();
+    });
+
     it('throws WxycError 400 when artistId is missing', async () => {
       const req = { query: {} } as unknown as Request;
       const res = createMockRes();
@@ -1877,11 +2044,105 @@ describe('proxy.controller', () => {
 
       await expect(getArtistMetadata(req, res as Response, mockNext)).rejects.toThrow('Connection refused');
     });
+
+    // --- Server-side response cache (BS#988) ---
+    describe('server-side response cache (BS#988)', () => {
+      it('serves an identical repeat request from cache without a second LML call', async () => {
+        mockGetArtistDetails.mockResolvedValue({
+          artist_id: 7001,
+          name: 'Broadcast',
+          profile: 'A British band.',
+          profile_tokens: null,
+          image_url: 'https://i.discogs.com/broadcast.jpg',
+          name_variations: [],
+          aliases: [],
+          members: [],
+          urls: [],
+          cached: false,
+        });
+
+        const req = { query: { artistId: '7001' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await getArtistMetadata(req, firstRes as Response, mockNext);
+        expect(mockGetArtistDetails).toHaveBeenCalledTimes(1);
+
+        const secondRes = createMockRes();
+        await getArtistMetadata(req, secondRes as Response, mockNext);
+
+        expect(mockGetArtistDetails).toHaveBeenCalledTimes(1);
+        expect(secondRes.status).toHaveBeenCalledWith(200);
+        const secondResult = (secondRes.json as jest.Mock).mock.calls[0][0];
+        expect(secondResult.discogsArtistId).toBe(7001);
+      });
+
+      it('negative-caches a confirmed 404: a repeat request rejects without re-invoking LML', async () => {
+        const { LmlClientError } = await import('@wxyc/lml-client');
+        mockGetArtistDetails.mockRejectedValue(new LmlClientError('Not found', 404));
+
+        const req = { query: { artistId: '404404' } } as unknown as Request;
+
+        await expect(getArtistMetadata(req, createMockRes() as Response, mockNext)).rejects.toThrow();
+        expect(mockGetArtistDetails).toHaveBeenCalledTimes(1);
+
+        await expect(getArtistMetadata(req, createMockRes() as Response, mockNext)).rejects.toThrow('not found');
+        // The second (cached) rejection never re-consults LML.
+        expect(mockGetArtistDetails).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not negative-cache a transient failure: a repeat request re-invokes LML', async () => {
+        // Mirrors the #1089 rule: only a confirmed absence (404) is
+        // negatively cached, never a timeout/5xx/network blip.
+        const { LmlClientError } = await import('@wxyc/lml-client');
+        mockGetArtistDetails.mockRejectedValue(new LmlClientError('LML request timed out', 504));
+
+        const req = { query: { artistId: '504504' } } as unknown as Request;
+
+        await expect(getArtistMetadata(req, createMockRes() as Response, mockNext)).rejects.toThrow(
+          'LML request timed out'
+        );
+        await expect(getArtistMetadata(req, createMockRes() as Response, mockNext)).rejects.toThrow(
+          'LML request timed out'
+        );
+
+        expect(mockGetArtistDetails).toHaveBeenCalledTimes(2);
+      });
+
+      it('projects cache_hit onto the Sentry span', async () => {
+        mockGetArtistDetails.mockResolvedValue({
+          artist_id: 8001,
+          name: 'Stereolab',
+          profile: null,
+          profile_tokens: null,
+          image_url: null,
+          name_variations: [],
+          aliases: [],
+          members: [],
+          urls: [],
+          cached: false,
+        });
+
+        const req = { query: { artistId: '8001' } } as unknown as Request;
+
+        await getArtistMetadata(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.artist.cache_hit': false });
+
+        await getArtistMetadata(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.metadata.artist.cache_hit': true });
+      });
+    });
   });
 
   // --- resolveEntity ---
 
   describe('resolveEntity', () => {
+    beforeEach(() => {
+      // BS#988: reset the response cache between tests — the artist/3840
+      // type+id pair is reused across a success case and a rejection case
+      // below, which would otherwise short-circuit on a cached hit.
+      __resetEntityResolveCacheForTests();
+    });
+
     it('throws WxycError 400 when type or id is missing', async () => {
       const req = { query: { type: 'artist' } } as unknown as Request;
       const res = createMockRes();
@@ -1962,6 +2223,66 @@ describe('proxy.controller', () => {
 
       await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow('LML request timed out');
     });
+
+    // --- Server-side response cache (BS#988) ---
+    describe('server-side response cache (BS#988)', () => {
+      it('serves an identical repeat request from cache without a second LML call', async () => {
+        mockResolveEntity.mockResolvedValue({ name: 'Broadcast', type: 'artist', id: 7002 });
+
+        const req = { query: { type: 'artist', id: '7002' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await resolveEntity(req, firstRes as Response, mockNext);
+        expect(mockResolveEntity).toHaveBeenCalledTimes(1);
+
+        const secondRes = createMockRes();
+        await resolveEntity(req, secondRes as Response, mockNext);
+
+        expect(mockResolveEntity).toHaveBeenCalledTimes(1);
+        expect(secondRes.json).toHaveBeenCalledWith({ name: 'Broadcast', type: 'artist', id: 7002 });
+      });
+
+      it('negative-caches a confirmed 404: a repeat request rejects without re-invoking LML', async () => {
+        const { LmlClientError } = await import('@wxyc/lml-client');
+        mockResolveEntity.mockRejectedValue(new LmlClientError('Not found', 404));
+
+        const req = { query: { type: 'release', id: '404405' } } as unknown as Request;
+
+        await expect(resolveEntity(req, createMockRes() as Response, mockNext)).rejects.toThrow();
+        expect(mockResolveEntity).toHaveBeenCalledTimes(1);
+
+        await expect(resolveEntity(req, createMockRes() as Response, mockNext)).rejects.toThrow('not found');
+        expect(mockResolveEntity).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not negative-cache a transient failure: a repeat request re-invokes LML', async () => {
+        const { LmlClientError } = await import('@wxyc/lml-client');
+        mockResolveEntity.mockRejectedValue(new LmlClientError('LML request timed out', 504));
+
+        const req = { query: { type: 'master', id: '504505' } } as unknown as Request;
+
+        await expect(resolveEntity(req, createMockRes() as Response, mockNext)).rejects.toThrow(
+          'LML request timed out'
+        );
+        await expect(resolveEntity(req, createMockRes() as Response, mockNext)).rejects.toThrow(
+          'LML request timed out'
+        );
+
+        expect(mockResolveEntity).toHaveBeenCalledTimes(2);
+      });
+
+      it('projects cache_hit onto the Sentry span', async () => {
+        mockResolveEntity.mockResolvedValue({ name: 'Stereolab', type: 'artist', id: 8002 });
+
+        const req = { query: { type: 'artist', id: '8002' } } as unknown as Request;
+
+        await resolveEntity(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.entity.resolve.cache_hit': false });
+
+        await resolveEntity(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.entity.resolve.cache_hit': true });
+      });
+    });
   });
 
   // --- getSpotifyTrack ---
@@ -1973,6 +2294,8 @@ describe('proxy.controller', () => {
       process.env = { ...originalEnv };
       process.env.SPOTIFY_CLIENT_ID = 'test-client-id';
       process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret';
+      // BS#988: reset the response cache between tests.
+      __resetSpotifyTrackCacheForTests();
     });
 
     afterAll(() => {
@@ -2065,6 +2388,109 @@ describe('proxy.controller', () => {
       await getSpotifyTrack(req, res as Response, mockNext);
 
       expect(res.status).toHaveBeenCalledWith(502);
+    });
+
+    // --- Server-side response cache (BS#988) ---
+    describe('server-side response cache (BS#988)', () => {
+      it('serves an identical repeat request from cache without a second Spotify call', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'mock-token', expires_in: 3600 }),
+        } as globalThis.Response);
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              name: 'Tomorrow Never Knows',
+              artists: [{ name: 'Broadcast' }],
+              album: { name: 'Tender Buttons', images: [{ url: 'https://i.scdn.co/image/xyz' }] },
+            }),
+        } as globalThis.Response);
+
+        const req = { params: { id: 'cache-hit-track-id' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await getSpotifyTrack(req, firstRes as Response, mockNext);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        const secondRes = createMockRes();
+        await getSpotifyTrack(req, secondRes as Response, mockNext);
+
+        // No further fetch calls (token or track) — served entirely from cache.
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(secondRes.json).toHaveBeenCalledWith({
+          title: 'Tomorrow Never Knows',
+          artist: 'Broadcast',
+          album: 'Tender Buttons',
+          artworkUrl: 'https://i.scdn.co/image/xyz',
+        });
+      });
+
+      it('negative-caches a confirmed 404: a repeat request short-circuits without re-invoking Spotify', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'mock-token', expires_in: 3600 }),
+        } as globalThis.Response);
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 404 } as globalThis.Response);
+
+        const req = { params: { id: 'negative-cache-track-id' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await getSpotifyTrack(req, firstRes as Response, mockNext);
+        expect(firstRes.status).toHaveBeenCalledWith(404);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        const secondRes = createMockRes();
+        await getSpotifyTrack(req, secondRes as Response, mockNext);
+
+        expect(secondRes.status).toHaveBeenCalledWith(404);
+        // No further fetch calls on the cached-negative repeat.
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not negative-cache a transient auth failure: a repeat request re-invokes Spotify', async () => {
+        // Mirrors the #1089 rule: only a confirmed absence (404) is
+        // negatively cached, never a transient upstream failure.
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 401 } as globalThis.Response);
+        mockFetch.mockResolvedValueOnce({ ok: false, status: 401 } as globalThis.Response);
+
+        const req = { params: { id: 'transient-failure-track-id' } } as unknown as Request;
+
+        const firstRes = createMockRes();
+        await getSpotifyTrack(req, firstRes as Response, mockNext);
+        expect(firstRes.status).toHaveBeenCalledWith(502);
+
+        const secondRes = createMockRes();
+        await getSpotifyTrack(req, secondRes as Response, mockNext);
+        expect(secondRes.status).toHaveBeenCalledWith(502);
+
+        // Both requests independently hit Spotify — nothing was cached.
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('projects cache_hit onto the Sentry span', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'mock-token', expires_in: 3600 }),
+        } as globalThis.Response);
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              name: 'Track',
+              artists: [{ name: 'Artist' }],
+              album: { name: 'Album', images: [] },
+            }),
+        } as globalThis.Response);
+
+        const req = { params: { id: 'sentry-cache-hit-track-id' } } as unknown as Request;
+
+        await getSpotifyTrack(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.spotify.track.cache_hit': false });
+
+        await getSpotifyTrack(req, createMockRes() as Response, mockNext);
+        expect(mockSpanSetAttributes).toHaveBeenCalledWith({ 'proxy.spotify.track.cache_hit': true });
+      });
     });
   });
 

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -1861,6 +1861,67 @@ describe('proxy.controller', () => {
         expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(2);
       });
 
+      it('does not cache when the critic-reviews read throws: a repeat request re-attempts the whole lookup', async () => {
+        // The critic-reviews sub-read is optional per-response (a throw
+        // degrades to omitting the field, same as before), but it must
+        // still prevent the whole album response from being memoized —
+        // otherwise a transient reviews-DB blip strands a reviews-less
+        // shape in the cache for the full TTL, same failure mode the
+        // sibling local-DB/LML tests above guard against.
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        mockLookupAlbumMetadataById.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+        mockLookupCriticReviewsByAlbumId.mockRejectedValue(new Error('reviews db blip'));
+
+        const req = {
+          query: { artistName: 'Flaky Reviews Artist', releaseTitle: 'Flaky Reviews Album' },
+        } as unknown as Request;
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+
+        // Both requests independently re-attempt the full lookup — nothing
+        // was cached from the first (failed-reviews) attempt.
+        expect(mockLookupCriticReviewsByAlbumId).toHaveBeenCalledTimes(2);
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+      });
+
+      it('still caches when the critic-reviews read succeeds', async () => {
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        mockLookupAlbumMetadataById.mockResolvedValue(null);
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+        mockLookupCriticReviewsByAlbumId.mockResolvedValue([
+          { source: 'The Quietus', url: 'https://thequietus.com/y', snippet: 'snippet' },
+        ]);
+
+        const req = {
+          query: { artistName: 'Healthy Reviews Artist', releaseTitle: 'Healthy Reviews Album' },
+        } as unknown as Request;
+
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        const secondRes = createMockRes();
+        await getAlbumMetadata(req, secondRes as Response, mockNext);
+
+        // The second request is served entirely from cache.
+        expect(mockLookupCriticReviewsByAlbumId).toHaveBeenCalledTimes(1);
+        expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+        expect((secondRes.json as jest.Mock).mock.calls[0][0].criticReviews).toEqual([
+          { source: 'The Quietus', url: 'https://thequietus.com/y', snippet: 'snippet' },
+        ]);
+      });
+
       it('keys the cache on the CRITIC_REVIEWS_ENABLED flag state so a flag flip is not served a stale shape', async () => {
         mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
         mockLookupAlbumMetadataById.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Closes #988.

`getAlbumMetadata`, `getArtistMetadata`, `resolveEntity`, and `getSpotifyTrack` in `apps/backend/controllers/proxy.controller.ts` only set a `Cache-Control` header today, so every call round-trips LML (or Spotify) even across devices and tabs. This wraps each in an in-process LRU cache, following the existing `artworkCache`/`negativeCache`/`tracklistCache` shape already in this file:

- **Capacity**: 2000 entries per endpoint, per the issue.
- **TTL**: 1h for album/artist/spotify, 24h for entity/resolve — matches the issue's stated TTLs (and, for entity/resolve, the existing client `Cache-Control` max-age; Discogs entity identities are effectively immutable once minted).
- **Negative caching honors #1089's rule**: only a confirmed absence (a definitive 404 from the upstream) is cached, never a transient failure (timeout/5xx/network) — caching a transient failure would strand a degraded response for the full TTL even after the upstream recovers.
  - `getArtistMetadata` / `resolveEntity` distinguish via `LmlClientError.statusCode === 404`.
  - `getSpotifyTrack` distinguishes via the Spotify fetch's own 404 (the existing 503 "not configured" and 502 "auth/fetch failed" paths are left uncached — the former is an environment-wide condition, not a per-track fact; the latter is transient).
  - `getAlbumMetadata` never returns a 404 (it always degrades to search-URL fallbacks), so there's no explicit negative cache there — instead the cache *write* is gated on the whole attempt (local DB read + LML round-trip) completing without error, so a DB blip or LML failure never memoizes a degraded response.
- **Cache key**: `getAlbumMetadata`'s key folds in `CRITIC_REVIEWS_ENABLED` — the one feature flag that changes its response shape — mirroring `trackSearchCacheKey` in `library.service.ts`. The cached value deliberately excludes the request-echoed `artistName`/`releaseTitle`/`trackTitle` base fields, so a hit never relabels a differently-cased request with an earlier caller's exact casing; those three are always assembled fresh from the current request.
- **Observability**: each handler projects a `cache_hit` boolean onto the active Sentry span (`proxy.metadata.album.cache_hit`, `proxy.metadata.artist.cache_hit`, `proxy.entity.resolve.cache_hit`, `proxy.spotify.track.cache_hit`), alongside `getAlbumMetadata`'s existing `upstream_calls` attribute.

No change to response shape on the wire; no cache invalidation on writes (out of scope per the issue — these are read-only proxy endpoints).

## Test plan

- [x] Unit tests: hit/miss per endpoint, confirmed-absence negative caching, transient-failure-is-never-cached (mirrors the #1089 artwork test), flag-state-hash key-collision for the album endpoint, `cache_hit` Sentry attribute projection. `npm run test:unit` — 5610/5610 passing.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged).
- [x] `npm run format:check` — clean.
- [ ] Integration/CI-Docker (`ci:testmock`) — not run locally due to a known local-env conflict between the native dev Postgres and the Docker-mapped port (documented BS local test-env pitfalls); relying on the PR's CI-Docker job to verify.