### PR TITLE
chore(dependabot): hold better-auth at 1.6.25 (client-plugin type regression)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,16 @@ updates:
       # upgrade TypeScript as a tracked change once the toolchain supports TS7.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+      # Hold better-auth 1.6.25: it tightened the client-plugin option-inference
+      # types so jwtClient() no longer satisfies BetterAuthClientPlugin, and
+      # `npm run typecheck` fails in shared/authentication/src/auth.client.ts
+      # (TS2322). 1.6.25 is the current latest, so there is no fixed release to
+      # move to. Lift this once an upstream version restores client-plugin type
+      # compatibility. See PR #1834 (closed).
+      - dependency-name: 'better-auth'
+        versions: ['1.6.25']
+      - dependency-name: '@better-auth/*'
+        versions: ['1.6.25']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Problem

Dependabot PR #1834 (better-auth 1.6.23 → 1.6.25) fails `npm run typecheck`. 1.6.25 tightened its client-plugin option-inference types, so the idiomatic `jwtClient()` in `shared/authentication/src/auth.client.ts:14` no longer satisfies `BetterAuthClientPlugin`:

```
src/auth.client.ts(14,65): error TS2322: Type '{ id: "better-auth-client"; ... $InferServerPlugin: { id: "jwt"; ... } }' is not assignable to type 'BetterAuthClientPlugin'.
```

1.6.25 is the current `latest`, so there is no fixed release to retarget, and hacking a cast into the auth client isn't warranted for a patch bump.

## Change

Add a scoped `ignore` for the `better-auth` group at exactly `1.6.25` (both `better-auth` and `@better-auth/*`). This holds the group at the working 1.6.23 and lets Dependabot re-propose automatically when a newer version publishes — at which point CI re-evaluates it. #1834 is closed.

Follows the existing TypeScript-hold convention in the same `ignore:` block. No runtime code changes.