### PR TITLE
Add daily discogs_unavailable recheck cron + manual endpoint (BS#1283)

### DIFF
--- a/Dockerfile.library-discogs-unavailable-recheck
+++ b/Dockerfile.library-discogs-unavailable-recheck
@@ -1,0 +1,46 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /library-discogs-unavailable-recheck-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/library-discogs-unavailable-recheck ./jobs/library-discogs-unavailable-recheck
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/library-discogs-unavailable-recheck
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /library-discogs-unavailable-recheck
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/library-discogs-unavailable-recheck/package* ./jobs/library-discogs-unavailable-recheck/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.backend and the BS#1015 lesson.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./library-discogs-unavailable-recheck-builder/jobs/library-discogs-unavailable-recheck/dist ./jobs/library-discogs-unavailable-recheck/dist
+COPY --from=builder ./library-discogs-unavailable-recheck-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./library-discogs-unavailable-recheck-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Per-statement timeout: the writer does small single-album transactions
+# (a bounded rotation UPDATE plus a single-row library UPDATE); 60 s is more
+# than enough headroom for this job's small daily batch.
+ENV DB_STATEMENT_TIMEOUT_MS=60000
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-library-discogs-unavailable-recheck
+
+CMD ["npm", "start", "--workspace=@wxyc/library-discogs-unavailable-recheck"]

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -913,6 +913,39 @@ export const markFound: RequestHandler<{ id: string }> = async (req, res) => {
   res.status(200).json(album);
 };
 
+/**
+ * POST /library/:id/discogs-recheck (BS#1283 / epic #1280 sub-issue 3).
+ *
+ * Manual counterpart to the daily `library-discogs-unavailable-recheck`
+ * cron: force-asks LML for a fresh Discogs match on this release (bypassing
+ * the runtime BS#1293 `discogsUnavailable` gate), so an MD can close the
+ * "embargo just lifted, want it now" gap instead of waiting for the next
+ * cron tick. Runs the same 0.95-confidence-floor / sticky-false-match-fixed
+ * writer path as the cron — see `libraryService.recheckDiscogsAvailability`.
+ *
+ * Gated on `catalog:write` (musicDirector + stationManager) — same bar as
+ * the other catalog-mutating routes on this router (`updateAlbum`,
+ * `addAlbum`), not the lighter `catalog:read` bar `markMissing`/`markFound`
+ * use, because this can rewrite `rotation.discogs_release_id`.
+ */
+export const manualDiscogsRecheck: RequestHandler<{ id: string }> = async (req, res) => {
+  const albumId = parseAlbumId(req.params.id);
+
+  const existing = await libraryService.getLibraryRowById(albumId);
+  if (!existing) {
+    throw new WxycError('Album not found', 404);
+  }
+  if (!existing.artist_name || !existing.album_title) {
+    throw new WxycError('Cannot recheck a release without artist_name and album_title', 400);
+  }
+  if (!isLmlConfigured()) {
+    throw new WxycError('LML is not configured', 503);
+  }
+
+  const result = await libraryService.recheckDiscogsAvailability(albumId, existing.artist_name, existing.album_title);
+  res.status(200).json(result);
+};
+
 // ---------------------------------------------------------------------------
 // GET /library/query — query-builder search over the catalog
 // ---------------------------------------------------------------------------

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -86,3 +86,12 @@ library_route.patch('/:id', requirePermissions({ catalog: ['write'] }), libraryC
 library_route.patch('/:id/missing', requirePermissions({ catalog: ['read'] }), libraryController.markMissing);
 
 library_route.patch('/:id/found', requirePermissions({ catalog: ['read'] }), libraryController.markFound);
+
+// BS#1283 (epic #1280 sub-issue 3): manual counterpart to the daily
+// library-discogs-unavailable-recheck cron. Gated to catalog:write (same bar
+// as updateAlbum/addAlbum) since it can rewrite rotation.discogs_release_id.
+library_route.post(
+  '/:id/discogs-recheck',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.manualDiscogsRecheck
+);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1861,6 +1861,19 @@ export const recheckDiscogsAvailability = async (
     caller: 'library-discogs-unavailable-recheck',
   });
 
+  // Distinguish a transient LML timeout body (`{timeout:true, results:[]}`,
+  // e.g. LML#370 cascade-exhaustion) from a definitive no-match — same guard
+  // as the daily cron's `jobs/library-discogs-unavailable-recheck/lml-fetch
+  // .ts`. Throw instead of stamping `last_discogs_recheck_at` / returning
+  // `no_match`: a timeout body is not evidence of "no Discogs match", and
+  // stamping it here would wrongly exclude the row from the cron's 7-day
+  // recheck window for a full week over a purely transient LML failure. The
+  // thrown error surfaces as a 5xx on the admin endpoint, which is retryable
+  // immediately (unlike the week-long deferral a wrong stamp would cause).
+  if (response.timeout) {
+    throw new Error('LML lookup returned a timeout body; treating as transient so the row stays retryable');
+  }
+
   const top = response.results?.[0];
   const releaseId = top?.artwork?.release_id;
   // `release_id: 0` is the BS#1185 streaming-only sentinel — not a linkable

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -3,6 +3,7 @@ import { LRUCache } from 'lru-cache';
 import * as Sentry from '@sentry/node';
 import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
+import WxycError from '../utils/error.js';
 import { db } from '@wxyc/database';
 import {
   AlbumFormat,
@@ -35,6 +36,7 @@ import {
 import {
   getRelease,
   lookupBySong,
+  lookupMetadata,
   isLmlConfigured,
   LmlClientError,
   resolveIdentity,
@@ -1811,6 +1813,109 @@ export const getLibraryRowById = async (album_id: number) => {
     .where(eq(library.id, album_id))
     .limit(1);
   return rows[0];
+};
+
+/**
+ * Outcome of a manual `POST /library/:id/discogs-recheck` (BS#1283 / epic
+ * #1280 sub-issue 3). Mirrors the outcome taxonomy of the daily
+ * `jobs/library-discogs-unavailable-recheck` cron's per-row path (that
+ * standalone job package can't import from `apps/backend`, so the logic
+ * below is intentionally duplicated — same pattern as
+ * `jobs/rotation-release-id-backfill/lml-fetch.ts`'s BS#1516 trust gate
+ * "mirrors the coordinator... which this job can't use because it imports
+ * lml-client directly").
+ */
+export type DiscogsRecheckOutcome =
+  | { outcome: 'matched'; discogsReleaseId: number; confidence: number }
+  | { outcome: 'low_confidence_match'; confidence: number }
+  | { outcome: 'no_match' };
+
+/** Same floor as the daily recheck cron's `CONFIDENCE_FLOOR` — see `jobs/library-discogs-unavailable-recheck/orchestrate.ts`'s module doc for the rationale (stricter than the runtime lookup path's confidence bands, closing the "Natanya adversarial loop"). */
+const DISCOGS_RECHECK_CONFIDENCE_FLOOR = 0.95;
+
+const stampDiscogsRecheckTimestamp = async (album_id: number): Promise<void> => {
+  await db
+    .update(library)
+    .set({ last_discogs_recheck_at: sql`now()` })
+    .where(eq(library.id, album_id));
+};
+
+/**
+ * Force-asks LML for a fresh Discogs match on a `discogs_unavailable`-
+ * flaggable release, bypassing the runtime BS#1293 gate via
+ * `forceLookup: true`. Applies the same 0.95 confidence floor, transactional
+ * high-confidence writer (NO `IS NULL` guard on the rotation UPDATE — the
+ * sticky-false-match fix, see `jobs/library-discogs-unavailable-recheck/
+ * writer.ts`'s module doc), and low-confidence Sentry counter as the daily
+ * cron. Used by the manual `POST /library/:id/discogs-recheck` admin
+ * endpoint so an MD can close the "embargo just lifted, want it now" gap
+ * without waiting for the next cron tick.
+ */
+export const recheckDiscogsAvailability = async (
+  album_id: number,
+  artist_name: string,
+  album_title: string
+): Promise<DiscogsRecheckOutcome> => {
+  const response = await lookupMetadata(artist_name, album_title, undefined, {
+    forceLookup: true,
+    caller: 'library-discogs-unavailable-recheck',
+  });
+
+  const top = response.results?.[0];
+  const releaseId = top?.artwork?.release_id;
+  // `release_id: 0` is the BS#1185 streaming-only sentinel — not a linkable
+  // Discogs release; treat as no_match, same as the cron's lml-fetch.ts.
+  if (typeof releaseId !== 'number' || releaseId <= 0) {
+    await stampDiscogsRecheckTimestamp(album_id);
+    return { outcome: 'no_match' };
+  }
+
+  const rawConfidence = top?.artwork?.confidence;
+  const confidence = typeof rawConfidence === 'number' ? rawConfidence : 0;
+
+  if (confidence < DISCOGS_RECHECK_CONFIDENCE_FLOOR) {
+    try {
+      Sentry.metrics.count('lml.lookup.recheck.match_found_on_flagged', 1, {
+        attributes: { confidence, artist_name, album_title, library_id: album_id },
+      });
+    } catch {
+      // Observability must never break the request path; swallow.
+    }
+    await stampDiscogsRecheckTimestamp(album_id);
+    return { outcome: 'low_confidence_match', confidence };
+  }
+
+  const written = await db.transaction(async (tx) => {
+    // No IS-NULL guard — BY DESIGN. See jobs/library-discogs-unavailable-
+    // recheck/writer.ts's module doc for the sticky-false-match rationale.
+    // rotation.album_id is not unique (re-bins/re-adds), so this updates
+    // EVERY rotation row for the album, not just one.
+    await tx
+      .update(rotation)
+      .set({
+        discogs_release_id: releaseId,
+        discogs_release_id_source: 'recheck_after_unavailable',
+      })
+      .where(eq(rotation.album_id, album_id));
+
+    const libraryUpdated = await tx
+      .update(library)
+      .set({
+        discogs_unavailable: false,
+        discogs_unavailable_note: null,
+        last_discogs_recheck_at: sql`now()`,
+      })
+      .where(eq(library.id, album_id))
+      .returning({ id: library.id });
+
+    return libraryUpdated.length === 1;
+  });
+
+  if (!written) {
+    throw new WxycError('Album not found', 404);
+  }
+
+  return { outcome: 'matched', discogsReleaseId: releaseId, confidence };
 };
 
 /** True when `artist_id` already owns an album with this `code_number` (excluding `exclude_album_id`). */

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -191,6 +191,17 @@ Recurring cron for BS#1813 / BS#1029. Reuses `BACKFILL_LML_*` (above), `LIVE_ACT
 - `ROTATION_RELEASE_ID_NO_MATCH_TTL_DAYS` (default `30`) — Rows with NULL `discogs_release_id` and a stamped `discogs_release_id_resolve_attempted_at` are skipped until this window expires. Rows whose LML call threw keep the marker NULL and retry on the next cron tick.
 - `DRY_RUN` (default unset / `false`) — when case-insensitively `'true'` or `'1'` (leading/trailing whitespace trimmed), the orchestrator skips every UPDATE, including marker-only attempts, and increments `rows_resolved_dry` instead of `rows_resolved` for trusted matches. Useful for confirming the candidate set before a real run; harmless to forget — the `discogs_release_id IS NULL` SELECT/WHERE predicate is idempotent across reruns.
 
+### Library discogs_unavailable recheck (`jobs/library-discogs-unavailable-recheck`)
+
+Daily cron for BS#1283 / epic #1280 sub-issue 3. Job-scoped limiter (not `BACKFILL_LML_*`) so this surface's accounting is independent of the other backfills'; read at module load by `lml-limiter.ts:createLmlLimiter` (first two) and `lml-fetch.ts` (third):
+
+- `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_BATCH_SIZE` (default `50`) — Candidate query `LIMIT`. Prevents a stampede if a bulk-flagging pass ever lands many `discogs_unavailable` rows at once.
+- `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_MAX_CONCURRENT` (default `1`) — Maximum concurrent in-flight recheck `/api/v1/lookup` calls.
+- `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_RATE_PER_MIN` (default `20`) — Token-bucket refill rate/capacity per minute.
+- `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_LML_TIMEOUT_MS` (default `8000`) — Per-call abort budget; same rationale as `rotation-release-id-backfill`'s `BACKFILL_LML_PER_CALL_TIMEOUT_MS` default (small recurring cohort, must not occupy LML's serialized Discogs fan-out).
+
+No `DRY_RUN` / no-match-TTL knob: the candidate query's own `last_discogs_recheck_at`-vs-7-days predicate is the idempotency + retry-window gate (a row rechecked today isn't reselected until the window passes), and there's no separate "confirmed no match" vs "never tried" marker to protect — every outcome (match / low-confidence / no-match) stamps the same timestamp.
+
 ### Rotation artist backfill (`jobs/rotation-artist-backfill`)
 
 Daily cron job for BS#1381. One BS call here = one batch of up to 50 `lml_identity_id`s; LML fans out internally to per-source release + artist Discogs calls, so this job has a fundamentally different timeout shape than the per-row backfill jobs above. Reuses `BACKFILL_LML_MAX_CONCURRENT` and `BACKFILL_LML_RATE_PER_MIN` (applied to **batch calls**, not Discogs egress), and adds:

--- a/docs/ops-cron-scheduling.md
+++ b/docs/ops-cron-scheduling.md
@@ -18,18 +18,19 @@ The breaker trips on LML's Discogs API work, driven by LML's HTTP endpoints — 
 
 ## Current slot table (UTC)
 
-| Time                          | Job                                   | Class                                                                               |
-| ----------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
-| 04:15                         | `artist-search-alias-consumer`        | light (`search-aliases/bulk`, bounded)                                              |
-| 04:30                         | `rotation-artist-backfill`            | **heavy drain**                                                                     |
-| 04:45                         | `catalog-popularity-freetext-resolve` | **heavy drain** (`bulkLookupMetadata`)                                              |
-| 05:35                         | `concerts-artist-lml-resolver`        | light (upcoming-show cohort)                                                        |
-| 05:45                         | `concerts-genre-enrichment`           | light (upcoming-show cohort)                                                        |
-| 06:05                         | `concerts-poster-enrichment`          | light (one call per distinct headliner)                                             |
-| 00:17 / 06:17 / 12:17 / 18:17 | `rotation-release-id-backfill`        | **heavy drain** (small active-rotation cohort, per-row `lookupMetadata`; TTL-gated) |
-| 07:00 Mon                     | `rotation-release-id-pollution-check` | light (weekly, read-only, paced)                                                    |
-| **09:00**                     | **`rotation-lml-identity-backfill`**  | **heavy drain** — moved here by BS#1665, was `0 6 * * *`                            |
-| **:10 hourly**                | **`flowsheet-metadata-backfill`**     | **exempt from slot-exclusivity** — BS#895 hourly recovery sweep, see below          |
+| Time                          | Job                                       | Class                                                                                                                |
+| ----------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 04:15                         | `artist-search-alias-consumer`            | light (`search-aliases/bulk`, bounded)                                                                               |
+| 04:30                         | `rotation-artist-backfill`                | **heavy drain**                                                                                                      |
+| 04:45                         | `catalog-popularity-freetext-resolve`     | **heavy drain** (`bulkLookupMetadata`)                                                                               |
+| 05:35                         | `concerts-artist-lml-resolver`            | light (upcoming-show cohort)                                                                                         |
+| 05:45                         | `concerts-genre-enrichment`               | light (upcoming-show cohort)                                                                                         |
+| **06:00**                     | **`library-discogs-unavailable-recheck`** | **light** (BS#1283 — `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_BATCH_SIZE`-bounded, default 50, per-row `lookupMetadata`) |
+| 06:05                         | `concerts-poster-enrichment`              | light (one call per distinct headliner)                                                                              |
+| 00:17 / 06:17 / 12:17 / 18:17 | `rotation-release-id-backfill`            | **heavy drain** (small active-rotation cohort, per-row `lookupMetadata`; TTL-gated)                                  |
+| 07:00 Mon                     | `rotation-release-id-pollution-check`     | light (weekly, read-only, paced)                                                                                     |
+| **09:00**                     | **`rotation-lml-identity-backfill`**      | **heavy drain** — moved here by BS#1665, was `0 6 * * *`                                                             |
+| **:10 hourly**                | **`flowsheet-metadata-backfill`**         | **exempt from slot-exclusivity** — BS#895 hourly recovery sweep, see below                                           |
 
 `rotation-lml-identity-backfill`'s new `0 9 * * *` slot is clear of the entire 04:15–06:05 stack, ~2h after the weekly Monday pollution check, and ~04:00–05:00 ET — still off-peak for DJs (cooperative pause covers the rest).
 

--- a/jobs/library-discogs-unavailable-recheck/job.ts
+++ b/jobs/library-discogs-unavailable-recheck/job.ts
@@ -1,0 +1,93 @@
+/**
+ * Entrypoint for jobs/library-discogs-unavailable-recheck (BS#1283 / epic
+ * #1280 sub-issue 3).
+ *
+ * Daily cron that rechecks `library` rows the MD flagged
+ * `discogs_unavailable`. Two classes of flagged release need different
+ * recovery behavior: audience-segment releases (never on Discogs — permanent
+ * skip is correct) and embargoed promos (eventually clear Discogs). Without
+ * this recheck the flag stays set forever and an embargoed promo never gets
+ * enriched after Discogs catches up. See `orchestrate.ts`'s module doc for
+ * the full design rationale (0.95 confidence floor, sticky-false-match fix).
+ *
+ * Schedule: `0 6 * * *` UTC daily, per this package's `cron-schedule` field
+ * (resolved by `scripts/resolve-cron-schedule.sh`, wired into
+ * `.github/workflows/deploy-base.yml`'s crontab-install step). Classified as
+ * a light-touch LML-hitting cron in `docs/ops-cron-scheduling.md` — bounded
+ * by `LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_BATCH_SIZE`, per-row
+ * `lookupMetadata` calls gated by this job's own limiter
+ * (`lml-limiter.ts`) — not subject to the heavy-drain ≥60 min slot-spacing
+ * rule.
+ *
+ * Invocation:
+ *   docker run --rm --env-file .env <image>
+ *
+ * Required env: LIBRARY_METADATA_URL (LML host), LML_API_KEY (bearer),
+ * DB_* (postgres connection).
+ *
+ * Optional env:
+ *   LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_BATCH_SIZE       default 50
+ *   LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_MAX_CONCURRENT   default 1
+ *   LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_RATE_PER_MIN     default 20
+ *   LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_LML_TIMEOUT_MS   default 8000
+ */
+
+import { closeDatabaseConnection, requirePositiveInt } from '@wxyc/database';
+
+import { runRecheck } from './orchestrate.js';
+import { loadCandidates, BATCH_SIZE_ENV, BATCH_SIZE_DEFAULT } from './query.js';
+import { lookupRecheck } from './lml-fetch.js';
+import { writeMatch, stampRecheckTimestamp } from './writer.js';
+import { initLogger, log, captureError, captureCounter, closeLogger } from './logger.js';
+
+const JOB_NAME = 'library-discogs-unavailable-recheck';
+
+/** Sentry counter incremented when LML finds a match on a flagged release, but the match's confidence falls below the 0.95 floor — see `orchestrate.ts`'s module doc for why this never auto-writes. */
+export const LOW_CONFIDENCE_METRIC = 'lml.lookup.recheck.match_found_on_flagged';
+
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    requireLmlConfigured();
+    const batchSize = requirePositiveInt(process.env[BATCH_SIZE_ENV], BATCH_SIZE_ENV, BATCH_SIZE_DEFAULT, {
+      context: JOB_NAME,
+    });
+    log('info', 'init', `${JOB_NAME} initialized`, { batch_size: batchSize });
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => loadCandidates(batchSize),
+      lookup: lookupRecheck,
+      writeMatch,
+      stamp: stampRecheckTimestamp,
+      recordLowConfidence: ({ libraryId, artistName, albumTitle, confidence }) => {
+        captureCounter(LOW_CONFIDENCE_METRIC, 1, {
+          confidence,
+          artist_name: artistName,
+          album_title: albumTitle,
+          library_id: libraryId,
+        });
+        log('warn', 'low_confidence_match', 'LML found a sub-floor match for a flagged release', {
+          library_id: libraryId,
+          confidence,
+        });
+      },
+    });
+
+    log('info', 'finished', `${JOB_NAME} done`, totals);
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/library-discogs-unavailable-recheck/lml-fetch.ts
+++ b/jobs/library-discogs-unavailable-recheck/lml-fetch.ts
@@ -1,0 +1,78 @@
+/**
+ * LML lookup helper for jobs/library-discogs-unavailable-recheck (BS#1283 /
+ * epic #1280 sub-issue 3).
+ *
+ * Delegates to `@wxyc/lml-client.lookupMetadata` (the shared HTTP +
+ * Sentry-instrumentation chokepoint introduced in BS#887) and injects:
+ *   - `forceLookup: true` (BS#1293's `LookupOptions.forceLookup`) so the
+ *     runtime `discogsUnavailable` gate is bypassed — this job's entire job
+ *     is to re-ask LML about a release the runtime path would otherwise
+ *     skip. Explicit per-call flag, not a caller-side handshake that flips
+ *     `discogsUnavailable` itself (the parent issue's self-review flagged
+ *     that shape as refactor-fragile).
+ *   - this job's own `defaultLmlLimiter` (job-scoped
+ *     LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_* env vars) so this surface's
+ *     accounting is separate and tunable from every other cron's.
+ *   - a per-call abort budget (`LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_LML_
+ *     TIMEOUT_MS`, default 8000 ms), matching the sibling backfill jobs'
+ *     posture of a tight fast-fail budget for a batch/backfill caller.
+ *
+ * Returns a discriminated `LookupOutcome` (`orchestrate.ts`): `match` (a
+ * Discogs release id plus the raw LML `artwork.confidence` score) or
+ * `no_match`. The 0.95 confidence floor is NOT applied here — see
+ * `orchestrate.ts`'s module doc for why that check lives in the orchestrator.
+ *
+ * Deliberately does NOT gate on `search_type` the way
+ * `jobs/rotation-release-id-backfill` does (BS#1516's `direct`-only trust
+ * gate) — the parent issue's spec is a flat confidence-score floor with no
+ * search_type condition, and adding one here would be an un-requested
+ * tightening beyond BS#1283's scope.
+ */
+
+import { lookupMetadata as sharedLookupMetadata } from '@wxyc/lml-client';
+
+import { defaultLmlLimiter } from './lml-limiter.js';
+import type { LookupOutcome } from './orchestrate.js';
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+const TIMEOUT_MS = envInt('LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_LML_TIMEOUT_MS', 8000);
+
+export const lookupRecheck = async (artist: string, album: string): Promise<LookupOutcome> => {
+  const response = await sharedLookupMetadata(artist, album, undefined, {
+    forceLookup: true,
+    limiter: defaultLmlLimiter,
+    timeoutMs: TIMEOUT_MS,
+    caller: 'library-discogs-unavailable-recheck',
+  });
+  // Distinguish a transient LML timeout body (`{timeout:true, results:[]}`,
+  // e.g. LML#370 cascade-exhaustion) from a definitive no-match. Throw so the
+  // orchestrator counts it as `lml_error` and leaves `last_discogs_recheck_at`
+  // untouched (retryable the next run) instead of stamping a row behind the
+  // 7-day recheck window on a response LML never actually finished resolving.
+  if (response.timeout) {
+    throw new Error('LML lookup returned a timeout body; treating as transient so the row stays retryable');
+  }
+
+  const top = response.results?.[0];
+  const releaseId = top?.artwork?.release_id;
+  // `release_id: 0` is the BS#1185 streaming-only sentinel — not a linkable
+  // Discogs release. This recheck's whole purpose is to find a real release
+  // id to persist on `rotation.discogs_release_id`, so the sentinel is not a
+  // match here (unlike the release-id backfill, which persists it and lets
+  // the orchestrator's sentinel counter own the rejection).
+  if (typeof releaseId !== 'number' || releaseId <= 0) {
+    return { kind: 'no_match' };
+  }
+
+  const rawConfidence = top?.artwork?.confidence;
+  const confidence = typeof rawConfidence === 'number' ? rawConfidence : 0;
+  return { kind: 'match', releaseId, confidence };
+};

--- a/jobs/library-discogs-unavailable-recheck/lml-limiter.ts
+++ b/jobs/library-discogs-unavailable-recheck/lml-limiter.ts
@@ -1,0 +1,47 @@
+/**
+ * Concurrency + rate-limit gate for jobs/library-discogs-unavailable-recheck
+ * (BS#1283).
+ *
+ * Mirrors jobs/rotation-release-id-backfill/lml-limiter.ts with job-scoped
+ * env names (LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_*) and the same
+ * stricter-than-runtime defaults (concurrency=1, rate=20/min). Copying the
+ * file keeps this job's blast-radius story identical to the other cron
+ * jobs' without coupling any of them to another's build graph. Per the
+ * BS#1826 policy layer (`shared/lml-client/src/policy.ts`), this job's
+ * registered caller (`library-discogs-unavailable-recheck`) is class 5
+ * (batch/backfill enrichment) — class 5 callers use a dedicated per-job
+ * limiter, never the shared `defaultLimiter`.
+ *
+ * The underlying primitives (Semaphore, TokenBucket, LmlLimiter,
+ * createLmlLimiter) live in @wxyc/lml-client post-BS#887.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  // Number() (not parseInt) so partial-parse strings like "20banana" surface
+  // as NaN and get rejected rather than silently coercing.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_RATE_PER_MIN', 20),
+  });
+
+/**
+ * Module-level singleton consumed by lml-fetch.ts. Reads
+ * LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_* from env at module load — mutating
+ * process.env after the first import of this module does NOT reconfigure the
+ * singleton. Tests that exercise different limits must call
+ * `createLmlLimiter()` directly with explicit config.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/library-discogs-unavailable-recheck/logger.ts
+++ b/jobs/library-discogs-unavailable-recheck/logger.ts
@@ -1,0 +1,110 @@
+/**
+ * Observability for jobs/library-discogs-unavailable-recheck (BS#1283): Sentry
+ * init + JSON logs.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the four
+ * tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when
+ * SENTRY_DSN is unset (the @sentry/node SDK silently no-ops in that case),
+ * so this module is safe to call from any environment.
+ *
+ * Mirrors `jobs/rotation-release-id-backfill/logger.ts` verbatim — the
+ * contract is identical, the duplication is to keep this job's build graph
+ * independent of the release-id backfill's package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 1;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
+  return parsed;
+};
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/**
+ * Increment a Sentry counter metric. v10 SDK shape — `Sentry.metrics.count(
+ * name, value, {attributes})`. Wrapped in try/catch: observability must never
+ * break the job's main loop (mirrors the `add_to_rotation` fallback-to-null
+ * counter in `apps/backend/services/library.service.ts`).
+ */
+export const captureCounter = (name: string, value: number, attributes: Record<string, unknown> = {}): void => {
+  try {
+    Sentry.metrics.count(name, value, { attributes });
+  } catch (err) {
+    console.warn(`logger: failed to emit counter metric "${name}"`, err);
+  }
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/library-discogs-unavailable-recheck/orchestrate.ts
+++ b/jobs/library-discogs-unavailable-recheck/orchestrate.ts
@@ -1,0 +1,148 @@
+/**
+ * Orchestrator for jobs/library-discogs-unavailable-recheck (BS#1283 / epic
+ * #1280 sub-issue 3).
+ *
+ * Iterates `library` rows the music director flagged `discogs_unavailable`,
+ * force-asks LML for a fresh Discogs match (bypassing the runtime BS#1293
+ * gate), and applies a 0.95 confidence floor before writing anything back —
+ * see `writer.ts` for the transactional match writer and the sticky-
+ * false-match rationale for its missing IS-NULL guard.
+ *
+ * Two classes of flagged release need different recovery behavior:
+ * audience-segment releases (never on Discogs — permanent skip is correct)
+ * and embargoed promos (eventually clear Discogs — the recheck exists to
+ * catch that). The 0.95 floor is deliberately *stricter* than the runtime
+ * lookup path's own confidence bands so a flagged audience-segment release
+ * doesn't get the same false-fuzzy-match re-found and auto-unflagged every
+ * day, fighting the MD forever (the "Natanya adversarial loop" the parent
+ * issue's self-review caught).
+ *
+ * Deps are injected so tests can drive the orchestrator without a live LML
+ * or DB — mirrors `jobs/rotation-release-id-backfill/orchestrate.ts`.
+ */
+
+/** The confidence floor a match must clear before `writeMatch` runs. See the module doc above for why this is stricter than the runtime lookup path's bands. */
+export const CONFIDENCE_FLOOR = 0.95;
+
+export type Candidate = {
+  id: number;
+  artist_name: string;
+  album_title: string;
+};
+
+export type LoadCandidatesFn = () => Promise<Candidate[]>;
+
+/**
+ * Outcome of one forced LML lookup. The 0.95 floor is NOT applied here —
+ * `lml-fetch.ts` reports the raw match (or `no_match`) and `runRecheck`
+ * below applies the floor, per the parent issue's file layout ("orchestrate.ts
+ * — glue + the 0.95 threshold check").
+ */
+export type LookupOutcome = { kind: 'match'; releaseId: number; confidence: number } | { kind: 'no_match' };
+
+export type LookupFn = (artist: string, album: string) => Promise<LookupOutcome>;
+
+export type WriteMatchFn = (
+  libraryId: number,
+  releaseId: number
+) => Promise<{ written: boolean; rotationRowsUpdated: number }>;
+
+export type StampFn = (libraryId: number) => Promise<{ written: boolean }>;
+
+export type RecordLowConfidenceFn = (params: {
+  libraryId: number;
+  artistName: string;
+  albumTitle: string;
+  confidence: number;
+}) => void;
+
+export type Totals = {
+  scanned: number;
+  matched: number;
+  low_confidence: number;
+  no_match: number;
+  lml_error: number;
+  db_error: number;
+  raced: number;
+};
+
+export type RunResult = { totals: Totals };
+
+export const runRecheck = async (deps: {
+  loadCandidates: LoadCandidatesFn;
+  lookup: LookupFn;
+  writeMatch: WriteMatchFn;
+  stamp: StampFn;
+  recordLowConfidence: RecordLowConfidenceFn;
+}): Promise<RunResult> => {
+  const totals: Totals = {
+    scanned: 0,
+    matched: 0,
+    low_confidence: 0,
+    no_match: 0,
+    lml_error: 0,
+    db_error: 0,
+    raced: 0,
+  };
+
+  const candidates = await deps.loadCandidates();
+  for (const candidate of candidates) {
+    totals.scanned += 1;
+
+    let outcome: LookupOutcome;
+    try {
+      outcome = await deps.lookup(candidate.artist_name, candidate.album_title);
+    } catch {
+      // Row stays unstamped (`last_discogs_recheck_at` untouched), so it's
+      // picked up again on the next day's run rather than being stamped
+      // behind the 7-day recheck window for a merely-transient LML failure.
+      totals.lml_error += 1;
+      continue;
+    }
+
+    if (outcome.kind === 'no_match') {
+      try {
+        const { written } = await deps.stamp(candidate.id);
+        if (written) totals.no_match += 1;
+        else totals.raced += 1;
+      } catch {
+        // Isolate a transient DB failure to this row instead of aborting the
+        // batch. The row stays unstamped and is retried the next run.
+        totals.db_error += 1;
+      }
+      continue;
+    }
+
+    if (outcome.confidence < CONFIDENCE_FLOOR) {
+      // MD wrongly flagged an album that's actually on Discogs — surface it
+      // in Sentry without auto-changing state (the Natanya adversarial-loop
+      // fix: never write on a sub-floor match).
+      deps.recordLowConfidence({
+        libraryId: candidate.id,
+        artistName: candidate.artist_name,
+        albumTitle: candidate.album_title,
+        confidence: outcome.confidence,
+      });
+      try {
+        const { written } = await deps.stamp(candidate.id);
+        if (written) totals.low_confidence += 1;
+        else totals.raced += 1;
+      } catch {
+        totals.db_error += 1;
+      }
+      continue;
+    }
+
+    try {
+      const { written } = await deps.writeMatch(candidate.id, outcome.releaseId);
+      if (written) totals.matched += 1;
+      else totals.raced += 1;
+    } catch {
+      // Isolate a transient DB failure (or a failed transaction) to this
+      // row; the row stays unstamped and is retried the next run.
+      totals.db_error += 1;
+    }
+  }
+
+  return { totals };
+};

--- a/jobs/library-discogs-unavailable-recheck/package.json
+++ b/jobs/library-discogs-unavailable-recheck/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/library-discogs-unavailable-recheck",
+  "cron-schedule": "0 6 * * *",
+  "version": "1.0.0",
+  "description": "WXYC recurring cron (BS#1283 / epic #1280 sub-issue 3): rechecks library rows the MD flagged `discogs_unavailable` — embargoed promos eventually clear Discogs, audience-segment releases never do. Force-bypasses the runtime discogsUnavailable gate, applies a 0.95 confidence floor, and overwrites any stale rotation.discogs_release_id on a high-confidence match (sticky-false-match fix).",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_discogs_unavailable_recheck:ci -f ../../Dockerfile.library-discogs-unavailable-recheck ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.67.0",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-discogs-unavailable-recheck/query.ts
+++ b/jobs/library-discogs-unavailable-recheck/query.ts
@@ -1,0 +1,45 @@
+/**
+ * Candidate query for jobs/library-discogs-unavailable-recheck (BS#1283 /
+ * epic #1280 sub-issue 3).
+ *
+ * Selects `library` rows (NOT `rotation` — the job scans the table its flag
+ * lives on) the MD flagged `discogs_unavailable`, excluding rows rechecked
+ * within the last 7 days. `ORDER BY last_discogs_recheck_at NULLS FIRST`
+ * gives never-rechecked rows priority (fair queueing); `LIMIT $BATCH_SIZE`
+ * prevents a stampede if a bulk-flagging pass ever lands many rows at once.
+ * The partial index `library_discogs_unavailable_idx` (BS#1281, sub-issue
+ * 1a) makes the `discogs_unavailable = true` predicate cheap.
+ *
+ * Rows lacking `artist_name` or `album_title` are excluded; LML can't
+ * resolve a release without both.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+import type { Candidate } from './orchestrate.js';
+
+export const BATCH_SIZE_ENV = 'LIBRARY_DISCOGS_UNAVAILABLE_RECHECK_BATCH_SIZE';
+export const BATCH_SIZE_DEFAULT = 50;
+
+export const RECHECK_WINDOW_DAYS = 7;
+
+export const loadCandidates = async (batchSize: number = BATCH_SIZE_DEFAULT): Promise<Candidate[]> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "artist_name",
+      "album_title"
+    FROM "wxyc_schema"."library"
+    WHERE "discogs_unavailable" = true
+      AND (
+        "last_discogs_recheck_at" IS NULL
+        OR "last_discogs_recheck_at" <= now() - (interval '1 day' * ${RECHECK_WINDOW_DAYS})
+      )
+      AND "artist_name" IS NOT NULL
+      AND "album_title" IS NOT NULL
+    ORDER BY "last_discogs_recheck_at" NULLS FIRST, "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as Candidate[];
+  return rows ?? [];
+};

--- a/jobs/library-discogs-unavailable-recheck/tsconfig.json
+++ b/jobs/library-discogs-unavailable-recheck/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }, { "path": "../../shared/lml-client" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-discogs-unavailable-recheck/tsup.config.ts
+++ b/jobs/library-discogs-unavailable-recheck/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/library-discogs-unavailable-recheck/writer.ts
+++ b/jobs/library-discogs-unavailable-recheck/writer.ts
@@ -1,0 +1,78 @@
+/**
+ * Writer for jobs/library-discogs-unavailable-recheck (BS#1283 / epic #1280
+ * sub-issue 3).
+ *
+ * `writeMatch` is the high-confidence-match writer: a single DB transaction
+ * that (1) overwrites `discogs_release_id` on EVERY `rotation` row for the
+ * album — deliberately NO `IS NULL` guard, unlike
+ * `jobs/rotation-release-id-backfill/writer.ts`'s idempotent single-row
+ * UPDATE — and (2) clears the library flag/note and stamps the recheck
+ * timestamp.
+ *
+ * The missing IS-NULL guard is BY DESIGN (fixes the parent issue's
+ * "sticky-false-match bug"): a release flagged `discogs_unavailable` may
+ * carry a stale, wrong `rotation.discogs_release_id` from before the MD
+ * flagged it (or from an earlier, now-superseded recheck run). Once this
+ * recheck gets a fresh ≥0.95-confidence match, that match is authoritative
+ * and MUST replace whatever was there — preserving the stale id would mean
+ * the flag clears (making the wrong match visible again) while the wrong id
+ * stays pinned forever, exactly the bug the parent issue's self-review
+ * caught. The data-preservation stance elsewhere in this codebase (avoid
+ * clobbering successfully-collected data) applies to flag-set time, not to
+ * recheck-found-correct-match time — see the parent issue body's "No
+ * `IS NULL` guard" section.
+ *
+ * `rotation.album_id` is not unique — a release can carry multiple active
+ * rotation rows over its lifecycle (re-bins, re-adds; see the `rotation`
+ * table's doc comment in `shared/database/src/schema.ts`) — so the UPDATE
+ * has no `LIMIT`/single-row assumption; ALL rows for the album_id are
+ * overwritten in the same transaction (parent issue test 9).
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { db, library, rotation } from '@wxyc/database';
+
+export const RECHECK_SOURCE = 'recheck_after_unavailable' as const;
+
+export const writeMatch = async (
+  libraryId: number,
+  releaseId: number
+): Promise<{ written: boolean; rotationRowsUpdated: number }> => {
+  return db.transaction(async (tx) => {
+    const rotationUpdated = await tx
+      .update(rotation)
+      .set({
+        discogs_release_id: releaseId,
+        discogs_release_id_source: RECHECK_SOURCE,
+      })
+      .where(eq(rotation.album_id, libraryId))
+      .returning({ id: rotation.id });
+
+    const libraryUpdated = await tx
+      .update(library)
+      .set({
+        discogs_unavailable: false,
+        discogs_unavailable_note: null,
+        last_discogs_recheck_at: sql`now()`,
+      })
+      .where(eq(library.id, libraryId))
+      .returning({ id: library.id });
+
+    return { written: libraryUpdated.length === 1, rotationRowsUpdated: rotationUpdated.length };
+  });
+};
+
+/**
+ * Stamps `last_discogs_recheck_at` only — used on both the `no_match` and
+ * `low_confidence` outcomes, neither of which touches `discogs_unavailable`,
+ * `discogs_unavailable_note`, or `rotation.discogs_release_id`. Not
+ * transactional: a single-row, single-column UPDATE needs no transaction.
+ */
+export const stampRecheckTimestamp = async (libraryId: number): Promise<{ written: boolean }> => {
+  const updated = await db
+    .update(library)
+    .set({ last_discogs_recheck_at: sql`now()` })
+    .where(eq(library.id, libraryId))
+    .returning({ id: library.id });
+  return { written: updated.length === 1 };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1069,6 +1069,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-discogs-unavailable-recheck": {
+      "name": "@wxyc/library-discogs-unavailable-recheck",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.67.0",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
@@ -6730,6 +6746,10 @@
     },
     "node_modules/@wxyc/library-canonical-entity-backfill": {
       "resolved": "jobs/library-canonical-entity-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/library-discogs-unavailable-recheck": {
+      "resolved": "jobs/library-discogs-unavailable-recheck",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {

--- a/shared/lml-client/src/policy.ts
+++ b/shared/lml-client/src/policy.ts
@@ -137,6 +137,11 @@ export const ALL_LML_CALLERS = [
   // caller-bearing call site — it only calls `refreshForIdentities`, which
   // takes no `caller` parameter — so it needs no entry here.
   'rotation-release-id-backfill',
+  // BS#1283 (epic #1280 sub-issue 3): the daily discogs_unavailable recheck
+  // cron. Class 5 — batch/backfill enrichment, dedicated per-job limiter
+  // (`jobs/library-discogs-unavailable-recheck/lml-limiter.ts`), never the
+  // shared `defaultLimiter`.
+  'library-discogs-unavailable-recheck',
 ] as const;
 
 export type LmlCaller = (typeof ALL_LML_CALLERS)[number];
@@ -177,6 +182,7 @@ const CALLER_CLASS: Record<LmlCaller, LmlCallerClass> = {
   'concerts-genre-enrichment': 5,
   'concerts-artist-lml-resolver': 5,
   'rotation-release-id-backfill': 5,
+  'library-discogs-unavailable-recheck': 5,
 };
 
 /**

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -34,6 +34,20 @@ const mockUpdateArtworkUrl = jest.fn<() => Promise<unknown>>();
 const mockGetLabelById = jest.fn<(id: number) => Promise<{ id: number; label_name: string } | undefined>>();
 const mockSearchLibrary = jest.fn<() => Promise<{ results: unknown[]; total: number }>>();
 
+// POST /library/:id/discogs-recheck (BS#1283).
+const mockRecheckDiscogsAvailability =
+  jest.fn<
+    (
+      id: number,
+      artistName: string,
+      albumTitle: string
+    ) => Promise<
+      | { outcome: 'matched'; discogsReleaseId: number; confidence: number }
+      | { outcome: 'low_confidence_match'; confidence: number }
+      | { outcome: 'no_match' }
+    >
+  >();
+
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
   getAlbumByLegacyId: mockGetAlbumByLegacyId,
@@ -73,6 +87,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   updateAlbumInDB: mockUpdateAlbumInDB,
   artistExistsInGenre: mockArtistExistsInGenre,
   albumCodeNumberTaken: mockAlbumCodeNumberTaken,
+  recheckDiscogsAvailability: mockRecheckDiscogsAvailability,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -124,6 +139,7 @@ import {
   getRotationTracks,
   updateAlbum,
   searchLibraryQueryEndpoint,
+  manualDiscogsRecheck,
 } from '../../../apps/backend/controllers/library.controller';
 
 function mockResponse(): Response {
@@ -1031,6 +1047,99 @@ describe('library.controller', () => {
 
       await expect(getAlbum(req, res, next)).rejects.toThrow('Invalid legacy_release_id');
       expect(mockGetAlbumByLegacyId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('manualDiscogsRecheck (BS#1283)', () => {
+    const flaggedRow = {
+      id: 42,
+      artist_name: 'Chuquimamani-Condori',
+      album_title: 'Edits',
+      discogs_unavailable: true,
+      discogs_unavailable_note: 'embargoed promo',
+    };
+
+    beforeEach(() => {
+      mockIsLmlConfigured.mockReturnValue(true);
+    });
+
+    it('returns 400 for a non-numeric id', async () => {
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(manualDiscogsRecheck(req, res, next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetLibraryRowById).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the album does not exist', async () => {
+      mockGetLibraryRowById.mockResolvedValue(undefined);
+      const req = { params: { id: '999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(manualDiscogsRecheck(req, res, next)).rejects.toThrow('Album not found');
+      expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the row has no artist_name/album_title to look up', async () => {
+      mockGetLibraryRowById.mockResolvedValue({ ...flaggedRow, artist_name: null, album_title: null });
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(manualDiscogsRecheck(req, res, next)).rejects.toThrow(
+        'Cannot recheck a release without artist_name and album_title'
+      );
+      expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when LML is not configured', async () => {
+      mockGetLibraryRowById.mockResolvedValue(flaggedRow);
+      mockIsLmlConfigured.mockReturnValue(false);
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(manualDiscogsRecheck(req, res, next)).rejects.toThrow('LML is not configured');
+      expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+    });
+
+    it('returns the matched outcome shape', async () => {
+      mockGetLibraryRowById.mockResolvedValue(flaggedRow);
+      mockRecheckDiscogsAvailability.mockResolvedValue({
+        outcome: 'matched',
+        discogsReleaseId: 99999,
+        confidence: 0.98,
+      });
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await manualDiscogsRecheck(req, res, next);
+
+      expect(mockRecheckDiscogsAvailability).toHaveBeenCalledWith(42, 'Chuquimamani-Condori', 'Edits');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ outcome: 'matched', discogsReleaseId: 99999, confidence: 0.98 });
+    });
+
+    it('returns the low_confidence_match outcome shape', async () => {
+      mockGetLibraryRowById.mockResolvedValue(flaggedRow);
+      mockRecheckDiscogsAvailability.mockResolvedValue({ outcome: 'low_confidence_match', confidence: 0.85 });
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await manualDiscogsRecheck(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ outcome: 'low_confidence_match', confidence: 0.85 });
+    });
+
+    it('returns the no_match outcome shape', async () => {
+      mockGetLibraryRowById.mockResolvedValue(flaggedRow);
+      mockRecheckDiscogsAvailability.mockResolvedValue({ outcome: 'no_match' });
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await manualDiscogsRecheck(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ outcome: 'no_match' });
     });
   });
 });

--- a/tests/unit/jobs/library-discogs-unavailable-recheck/lml-fetch.test.ts
+++ b/tests/unit/jobs/library-discogs-unavailable-recheck/lml-fetch.test.ts
@@ -1,0 +1,98 @@
+// Pins jobs/library-discogs-unavailable-recheck/lml-fetch.ts: forceLookup is
+// always set (issue test 5), the raw confidence score passes through
+// untouched (the 0.95 floor lives in orchestrate.ts, not here), the BS#1185
+// streaming-only sentinel (release_id 0) is treated as no_match, and an LML
+// timeout body throws so the row stays retryable.
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const loadModule = async (
+  mockLookup: jest.Mock
+): Promise<typeof import('../../../../jobs/library-discogs-unavailable-recheck/lml-fetch.js')> => {
+  jest.doMock('../../../../jobs/library-discogs-unavailable-recheck/lml-limiter.js', () => ({
+    defaultLmlLimiter: { run: jest.fn() },
+  }));
+  jest.doMock('@wxyc/lml-client', () => ({
+    lookupMetadata: mockLookup,
+  }));
+  return import('../../../../jobs/library-discogs-unavailable-recheck/lml-fetch.js');
+};
+
+describe('jobs/library-discogs-unavailable-recheck/lml-fetch', () => {
+  it('always passes forceLookup: true (issue test 5)', async () => {
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 12345, confidence: 0.98 } }] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+    await lookupRecheck('Chuquimamani-Condori', 'Edits');
+
+    expect(mockLookup).toHaveBeenCalledTimes(1);
+    const [artist, album, song, options] = mockLookup.mock.calls[0] as [
+      string,
+      string,
+      undefined,
+      Record<string, unknown>,
+    ];
+    expect(artist).toBe('Chuquimamani-Condori');
+    expect(album).toBe('Edits');
+    expect(song).toBeUndefined();
+    expect(options.forceLookup).toBe(true);
+    expect(options.caller).toBe('library-discogs-unavailable-recheck');
+  });
+
+  it('returns the raw confidence score untouched — no floor applied here', async () => {
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 55555, confidence: 0.42 } }] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+    const result = await lookupRecheck('Some Artist', 'Some Album');
+
+    expect(result).toEqual({ kind: 'match', releaseId: 55555, confidence: 0.42 });
+  });
+
+  it('defaults confidence to 0 when LML omits it', async () => {
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 1 } }] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+    const result = await lookupRecheck('Some Artist', 'Some Album');
+
+    expect(result).toEqual({ kind: 'match', releaseId: 1, confidence: 0 });
+  });
+
+  it('returns no_match when LML has no candidate', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ search_type: 'none', results: [] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+    const result = await lookupRecheck('Some Artist', 'Some Album');
+
+    expect(result).toEqual({ kind: 'no_match' });
+  });
+
+  it('treats the BS#1185 streaming-only sentinel (release_id 0) as no_match', async () => {
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 0, confidence: 0.9 } }] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+    const result = await lookupRecheck('Some Artist', 'Some Album');
+
+    expect(result).toEqual({ kind: 'no_match' });
+  });
+
+  it('throws on a transient LML timeout body so the row stays retryable', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ timeout: true, results: [] });
+
+    const { lookupRecheck } = await loadModule(mockLookup);
+
+    await expect(lookupRecheck('Some Artist', 'Some Album')).rejects.toThrow(/timeout/i);
+  });
+});

--- a/tests/unit/jobs/library-discogs-unavailable-recheck/orchestrate.test.ts
+++ b/tests/unit/jobs/library-discogs-unavailable-recheck/orchestrate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for jobs/library-discogs-unavailable-recheck orchestrate.ts
+ * (BS#1283). Drives `runRecheck` with injected deps — no live DB or LML.
+ *
+ * Covers issue tests 3 (low-confidence match) and 4 (miss), plus the
+ * lml_error / db_error / raced isolation properties mirrored from the
+ * sibling `rotation-release-id-backfill` orchestrator.
+ */
+import { jest } from '@jest/globals';
+
+import {
+  CONFIDENCE_FLOOR,
+  runRecheck,
+  type Candidate,
+  type LookupOutcome,
+} from '../../../../jobs/library-discogs-unavailable-recheck/orchestrate';
+
+const candidate: Candidate = { id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' };
+
+describe('runRecheck', () => {
+  test('confidence floor is 0.95', () => {
+    expect(CONFIDENCE_FLOOR).toBe(0.95);
+  });
+
+  test('high-confidence match: writes and counts matched (issue test 2 path)', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockResolvedValue({
+      kind: 'match',
+      releaseId: 99999,
+      confidence: 0.98,
+    });
+    const writeMatch = jest.fn().mockResolvedValue({ written: true, rotationRowsUpdated: 1 });
+    const stamp = jest.fn().mockResolvedValue({ written: true });
+    const recordLowConfidence = jest.fn();
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch,
+      stamp,
+      recordLowConfidence,
+    });
+
+    expect(writeMatch).toHaveBeenCalledWith(42, 99999);
+    expect(stamp).not.toHaveBeenCalled();
+    expect(recordLowConfidence).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ scanned: 1, matched: 1, low_confidence: 0, no_match: 0 });
+  });
+
+  test('low-confidence match (issue test 3): no write, Sentry counter fires, timestamp stamped', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockResolvedValue({
+      kind: 'match',
+      releaseId: 55555,
+      confidence: 0.85,
+    });
+    const writeMatch = jest.fn();
+    const stamp = jest.fn().mockResolvedValue({ written: true });
+    const recordLowConfidence = jest.fn();
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch,
+      stamp,
+      recordLowConfidence,
+    });
+
+    expect(writeMatch).not.toHaveBeenCalled();
+    expect(stamp).toHaveBeenCalledWith(42);
+    expect(recordLowConfidence).toHaveBeenCalledWith({
+      libraryId: 42,
+      artistName: 'Jessica Pratt',
+      albumTitle: 'On Your Own Love Again',
+      confidence: 0.85,
+    });
+    expect(totals).toMatchObject({ scanned: 1, matched: 0, low_confidence: 1, no_match: 0 });
+  });
+
+  test('a match exactly at the floor (0.95) counts as high-confidence, not low-confidence', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockResolvedValue({
+      kind: 'match',
+      releaseId: 1,
+      confidence: 0.95,
+    });
+    const writeMatch = jest.fn().mockResolvedValue({ written: true, rotationRowsUpdated: 1 });
+    const stamp = jest.fn().mockResolvedValue({ written: true });
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch,
+      stamp,
+      recordLowConfidence: jest.fn(),
+    });
+
+    expect(writeMatch).toHaveBeenCalledWith(42, 1);
+    expect(totals.matched).toBe(1);
+    expect(totals.low_confidence).toBe(0);
+  });
+
+  test('miss (issue test 4): only the timestamp is stamped', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockResolvedValue({ kind: 'no_match' });
+    const writeMatch = jest.fn();
+    const stamp = jest.fn().mockResolvedValue({ written: true });
+    const recordLowConfidence = jest.fn();
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch,
+      stamp,
+      recordLowConfidence,
+    });
+
+    expect(writeMatch).not.toHaveBeenCalled();
+    expect(recordLowConfidence).not.toHaveBeenCalled();
+    expect(stamp).toHaveBeenCalledWith(42);
+    expect(totals).toMatchObject({ scanned: 1, matched: 0, low_confidence: 0, no_match: 1 });
+  });
+
+  test('isolates a thrown LML lookup to lml_error and leaves the row unstamped (retryable)', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockRejectedValue(new Error('LML timeout'));
+    const stamp = jest.fn();
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch: jest.fn(),
+      stamp,
+      recordLowConfidence: jest.fn(),
+    });
+
+    expect(stamp).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ scanned: 1, lml_error: 1, matched: 0, low_confidence: 0, no_match: 0 });
+  });
+
+  test('isolates a thrown DB write to db_error without aborting the batch', async () => {
+    const lookup = jest
+      .fn<() => Promise<LookupOutcome>>()
+      .mockResolvedValueOnce({ kind: 'match', releaseId: 1, confidence: 0.99 })
+      .mockResolvedValueOnce({ kind: 'no_match' });
+    const writeMatch = jest.fn().mockRejectedValue(new Error('connection reset'));
+    const stamp = jest.fn().mockResolvedValue({ written: true });
+
+    const second: Candidate = { id: 43, artist_name: 'Cat Power', album_title: 'Moon Pix' };
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate, second]),
+      lookup,
+      writeMatch,
+      stamp,
+      recordLowConfidence: jest.fn(),
+    });
+
+    expect(totals).toMatchObject({ scanned: 2, db_error: 1, matched: 0, no_match: 1 });
+    expect(stamp).toHaveBeenCalledWith(43);
+  });
+
+  test('surfaces a raced write (0 rows affected) distinctly from a successful write', async () => {
+    const lookup = jest.fn<() => Promise<LookupOutcome>>().mockResolvedValue({
+      kind: 'match',
+      releaseId: 1,
+      confidence: 0.99,
+    });
+    const writeMatch = jest.fn().mockResolvedValue({ written: false, rotationRowsUpdated: 0 });
+
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([candidate]),
+      lookup,
+      writeMatch,
+      stamp: jest.fn(),
+      recordLowConfidence: jest.fn(),
+    });
+
+    expect(totals).toMatchObject({ scanned: 1, matched: 0, raced: 1 });
+  });
+
+  test('cadence (issue test 6): an empty candidate list is a no-op', async () => {
+    const { totals } = await runRecheck({
+      loadCandidates: () => Promise.resolve([]),
+      lookup: jest.fn(),
+      writeMatch: jest.fn(),
+      stamp: jest.fn(),
+      recordLowConfidence: jest.fn(),
+    });
+
+    expect(totals).toMatchObject({ scanned: 0, matched: 0, low_confidence: 0, no_match: 0 });
+  });
+});

