### PR TITLE
fix(metadata-no-match-digest): stop the digest query crashing on the postgres-js date passthrough

### DIFF
--- a/jobs/metadata-no-match-digest/README.md
+++ b/jobs/metadata-no-match-digest/README.md
@@ -68,7 +68,7 @@ Point `DB_*` at a snapshot (or prod -- the job is read-only) and leave `EMAIL_EN
 
 - `job.ts` -- thin process entrypoint: init logging, run once, capture any failure to Sentry once, always close the DB pool + logger.
 - `orchestrate.ts` -- the `run()` spine (watermark read → window resolve → query → render → send-or-skip → conditional watermark advance), separated from `job.ts` so it's unit-testable without the module-load `void main()`.
-- `query.ts` -- the digest SQL (`updated_at`-keyed, `entry_type='track'`, `LIMIT MAX_DIGEST_ROWS`) + `NoMatchRow` row type + the `unwrapRows` result-shape guard.
+- `query.ts` -- the digest SQL (`updated_at`-keyed, `entry_type='track'`, `LIMIT MAX_DIGEST_ROWS`) + `NoMatchRow` row type + the `unwrapRows` result-shape guard. The `> :since` bound is pre-stringified (`${since.toISOString()}::timestamptz`) and the timestamps are selected as `extract(epoch ...)` and rebuilt into `Date`s, because `@wxyc/database`'s Drizzle client rebinds the postgres-js date-family parser **and** serializer to a passthrough: a raw JS `Date` param throws inside postgres-js's `Bind`, and timestamptz reads come back as strings (see the file header and `feedback_drizzle_date_serializer_override`). Compiled to `dist/query.cjs` (tsup cjs entry) so the integration spec runs the REAL function through that driver.
 - `format.ts` -- pure rendering (subject, sections, grouping, Discogs URL synthesis, PT time formatting). No DB/network; heavily unit-tested.
 - `watermark.ts` -- `cronjob_runs` read/write + the first-run window bound + the advance-on-success/no-advance-on-failure decision.
 - `email.ts` -- self-contained SES sender (does not import `@wxyc/authentication` -- see the header comment for why).

--- a/jobs/metadata-no-match-digest/logger.ts
+++ b/jobs/metadata-no-match-digest/logger.ts
@@ -72,8 +72,24 @@ export const captureError = (error: unknown, step: string, extra: Record<string,
  * `(err as Error).message` would emit `undefined` and the JSON logger would
  * drop the key. The canonical safe pattern from
  * flowsheet-metadata-backfill/orchestrate.ts.
+ *
+ * Also appends `error.cause.message` when present and distinct: Drizzle wraps
+ * driver errors as `DrizzleQueryError: Failed query: <sql>` and hides the real
+ * failure (a PG error, or the postgres-js/Node `TypeError` from the date
+ * serializer passthrough -- see `query.ts`) on `.cause`. Logging only
+ * `.message` made the original enriched_no_match-digest failure undiagnosable
+ * from stdout; surfacing the cause mirrors BS#975's observability fix.
  */
-export const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+export const errorMessage = (error: unknown): string => {
+  if (!(error instanceof Error)) return String(error);
+  // Only Error and string causes are surfaced -- the realistic shapes here
+  // (Drizzle wraps an underlying driver Error; a `throw 'msg'` carries a
+  // string). An exotic object cause is left off rather than emit a useless
+  // `[object Object]`.
+  const cause: unknown = (error as { cause?: unknown }).cause;
+  const causeText = cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : undefined;
+  return causeText && causeText !== error.message ? `${error.message} [cause: ${causeText}]` : error.message;
+};
 
 export const closeLogger = async (): Promise<void> => {
   await Sentry.close(2000);

--- a/jobs/metadata-no-match-digest/query.ts
+++ b/jobs/metadata-no-match-digest/query.ts
@@ -15,6 +15,25 @@
  * so parallel Jest workers on per-schema DBs don't collide -- mirrors
  * `jobs/flowsheet-ghost-row-sweep/orchestrate.ts` and
  * `jobs/flowsheet-metadata-backfill/worklist.ts`.
+ *
+ * ## The postgres-js date-serializer trap (why not `${since}` and raw
+ * timestamptz columns)
+ *
+ * `@wxyc/database`'s Drizzle client rebinds the postgres-js parsers AND
+ * serializers for the date-family type OIDs (1184 timestamptz, ...) to a
+ * transparent passthrough `(val) => val` (see drizzle-orm's postgres-js
+ * `driver` + the `feedback_drizzle_date_serializer_override` note). That has
+ * two consequences a raw `db.execute` must design around:
+ *   - OUTBOUND: a JS `Date` bound via `${since}` is passed through unserialized
+ *     into postgres-js's `Bind`, which then does `Buffer.byteLength(dateObj)`
+ *     and throws `ERR_INVALID_ARG_TYPE`, surfacing only as the opaque
+ *     `DrizzleQueryError: Failed query: ...` wrapper. So the `> :since` bound is
+ *     pre-stringified: `${since.toISOString()}::timestamptz`.
+ *   - INBOUND: timestamptz columns come back as raw PG text strings (the parser
+ *     passthrough), not `Date`s. Rather than parse PG's default timestamptz text
+ *     in JS, the three timestamps are selected as `extract(epoch from ...)`
+ *     (float8 seconds -- an OID postgres-js parses to a real number) and
+ *     rebuilt into `Date`s in the row mapper below.
  */
 import { sql } from 'drizzle-orm';
 import { db } from '@wxyc/database';
@@ -68,6 +87,42 @@ export interface NoMatchRow {
 }
 
 /**
+ * The row shape `db.execute` actually returns for the SELECT below: the three
+ * timestamps arrive as `extract(epoch from ...)` float8 seconds (a real JS
+ * `number` -- postgres-js does NOT passthrough-override float8's parser), the
+ * rest keep native postgres-js typing (int4 -> number, text -> string). Mapped
+ * to `NoMatchRow` (epoch -> `Date`) in `queryNoMatchRows`.
+ */
+interface RawNoMatchRow {
+  id: number;
+  artist_name: string | null;
+  track_title: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  rotation_id: number | null;
+  album_id: number | null;
+  dj_name: string | null;
+  show_id: number | null;
+  updated_at_epoch: number | string;
+  add_time_epoch: number | string;
+  start_time_epoch: number | string | null;
+  show_name: string | null;
+}
+
+/**
+ * `extract(epoch from ts)` is seconds-since-epoch (float8); `* 1000` -> ms for
+ * the `Date` ctor. `Number(...)` also copes if a driver/version returns it as a
+ * string. NULL (nullable `shows.start_time` via the LEFT JOIN) -> `null`.
+ * Minute-granularity rendering (`format.ts`) makes any sub-second float error
+ * irrelevant.
+ */
+const epochToDate = (epochSeconds: number | string | null): Date | null =>
+  epochSeconds == null ? null : new Date(Number(epochSeconds) * 1000);
+
+/** As `epochToDate`, for the two NOT NULL timestamp columns (never null-epoch). */
+const epochToDateStrict = (epochSeconds: number | string): Date => new Date(Number(epochSeconds) * 1000);
+
+/**
  * Rows that flipped to `enriched_no_match` strictly after `since`
  * (exclusive -- matches the watermark's `> :last_run` semantics), newest
  * rotation/catalog-linked rows first (`rotation_id IS NOT NULL` sorts
@@ -75,6 +130,10 @@ export interface NoMatchRow {
  * `MAX_DIGEST_ROWS`. Restricted to `entry_type = 'track'`: only track rows
  * are ever enriched (markers/messages stay `pending`), but the explicit
  * predicate hardens against a stray non-track row surfacing.
+ *
+ * `since` is pre-stringified and the timestamps are selected as epoch to
+ * sidestep the postgres-js date-serializer/parser passthrough -- see the file
+ * header.
  */
 export const queryNoMatchRows = async (since: Date): Promise<NoMatchRow[]> => {
   const query = sql`
