### PR TITLE
fix(proxy): refine cache-freshness + bounds on the BS#988 proxy caches (BS#1893)

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -468,6 +468,12 @@ function parseDiscogsReleaseIdFromUrl(url: string): number | undefined {
 
 const albumMetadataCache = new LRUCache<string, Record<string, unknown>>({
   max: 2000,
+  // BS#1893: bound worst-case memory, not just entry count. An album entry can
+  // carry a large `tracklist` (box sets, 100+ tracks) plus `bioTokens`; the
+  // count-only cap let a pathological Discogs release balloon this cache
+  // unbounded per entry. Mirrors the sibling `artworkCache`'s `maxSize` cap.
+  maxSize: 32 * 1024 * 1024, // 32 MB total
+  sizeCalculation: (value) => Buffer.byteLength(JSON.stringify(value)) || 1,
   ttl: 1000 * 60 * 60, // 1h (BS#988)
 });
 
@@ -478,6 +484,14 @@ export function __resetAlbumMetadataCacheForTests(): void {
 
 /** Base fields excluded from the cached value — see the cache's doc comment above. */
 const ALBUM_METADATA_BASE_FIELDS = new Set(['artistName', 'releaseTitle', 'trackTitle']);
+
+// BS#1893: `metadata_status` values whose row is still mid-enrichment. A
+// `pending` / `enriching` album has no terminal `album_metadata` yet — the CDC
+// worker lands enrichment seconds later — so memoizing the point-in-time
+// snapshot would strand a stale `metadataStatus` + missing fields for the full
+// 1h TTL on this proxy path. The terminal states (`enriched_match`,
+// `enriched_no_match`, `failed_no_retry`) are stable and safe to cache.
+const NON_TERMINAL_METADATA_STATUSES = new Set(['pending', 'enriching']);
 
 function extractAlbumMetadataEnrichment(metadata: Record<string, unknown>): Record<string, unknown> {
   const enrichment: Record<string, unknown> = {};
@@ -693,6 +707,13 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
       }
     }
 
+    // BS#1893: never memoize a non-terminal (pending/enriching) snapshot. Its
+    // enrichment lands seconds later via the CDC worker, and a 1h-cached pending
+    // snapshot would mask that freshness on this path until the TTL expires.
+    if (typeof metadata.metadataStatus === 'string' && NON_TERMINAL_METADATA_STATUSES.has(metadata.metadataStatus)) {
+      cacheable = false;
+    }
+
     if (cacheable) {
       albumMetadataCache.set(cacheKey, extractAlbumMetadataEnrichment(metadata));
     }
@@ -817,12 +838,25 @@ export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistM
 
 const entityResolveCache = new LRUCache<string, { body: Record<string, unknown> | null }>({
   max: 2000,
-  ttl: 1000 * 60 * 60 * 24, // 24h (BS#988)
+  ttl: 1000 * 60 * 60 * 24, // 24h (BS#988) — positive resolutions are immutable
 });
+
+// BS#1893: a confirmed 404 is negative-cached, but LML resolves entities out of
+// its discogs-cache, which has known transient-404 windows during rebuilds (the
+// discogs-cache-rebuild <-> LML race). Decouple the negative TTL from the 24h
+// positive one so a rebuild-transient absence self-corrects in minutes instead
+// of pinning "not found" per container for a full day. Mirrors the sibling
+// `tracklistCache`'s 10-min 404 memo.
+const ENTITY_RESOLVE_NEGATIVE_TTL_MS = 1000 * 60 * 10; // 10 min
 
 /** Test-only: drop cached entries between cases. */
 export function __resetEntityResolveCacheForTests(): void {
   entityResolveCache.clear();
+}
+
+/** Test-only: remaining TTL (ms) for a cached entity-resolve entry. */
+export function __getEntityResolveRemainingTtlForTests(type: string, id: number): number {
+  return entityResolveCache.getRemainingTTL(entityResolveCacheKey(type, id));
 }
 
 function entityResolveCacheKey(type: string, id: number): string {
@@ -867,7 +901,9 @@ export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResol
         // request for the same type+id doesn't re-hit LML for the rest of
         // the TTL. Any other status is a transient failure and is
         // deliberately NOT cached; the original error still propagates.
-        entityResolveCache.set(cacheKey, { body: null });
+        // BS#1893: give the 404 a short TTL (not the 24h positive default) so a
+        // discogs-cache-rebuild-transient absence self-corrects quickly.
+        entityResolveCache.set(cacheKey, { body: null }, { ttl: ENTITY_RESOLVE_NEGATIVE_TTL_MS });
       }
       throw err;
     }

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -182,6 +182,7 @@ import {
   __resetAlbumMetadataCacheForTests,
   __resetArtistMetadataCacheForTests,
   __resetEntityResolveCacheForTests,
+  __getEntityResolveRemainingTtlForTests,
   __resetSpotifyTrackCacheForTests,
 } from '../../../apps/backend/controllers/proxy.controller';
 