--- a/tests/unit/jobs/library-discogs-unavailable-recheck/query.test.ts
+++ b/tests/unit/jobs/library-discogs-unavailable-recheck/query.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for jobs/library-discogs-unavailable-recheck query.ts (BS#1283).
+ *
+ * Pins the candidate predicate: `library` rows flagged `discogs_unavailable`
+ * outside the 7-day recheck window, `NULLS FIRST` priority, `LIMIT`-bounded.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { loadCandidates } from '../../../../jobs/library-discogs-unavailable-recheck/query';
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: string | string[]; raw?: string }>;
+};
+
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+describe('loadCandidates', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  test('selects library rows flagged discogs_unavailable, not rotation rows', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([
+      { id: 42, artist_name: 'Chuquimamani-Condori', album_title: 'Edits' },
+    ]);
+
+    const rows = await loadCandidates(50);
+
+    expect(rows).toEqual([{ id: 42, artist_name: 'Chuquimamani-Condori', album_title: 'Edits' }]);
+    const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(text).toMatch(/FROM\s+"?wxyc_schema"?\."?library"?/i);
+    expect(text).not.toMatch(/FROM\s+"?wxyc_schema"?\."?rotation"?/i);
+    expect(text).toMatch(/"discogs_unavailable"\s*=\s*true/i);
+    expect(text).toMatch(/"artist_name"\s+IS\s+NOT\s+NULL/i);
+    expect(text).toMatch(/"album_title"\s+IS\s+NOT\s+NULL/i);
+  });
+
+  test('gives never-rechecked rows priority via NULLS FIRST, then bounds with LIMIT', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await loadCandidates(25);
+
+    const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]).replace(/\s+/g, ' ');
+    expect(text).toMatch(/ORDER BY\s+"last_discogs_recheck_at"\s+NULLS FIRST,\s*"id"\s+ASC/i);
+    expect(text).toContain('LIMIT');
+  });
+
+  test('excludes rows rechecked within the 7-day window and includes rows outside it', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await loadCandidates(50);
+
+    const text = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]).replace(/\s+/g, ' ');
+    expect(text).toContain('"last_discogs_recheck_at" IS NULL');
+    expect(text).toContain('"last_discogs_recheck_at" <= now() - (interval');
+    expect(text).toContain("interval '1 day'");
+  });
+});