@@ -88,17 +147,34 @@ export const queryNoMatchRows = async (since: Date): Promise<NoMatchRow[]> => {
       f."album_id" AS "album_id",
       f."dj_name" AS "dj_name",
       f."show_id" AS "show_id",
-      f."updated_at" AS "updated_at",
-      f."add_time" AS "add_time",
-      s."show_name" AS "show_name",
-      s."start_time" AS "start_time"
+      extract(epoch from f."updated_at") AS "updated_at_epoch",
+      extract(epoch from f."add_time") AS "add_time_epoch",
+      extract(epoch from s."start_time") AS "start_time_epoch",
+      s."show_name" AS "show_name"
     FROM ${FLOWSHEET_TABLE} f
     LEFT JOIN ${SHOWS_TABLE} s ON s."id" = f."show_id"
     WHERE f."metadata_status" = 'enriched_no_match'
       AND f."entry_type" = 'track'
-      AND f."updated_at" > ${since}
+      AND f."updated_at" > ${since.toISOString()}::timestamptz
     ORDER BY (f."rotation_id" IS NOT NULL) DESC, f."updated_at" DESC
     LIMIT ${MAX_DIGEST_ROWS}
   `;
-  return unwrapRows<NoMatchRow>(await db.execute(query));
+  const raw = unwrapRows<RawNoMatchRow>(await db.execute(query));
+  return raw.map((r) => ({
+    id: r.id,
+    artist_name: r.artist_name,
+    track_title: r.track_title,
+    album_title: r.album_title,
+    record_label: r.record_label,
+    rotation_id: r.rotation_id,
+    album_id: r.album_id,
+    dj_name: r.dj_name,
+    show_id: r.show_id,
+    // updated_at / add_time are NOT NULL columns; start_time is nullable
+    // (the LEFT JOIN can miss).
+    updated_at: epochToDateStrict(r.updated_at_epoch),
+    add_time: epochToDateStrict(r.add_time_epoch),
+    show_name: r.show_name,
+    start_time: epochToDate(r.start_time_epoch),
+  }));
 };

--- a/jobs/metadata-no-match-digest/tsup.config.ts
+++ b/jobs/metadata-no-match-digest/tsup.config.ts
@@ -6,8 +6,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig((options) => ({
-  entry: ['job.ts'],
-  format: ['esm'],
+  // `job.ts` is the ESM CLI entrypoint the Docker image runs (dist/job.js).
+  // `query.ts` also emits a CommonJS bundle (dist/query.cjs) so the babel-jest
+  // integration spec can `require` and run the REAL `queryNoMatchRows` against
+  // Postgres through `@wxyc/database`'s postgres-js driver -- the only way to
+  // cover the date-serializer/parser passthrough the bare-postgres-js mirror
+  // could never reach (mirrors jobs/artist-unicode-dedup's dist/merge.cjs).
+  entry: ['job.ts', 'query.ts'],
+  format: ['esm', 'cjs'],
   outDir: 'dist',
   clean: true,
   onSuccess: options.watch ? 'node ./dist/job.js' : undefined,

--- a/tests/integration/metadata-no-match-digest.spec.js
+++ b/tests/integration/metadata-no-match-digest.spec.js
@@ -1,67 +1,83 @@
 /**
- * Integration test for the metadata-no-match-digest query, against real
- * PostgreSQL. The unit suite (orchestrate.test.ts / format.test.ts) pins the
- * job's control flow and rendering under mocks; this spec validates the
- * SELECT's *semantics* on real PG: the strict `updated_at > :since` watermark
- * boundary, the `entry_type = 'track'` guard, the `metadata_status =
- * 'enriched_no_match'` filter, the rotation-linked-first ordering, and the
- * `LIMIT` cap.
+ * Integration test for `jobs/metadata-no-match-digest`'s query against real
+ * PostgreSQL. Runs the REAL compiled `queryNoMatchRows` (`dist/query.cjs`) so
+ * the `@wxyc/database` postgres-js driver -- with Drizzle's date-family
+ * parser/serializer passthrough -- is exercised end to end. That driver seam is
+ * exactly what an earlier bare-`postgres()` mirror of the SQL could never
+ * reach: it let two prod-only defects ship green --
+ *   (1) OUTBOUND: binding a JS `Date` for the `updated_at > :since` bound threw
+ *       `ERR_INVALID_ARG_TYPE` inside postgres-js's `Bind`, surfaced only as
+ *       Drizzle's opaque "Failed query: ..." wrapper (the digest failed on its
+ *       first real run);
+ *   (2) INBOUND: timestamptz columns come back as raw strings, so `format.ts`'s
+ *       `formatPacificDateTime(row.start_time)` would throw on any
+ *       rotation-linked row carrying a show start time.
+ * query.ts fixes both (pre-stringified `::timestamptz` bound + epoch-selected
+ * timestamps rebuilt into Dates); this spec pins that the real function no
+ * longer throws AND returns `Date`-typed timestamps, plus the SELECT semantics
+ * (watermark boundary, entry_type / status filters, rotation-first ordering).
  *
- * Pure SQL -- does NOT import `jobs/metadata-no-match-digest/query.ts` (the
- * integration runner is babel-jest with no TS support). The statement below
- * mirrors `queryNoMatchRows`; when query.ts is hand-edited the SQL here must
- * follow. Every seeded artist carries an 'nmd-' marker and every row's id is
- * tracked for teardown, so the spec never leaks rows into the shared schema.
+ * `dist/query.cjs` is produced by the workspace `build` (tsup esm+cjs); CI's
+ * Build step runs before the integration tier. Rebuild after editing query.ts
+ * (`npm run build --workspace=@wxyc/metadata-no-match-digest`). Needs the Docker
+ * integration DB (the `pg` marker tier). Every seeded artist carries an 'nmd-'
+ * marker and every seeded id is tracked for teardown.
  */
 
+// The repo-wide `tests/__mocks__/drizzle-orm.ts` manual mock (for the ts-jest
+// unit tier) is auto-applied to every `drizzle-orm` require, including here.
+// `dist/query.cjs` needs the REAL drizzle-orm (its `sql` template builds the
+// query `@wxyc/database`'s driver runs), so unmock it -- same pattern as
+// `artist-unicode-dedup-merge.spec.js` / `rotation-match.spec.js`. Hoisted
+// above the requires by babel-plugin-jest-hoist.
+jest.unmock('drizzle-orm');
+
+const path = require('path');
 const { getTestDb } = require('../utils/db');
+
+// The REAL compiled query core -- no reimplementation, so the driver behavior
+// under test is the one that ships.
+const { queryNoMatchRows, MAX_DIGEST_ROWS } = require(
+  path.join(__dirname, '..', '..', 'jobs', 'metadata-no-match-digest', 'dist', 'query.cjs')
+);
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
-/**
- * Mirror of `jobs/metadata-no-match-digest/query.ts:queryNoMatchRows`
- * (projection trimmed to the columns these assertions read). `limit`
- * defaults to the production `MAX_DIGEST_ROWS`.
- */
-async function queryNoMatchRows(sql, since, { limit = 5000 } = {}) {
-  return sql`
-    SELECT
-      f."id" AS id,
-      f."artist_name" AS artist_name,
-      f."rotation_id" AS rotation_id,
-      f."updated_at" AS updated_at,
-      s."show_name" AS show_name
-    FROM ${sql(SCHEMA)}.flowsheet f
-    LEFT JOIN ${sql(SCHEMA)}.shows s ON s."id" = f."show_id"
-    WHERE f."metadata_status" = 'enriched_no_match'
-      AND f."entry_type" = 'track'
-      AND f."updated_at" > ${since}
-    ORDER BY (f."rotation_id" IS NOT NULL) DESC, f."updated_at" DESC
-    LIMIT ${limit}
-  `;
-}
-
-describe('metadata-no-match-digest query (real PG)', () => {
+describe('metadata-no-match-digest queryNoMatchRows (REAL fn, real PG)', () => {
   let sql;
   const flowsheetIds = [];
+  const showIds = [];
   const rotationIds = [];
 
-  /** Insert a flowsheet row already stamped `enriched_no_match` (or an override), returning its id + trigger-set updated_at. */
+  /** Insert a flowsheet row already stamped `enriched_no_match` (or an override), returning its id. */
   async function seedRow(
     artist,
-    { entryType = 'track', rotationId = null, metadataStatus = 'enriched_no_match' } = {}
+    { entryType = 'track', rotationId = null, showId = null, metadataStatus = 'enriched_no_match' } = {}
   ) {
     const rows = await sql`
       INSERT INTO ${sql(SCHEMA)}.flowsheet
         (play_order, entry_type, artist_name, album_title, track_title,
-         request_flag, segue, rotation_id, add_time, metadata_status)
+         request_flag, segue, rotation_id, show_id, add_time, metadata_status)
       VALUES
         (91234, ${entryType}, ${artist}, 'NMD Album', 'NMD Track',
-         false, false, ${rotationId}, now(), ${metadataStatus})
-      RETURNING id, updated_at
+         false, false, ${rotationId}, ${showId}, now(), ${metadataStatus})
+      RETURNING id
     `;
-    flowsheetIds.push(rows[0].id);
-    return rows[0];
+    const id = Number(rows[0].id);
+    flowsheetIds.push(id);
+    return id;
+  }
+
+  /** Insert a show (its `start_time` NOT NULL default now() exercises the inbound-date path via the LEFT JOIN). */
+  async function seedShow() {
+    const rows = await sql`
+      INSERT INTO ${sql(SCHEMA)}.shows (show_name, start_time)
+      VALUES ('nmd-show', now())
+      RETURNING id
+    `;
+    const id = Number(rows[0].id);
+    showIds.push(id);
+    return id;
   }
 
   async function seedRotation() {
@@ -70,92 +86,110 @@ describe('metadata-no-match-digest query (real PG)', () => {
       VALUES (NULL, 'H', 'nmd-rotation-artist', 'nmd-rotation-album')
       RETURNING id
     `;
