### PR TITLE
1c: Wire discogsUnavailable through callers + album-level-backfill candidate filter

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -103,10 +103,17 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     const artistName = body.alternate_artist_name || body.artist_name || '';
     const [streamingResult, artworkResult] = await Promise.allSettled([
       checkStreamingAvailability(artistName, body.album_title, { caller: 'library-add-album-streaming' }),
+      // BS#1294 (1c): pre-read the just-inserted row's discogs_unavailable
+      // flag. On the fresh-insert path this is always false (the row was
+      // just created with the schema default — BS#1281 / plan §3), so the
+      // gate is a no-op here. Wired for consistency with the other three
+      // lookupMetadata callers, and for the day addAlbum gains a dedup/
+      // upsert path that could re-touch an already-flagged row.
       lmlLookupCoordinator.lookup(artistName, body.album_title, undefined, {
         caller: 'library-add-album',
         warm_cache: true,
         requireSearchType: 'direct',
+        discogsUnavailable: inserted_album.discogs_unavailable,
       }),
     ]);
 

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -60,7 +60,7 @@ import { lookupMetadata, type LookupOptions, type LookupResponse } from '@wxyc/l
  */
 export type CoordinatorLookupOptions = Pick<
   LookupOptions,
-  'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'
+  'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter' | 'discogsUnavailable'
 > & {
   /**
    * When set, the coordinator returns `null` if the resolved response's
@@ -217,6 +217,7 @@ export class LmlLookupCoordinator {
       timeoutMs: options?.timeoutMs,
       caller: options?.caller,
       limiter: options?.limiter,
+      discogsUnavailable: options?.discogsUnavailable,
     });
   }
 

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -167,7 +167,14 @@ export interface ResolvedAlbum {
  * Same statement-timeout wrapper as `enumeratePendingAlbumIds` — the
  * `library` table is PK-lookup-shaped via `= ANY($1)` but the `artists`
  * LEFT JOIN can be slow if the artist row count grows; the timeout caps
- * the worst case. */
+ * the worst case.
+ *
+ * BS#1294 (1c): `AND l."discogs_unavailable" = false` is the primary
+ * bulk-path gate — flagged albums are excluded here, before they ever
+ * enter a batch or reach `bulkLookupMetadata`, which is cheaper than the
+ * per-item gate in `@wxyc/lml-client` (BS#1293, defense-in-depth) because
+ * it never builds the LML request payload for them. The partial index
+ * `library_discogs_unavailable_idx` (BS#1281) makes this predicate cheap. */
 export const resolveAlbums = async (
   albumIds: number[],
   timeoutMs: number = READ_TIMEOUT_DEFAULT
@@ -200,6 +207,7 @@ export const resolveAlbums = async (
       LEFT JOIN "wxyc_schema"."artists" a ON l."artist_id" = a."id"
       WHERE l."id" = ANY(${idArrayLiteral}::int[])
         AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
+        AND l."discogs_unavailable" = false
     `)) as unknown as Array<{ album_id: number; artist_name: string; album_title: string }>;
     return rows.map((r) => ({
       album_id: Number(r.album_id),

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -84,6 +84,13 @@ export type EnrichRow = {
   // (free-form entries, until their linkage resolves). Sourced from the
   // orchestrator's SELECT (`loadBatch` in orchestrate.ts).
   album_id: number | null;
+  // BS#1294 (1c): the linked album's `library.discogs_unavailable` flag,
+  // pre-read by the orchestrator's batch loader (LEFT JOIN library) and
+  // passed through to the lookupMetadata gate (BS#1293). Optional/undefined
+  // for unlinked rows (album_id IS NULL — no library row to join) and in
+  // hand-built test fixtures that predate this field; the lookup helper
+  // treats both the same as `false`.
+  discogs_unavailable?: boolean;
 };
 
 export type EnrichOutcome = 'enriched_match' | 'enriched_match_raced' | 'enriched_no_match' | 'enriched_no_match_raced';

--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -121,7 +121,15 @@ const hasUpstreamTimeout = (response: LookupResponse): boolean => response.timeo
  */
 export type LookupResult = { response: LookupResponse; cacheHit: boolean };
 
-export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LookupResult> => {
+export const lookupMetadata = async (
+  artist: string,
+  album?: string,
+  track?: string,
+  // BS#1294 (1c): pre-read `library.discogs_unavailable` from the
+  // orchestrator's batch loader; forwarded to the BS#1293 gate in
+  // `@wxyc/lml-client`, which short-circuits the LML call.
+  discogsUnavailable?: boolean
+): Promise<LookupResult> => {
   const cached = activeCache.get(artist, album);
   if (cached !== undefined) return { response: cached, cacheHit: true };
 
@@ -129,6 +137,7 @@ export const lookupMetadata = async (artist: string, album?: string, track?: str
     limiter: defaultLmlLimiter,
     timeoutMs: TIMEOUT_MS,
     caller: 'flowsheet-metadata-backfill',
+    discogsUnavailable,
   });
 
   if (!hasUpstreamTimeout(response)) {

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -115,6 +115,7 @@ import { captureError, log } from './logger.js';
 import {
   buildWorkList as defaultBuildWorkList,
   FLOWSHEET_TABLE,
+  LIBRARY_TABLE,
   unwrapRows,
   type BuildWorkListFn,
   type BuildSelfHealCandidatesFn,
@@ -343,7 +344,14 @@ export const resolvePartitionFilter = (
  * the wall-clock budget the throttle would otherwise spend waiting after
  * a no-op cache return.
  */
-export type LookupFn = (artist: string, album?: string, track?: string) => Promise<LookupResult>;
+export type LookupFn = (
+  artist: string,
+  album?: string,
+  track?: string,
+  // BS#1294 (1c): pre-read `row.discogs_unavailable`, forwarded to the
+  // BS#1293 gate.
+  discogsUnavailable?: boolean
+) => Promise<LookupResult>;
 
 export type EnrichFn = (row: EnrichRow, response: LookupResponse) => Promise<EnrichOutcome>;
 
@@ -553,7 +561,7 @@ export const processRow = async (
 
   let result: LookupResult;
   try {
-    result = await deps.lookup(artist, album, track);
+    result = await deps.lookup(artist, album, track, row.discogs_unavailable);
   } catch (error) {
     log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
       flowsheet_id: row.id,
@@ -668,15 +676,17 @@ const loadBatchByIds = async (ids: number[]): Promise<BatchRow[]> => {
   return unwrapRows<BatchRow>(
     await db.execute(sql`
     SELECT
-      "id",
-      "artist_name",
-      "album_title",
-      "track_title",
-      "album_id",
-      "metadata_status"
-    FROM ${FLOWSHEET_TABLE}
-    WHERE "id" = ANY(${idArrayLiteral}::int[])
-      AND "metadata_status" = 'pending'
+      f."id",
+      f."artist_name",
+      f."album_title",
+      f."track_title",
+      f."album_id",
+      f."metadata_status",
+      COALESCE(l."discogs_unavailable", false) AS "discogs_unavailable"
+    FROM ${FLOWSHEET_TABLE} f
+    LEFT JOIN ${LIBRARY_TABLE} l ON f."album_id" = l."id"
+    WHERE f."id" = ANY(${idArrayLiteral}::int[])
+      AND f."metadata_status" = 'pending'
   `),
     'batch load'
   );
@@ -700,14 +710,16 @@ const loadSelfHealRowsByIds = async (ids: number[]): Promise<EnrichRow[]> => {
   return unwrapRows<EnrichRow>(
     await db.execute(sql`
     SELECT
-      "id",
-      "artist_name",
-      "album_title",
-      "track_title",
-      "album_id"
-    FROM ${FLOWSHEET_TABLE}
-    WHERE "id" = ANY(${idArrayLiteral}::int[])
-      AND "metadata_status" = 'enriched_no_match'
+      f."id",
+      f."artist_name",
+      f."album_title",
+      f."track_title",
+      f."album_id",
+      COALESCE(l."discogs_unavailable", false) AS "discogs_unavailable"
+    FROM ${FLOWSHEET_TABLE} f
+    LEFT JOIN ${LIBRARY_TABLE} l ON f."album_id" = l."id"
+    WHERE f."id" = ANY(${idArrayLiteral}::int[])
+      AND f."metadata_status" = 'enriched_no_match'
   `),
     'self-heal batch load'
   );

--- a/jobs/flowsheet-metadata-backfill/worklist.ts
+++ b/jobs/flowsheet-metadata-backfill/worklist.ts
@@ -85,6 +85,9 @@ import { db } from '@wxyc/database';
  */
 const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
 export const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+// BS#1294 (1c): the batch loader LEFT JOINs library to pre-read
+// `discogs_unavailable` for the lookupMetadata gate (BS#1293).
+export const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
 const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
 const ARTIST_SEARCH_ALIAS_TABLE = sql.raw(`"${SCHEMA}"."artist_search_alias"`);
 const ROTATION_TABLE = sql.raw(`"${SCHEMA}"."rotation"`);

--- a/jobs/rotation-release-id-backfill/lml-fetch.ts
+++ b/jobs/rotation-release-id-backfill/lml-fetch.ts
@@ -64,7 +64,14 @@ const decodeHtmlEntities = (input: string): string =>
     return String.fromCodePoint(codepoint);
   });
 
-export const lookupReleaseId = async (artist: string, album: string): Promise<LookupOutcome> => {
+export const lookupReleaseId = async (
+  artist: string,
+  album: string,
+  // BS#1294 (1c): pre-read `library.discogs_unavailable` via the candidate
+  // query's LEFT JOIN (`query.ts`); forwarded to the BS#1293 gate in
+  // `@wxyc/lml-client`, which short-circuits the LML call.
+  discogsUnavailable?: boolean
+): Promise<LookupOutcome> => {
   const response = await sharedLookupMetadata(decodeHtmlEntities(artist), decodeHtmlEntities(album), undefined, {
     limiter: defaultLmlLimiter,
     timeoutMs: TIMEOUT_MS,
@@ -72,6 +79,7 @@ export const lookupReleaseId = async (artist: string, album: string): Promise<Lo
     // see the plan's "rotation-*-backfill" entry in the caller→class map)
     // so the CI guard's jobs/** backstop can verify it.
     caller: 'rotation-release-id-backfill',
+    discogsUnavailable,
   });
   const releaseId = response.results?.[0]?.artwork?.release_id ?? null;
   if (releaseId === null) {

--- a/jobs/rotation-release-id-backfill/orchestrate.ts
+++ b/jobs/rotation-release-id-backfill/orchestrate.ts
@@ -32,6 +32,11 @@ export type Candidate = {
   id: number;
   artist_name: string;
   album_title: string;
+  // BS#1294 (1c): pre-read via `query.ts`'s LEFT JOIN on `library`; forwarded
+  // to the lookupMetadata gate (BS#1293). Optional — absent in hand-built
+  // test fixtures that predate this field, and `lookupReleaseId` treats
+  // undefined the same as `false`.
+  discogs_unavailable?: boolean;
 };
 
 export type LoadCandidatesFn = () => Promise<Candidate[]>;
@@ -46,7 +51,7 @@ export type LoadCandidatesFn = () => Promise<Candidate[]>;
 export type LookupOutcome =
   { kind: 'resolved'; releaseId: number } | { kind: 'no_match' } | { kind: 'trust_rejected'; searchType: string };
 
-export type LookupFn = (artist: string, album: string) => Promise<LookupOutcome>;
+export type LookupFn = (artist: string, album: string, discogsUnavailable?: boolean) => Promise<LookupOutcome>;
 
 export type WriteFn = (rotationId: number, releaseId: number) => Promise<{ written: boolean }>;
 export type MarkAttemptedFn = (rotationId: number) => Promise<{ written: boolean }>;
@@ -158,7 +163,7 @@ export const runBackfill = async (deps: {
     totals.scanned += 1;
     let outcome: LookupOutcome;
     try {
-      outcome = await deps.lookup(candidate.artist_name, candidate.album_title);
+      outcome = await deps.lookup(candidate.artist_name, candidate.album_title, candidate.discogs_unavailable);
     } catch {
       // The row stays `discogs_release_id IS NULL`, so it's picked up
       // again on the next run when LML's cache is warmer. The job entry

--- a/jobs/rotation-release-id-backfill/query.ts
+++ b/jobs/rotation-release-id-backfill/query.ts
@@ -10,6 +10,15 @@
  * Rows lacking `artist_name` or `album_title` are also excluded; LML can't
  * resolve a release without both columns, so writing them as `unresolved`
  * would only add noise to the counter.
+ *
+ * BS#1294 (1c): LEFT JOINs `library` on `rotation.album_id` to pre-read
+ * `discogs_unavailable` at candidate-load time (this job's existing
+ * batched-candidate pattern — it does not read per-row today) and forwards
+ * it through `orchestrate.ts` to the lookupMetadata gate (BS#1293). A LEFT
+ * (not INNER) JOIN is required: `rotation.album_id` is nullable (freeform /
+ * unlinked rotation rows), and those rows must still be candidates —
+ * `COALESCE(..., false)` treats "no linked library row" the same as "not
+ * flagged".
  */
 
 import { sql } from 'drizzle-orm';
@@ -23,19 +32,21 @@ export const NO_MATCH_TTL_DAYS_DEFAULT = 30;
 export const loadCandidates = async (noMatchTtlDays: number = NO_MATCH_TTL_DAYS_DEFAULT): Promise<Candidate[]> => {
   const rows = (await db.execute(sql`
     SELECT
-      "id",
-      "artist_name",
-      "album_title"
-    FROM "wxyc_schema"."rotation"
-    WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
-      AND "discogs_release_id" IS NULL
-      AND "artist_name" IS NOT NULL
-      AND "album_title" IS NOT NULL
+      r."id",
+      r."artist_name",
+      r."album_title",
+      COALESCE(l."discogs_unavailable", false) AS "discogs_unavailable"
+    FROM "wxyc_schema"."rotation" r
+    LEFT JOIN "wxyc_schema"."library" l ON r."album_id" = l."id"
+    WHERE (r."kill_date" IS NULL OR r."kill_date" > CURRENT_DATE)
+      AND r."discogs_release_id" IS NULL
+      AND r."artist_name" IS NOT NULL
+      AND r."album_title" IS NOT NULL
       AND (
-        "discogs_release_id_resolve_attempted_at" IS NULL
-        OR "discogs_release_id_resolve_attempted_at" <= now() - (interval '1 day' * ${noMatchTtlDays})
+        r."discogs_release_id_resolve_attempted_at" IS NULL
+        OR r."discogs_release_id_resolve_attempted_at" <= now() - (interval '1 day' * ${noMatchTtlDays})
       )
-    ORDER BY "id" ASC
+    ORDER BY r."id" ASC
   `)) as unknown as Candidate[];
   return rows ?? [];
 };

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -479,6 +479,63 @@ describe('library.controller', () => {
         expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
       });
     });
+
+    describe('discogs_unavailable gate (BS#1294 1c)', () => {
+      beforeEach(() => {
+        mockGetArtistNameById.mockResolvedValue('Juana Molina');
+        mockIsLmlConfigured.mockReturnValue(true);
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: null });
+        mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
+        mockMapLookupToCanonicalEntity.mockReturnValue(null);
+      });
+
+      const req = () =>
+        ({
+          body: {
+            album_title: 'DOGA',
+            artist_id: 42,
+            // The artwork-lookup call reads `body.artist_name` directly (not
+            // the canonical name resolved via getArtistNameById), so it must
+            // be present here to assert the exact call args below.
+            artist_name: 'Juana Molina',
+            label: 'Sonamos',
+            genre_id: 11,
+            format_id: 1,
+          },
+        }) as unknown as Request;
+
+      it('pre-reads the freshly inserted row and forwards discogsUnavailable: false to the artwork lookup (fresh-insert no-op)', async () => {
+        mockInsertAlbum.mockImplementation((album) =>
+          Promise.resolve({ id: 501, ...album, discogs_unavailable: false })
+        );
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockLookupMetadata).toHaveBeenCalledWith(
+          'Juana Molina',
+          'DOGA',
+          undefined,
+          expect.objectContaining({ caller: 'library-add-album', discogsUnavailable: false })
+        );
+      });
+
+      it('forwards discogsUnavailable: true when the inserted row is already flagged (constructed case — never happens on fresh-insert)', async () => {
+        mockInsertAlbum.mockImplementation((album) =>
+          Promise.resolve({ id: 501, ...album, discogs_unavailable: true })
+        );
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockLookupMetadata).toHaveBeenCalledWith(
+          'Juana Molina',
+          'DOGA',
+          undefined,
+          expect.objectContaining({ caller: 'library-add-album', discogsUnavailable: true })
+        );
+      });
+    });
   });
 
   describe('getRotationTracks', () => {

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -230,6 +230,17 @@ describe('resolveAlbums', () => {
     expect(setLocalCall).toBeDefined();
     expect(renderSql(setLocalCall?.[0])).toMatch(/90000ms/);
   });
+
+  it('BS#1294 (1c): filters out library rows flagged discogs_unavailable (primary bulk-path gate)', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+
+    await resolveAlbums([1, 2, 3]);
+
+    const call = findExecuteCallMatching(/FROM\s+"?wxyc_schema"?\."?library"?/i);
+    expect(call).toBeDefined();
+    const text = renderSql(call?.[0]);
+    expect(text).toMatch(/l\."?discogs_unavailable"?\s*=\s*false/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/jobs/flowsheet-metadata-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/lml-fetch.test.ts
@@ -122,6 +122,21 @@ describe('jobs/flowsheet-metadata-backfill/lml-fetch (BS#994 / BS#1180 timeout k
     expect(callArgs.limiter).toBeDefined();
     expect(callArgs).toHaveProperty('timeoutMs', 35_000);
   });
+
+  it('BS#1294 (1c): forwards discogsUnavailable through to the shared lookupMetadata opts', async () => {
+    delete process.env.BACKFILL_LML_PER_CALL_TIMEOUT_MS;
+    const mockLookup = jest.fn().mockResolvedValue(emptyResponse);
+
+    const { lookupMetadata } = await loadModule(mockLookup);
+    await lookupMetadata('Chuquimamani-Condori', 'Edits', 'Call Your Name', true);
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Chuquimamani-Condori',
+      'Edits',
+      'Call Your Name',
+      expect.objectContaining({ discogsUnavailable: true })
+    );
+  });
 });
 
 describe('jobs/flowsheet-metadata-backfill/lml-fetch (run-scoped (artist, album) dedup)', () => {

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -309,7 +309,7 @@ describe('processRow', () => {
     const result = await processRow(row, { lookup, enrich });
 
     expect(result).toEqual({ outcome: 'enriched_match', cacheHit: false });
-    expect(lookup).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise');
+    expect(lookup).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise', undefined);
     expect(enrich).toHaveBeenCalledWith(row, matchedResponse);
   });
 
@@ -501,7 +501,17 @@ describe('processRow', () => {
 
     await processRow(sparseRow, { lookup, enrich });
 
-    expect(lookup).toHaveBeenCalledWith('Lone Anonymous', undefined, undefined);
+    expect(lookup).toHaveBeenCalledWith('Lone Anonymous', undefined, undefined, undefined);
+  });
+
+  it('BS#1294 (1c): forwards row.discogs_unavailable to the lookup call', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult(false));
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
+    const flaggedRow = { ...row, discogs_unavailable: true };
+
+    await processRow(flaggedRow, { lookup, enrich });
+
+    expect(lookup).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise', true);
   });
 });
 
@@ -748,6 +758,38 @@ describe('runBackfill (BS#1591 work-list drain)', () => {
     expect(values2).toContain('{20}');
   });
 
+  it('BS#1294 (1c): batch SELECT LEFT JOINs library and pre-reads discogs_unavailable; flagged rows never reach LML', async () => {
+    const buildWorkList = injectWorkList([[10, 12]]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ ...rowFor(10), discogs_unavailable: true }]);
+
+    const flaggedLookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult(false));
+
+    const result = await runBackfill({
+      lookup: flaggedLookup,
+      enrich,
+      batchSize: 1,
+      throttleMs: 0,
+      liveActivityLookbackSeconds: 0,
+      playFloor: 5,
+      floorRecencyDays: 7,
+      buildWorkList,
+    });
+
+    const sql1 = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    // renderSql doesn't traverse the nested `sql.raw` table-name chunks
+    // (FLOWSHEET_TABLE / LIBRARY_TABLE both render as empty strings here —
+    // the pre-existing tests above never assert on `FROM` content for the
+    // same reason), so pin the JOIN shape via the alias + ON clause instead.
+    expect(sql1).toMatch(/LEFT\s+JOIN/i);
+    expect(sql1).toMatch(/ON\s+f\."?album_id"?\s*=\s*l\."?id"?/i);
+    expect(sql1).toMatch(/COALESCE\s*\(\s*l\."?discogs_unavailable"?\s*,\s*false\s*\)\s+AS\s+"?discogs_unavailable"?/i);
+
+    // The flag reached the lookup call — lml-client's gate (BS#1293) is
+    // what actually skips the LML call; this pins the wire, not the gate.
+    expect(flaggedLookup).toHaveBeenCalledWith('artist-10', undefined, undefined, true);
+    expect(result.totals.scanned).toBe(1);
+  });
+
   it('no-wedge: a failing row is never re-selected within the run; it stays for the next run (BS#1011 lineage)', async () => {
     // The hard-won BS#1011 property under the new ordering: an lml_error row
     // stays metadata_attempt_at IS NULL (deliberately retryable), so a naive
@@ -818,7 +860,7 @@ describe('runBackfill (BS#1591 work-list drain)', () => {
     expect(result.totals.stale_skipped).toBe(1);
     expect(result.totals.scanned).toBe(1);
     expect(lookup).toHaveBeenCalledTimes(1);
-    expect(lookup).toHaveBeenCalledWith('artist-20', undefined, undefined);
+    expect(lookup).toHaveBeenCalledWith('artist-20', undefined, undefined, undefined);
   });
 
   it('reconciles worker-terminal rows with a marker-only stamp and zero LML calls (worker_reconciled)', async () => {
@@ -857,7 +899,7 @@ describe('runBackfill (BS#1591 work-list drain)', () => {
     expect(result.totals.scanned).toBe(1);
     expect(result.totals.enriched_match).toBe(1);
     expect(lookup).toHaveBeenCalledTimes(1);
-    expect(lookup).toHaveBeenCalledWith('artist-20', undefined, undefined);
+    expect(lookup).toHaveBeenCalledWith('artist-20', undefined, undefined, undefined);
 
     // The reconcile statement is a marker-guarded, marker-only UPDATE with
     // RETURNING (the count comes from rows actually stamped), binding the

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -202,3 +202,33 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (search_type trust gate, B
     expect(result).toEqual({ kind: 'resolved', releaseId: 35719330 });
   });
 });
+
+describe('jobs/rotation-release-id-backfill/lml-fetch (discogsUnavailable gate, BS#1294)', () => {
+  it('forwards discogsUnavailable through to the shared lookupMetadata opts', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ search_type: 'none', results: [] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('Jessica Pratt', 'On Your Own Love Again', true);
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Jessica Pratt',
+      'On Your Own Love Again',
+      undefined,
+      expect.objectContaining({ discogsUnavailable: true })
+    );
+  });
+
+  it('omits discogsUnavailable (undefined) when the caller does not pass it', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ search_type: 'none', results: [] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('Jessica Pratt', 'On Your Own Love Again');
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Jessica Pratt',
+      'On Your Own Love Again',
+      undefined,
+      expect.objectContaining({ discogsUnavailable: undefined })
+    );
+  });
+});

--- a/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
@@ -50,6 +50,21 @@ describe('runBackfill', () => {
     expect(result.totals.raced).toBe(0);
   });
 
+  test('BS#1294 (1c): forwards candidate.discogs_unavailable to the lookup call', async () => {
+    const loadCandidates = makeLoadCandidates([
+      { id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again', discogs_unavailable: true },
+    ]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'no_match' });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+    const markAttempted = makeMarkAttempted();
+
+    await runBackfill({ loadCandidates, lookup, write, markAttempted });
+
+    // The flag reached the lookup call — lml-client's gate (BS#1293) is
+    // what actually skips the LML call; this pins the wire, not the gate.
+    expect(lookup).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again', true);
+  });
+
   test('LML finds no Discogs match → unresolved counter, no write', async () => {
     const loadCandidates = makeLoadCandidates([
       { id: 99, artist_name: 'Chuquimamani-Condori', album_title: 'Untitled Acetate' },

--- a/tests/unit/jobs/rotation-release-id-backfill/query.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/query.test.ts
@@ -52,7 +52,7 @@ describe('loadCandidates', () => {
     expect(rows).toEqual([{ id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' }]);
     const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
     expect(text).toMatch(/FROM\s+"?wxyc_schema"?\."?rotation"?/i);
-    expect(text).toMatch(/"kill_date"\s+IS\s+NULL\s+OR\s+"kill_date"\s+>\s+CURRENT_DATE/i);
+    expect(text).toMatch(/"?\w*"?\."?kill_date"?\s+IS\s+NULL\s+OR\s+"?\w*"?\."?kill_date"?\s*>\s*CURRENT_DATE/i);
     expect(text).toMatch(/"discogs_release_id"\s+IS\s+NULL/i);
     expect(text).toMatch(/"artist_name"\s+IS\s+NOT\s+NULL/i);
     expect(text).toMatch(/"album_title"\s+IS\s+NOT\s+NULL/i);
@@ -77,5 +77,21 @@ describe('loadCandidates', () => {
     const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
     expect(text).not.toMatch(/tubafrenzy_paste/i);
     expect(text).not.toMatch(/discogs_release_id_source\s*=/i);
+  });
+
+  test('BS#1294 (1c): LEFT JOINs library on album_id and pre-reads discogs_unavailable, defaulting unlinked rows to false', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([
+      { id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again', discogs_unavailable: true },
+    ]);
+
+    await loadCandidates(30);
+
+    const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(text).toMatch(/LEFT\s+JOIN\s+"?wxyc_schema"?\."?library"?/i);
+    expect(text).toMatch(/ON\s+r\."?album_id"?\s*=\s*l\."?id"?/i);
+    // COALESCE to false so rotation rows with no linked library row (a
+    // nullable album_id — freeform / unlinked entries) remain candidates
+    // instead of being silently excluded by a NULL flag.
+    expect(text).toMatch(/COALESCE\s*\(\s*l\."?discogs_unavailable"?\s*,\s*false\s*\)\s+AS\s+"?discogs_unavailable"?/i);
   });
 });

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -100,6 +100,22 @@ describe('LmlLookupCoordinator', () => {
         expect.objectContaining({ extended: true })
       );
     });
+
+    it('BS#1294 (1c): forwards discogsUnavailable through to lookupMetadata', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'library-add-album',
+        discogsUnavailable: true,
+      });
+
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        'Autechre',
+        'Confield',
+        undefined,
+        expect.objectContaining({ discogsUnavailable: true })
+      );
+    });
   });
 
   describe('in-flight coalescing', () => {


### PR DESCRIPTION
## Summary

- Pre-reads `library.discogs_unavailable` and forwards it through the BS#1293 `lml-client` gate at all three runtime `lookupMetadata` call sites:
  - `apps/backend/controllers/library.controller.ts` — library-add real-time enrichment, via `LmlLookupCoordinator` (extended with a `discogsUnavailable` option). Per plan §3, on the fresh-insert path this is always `false` (the row was just created with the schema default), so the gate is a no-op here — wired for consistency and for the day `addAlbum` gains a dedup/upsert path.
  - `jobs/flowsheet-metadata-backfill` — the batch loader (`loadBatchByIds` / `loadSelfHealRowsByIds`) LEFT JOINs `library` to pre-read the flag and passes it through `EnrichRow` → `processRow` → the job's `lookupMetadata` shim.
  - `jobs/rotation-release-id-backfill` — `query.ts`'s `loadCandidates` LEFT JOINs `library` on `rotation.album_id` (per the resolved design decision — this job's existing batched-candidate pattern), extending `Candidate` with `discogs_unavailable`, threaded through `orchestrate.ts` to `lookupReleaseId`.
- Adds `AND library.discogs_unavailable = false` to `jobs/album-level-backfill`'s `resolveAlbums` candidate-resolution query — the primary bulk-path gate, since flagged albums never enter a batch or reach `bulkLookupMetadata`. The `lml-client` per-item gate (sub-issue 1b) remains defense-in-depth.

All new/changed fields are optional and default via `COALESCE(..., false)` in SQL or `?? false`-equivalent handling in code, so every existing caller that doesn't pass the flag is unaffected.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run typecheck` (root: `@wxyc/database` + `shared/**` + `apps/**`) — clean
- [x] `npx tsc --noEmit` against each touched `jobs/*` package's own `tsconfig.json` (not covered by the root typecheck script) — clean
- [x] `npm run format:check` — clean
- [x] Full unit suite (`jest --config jest.unit.config.ts`) — 366 suites / 5623 tests passing, including new coverage for all 5 tests the issue specifies:
  1. library-add wire (flagged album → `discogsUnavailable` forwarded to the artwork lookup)
  2. flowsheet-metadata-backfill wire (LEFT JOIN + pass-through to `lookupMetadata`)
  3. rotation-release-id-backfill wire (LEFT JOIN + pass-through to `lookupReleaseId`)
  4. album-level-backfill candidate filter (`discogs_unavailable = false` in `resolveAlbums`)
  5. End-to-end wiring is covered at the unit level per call site above; the actual "zero LML HTTP requests" behavior is enforced inside `@wxyc/lml-client`'s gate (sub-issue 1b, already merged and tested there) — this PR pins that every caller reaches that gate with the right flag.

Closes #1294