--- a/tests/unit/jobs/library-discogs-unavailable-recheck/writer.test.ts
+++ b/tests/unit/jobs/library-discogs-unavailable-recheck/writer.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for jobs/library-discogs-unavailable-recheck writer.ts (BS#1283).
+ *
+ * Pins two load-bearing correctness properties from the parent issue:
+ *   - Test 2 (sticky-false-match regression): the rotation UPDATE carries NO
+ *     `discogs_release_id IS NULL` guard, so a stale false id is overwritten
+ *     by a fresh high-confidence match.
+ *   - Test 9 (multi-rotation-row): the rotation UPDATE's WHERE clause keys
+ *     only on `album_id` (no row-count assumption), so every rotation row
+ *     for the album is updated in one statement.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { stampRecheckTimestamp, writeMatch } from '../../../../jobs/library-discogs-unavailable-recheck/writer';
+
+type MockChain = Record<string, jest.Mock>;
+const chain = (db as unknown as { _chain: MockChain })._chain;
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: string | string[]; raw?: string }>;
+};
+
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+describe('writeMatch', () => {
+  beforeEach(() => {
+    chain.returning.mockReset();
+    chain.set.mockClear();
+    chain.where.mockClear();
+    chain.update.mockClear();
+  });
+
+  test('overwrites discogs_release_id with no IS NULL guard (sticky-false-match regression, issue test 2)', async () => {
+    // rotation UPDATE resolves first (1 stale row overwritten), library
+    // UPDATE resolves second.
+    chain.returning.mockResolvedValueOnce([{ id: 7001 }]).mockResolvedValueOnce([{ id: 42 }]);
+
+    const result = await writeMatch(42, 99999);
+
+    expect(result).toEqual({ written: true, rotationRowsUpdated: 1 });
+
+    // First .set() call is the rotation UPDATE.
+    const rotationSetArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(rotationSetArg.discogs_release_id).toBe(99999);
+    expect(rotationSetArg.discogs_release_id_source).toBe('recheck_after_unavailable');
+    // No IS NULL condition anywhere in the rotation UPDATE's WHERE args.
+    const rotationWhereArg = chain.where.mock.calls[0]?.[0];
+    expect(renderSql(rotationWhereArg)).not.toMatch(/IS NULL/i);
+
+    // Second .set() call is the library UPDATE: flag + note cleared, timestamp stamped.
+    const librarySetArg = chain.set.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(librarySetArg.discogs_unavailable).toBe(false);
+    expect(librarySetArg.discogs_unavailable_note).toBeNull();
+    expect(renderSql(librarySetArg.last_discogs_recheck_at)).toMatch(/now\(\)/i);
+  });
+
+  test('keys the rotation UPDATE on album_id only, updating every rotation row for the album (multi-rotation-row, issue test 9)', async () => {
+    // Simulate 3 stale rotation rows for the same album_id all getting overwritten.
+    chain.returning
+      .mockResolvedValueOnce([{ id: 7001 }, { id: 7002 }, { id: 7003 }])
+      .mockResolvedValueOnce([{ id: 42 }]);
+
+    const result = await writeMatch(42, 99999);
+
+    expect(result).toEqual({ written: true, rotationRowsUpdated: 3 });
+  });
+
+  test('reports written:false when the library UPDATE affects zero rows (album deleted mid-run)', async () => {
+    chain.returning.mockResolvedValueOnce([{ id: 7001 }]).mockResolvedValueOnce([]);
+
+    const result = await writeMatch(42, 99999);
+
+    expect(result).toEqual({ written: false, rotationRowsUpdated: 1 });
+  });
+
+  test('is transactional: both UPDATEs run inside db.transaction', async () => {
+    chain.returning.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 42 }]);
+
+    await writeMatch(42, 99999);
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stampRecheckTimestamp', () => {
+  beforeEach(() => {
+    chain.returning.mockReset();
+    chain.set.mockClear();
+  });
+
+  test('stamps only last_discogs_recheck_at, touching neither the flag nor the note', async () => {
+    chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const result = await stampRecheckTimestamp(42);
+
+    expect(result).toEqual({ written: true });
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(setArg)).toEqual(['last_discogs_recheck_at']);
+    expect(renderSql(setArg.last_discogs_recheck_at)).toMatch(/now\(\)/i);
+  });
+
+  test('returns written:false when the UPDATE affects zero rows', async () => {
+    chain.returning.mockResolvedValueOnce([]);
+
+    const result = await stampRecheckTimestamp(42);
+
+    expect(result).toEqual({ written: false });
+  });
+});