@@ -439,6 +440,60 @@ describe('proxy.controller', () => {
       // starts cold, same discipline as `__resetLibraryTracksCacheForTests`
       // below in the `libraryTracks` suite.
       __resetAlbumMetadataCacheForTests();
+    });
+
+    // BS#1893: don't memoize a non-terminal (pending/enriching) album snapshot —
+    // its enrichment lands seconds later via the CDC worker, and a 1h-cached
+    // pending snapshot would mask that freshness on this path. The lru-cache mock
+    // isn't wired into the controller (nested install; see the mock note up top),
+    // so these assert the REAL cache's observable effect: does a repeat request
+    // re-resolve the linked row, or short-circuit on a cached response?
+    describe('non-terminal metadata_status caching (BS#1893)', () => {
+      it('does not cache a pending album snapshot: a repeat request re-resolves instead of serving stale pending', async () => {
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
+          record_label: null,
+          label_id: null,
+          metadata_status: 'pending',
+        });
+        mockLookupAlbumMetadataById.mockResolvedValue(null); // no album_metadata row yet
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = { query: { artistName: 'Pending Artist', releaseTitle: 'Pending Album' } } as unknown as Request;
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+
+        // Not cached → the second request re-resolves the linked row.
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(2);
+      });
+
+      it('caches a terminal (enriched_match) album snapshot: a repeat request short-circuits without re-resolving', async () => {
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
+          record_label: null,
+          label_id: null,
+          metadata_status: 'enriched_match',
+        });
+        mockLookupAlbumMetadataById.mockResolvedValue({
+          artwork_url: 'https://i.discogs.com/enriched.jpg',
+          discogs_url: 'https://www.discogs.com/release/1',
+          release_year: 2020,
+        });
+
+        const req = { query: { artistName: 'Enriched Artist', releaseTitle: 'Enriched Album' } } as unknown as Request;
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+        await getAlbumMetadata(req, createMockRes() as Response, mockNext);
+
+        // Cached (a terminal, stable snapshot) → the second request is served
+        // from the response cache and never re-resolves. Also exercises the new
+        // `sizeCalculation`/`maxSize` write path (BS#1893) end to end.
+        expect(mockSelectLinkedFlowsheetRow).toHaveBeenCalledTimes(1);
+      });
     });
 
     // ADR 0012: attach external critic-review snippets, flag-gated. These run
@@ -1869,7 +1924,14 @@ describe('proxy.controller', () => {
         // shape in the cache for the full TTL, same failure mode the
         // sibling local-DB/LML tests above guard against.
         mockCriticReviewsConfig.mockReturnValue({ enabled: true });
-        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        // Terminal status so caching is gated ONLY by the reviews-throw guard
+        // under test, not by BS#1893's non-terminal (pending) rule.
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
+          record_label: null,
+          label_id: null,
+          metadata_status: 'enriched_no_match',
+        });
         mockLookupAlbumMetadataById.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [],
