### PR TITLE
feat(sse): broadcast liveFs:insert on flowsheet track insert (BS#1888)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^2.4.0",
+    "@wxyc/shared": "^2.6.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/apps/backend/services/metadata-broadcast/index.ts
+++ b/apps/backend/services/metadata-broadcast/index.ts
@@ -1,2 +1,2 @@
-export { setupMetadataBroadcast, filterMetadataUpdate } from './metadata-broadcast.js';
+export { setupMetadataBroadcast, filterMetadataUpdate, filterMetadataInsert } from './metadata-broadcast.js';
 export type { LiveFsUpdatePayload } from './metadata-broadcast.js';

--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -46,6 +46,7 @@
 import * as Sentry from '@sentry/node';
 import type { CdcEvent } from '@wxyc/database';
 import { onCdcEvent } from '@wxyc/database';
+import type { LiveFsInsertEvent } from '@wxyc/shared/dtos';
 import { serverEventsMgr, Topics, FsEvents } from '../../utils/serverEvents.js';
 import { pickClientFacingColumns } from '../../utils/flowsheet-projection.js';
 
@@ -91,6 +92,48 @@ export function filterMetadataUpdate(event: CdcEvent): LiveFsUpdatePayload | nul
 }
 
 /**
+ * Pure filter for the `liveFs:insert` broadcast (BS#1888) — returns the
+ * client-facing row payload on a match, null on skip.
+ *
+ * Fires on a flowsheet INSERT of a `track` row: the Epic C ([#877]) "a new
+ * track was played" event. The CDC trigger captures every insert source (a
+ * dj-site/iOS `addEntry`, the flowsheet ETL, the auto-dj orchestrator), so a
+ * subscriber appends the row live regardless of origin, no polling. The row is
+ * `metadata_status: 'pending'` at insert; its enrichment fields arrive seconds
+ * later as the existing `liveFs:update`. INSERT and UPDATE are distinct CDC
+ * actions, so the two broadcasters never double-emit for one row.
+ *
+ * Scoped to `entry_type === 'track'`. Marker / message rows (`show_start`,
+ * `dj_join`, breakpoints, talksets) are excluded: they aren't the "new track"
+ * signal the iOS consumer ([wxyc-ios-64#269]) appends, and excluding them keeps
+ * a bulk historical flowsheet import from flooding live subscribers with
+ * non-track rows. A steady-state insert is always a live/recent row, so a
+ * normal play still broadcasts.
+ *
+ * Same `CLIENT_FACING_FLOWSHEET_COLUMNS` projection as the update broadcast
+ * (BS#1534) — internal CDC columns never ride the anonymous stream. The payload
+ * is the generated `LiveFsInsertEvent['payload']` (`FlowsheetEntryResponse`)
+ * from `@wxyc/shared` (#273), whose enrichment fields are nullable so a
+ * pre-enrichment row is valid.
+ */
+export function filterMetadataInsert(event: CdcEvent): LiveFsInsertEvent['payload'] | null {
+  if (event.table !== 'flowsheet') return null;
+  if (event.action !== 'INSERT') return null;
+  if (!event.data) return null;
+
+  const data = event.data as Record<string, unknown>;
+  if (data.entry_type !== 'track') return null;
+
+  const id = data.id;
+  if (typeof id !== 'number') return null;
+
+  return {
+    ...pickClientFacingColumns(data),
+    id,
+  } as LiveFsInsertEvent['payload'];
+}
+
+/**
  * Register the metadata-broadcast CDC handler. Call once at startup, after
  * `serverEventsMgr` is ready. Sits alongside `setupCdcWebSocket()` — both
  * register independent `onCdcEvent` handlers against the per-process LISTEN
@@ -117,6 +160,27 @@ export function setupMetadataBroadcast(): void {
       Sentry.captureException(err, {
         tags: { module: 'metadata-broadcast', subsystem: 'sse' },
         extra: { id: payload.id, metadata_status: payload.metadata_status },
+      });
+    }
+  });
+
+  // BS#1888: broadcast `liveFs:insert` the instant a track row is created,
+  // before enrichment. A separate `onCdcEvent` registration (INSERT vs the
+  // update handler's UPDATE) so the two never double-emit for one row — a track
+  // fires `insert` on creation, then `update` when its metadata_status reaches a
+  // terminal state. Same per-process LISTEN + own-clients-only fan-out.
+  onCdcEvent((event) => {
+    const payload = filterMetadataInsert(event);
+    if (!payload) return;
+    try {
+      serverEventsMgr.broadcast(Topics.liveFs, {
+        type: FsEvents.insert,
+        payload,
+      });
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { module: 'metadata-broadcast', subsystem: 'sse' },
+        extra: { id: payload.id },
       });
     }
   });

--- a/apps/backend/utils/serverEvents.ts
+++ b/apps/backend/utils/serverEvents.ts
@@ -25,7 +25,11 @@ export const PrimaryDjEvents = {
 } as const;
 
 export const FsEvents = {
-  add: 'add',
+  // `insert` is the `LiveFsInsertEvent` discriminator (wxyc-shared#273); it is
+  // broadcast on a new track row (BS#1888). `update`/`refetch` are the existing
+  // members. (Renamed from the never-broadcast `add: 'add'`, whose value didn't
+  // match the contract discriminator.)
+  insert: 'insert',
   delete: 'delete',
   update: 'update',
   refetch: 'refetch',

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^2.4.0",
+        "@wxyc/shared": "^2.6.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -1030,6 +1030,7 @@
       "dependencies": {
         "@sentry/node": "^10.67.0",
         "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0"
       },
       "devDependencies": {
@@ -6748,9 +6749,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "2.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.4.0/8b253aa0d0fa1a9a807c1f32445f3ac759ac666e",
-      "integrity": "sha512-ICFYS2QetuWY+ToFacWGVKjYskAJJJq1aWTXSFDOxsS/nixx7RGkejg2RCvNE2Y685nL1eh0+MT/BVKQK8+LRg==",
+      "version": "2.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.6.0/9473a3aef11e99a8b0a0cee2f39064b228407c7e",
+      "integrity": "sha512-AXarRgyHvISrGtijbB/RqGBwBZZw+2fACi7aZZMq4GO7TG+1s/y4Zjkp9q2TZKOHHB0xLyYCUorB71qipfIhMQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -6760,7 +6761,7 @@
       },
       "peerDependencies": {
         "better-auth": "^1.5.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@wxyc/streaming-url-remediation": {

--- a/tests/unit/apps/backend/services/metadata-broadcast.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast.test.ts
@@ -20,7 +20,7 @@ jest.mock('@sentry/node', () => ({
 
 jest.mock('../../../../../apps/backend/utils/serverEvents.js', () => ({
   Topics: { liveFs: 'live-fs-topic' },
-  FsEvents: { update: 'update' },
+  FsEvents: { update: 'update', insert: 'insert' },
   serverEventsMgr: { broadcast: jest.fn() },
 }));
 
@@ -31,6 +31,7 @@ jest.mock('@wxyc/database', () => ({
 import * as Sentry from '@sentry/node';
 import {
   filterMetadataUpdate,
+  filterMetadataInsert,
   setupMetadataBroadcast,
 } from '../../../../../apps/backend/services/metadata-broadcast/metadata-broadcast';
 import { onCdcEvent } from '@wxyc/database';
@@ -197,5 +198,146 @@ describe('setupMetadataBroadcast Sentry path (BS-2)', () => {
 
     expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
     expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+const flowsheetInsert = (overrides: Partial<Record<string, unknown>> = {}): CdcEvent => ({
+  table: 'flowsheet',
+  schema: 'wxyc_schema',
+  action: 'INSERT',
+  data: {
+    id: 77,
+    entry_type: 'track',
+    metadata_status: 'pending',
+    ...overrides,
+  },
+  timestamp: 1779856000000,
+});
+
+describe('filterMetadataInsert (BS#1888)', () => {
+  // Symmetric with filterMetadataUpdate: a flowsheet INSERT of a `track` row is
+  // the Epic C "a new track was played" event. The CDC trigger captures every
+  // insert source (dj-site/iOS addEntry, flowsheet ETL, auto-dj), so a live
+  // subscriber appends the row regardless of origin. The row is `pending` at
+  // insert; enrichment arrives seconds later as the existing `liveFs:update`.
+
+  it('projects the client-facing row as the payload on a track INSERT, dropping internal columns', () => {
+    const event = flowsheetInsert({
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      track_title: 'Back, Baby',
+      record_label: 'Drag City',
+      // pre-enrichment: enrichment fields still null
+      artwork_url: null,
+      release_year: null,
+      // internal columns on the raw CDC row — must be stripped
+      search_doc: "'jessica':1A",
+      composer: 'Jessica Pratt',
+      legacy_entry_id: 8888,
+    });
+    expect(filterMetadataInsert(event)).toEqual({
+      id: 77,
+      entry_type: 'track',
+      metadata_status: 'pending',
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      track_title: 'Back, Baby',
+      record_label: 'Drag City',
+      artwork_url: null,
+      release_year: null,
+    });
+  });
+
+  it('strips every internal column and keeps client columns from a full CDC row', () => {
+    // makeFullFlowsheetRow() supplies its own id (42) + entry_type ('track'),
+    // which win over flowsheetInsert's defaults via the spread.
+    const payload = filterMetadataInsert(flowsheetInsert(makeFullFlowsheetRow()));
+    expect(payload).not.toBeNull();
+    for (const internalKey of INTERNAL_FLOWSHEET_COLUMNS) {
+      expect(payload).not.toHaveProperty(internalKey);
+    }
+    expect(payload).toMatchObject({ id: 42, entry_type: 'track' });
+  });
+
+  it('skips a non-track INSERT (marker/message rows are not the "new track" signal)', () => {
+    expect(filterMetadataInsert(flowsheetInsert({ entry_type: 'breakpoint' }))).toBeNull();
+    expect(filterMetadataInsert(flowsheetInsert({ entry_type: 'message' }))).toBeNull();
+    expect(filterMetadataInsert(flowsheetInsert({ entry_type: 'dj_join' }))).toBeNull();
+  });
+
+  it('skips UPDATE events (those are the enrichment output, handled by filterMetadataUpdate)', () => {
+    expect(filterMetadataInsert({ ...flowsheetInsert(), action: 'UPDATE' })).toBeNull();
+  });
+
+  it('skips DELETE events', () => {
+    expect(filterMetadataInsert({ ...flowsheetInsert(), action: 'DELETE' })).toBeNull();
+  });
+
+  it('skips events for tables other than flowsheet', () => {
+    expect(filterMetadataInsert({ ...flowsheetInsert(), table: 'rotation' })).toBeNull();
+  });
+
+  it('skips when data is missing', () => {
+    expect(filterMetadataInsert({ ...flowsheetInsert(), data: null })).toBeNull();
+  });
+
+  it('skips when id is missing or not a number', () => {
+    expect(filterMetadataInsert(flowsheetInsert({ id: undefined }))).toBeNull();
+    expect(filterMetadataInsert(flowsheetInsert({ id: 'seventy-seven' }))).toBeNull();
+  });
+});
+
+describe('setupMetadataBroadcast liveFs:insert registration (BS#1888)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('broadcasts a liveFs:insert on a track INSERT via a second CDC registration', () => {
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => undefined);
+
+    setupMetadataBroadcast();
+
+    // Two registrations: [0] = update (asserted above), [1] = insert.
+    expect((onCdcEvent as jest.Mock).mock.calls.length).toBe(2);
+    const insertCb = (onCdcEvent as jest.Mock).mock.calls[1][0] as (event: CdcEvent) => void;
+    insertCb(flowsheetInsert({ artist_name: 'Stereolab', album_title: 'Aluminum Tunes' }));
+
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
+    const [topic, frame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    expect(topic).toBe('live-fs-topic');
+    expect(frame).toMatchObject({
+      type: 'insert',
+      payload: expect.objectContaining({ id: 77, entry_type: 'track', metadata_status: 'pending' }),
+    });
+  });
+
+  it('does not broadcast on a non-track INSERT', () => {
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => undefined);
+
+    setupMetadataBroadcast();
+
+    const insertCb = (onCdcEvent as jest.Mock).mock.calls[1][0] as (event: CdcEvent) => void;
+    insertCb(flowsheetInsert({ entry_type: 'show_start' }));
+
+    expect(serverEventsMgr.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('captures an insert-broadcast exception to Sentry with module tag', () => {
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => {
+      throw new Error('insert boom');
+    });
+
+    setupMetadataBroadcast();
+
+    const insertCb = (onCdcEvent as jest.Mock).mock.calls[1][0] as (event: CdcEvent) => void;
+    insertCb(flowsheetInsert());
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    const [err, context] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect((err as Error).message).toBe('insert boom');
+    expect(context).toMatchObject({
+      tags: expect.objectContaining({ module: 'metadata-broadcast' }),
+      extra: expect.objectContaining({ id: 77 }),
+    });
   });
 });


### PR DESCRIPTION
## Problem

When a flowsheet track row is created, Backend broadcasts **nothing** to `/events` SSE subscribers — clients (iOS#269, dj-site) learn of a new track only on the next reconciliation poll, the latency floor Epic C ([#877](https://github.com/WXYC/Backend-Service/issues/877)) set out to remove. The `LiveFsInsertEvent` contract member now exists (wxyc-shared#273, published in `@wxyc/shared@2.6.0`); this is the producer half.

## What

On a flowsheet **INSERT** of a `track` row, Backend broadcasts a public `liveFs:insert` on `Topics.liveFs` carrying the newly-inserted (pending, pre-enrichment) row, typed to the generated `LiveFsInsertEvent['payload']` (`FlowsheetEntryResponse`) from `@wxyc/shared`.

### Emission point — CDC-driven, in `metadata-broadcast`

A **second `onCdcEvent` registration** in `apps/backend/services/metadata-broadcast/metadata-broadcast.ts`, symmetric with the existing `liveFs:update` broadcaster. It's the preferred emission point per the ticket and `docs/cdc.md`:

- **Covers all insert sources.** The CDC trigger captures every write, so a dj-site/iOS `addEntry`, the flowsheet ETL, and the auto-dj orchestrator all broadcast — not just the API path.
- **No double-emit.** INSERT and UPDATE are distinct CDC actions: a track fires `insert` on creation, then the existing `update` when its `metadata_status` reaches a terminal state. The `update`/`refetch` paths are untouched.
- **Same projection.** The row rides the same `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list (BS#1534), so internal CDC columns (`search_doc`, `composer`, `legacy_*`, …) never reach the anonymous `/events/stream`.

### Scope — `entry_type='track'`

Marker/message rows (`show_start`, `dj_join`, breakpoints, talksets) are **excluded**: they aren't the "new track" signal iOS#269 appends (and would trip the known iOS marker-row misrender, iOS#693), and excluding them keeps a bulk historical flowsheet import from flooding live subscribers. A steady-state insert is always a live/recent row, so a normal play still broadcasts.

### Also

- Renames the never-broadcast `FsEvents.add` (`'add'`) → `FsEvents.insert` (`'insert'`) so the constant matches the contract discriminator (`'add'` ≠ the contract's `insert`). It had zero references.
- Bumps `apps/backend`'s `@wxyc/shared` to `^2.6.0` (+ lockfile) — the release carrying `LiveFsInsertEvent`.

## Test plan

- [x] `npm run test:unit` — **5636 passed**. New `filterMetadataInsert` suite (projects a track INSERT, strips internal columns, skips non-track / UPDATE / DELETE / wrong-table / missing-data / bad-id) + a `setupMetadataBroadcast` suite asserting the second registration broadcasts exactly one `{ type: 'insert', payload }`, skips non-track inserts, and routes exceptions to Sentry.
- [x] `npm run typecheck` clean (all workspaces); `prettier --check` + `eslint` clean (0 errors) on changed files.

## Cross-repo

Contract half: wxyc-shared#273 (merged, `@wxyc/shared@2.6.0` published). Downstream consumer: [WXYC/wxyc-ios-64#269](https://github.com/WXYC/wxyc-ios-64/issues/269) (held for the coordinated iOS release; this unblocks it).

Closes #1888