--- a/tests/unit/routes/library-discogs-recheck-permissions.route.test.ts
+++ b/tests/unit/routes/library-discogs-recheck-permissions.route.test.ts
@@ -1,0 +1,160 @@
+// Set required env vars before module load (ts-jest transforms imports to
+// requires, so these execute before the auth middleware module's top-level
+// code runs). Mirrors tests/unit/routes/library-missing-found-permissions.route.test.ts.
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+// Mock jose so we can hand back an arbitrary role in the verified JWT payload
+// without a real JWKS endpoint. requirePermissions's non-bypass branch is
+// what actually enforces role/permission checks.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+// jest.unit.config.ts's moduleNameMapper sends `@wxyc/authentication` to
+// tests/mocks/authentication.mock.ts (a stub that ignores the role/permission
+// argument entirely). library.route.ts imports requirePermissions from that
+// package specifier, so this route-wiring test needs the REAL implementation
+// wired back in to actually exercise the catalog:write gate (issue test 8).
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
+import express from 'express';
+import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
+
+const mockGetLibraryRowById = jestGlobals.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockRecheckDiscogsAvailability = jestGlobals.fn<() => Promise<Record<string, unknown>>>();
+
+// Collaborator mocks below mirror the missing/found route-permission test —
+// only enough is stubbed here to let library.route's import chain resolve
+// without touching a real DB, LML, or lru-cache.
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getAlbumFromDB: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: jest.fn(),
+  getRotationTracksFromRelease: jest.fn(),
+  getLibraryRowById: mockGetLibraryRowById,
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+  recheckDiscogsAvailability: mockRecheckDiscogsAvailability,
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => true,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+/**
+ * BS#1283 (epic #1280 sub-issue 3), issue test 8: POST /library/:id/discogs
+ * -recheck is gated to catalog:write (musicDirector+), the same bar as
+ * updateAlbum/addAlbum — DJs/members (catalog:read only) must be rejected.
+ */
+describe('POST /library/:id/discogs-recheck — permission tier (BS#1283)', () => {
+  beforeEach(() => {
+    mockGetLibraryRowById.mockReset().mockResolvedValue({
+      id: 1,
+      artist_name: 'Chuquimamani-Condori',
+      album_title: 'Edits',
+      discogs_unavailable: true,
+    });
+    mockRecheckDiscogsAvailability.mockReset().mockResolvedValue({ outcome: 'no_match' });
+  });
+
+  test('a musicDirector-role token is authorized', async () => {
+    mockRole('musicDirector');
+    const res = await request(app).post('/library/1/discogs-recheck').set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(200);
+    expect(mockRecheckDiscogsAvailability).toHaveBeenCalledWith(1, 'Chuquimamani-Condori', 'Edits');
+  });
+
+  test('a dj-role token (catalog:read only) is rejected', async () => {
+    mockRole('dj');
+    const res = await request(app).post('/library/1/discogs-recheck').set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(403);
+    expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+  });
+
+  test('a member-role token (catalog:read only) is rejected', async () => {
+    mockRole('member');
+    const res = await request(app).post('/library/1/discogs-recheck').set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(403);
+    expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+  });
+
+  test('a request with no Authorization header is rejected', async () => {
+    const res = await request(app).post('/library/1/discogs-recheck');
+    expect(res.status).toBe(401);
+    expect(mockRecheckDiscogsAvailability).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/library.service.discogsRecheck.test.ts
+++ b/tests/unit/services/library.service.discogsRecheck.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for `recheckDiscogsAvailability` (BS#1283 / epic #1280
+ * sub-issue 3), the apps/backend-side twin of the
+ * `jobs/library-discogs-unavailable-recheck` cron's per-row path, used by
+ * `POST /library/:id/discogs-recheck`.
+ *
+ * Covers the same three outcome shapes and the sticky-false-match /
+ * multi-rotation-row correctness properties the cron's own writer tests pin
+ * (`tests/unit/jobs/library-discogs-unavailable-recheck/writer.test.ts`),
+ * plus `forceLookup: true` always being set on the wire call.
+ *
+ * Uses ONLY the shared `db._chain` singleton from `tests/mocks/database.mock
+ * .ts` (never `db.update.mockReturnValue(otherChain)`) — every chain method
+ * already auto-returns the singleton `_chain`, and overriding `db.update`'s
+ * return value on one test would leak into every later test in this file
+ * (`mockReturnValue` survives `clearAllMocks()`; only `mockReset()` clears
+ * it).
+ */
+
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockLookupBySong = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+const mockGetRelease = jest.fn<() => Promise<unknown>>();
+const mockResolveIdentity = jest.fn<() => Promise<unknown>>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  lookupBySong: mockLookupBySong,
+  isLmlConfigured: mockIsLmlConfigured,
+  getRelease: mockGetRelease,
+  resolveIdentity: mockResolveIdentity,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: () => Promise.resolve(null) },
+}));
+
+const mockSentryMetricsCount = jest.fn<(name: string, value: number, opts: unknown) => void>();
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(_opts: unknown, callback: () => T | Promise<T>): Promise<T> => Promise.resolve(callback()),
+  getActiveSpan: () => ({ setAttribute: jest.fn(), setAttributes: jest.fn() }),
+  metrics: { count: mockSentryMetricsCount },
+}));
+
+import { recheckDiscogsAvailability } from '../../../apps/backend/services/library.service';
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: unknown; raw?: string }>;
+};
+
+/**
+ * Renders a real drizzle-orm SQL fragment (or a nested Param's raw value) to
+ * a searchable string. Mirrors the `renderSql` helper in the
+ * `jobs/library-discogs-unavailable-recheck` job's writer test — this test
+ * file exercises the REAL `eq`/`sql` from drizzle-orm (not the
+ * `tests/__mocks__/drizzle-orm.ts` automock some other service test files
+ * opt into), same as `library.service.addToRotation.test.ts`.
+ */
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (chunk.value !== undefined) return JSON.stringify(chunk.value);
+        return '';
+      })
+      .join(' ');
+  }
+  return JSON.stringify(obj);
+};
+
+const chainSet = (db as unknown as { _chain: { set: jest.Mock } })._chain.set;
+const chainWhere = (db as unknown as { _chain: { where: jest.Mock } })._chain.where;
+const chainReturning = (db as unknown as { _chain: { returning: jest.Mock } })._chain.returning;
+
+describe('recheckDiscogsAvailability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // `.returning()`'s default resolved value (from createMockQueryChain's
+    // constructor arg, `[]`) doesn't fit every path here — reset so each
+    // test queues exactly the return sequence its code path needs.
+    chainReturning.mockReset();
+    chainReturning.mockResolvedValue([{ id: 42 }]);
+  });
+
+  it('always passes forceLookup: true on the wire call', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({ results: [{ artwork: { release_id: 1, confidence: 0.5 } }] });
+
+    await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    const [artist, album, song, options] = (mockLookupMetadata as jest.Mock).mock.calls[0] as [
+      string,
+      string,
+      undefined,
+      Record<string, unknown>,
+    ];
+    expect(artist).toBe('Some Artist');
+    expect(album).toBe('Some Album');
+    expect(song).toBeUndefined();
+    expect(options.forceLookup).toBe(true);
+    expect(options.caller).toBe('library-discogs-unavailable-recheck');
+  });
+
+  it('matched (confidence >= 0.95): overwrites rotation.discogs_release_id with no IS NULL guard, clears the flag/note, returns the matched shape', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({
+      results: [{ artwork: { release_id: 99999, confidence: 0.98 } }],
+    });
+    // db.transaction's mock passes the shared mockDb through as `tx`, so the
+    // rotation UPDATE (no .returning()) then the library UPDATE's single
+    // .returning() call resolve from this queue in call order.
+    chainReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const result = await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(result).toEqual({ outcome: 'matched', discogsReleaseId: 99999, confidence: 0.98 });
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+
+    const rotationSetArg = chainSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(rotationSetArg.discogs_release_id).toBe(99999);
+    expect(rotationSetArg.discogs_release_id_source).toBe('recheck_after_unavailable');
+
+    const librarySetArg = chainSet.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(librarySetArg.discogs_unavailable).toBe(false);
+    expect(librarySetArg.discogs_unavailable_note).toBeNull();
+
+    // Neither UPDATE's WHERE arg mentions an IS NULL guard on discogs_release_id.
+    for (const call of chainWhere.mock.calls) {
+      expect(renderSql(call[0])).not.toMatch(/IS NULL/i);
+    }
+    // The rotation UPDATE's WHERE keys on album_id (not id).
+    expect(renderSql(chainWhere.mock.calls[0]?.[0])).toContain('album_id');
+  });
+
+  it('low_confidence_match (< 0.95): does not write rotation/library, fires the Sentry counter, stamps the timestamp', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({
+      results: [{ artwork: { release_id: 55555, confidence: 0.85 } }],
+    });
+
+    const result = await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(result).toEqual({ outcome: 'low_confidence_match', confidence: 0.85 });
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(mockSentryMetricsCount).toHaveBeenCalledWith(
+      'lml.lookup.recheck.match_found_on_flagged',
+      1,
+      expect.objectContaining({
+        attributes: expect.objectContaining({ confidence: 0.85, library_id: 42 }),
+      })
+    );
+    // Only the timestamp UPDATE ran (db.update once, no transaction).
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(chainSet).toHaveBeenCalledWith(expect.objectContaining({ last_discogs_recheck_at: expect.anything() }));
+    expect(Object.keys(chainSet.mock.calls[0]?.[0] as Record<string, unknown>)).toEqual(['last_discogs_recheck_at']);
+  });
+
+  it('no_match: stamps only the timestamp, no Sentry counter', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({ results: [] });
+
+    const result = await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(result).toEqual({ outcome: 'no_match' });
+    expect(mockSentryMetricsCount).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(db.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats the BS#1185 streaming-only sentinel (release_id 0) as no_match', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({
+      results: [{ artwork: { release_id: 0, confidence: 0.9 } }],
+    });
+
+    const result = await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(result).toEqual({ outcome: 'no_match' });
+  });
+
+  it('multi-rotation-row: updates ALL rotation rows for the album_id in one statement (issue test 9)', async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({
+      results: [{ artwork: { release_id: 12345, confidence: 0.99 } }],
+    });
+    // The writer never calls .returning() on the rotation UPDATE — the
+    // "multi-row" property is that the WHERE clause has no per-row
+    // narrowing, not a returned row count. The single .returning() call is
+    // the library UPDATE.
+    chainReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const result = await recheckDiscogsAvailability(42, 'Some Artist', 'Some Album');
+
+    expect(result).toEqual({ outcome: 'matched', discogsReleaseId: 12345, confidence: 0.99 });
+
+    // The rotation UPDATE's WHERE keys only on album_id — no id/limit
+    // narrowing that would cap it to a single row.
+    expect(renderSql(chainWhere.mock.calls[0]?.[0])).toContain('album_id');
+  });
+});