-    rotationIds.push(rows[0].id);
-    return rows[0].id;
+    const id = Number(rows[0].id);
+    rotationIds.push(id);
+    return id;
   }
 
   beforeAll(() => {
     sql = getTestDb();
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     if (flowsheetIds.length > 0) {
       await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${flowsheetIds})`;
+      flowsheetIds.length = 0;
     }
     if (rotationIds.length > 0) {
       await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id = ANY(${rotationIds})`;
+      rotationIds.length = 0;
+    }
+    if (showIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.shows WHERE id = ANY(${showIds})`;
+      showIds.length = 0;
     }
   });
 
-  it('returns only rows updated strictly after `since` (the exclusive watermark boundary on updated_at)', async () => {
+  it('runs without throwing and returns Date-typed timestamps for a rotation+show-linked row (the driver-seam regression)', async () => {
+    const [{ since }] = await sql`SELECT now() - interval '1 minute' AS since`;
+    const showId = await seedShow();
+    const rotationId = await seedRotation();
+    const id = await seedRow('nmd-driver-seam', { rotationId, showId });
+
+    // Before the fix this rejected with Drizzle's "Failed query" wrapper.
+    const rows = await queryNoMatchRows(since);
+
+    const row = rows.find((r) => r.id === id);
+    expect(row).toBeDefined();
+    expect(row.updated_at).toBeInstanceOf(Date); // NOT NULL -> always a Date
+    expect(row.add_time).toBeInstanceOf(Date);
+    expect(row.start_time).toBeInstanceOf(Date); // from the joined show -> exercises the inbound-date path
+    expect(Number.isNaN(row.start_time.getTime())).toBe(false);
+    expect(row.rotation_id).toBe(rotationId);
+    expect(row.show_id).toBe(showId);
+  });
+
+  it('leaves start_time null for a freeform row with no show (LEFT JOIN miss)', async () => {
+    const [{ since }] = await sql`SELECT now() - interval '1 minute' AS since`;
+    const id = await seedRow('nmd-null-start');
+
+    const row = (await queryNoMatchRows(since)).find((r) => r.id === id);
+    expect(row).toBeDefined();
+    expect(row.start_time).toBeNull();
+    expect(row.rotation_id).toBeNull();
+  });
+
+  it('returns only rows updated strictly after `since` (the exclusive watermark boundary)', async () => {
     const older = await seedRow('nmd-boundary-older');
-    // Capture the boundary from the DB clock with a >1ms gap on each side.
-    // postgres-js parses timestamptz into a millisecond-precision JS Date, so
-    // a boundary taken directly from a row's microsecond `updated_at` would
-    // round DOWN and (wrongly) re-include that row under the strict `>`; the
-    // pg_sleep gaps make the boundary unambiguous regardless of that rounding.
-    // (Production is unaffected: the watermark is a JS-generated `runStart`,
-    // already millisecond precision.)
+    // Capture the boundary from the DB clock with a >1ms gap on each side so the
+    // exclusive `>` verdict is unambiguous regardless of driver sub-ms rounding.
     await sql`SELECT pg_sleep(0.02)`;
     const [{ since }] = await sql`SELECT now() AS since`;
     await sql`SELECT pg_sleep(0.02)`;
     const newer = await seedRow('nmd-boundary-newer');
 
-    const ids = (await queryNoMatchRows(sql, since)).map((r) => r.id);
-
-    expect(ids).toContain(newer.id); // updated after the boundary
-    expect(ids).not.toContain(older.id); // updated before the boundary -- excluded
+    const ids = (await queryNoMatchRows(since)).map((r) => r.id);
+    expect(ids).toContain(newer);
+    expect(ids).not.toContain(older);
   });
 
   it("excludes non-'track' entry types even when stamped enriched_no_match", async () => {
-    const { updated_at: since } = await seedRow('nmd-entrytype-anchor');
+    const [{ since }] = await sql`SELECT now() - interval '1 minute' AS since`;
     const track = await seedRow('nmd-entrytype-track', { entryType: 'track' });
     const talkset = await seedRow('nmd-entrytype-talkset', { entryType: 'talkset' });
 
-    const ids = (await queryNoMatchRows(sql, since)).map((r) => r.id);
-
-    expect(ids).toContain(track.id);
-    expect(ids).not.toContain(talkset.id);
+    const ids = (await queryNoMatchRows(since)).map((r) => r.id);
+    expect(ids).toContain(track);
+    expect(ids).not.toContain(talkset);
   });
 
   it('excludes rows that are not in the enriched_no_match state', async () => {
-    const { updated_at: since } = await seedRow('nmd-status-anchor');
+    const [{ since }] = await sql`SELECT now() - interval '1 minute' AS since`;
     const noMatch = await seedRow('nmd-status-nomatch', { metadataStatus: 'enriched_no_match' });
     const matched = await seedRow('nmd-status-match', { metadataStatus: 'enriched_match' });
 
-    const ids = (await queryNoMatchRows(sql, since)).map((r) => r.id);
-
-    expect(ids).toContain(noMatch.id);
-    expect(ids).not.toContain(matched.id);
+    const ids = (await queryNoMatchRows(since)).map((r) => r.id);
+    expect(ids).toContain(noMatch);
+    expect(ids).not.toContain(matched);
   });
 
   it('orders rotation/catalog-linked rows ahead of freeform', async () => {
-    const { updated_at: since } = await seedRow('nmd-order-anchor');
+    const [{ since }] = await sql`SELECT now() - interval '1 minute' AS since`;
     const rotationId = await seedRotation();
     // Freeform seeded first (older), rotation-linked second (newer) -- so the
     // rotation-first ordering must override the newest-first tiebreak.
     const freeform = await seedRow('nmd-order-freeform', { rotationId: null });
     const linked = await seedRow('nmd-order-linked', { rotationId });
 
-    const result = await queryNoMatchRows(sql, since);
-    const linkedPos = result.findIndex((r) => r.id === linked.id);
-    const freeformPos = result.findIndex((r) => r.id === freeform.id);
-
+    const result = await queryNoMatchRows(since);
+    const linkedPos = result.findIndex((r) => r.id === linked);
+    const freeformPos = result.findIndex((r) => r.id === freeform);
     expect(linkedPos).toBeGreaterThanOrEqual(0);
     expect(freeformPos).toBeGreaterThanOrEqual(0);
     expect(linkedPos).toBeLessThan(freeformPos);
   });
 
-  it('caps the result set at the LIMIT', async () => {
-    const { updated_at: since } = await seedRow('nmd-limit-anchor');
-    await seedRow('nmd-limit-1');
-    await seedRow('nmd-limit-2');
-    await seedRow('nmd-limit-3');
-
-    const capped = await queryNoMatchRows(sql, since, { limit: 2 });
-    const uncapped = await queryNoMatchRows(sql, since, { limit: 100 });
-
-    expect(capped).toHaveLength(2);
-    expect(uncapped.length).toBeGreaterThanOrEqual(3);
+  it('exports the MAX_DIGEST_ROWS cap the query LIMITs on', () => {
+    expect(MAX_DIGEST_ROWS).toBe(5000);
   });
 });

--- a/tests/unit/jobs/metadata-no-match-digest/logger.test.ts
+++ b/tests/unit/jobs/metadata-no-match-digest/logger.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for logger.errorMessage -- specifically the `.cause` surfacing
+ * added after the enriched_no_match-digest date-serializer failure logged only
+ * Drizzle's opaque "Failed query: ..." wrapper, hiding the real cause. Sentry
+ * init/log/capture are exercised by the job at runtime, not here.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { errorMessage } from '../../../../jobs/metadata-no-match-digest/logger';
+
+describe('logger.errorMessage', () => {
+  it('returns the plain message when there is no cause', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('appends an Error cause message (the DrizzleQueryError -> real driver error case)', () => {
+    const wrapped = new Error('Failed query: SELECT ...');
+    (wrapped as { cause?: unknown }).cause = new TypeError('The "string" argument must be of type string');
+    expect(errorMessage(wrapped)).toBe(
+      'Failed query: SELECT ... [cause: The "string" argument must be of type string]'
+    );
+  });
+
+  it('appends a non-Error cause via String()', () => {
+    const wrapped = new Error('outer');
+    (wrapped as { cause?: unknown }).cause = 'inner detail';
+    expect(errorMessage(wrapped)).toBe('outer [cause: inner detail]');
+  });
+
+  it('does not duplicate when the cause message equals the wrapper message', () => {
+    const wrapped = new Error('same');
+    (wrapped as { cause?: unknown }).cause = new Error('same');
+    expect(errorMessage(wrapped)).toBe('same');
+  });
+
+  it('coerces a non-Error throw to a string', () => {
+    expect(errorMessage('just a string')).toBe('just a string');
+    expect(errorMessage({ code: 42 })).toBe('[object Object]');
+  });
+});


### PR DESCRIPTION
## Summary

The `metadata-no-match-digest` daily cron (shipped in #1912 / #1913) **failed on every run**. Caught by manually dry-running the deployed image while verifying the newly-registered cron:

```
{"level":"error","step":"failed","error_message":"Failed query: \n SELECT ... f.\"updated_at\" > $1 ... params: Fri Jul 31 2026 15:55:06 GMT+0000,5000"}
```

`query.ts` bound a raw JS `Date` for the `updated_at > :since` watermark and read raw `timestamptz` columns via `db.execute`. `@wxyc/database`'s Drizzle client rebinds the postgres-js date-family **parser and serializer** to a passthrough `(val) => val`, so:

- **outbound** — the `Date` reaches `Bind` → `Buffer.byteLength(Date)` → `ERR_INVALID_ARG_TYPE`, surfaced only as Drizzle's opaque `Failed query` wrapper;
- **inbound** — `timestamptz` reads back as a string, a latent `format.ts` crash on any rotation-linked row with a show start time.

Nothing tested the real `query.ts` through the real driver: unit tests mock the DB, and the integration spec used a bare `postgres()` client (native `Date` handling) — so both shipped green. This is the same trap documented in `feedback_drizzle_date_serializer_override` (BS#975/#976).

Fails **safely** today (query throws → non-zero exit → Sentry → watermark unadvanced → no data loss, no bad email), so there's no urgency beyond restoring the digest before its first scheduled fire (2026-08-02 08:07 AM PDT).

## Changes

- **`query.ts`** — pre-stringify the bound (`${since.toISOString()}::timestamptz`) and select the three timestamps as `extract(epoch …)` (float8 → real number), rebuilding `Date`s in the row mapper so `NoMatchRow`'s `Date` contract holds.
- **`tsup.config.ts`** — also emit `dist/query.cjs` so the babel-jest integration spec can `require` and run the **real** `queryNoMatchRows` through the real driver (mirrors `jobs/artist-unicode-dedup`'s `dist/merge.cjs`).
- **`tests/integration/metadata-no-match-digest.spec.js`** — replaced the bare-postgres-js SQL mirror (which could never reach the driver seam) with a real-driver spec: asserts no-throw + `Date`-typed timestamps, plus watermark-boundary / `entry_type` / status / rotation-first-ordering semantics.
- **`logger.ts`** — `errorMessage` now surfaces `error.cause`, so a Drizzle-wrapped driver failure is never opaque in stdout/Sentry again (the reason this was undiagnosable). Adds a focused unit test.

## Testing

- `test:unit` (metadata-no-match-digest): **64 passed**, incl. the new `logger.test.ts`.
- `tsc --noEmit` (job) clean; `eslint` clean; `prettier --check` clean; `tsup` build emits `dist/query.cjs`.
- Root cause independently confirmed against the installed `drizzle-orm` postgres-js `driver` (serializer/parser passthrough) and postgres-js `types.js` (the native `timestamptz` serializer it defeats).
- The integration tier (real driver + Docker PG) runs in CI — it needs the full stack, which isn't runnable locally here (BS#1728/#1729).

Closes #1917
