### PR TITLE
fix(artwork): don't negative-cache LML soft-degraded 200s (BS#1890)

### DIFF
--- a/apps/backend/services/artwork/providers/discogs.ts
+++ b/apps/backend/services/artwork/providers/discogs.ts
@@ -61,6 +61,21 @@ export class DiscogsProvider implements ArtworkProvider {
       });
     }
 
+    // BS#1890: BS#1089 only closed LML's *throw* path. LML has a second
+    // transient mode that returns HTTP 200: `timeout: true` (server-side hard
+    // cap fired mid-pipeline, LML#370) or `degraded: true` (deliberately shed
+    // the enrichment tail — and `fetch_artwork` is one of those shed steps —
+    // under a caller deadline / admission pressure / unavailable upstream,
+    // LML#930). Either is "couldn't answer," not a confirmed absence. When such
+    // a response yields no usable artwork, throw so the finder folds it into
+    // BS#1089's `errored` tagging and the proxy skips the 24h negative cache —
+    // same posture as a timeout/5xx. A degraded response that still carried
+    // artwork (warm-cache hit) is a real result and falls through untouched.
+    if (results.length === 0 && (lookupResponse.timeout === true || lookupResponse.degraded === true)) {
+      const mode = lookupResponse.timeout === true ? 'timeout' : 'degraded';
+      throw new Error(`[DiscogsProvider] LML returned a soft-degraded ${mode} 200 with no usable artwork`);
+    }
+
     results.sort((a, b) => b.confidence - a.confidence);
     return results;
   }

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -163,6 +163,77 @@ describe('artwork DiscogsProvider', () => {
         caller: 'artwork-discogs-fallback',
       });
     });
+
+    it('throws on a soft-degraded LML 200 (timeout) with no usable artwork (BS#1890)', async () => {
+      // BS#1089 covered LML's *throw* path; LML has a second transient mode it
+      // missed: an HTTP 200 with empty `results` because the server-side hard
+      // cap fired (`timeout: true`, LML#370). That is "ran out of time," not a
+      // confirmed absence — treat it exactly like the throw path so the finder
+      // tags the response `errored` and the proxy skips the 24h negative cache.
+      mockLookupMetadata.mockResolvedValue({
+        results: [],
+        timeout: true,
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      await expect(provider.search({ artist: 'Autechre', album: 'Confield' })).rejects.toThrow(/degraded|timeout/i);
+    });
+
+    it('throws on a soft-degraded LML 200 (degraded) with no usable artwork (BS#1890)', async () => {
+      // `degraded: true` (LML#930) means LML deliberately shed the enrichment
+      // tail — and `fetch_artwork` is one of those shed tail steps — under a
+      // caller deadline / admission pressure / unavailable upstream. An empty
+      // artwork sweep here is "couldn't ask," not "no artwork exists."
+      mockLookupMetadata.mockResolvedValue({
+        results: [],
+        degraded: true,
+        degraded_reason: 'deadline_exceeded',
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      await expect(provider.search({ artist: 'Autechre', album: 'Confield' })).rejects.toThrow(/degraded|timeout/i);
+    });
+
+    it('returns artwork on a degraded 200 that still carried a usable result (BS#1890)', async () => {
+      // A degraded response whose (warm-cache) results still include artwork is
+      // a real hit — return it rather than throwing. The transient signal only
+      // matters when the degraded sweep produced nothing usable.
+      mockLookupMetadata.mockResolvedValue({
+        results: [
+          {
+            library_item: {
+              id: 1,
+              title: 'Confield',
+              artist: 'Autechre',
+              call_number: 'Electronic CD AUT 1/1',
+              library_url: 'https://library.wxyc.org/1',
+            },
+            artwork: {
+              release_id: 12345,
+              release_url: 'https://www.discogs.com/release/12345',
+              artwork_url: 'https://i.discogs.com/confield.jpg',
+              album: 'Confield',
+              artist: 'Autechre',
+              confidence: 0.95,
+            },
+          },
+        ],
+        degraded: true,
+        degraded_reason: 'cache_only',
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].artworkUrl).toBe('https://i.discogs.com/confield.jpg');
+    });
   });
 
   describe('searchTrack', () => {


### PR DESCRIPTION
## Problem

[BS#1089](https://github.com/WXYC/Backend-Service/issues/1089) (PR #1889) stopped the artwork negative cache from stranding LML's **throw** path — a timeout/5xx/network blip now rethrows, gets tagged `errored`, and the 24h negative-cache write is skipped. It left a second transient mode open: LML can return **HTTP 200 with empty `results`** when

- the server-side hard cap fired mid-pipeline (`timeout: true`, [LML#370](https://github.com/WXYC/library-metadata-lookup/issues/370)), or
- LML deliberately shed the enrichment tail — and `fetch_artwork` is one of those shed tail steps — under a caller deadline / admission pressure / unavailable upstream (`degraded: true`, [LML#930](https://github.com/WXYC/library-metadata-lookup/issues/930)).

`DiscogsProvider.search` iterated only `lookupResponse.results` and ignored both signals, so a budget-degraded empty was treated as a confirmed absence and negative-cached for the full 24h per-process TTL — exactly the class BS#1089 set out to eliminate, left unaddressed for the degraded-200 path.

## Fix

`DiscogsProvider.search` now throws when the LML response is `timeout: true` **or** `degraded: true` **and** produced no usable artwork. That reuses BS#1089's entire pipeline with no change to `finder.ts` or `proxy.controller.ts`:

- `ArtworkFinder.find` catches the throw → `anyProviderErrored` → `erroredResponse({ errored: true })` when nothing else matched;
- `proxy.searchArtwork` sees `errored` → skips the negative cache and returns a retryable **502**, so a follow-up request re-attempts.

A degraded response that **still carried artwork** (warm-cache hit) is a real result and returns untouched — the transient signal only fires when the degraded sweep yielded nothing usable. A genuine confirmed-empty (`timeout`/`degraded` both false, empty `results`) still negative-caches, unchanged.

## Precondition — resolved, no upstream ticket needed

The ticket flagged an open question: does LML's `/lookup` response actually surface a degraded/timeout flag? **Yes.** Both `timeout` (LML#370) and `degraded` (LML#930) are declared on `LookupResponse` in `wxyc-shared/api.yaml`, ride the `@wxyc/lml-client` `LookupResponse` type this code already consumes, and are **deployed to LML prod** (LML#930 is on `origin/prod`). So Backend can already distinguish a budget-degraded empty from a confirmed empty; no prerequisite LML contract change is required.

## Test plan

- [x] `npm run test:unit` — new provider tests: degraded/timeout-200 with no artwork **throws**; a degraded-200 that still carried artwork **returns the hit**. (`artwork.discogs-provider.test.ts`)
- [x] The transitive chain (throw → `errored` → 502 + no negative-cache write, and a follow-up re-attempt) is already locked by BS#1089's `artwork.finder.test.ts` + `proxy.controller.test.ts` — 119 tests green across all three suites.
- [x] `npm run typecheck` clean (all workspaces); `prettier --check` + `eslint` clean on changed files.

Closes #1890