--- a/tests/unit/services/library.service.discogsRecheck.test.ts
+++ b/tests/unit/services/library.service.discogsRecheck.test.ts
@@ -187,6 +187,17 @@ describe('recheckDiscogsAvailability', () => {
     expect(result).toEqual({ outcome: 'no_match' });
   });
 
+  it("LML timeout body: throws and does NOT stamp last_discogs_recheck_at or write no_match (mirrors the cron's lml-fetch.ts guard)", async () => {
+    (mockLookupMetadata as jest.Mock).mockResolvedValue({ timeout: true, results: [] });
+
+    await expect(recheckDiscogsAvailability(42, 'Some Artist', 'Some Album')).rejects.toThrow(/timeout/i);
+
+    // No timestamp stamp, no rotation/library writes, no Sentry counter.
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(mockSentryMetricsCount).not.toHaveBeenCalled();
+  });
+
   it('multi-rotation-row: updates ALL rotation rows for the album_id in one statement (issue test 9)', async () => {
     (mockLookupMetadata as jest.Mock).mockResolvedValue({
       results: [{ artwork: { release_id: 12345, confidence: 0.99 } }],

--- a/tests/unit/shared/lml-client/policy.test.ts
+++ b/tests/unit/shared/lml-client/policy.test.ts
@@ -78,6 +78,7 @@ describe('lml-client policy', () => {
         'concerts-genre-enrichment': 5,
         'concerts-artist-lml-resolver': 5,
         'rotation-release-id-backfill': 5,
+        'library-discogs-unavailable-recheck': 5,
       };
       for (const [caller, expectedClass] of Object.entries(expected) as [LmlCaller, LmlCallerClass][]) {
         expect(resolveLmlPolicy(caller).class).toBe(expectedClass);


### PR DESCRIPTION
## Summary

Closes #1283. Sub-issue 3 of epic #1280 (the MD-set "Not on Discogs" flag).

- New workspace package `jobs/library-discogs-unavailable-recheck`: a daily `0 6 * * *` UTC cron that rechecks `library` rows the music director flagged `discogs_unavailable`. Force-bypasses the runtime `discogsUnavailable` gate (`LookupOptions.forceLookup`) and applies a 0.95 confidence floor — stricter than the runtime lookup path's own bands — before writing anything back.
- High-confidence matches (>=0.95) overwrite `rotation.discogs_release_id` on **every** rotation row for the album in a single transaction, with **no `IS NULL` guard**. This is by design: it fixes the sticky-false-match bug where a stale wrong id survives a recheck because the flag clears while the wrong id stays pinned.
- Sub-floor matches only increment a Sentry counter (`lml.lookup.recheck.match_found_on_flagged`) — never auto-write — closing the audience-segment "Natanya adversarial loop" the parent issue's self-review caught.
- Misses and low-confidence matches stamp `last_discogs_recheck_at` so the row exits the 7-day recheck window; the flag is preserved.
- `POST /library/:id/discogs-recheck` (`catalog:write`) — manual counterpart to the cron, running the identical outcome logic (`library.service.ts#recheckDiscogsAvailability`) so an MD can close the "embargo just lifted, want it now" gap without waiting for the next tick.
- Registers `library-discogs-unavailable-recheck` as a class-5 caller in the BS#1826 LML policy layer (`shared/lml-client/src/policy.ts`), adds `Dockerfile.library-discogs-unavailable-recheck` mirroring the sibling backfill jobs, and documents the new env vars (`docs/env-vars.md`) plus a light-touch `06:00 UTC` cron slot (`docs/ops-cron-scheduling.md`).

**Activation note (per epic #1280's decision):** this lands as designed — the daily schedule goes live on the next Backend-Service deploy (crontab is installed by `deploy-base.yml`'s per-target step, which resolves the schedule from this package's `cron-schedule` field).

## Test plan

- [x] `npm run test:unit` — 372 suites / 5653 tests, all green (includes the new job's `query`/`writer`/`lml-fetch`/`orchestrate` unit tests, the `recheckDiscogsAvailability` service tests, the controller outcome-shape tests, and a route-level `catalog:write` permission test).
- [x] Pins the parent issue's 9 listed tests: candidate query shape, sticky-false-match regression (rotation overwrite with no `IS NULL` guard), low-confidence match (no write + Sentry counter + timestamp), miss (timestamp only), `forceLookup: true` always set, cadence (empty-candidate no-op — the 7-day window is exercised at the query-shape level), manual-endpoint outcome shapes, manual-endpoint `catalog:write` auth gate, and multi-rotation-row (all rows for `album_id` updated in one statement).
- [x] `npm run lint` — 0 errors (797 pre-existing `security/detect-object-injection`-style warnings across the repo, unrelated to this change).
- [x] `npm run format:check` — clean.
- [x] `npm run typecheck` — clean (root command covers `apps/**`/`shared/**`; additionally ran `tsc --noEmit` and `tsup` directly inside the new `jobs/library-discogs-unavailable-recheck` package, since the root `typecheck` script doesn't glob `jobs/**` — both clean).
- [x] `npm run check:lml-callers` — PASS, new caller registered.
- [ ] Integration/e2e (`npm run test:integration`) — **skipped**: no local Postgres fixture is provisioned in this disposable worktree (no `.env`, no BS-specific DB container running). Relying on remote CI for this tier; the schema this job depends on (`discogs_unavailable`, `discogs_unavailable_note`, `last_discogs_recheck_at`, `recheck_after_unavailable` enum value) already shipped in sub-issue 1a (#1281), so no new migration risk here.