@@ -1894,7 +1956,15 @@ describe('proxy.controller', () => {
 
       it('still caches when the critic-reviews read succeeds', async () => {
         mockCriticReviewsConfig.mockReturnValue({ enabled: true });
-        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        // Terminal status so the response is cacheable — this test asserts a
+        // successful reviews read does NOT block caching (BS#1893's pending rule
+        // would otherwise mask that behavior).
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
+          record_label: null,
+          label_id: null,
+          metadata_status: 'enriched_no_match',
+        });
         mockLookupAlbumMetadataById.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [],
@@ -1923,7 +1993,15 @@ describe('proxy.controller', () => {
       });
 
       it('keys the cache on the CRITIC_REVIEWS_ENABLED flag state so a flag flip is not served a stale shape', async () => {
-        mockSelectLinkedFlowsheetRow.mockResolvedValue(defaultLinkedRow());
+        // Terminal status so both flag states cache — the two LML calls below
+        // then prove the flag is part of the KEY (each flag state is a distinct
+        // cold entry), not merely that BS#1893 skipped caching a pending row.
+        mockSelectLinkedFlowsheetRow.mockResolvedValue({
+          album_id: DEFAULT_LINKED_ALBUM_ID,
+          record_label: null,
+          label_id: null,
+          metadata_status: 'enriched_no_match',
+        });
         mockLookupAlbumMetadataById.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [],
@@ -2330,6 +2408,30 @@ describe('proxy.controller', () => {
         );
 
         expect(mockResolveEntity).toHaveBeenCalledTimes(2);
+      });
+
+      it('negative-caches a 404 with a short TTL, decoupled from the 24h positive TTL (BS#1893)', async () => {
+        const { LmlClientError } = await import('@wxyc/lml-client');
+
+        // A 404 mid discogs-cache-rebuild is transient-prone; its negative memo
+        // must expire in minutes, not sit for the 24h positive TTL.
+        mockResolveEntity.mockRejectedValueOnce(new LmlClientError('Not found', 404));
+        const negReq = { query: { type: 'release', id: '909090' } } as unknown as Request;
+        await expect(resolveEntity(negReq, createMockRes() as Response, mockNext)).rejects.toThrow();
+
+        const negTtl = __getEntityResolveRemainingTtlForTests('release', 909090);
+        expect(negTtl).toBeGreaterThan(0);
+        // ~10 min (small slack for the sub-ms cache clock), and — the point of
+        // the decoupling — far below the 24h positive TTL asserted just below.
+        expect(negTtl).toBeLessThanOrEqual(10 * 60 * 1000 + 1000);
+
+        // A positive resolution keeps the long 24h TTL — proves the decoupling.
+        mockResolveEntity.mockResolvedValueOnce({ name: 'Broadcast', type: 'artist', id: 7003 });
+        const posReq = { query: { type: 'artist', id: '7003' } } as unknown as Request;
+        await resolveEntity(posReq, createMockRes() as Response, mockNext);
+
+        const posTtl = __getEntityResolveRemainingTtlForTests('artist', 7003);
+        expect(posTtl).toBeGreaterThan(60 * 60 * 1000); // well over an hour
       });
 
       it('projects cache_hit onto the Sentry span', async () => {


### PR DESCRIPTION
## Context

[BS#988](https://github.com/WXYC/Backend-Service/issues/988) (PR #1891) added four in-process LRU caches to the metadata proxy endpoints. Its review flagged three non-blocking cache-policy refinements — all bounded/self-correcting, none blocked the merge. This PR lands all three; each is an independent hunk in `apps/backend/controllers/proxy.controller.ts`.

## Refinements

### 1. `resolveEntity` 404 → short negative TTL, decoupled from the 24h positive

`resolveEntity` negative-cached a confirmed 404 for **24h** on the premise that resolved Discogs identities are immutable. But LML resolves entities out of its discogs-cache, which has known transient-404 windows during rebuilds (the documented discogs-cache-rebuild ↔ LML race). A transient 404 mid-rebuild pinned that entity as "not found" for 24h per container. Now the negative write uses a per-entry **10-min** TTL (`ENTITY_RESOLVE_NEGATIVE_TTL_MS`), matching the sibling `tracklistCache`'s 404 memo; **positive** resolutions keep the 24h TTL.

### 2. `getAlbumMetadata` no longer caches a non-terminal (`pending`/`enriching`) snapshot

A just-played track whose album is still `metadata_status='pending'` had its point-in-time snapshot — stale `metadataStatus` + missing enrichment — cached for 1h, so enrichment the CDC worker lands seconds later wasn't visible on this proxy path until the TTL expired. Now a response whose resolved `metadataStatus` is non-terminal (`pending`/`enriching`) sets `cacheable = false`, folding into BS#988's existing degraded-response gate. The terminal statuses (`enriched_match`/`enriched_no_match`/`failed_no_retry`) are stable and still cache.

### 3. `albumMetadataCache` gains a `maxSize` cap

The four BS#988 caches were count-bounded only (`max: 2000`), unlike `artworkCache`'s 20 MB cap. An album entry can carry a large `tracklist` (box sets, 100+ tracks) + `bioTokens`. Added `maxSize: 32 MB` + `sizeCalculation` on the album cache (the one the ticket calls out "at minimum"), so a pathological Discogs release is individually size-bounded.

## Tests

- **New** (`proxy.controller.test.ts`, assert on the real cache's observable behavior — the lru-cache mock isn't wired into the controller):
  - non-terminal `pending` album → a repeat request re-resolves (not cached); terminal `enriched_match` → repeat short-circuits (cached, and exercises the new `sizeCalculation` write path).
  - `resolveEntity` 404 negative entry has a ≤10-min remaining TTL while a positive entry keeps a >1h TTL — proving the decoupling (via a test-only `__getEntityResolveRemainingTtlForTests` helper).
- **Updated**: three co-located BS#988 caching tests moved off the default `pending` linked row to a terminal status, so they still isolate their stated behavior (reviews-throw guard / reviews-success caching / flag-keying) instead of passing for free under refinement #2.
- `npm run test:unit` — **5615 passed**; `npm run typecheck` clean (all workspaces); `prettier --check` + `eslint` clean on changed files.

Closes #1893