### PR TITLE
feat(enrichment-worker): bounded self-heal of unresolved streaming links

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.68.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^2.3.0",
+    "@wxyc/shared": "^3.1.0",
     "better-auth": "^1.6.23",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^2.6.0",
+    "@wxyc/shared": "^3.1.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -114,13 +114,20 @@ export function inferIncomingStreamingStatus(
  *   2. `incomingStatus === undefined` → the service was not consulted (or
  *      its verdict was genuinely unknown) this round; return `current`
  *      unchanged. Never invent a verdict LML didn't assert.
- *   3. `'verified'` → adopt the incoming url and status.
- *   4. `'absent'` → terminal; url forced null regardless of any stray
- *      incoming url (LML's contract pairs `absent` with a null url, but the
- *      guard is defensive). Negative-cached: `precheck.ts` never re-asks an
- *      `absent` field — the exact per-play amplifier BS#1747 killed.
- *   5. `'unresolved'` → transient; status flips to `'unresolved'`, url
- *      carries forward from `current` (never fabricated — a non-verified
+ *   3. incoming `'verified'` → adopt the incoming url and status. This is the
+ *      one transition allowed to supersede a prior terminal `absent` (a
+ *      release that finally appeared on the service) — checked ahead of rule
+ *      4 so a genuine positive always wins.
+ *   4. `current.status === 'absent'` → terminal, return `current` unchanged.
+ *      A negative-cached field is NEVER downgraded by a later
+ *      `unresolved`/`absent` flap: that would resurrect it for re-ask
+ *      (`precheck.ts` selects on `unresolved`), the exact per-play amplifier
+ *      BS#1747/#1089 killed. Only rule 3's genuine `verified` may supersede it.
+ *   5. incoming `'absent'` → adopt terminal `absent`; url forced null
+ *      regardless of any stray incoming url (LML's contract pairs `absent`
+ *      with a null url, but the guard is defensive).
+ *   6. incoming `'unresolved'` → transient; status flips to `'unresolved'`,
+ *      url carries forward from `current` (never fabricated — a non-verified
  *      service carries no url by LML's contract).
  */
 export function mergeStreamingField(
@@ -131,6 +138,7 @@ export function mergeStreamingField(
   if (current.status === 'verified') return current;
   if (incomingStatus === undefined) return current;
   if (incomingStatus === 'verified') return { status: 'verified', url: incomingUrl ?? null };
+  if (current.status === 'absent') return current;
   if (incomingStatus === 'absent') return { status: 'absent', url: null };
   return { status: 'unresolved', url: current.url };
 }

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -40,12 +40,269 @@
  * (BS#1184 / BS#1192: shared `synthesizeSearchUrls` omits Spotify; the
  * inline version here persists a synthesized URL). Pinned by parity test:
  *   - tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts (BS#889 / BS#1189)
+ *
+ * BS#1915 (bounded self-heal of unresolved streaming links). The linked-match
+ * arm now reads the album's PRIOR persisted spotify/apple_music/bandcamp
+ * status+url before writing, and merges each field with the fresh LML
+ * verdict via `mergeStreamingField` (never downgrading an already-`verified`
+ * field, forcing `absent` fields' url to null and terminal, and leaving
+ * `unresolved` fields transient/retry-eligible). `streaming_reask_attempts`
+ * — one shared per-album counter, not per-service, since a single LML
+ * re-ask resolves all three services' verdicts at once — increments ONLY on
+ * the `onConflictDoUpdate` branch (a genuine re-ask against an EXISTING
+ * row); a fresh album's first-ever write leaves the column at its schema
+ * DEFAULT 0, because the first ask is not a re-ask. Migration 0135 (schema)
+ * carries the full design rationale; `precheck.ts` is the read side that
+ * gates further re-asks at `STREAMING_REASK_ATTEMPT_CAP`.
  */
 
 import { and, eq, sql } from 'drizzle-orm';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
-import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
+import type { DiscogsMatchResult, LookupResponse, StreamingResolutionStatus } from '@wxyc/lml-client';
 import { cleanDiscogsBio, filterSpacerGif } from '@wxyc/metadata';
+
+/**
+ * Bound on `album_metadata.streaming_reask_attempts` (BS#1915). Once an
+ * album has been re-asked this many times with a field still `unresolved`,
+ * `precheck.ts` stops treating it as re-ask-eligible — the "no unbounded
+ * re-ask loop" half of the #1747 amplifier guard. A named, tunable constant
+ * (not env-derived, mirroring the codebase's per-caller hardcoded-override
+ * convention in `shared/lml-client/src/policy.ts` for values with no
+ * expected operational need to tune live) so precheck.ts, enrich.ts, and
+ * the streaming-reask sweep can't drift against three independent copies.
+ */
+export const STREAMING_REASK_ATTEMPT_CAP = 3;
+
+/** One persisted streaming-service field's state: its resolution verdict (if any) and its url (if verified). */
+export interface StreamingFieldState {
+  status: StreamingResolutionStatus | null;
+  url: string | null;
+}
+
+/**
+ * Infer the effective incoming per-service verdict for one streaming field
+ * on a fresh LML response, combining LML#1053's explicit `streaming_status`
+ * (when present) with the legacy url-presence signal.
+ *
+ * Explicit status always wins. A bare non-null url with NO explicit status
+ * is inferred `'verified'` — a url existing IS the verification, and this
+ * keeps the merge backward compatible with LML responses that predate the
+ * LML#1053 producer rollout (or a path that resolves a url without ever
+ * populating `streaming_status`), which is exactly today's `matchResponse`
+ * shape in the existing test suite. No url and no explicit status is
+ * genuinely unknown — returns `undefined` rather than inventing a verdict
+ * LML never actually asserted (an `unresolved` or `absent` guess here would
+ * corrupt the merge's terminal/negative-cache guarantees).
+ */
+export function inferIncomingStreamingStatus(
+  explicitStatus: StreamingResolutionStatus | undefined,
+  url: string | null | undefined
+): StreamingResolutionStatus | undefined {
+  if (explicitStatus) return explicitStatus;
+  return url ? 'verified' : undefined;
+}
+
+/**
+ * Merge one persisted streaming-service field with a fresh incoming verdict
+ * (already combined via `inferIncomingStreamingStatus`).
+ *
+ * Rules, in priority order:
+ *   1. `current.status === 'verified'` → return `current` unchanged. A
+ *      verified URL is NEVER overwritten — not by a fresh 'verified' (which
+ *      would carry the same URL anyway), and certainly not by a later
+ *      'unresolved'/'absent' flap from a re-ask.
+ *   2. `incomingStatus === undefined` → the service was not consulted (or
+ *      its verdict was genuinely unknown) this round; return `current`
+ *      unchanged. Never invent a verdict LML didn't assert.
+ *   3. `'verified'` → adopt the incoming url and status.
+ *   4. `'absent'` → terminal; url forced null regardless of any stray
+ *      incoming url (LML's contract pairs `absent` with a null url, but the
+ *      guard is defensive). Negative-cached: `precheck.ts` never re-asks an
+ *      `absent` field — the exact per-play amplifier BS#1747 killed.
+ *   5. `'unresolved'` → transient; status flips to `'unresolved'`, url
+ *      carries forward from `current` (never fabricated — a non-verified
+ *      service carries no url by LML's contract).
+ */
+export function mergeStreamingField(
+  current: StreamingFieldState,
+  incomingStatus: StreamingResolutionStatus | undefined,
+  incomingUrl: string | null | undefined
+): StreamingFieldState {
+  if (current.status === 'verified') return current;
+  if (incomingStatus === undefined) return current;
+  if (incomingStatus === 'verified') return { status: 'verified', url: incomingUrl ?? null };
+  if (incomingStatus === 'absent') return { status: 'absent', url: null };
+  return { status: 'unresolved', url: current.url };
+}
+
+/**
+ * Read the album's prior persisted per-service streaming state before a
+ * (re-)write. Returns all-null state for an album with no `album_metadata`
+ * row yet (a fresh first-ever match) — `mergeStreamingField` treats that
+ * identically to a row whose columns are all still NULL.
+ */
+async function selectPriorStreamingState(albumId: number): Promise<{
+  spotify: StreamingFieldState;
+  apple_music: StreamingFieldState;
+  bandcamp: StreamingFieldState;
+}> {
+  const rows = await db
+    .select({
+      spotify_status: album_metadata.spotify_status,
+      spotify_url: album_metadata.spotify_url,
+      apple_music_status: album_metadata.apple_music_status,
+      apple_music_url: album_metadata.apple_music_url,
+      bandcamp_status: album_metadata.bandcamp_status,
+      bandcamp_url: album_metadata.bandcamp_url,
+    })
+    .from(album_metadata)
+    .where(eq(album_metadata.album_id, albumId))
+    .limit(1);
+  const prior = rows[0] as
+    | {
+        spotify_status: string | null;
+        spotify_url: string | null;
+        apple_music_status: string | null;
+        apple_music_url: string | null;
+        bandcamp_status: string | null;
+        bandcamp_url: string | null;
+      }
+    | undefined;
+  return {
+    spotify: {
+      status: (prior?.spotify_status ?? null) as StreamingResolutionStatus | null,
+      url: prior?.spotify_url ?? null,
+    },
+    apple_music: {
+      status: (prior?.apple_music_status ?? null) as StreamingResolutionStatus | null,
+      url: prior?.apple_music_url ?? null,
+    },
+    bandcamp: {
+      status: (prior?.bandcamp_status ?? null) as StreamingResolutionStatus | null,
+      url: prior?.bandcamp_url ?? null,
+    },
+  };
+}
+
+/**
+ * UPSERT a matched album's full metadata payload into `album_metadata`,
+ * merging the three streaming-verdict fields against the album's prior
+ * state (BS#1915 — see `mergeStreamingField` / `inferIncomingStreamingStatus`
+ * above) and bumping the shared `streaming_reask_attempts` counter on a
+ * genuine re-ask (the `onConflictDoUpdate` branch, which fires only when a
+ * row already existed for this album).
+ *
+ * Extracted from `finalizeRow`'s linked-match arm so BOTH callers share one
+ * write path: the live CDC handler (via `finalizeRow`, which also owns the
+ * flowsheet-row-scoped composer write) and the hourly streaming-reask sweep
+ * (`streaming-reask.ts`), which has no flowsheet row to finalize — it
+ * operates directly on `album_metadata` for an already-terminal album.
+ */
+export async function upsertMatchedAlbumMetadata(
+  albumId: number,
+  artwork: DiscogsMatchResult,
+  searchUrls: { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string }
+): Promise<void> {
+  const prior = await selectPriorStreamingState(albumId);
+  const spotify = mergeStreamingField(
+    prior.spotify,
+    inferIncomingStreamingStatus(artwork.streaming_status?.spotify, artwork.spotify_url),
+    artwork.spotify_url
+  );
+  const appleMusic = mergeStreamingField(
+    prior.apple_music,
+    inferIncomingStreamingStatus(artwork.streaming_status?.apple_music, artwork.apple_music_url),
+    artwork.apple_music_url
+  );
+  const bandcamp = mergeStreamingField(
+    prior.bandcamp,
+    inferIncomingStreamingStatus(artwork.streaming_status?.bandcamp, artwork.bandcamp_url),
+    artwork.bandcamp_url
+  );
+
+  // The album_metadata UPSERT is idempotent (same album_id → same row) and
+  // guarded by `updated_at < NOW()` so a concurrent stale write (e.g. a
+  // delayed drift-repair backfill) can't overwrite a fresher enrichment.
+  const payload = {
+    artwork_url: filterSpacerGif(artwork.artwork_url),
+    discogs_url: artwork.release_url ?? null,
+    // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
+    // render literal "0". Mirrors metadata.service.ts (#1002).
+    release_year: artwork.release_year || null,
+    // A verified streaming URL wins outright; anything else (absent /
+    // unresolved / never-consulted) falls back to the synthesized search
+    // URL for Spotify and Bandcamp — unchanged from pre-#1915 behavior, and
+    // never a downgrade of a prior verified URL (merged above). Apple Music
+    // has NO fallback — null is load-bearing "no verified iTunes match"
+    // (BS#1192), now disambiguated by `apple_music_status` instead of
+    // silently freezing a transient null (BS#1915 — the whole point of
+    // this ticket).
+    spotify_url: spotify.status === 'verified' ? spotify.url : searchUrls.spotify_url,
+    spotify_status: spotify.status,
+    apple_music_url: appleMusic.url,
+    apple_music_status: appleMusic.status,
+    youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+    bandcamp_url: bandcamp.status === 'verified' ? bandcamp.url : searchUrls.bandcamp_url,
+    bandcamp_status: bandcamp.status,
+    soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+    artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+    artist_wikipedia_url: artwork.wikipedia_url ?? null,
+    // LML-only enrichment fields (BS#1336). Present on `artwork` only
+    // because handler.ts now sets `extended: true`; without it these would
+    // all write null. Persisting them lets the BS#1331 cache-first read
+    // path emit the artist+release subtree on a hit instead of shedding
+    // it. `profile_tokens` maps to the `bio_tokens` column (iOS's
+    // `bioTokens`). No cleanup/synthesis here — raw passthroughs of what
+    // LML resolved for the top-1 release match; the read side
+    // (`buildLocalMetadataResponse`) projects + filters to match the
+    // cold-fallthrough wire shape.
+    discogs_artist_id: artwork.discogs_artist_id ?? null,
+    label: artwork.label ?? null,
+    full_release_date: artwork.full_release_date ?? null,
+    genres: artwork.genres ?? null,
+    styles: artwork.styles ?? null,
+    tracklist: artwork.tracklist ?? null,
+    artist_image_url: artwork.artist_image_url ?? null,
+    bio_tokens: artwork.profile_tokens ?? null,
+  };
+  await db
+    .insert(album_metadata)
+    .values({ album_id: albumId, ...payload, updated_at: sql`NOW()` })
+    .onConflictDoUpdate({
+      target: album_metadata.album_id,
+      set: {
+        ...payload,
+        // BS#1915: bump the shared per-album re-ask counter ONLY on a
+        // genuine re-ask — this conflict branch fires exactly when a row
+        // already existed for this album. A fresh album's first-ever
+        // INSERT above leaves the column at its schema DEFAULT 0; the
+        // first ask is not a re-ask.
+        streaming_reask_attempts: sql`${album_metadata.streaming_reask_attempts} + 1`,
+        updated_at: sql`NOW()`,
+      },
+      setWhere: sql`${album_metadata.updated_at} < NOW()`,
+    });
+}
+
+/**
+ * Bump the shared per-album `streaming_reask_attempts` counter with no
+ * other write — the hourly streaming-reask sweep's outcome when LML
+ * responds but returns no artwork at all for a candidate that previously
+ * matched (a rare Discogs-side flap, not the common case). Spending an
+ * attempt without a fresh verdict still counts toward the bound: an album
+ * that keeps failing to re-match must still eventually stop being retried.
+ * Does NOT touch `updated_at`'s `setWhere` guard semantics — this is a
+ * plain UPDATE, not the insert/upsert `finalizeRow` path uses.
+ */
+export async function bumpStreamingReaskAttempts(albumId: number): Promise<void> {
+  await db
+    .update(album_metadata)
+    .set({
+      streaming_reask_attempts: sql`${album_metadata.streaming_reask_attempts} + 1`,
+      updated_at: sql`NOW()`,
+    })
+    .where(eq(album_metadata.album_id, albumId));
+}
 
 export type EnrichRow = {
   id: number;
@@ -181,53 +438,12 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
 
   if (artwork) {
     if (row.album_id !== null) {
-      // Linked + match: 10-col payload lands in album_metadata; flowsheet
-      // UPDATE only flips status. The album_metadata UPSERT is idempotent
-      // (same album_id → same row) and guarded by `updated_at < NOW()` so
-      // a concurrent stale write (e.g. delayed drift-repair backfill)
-      // can't overwrite a fresher enrichment.
-      const payload = {
-        artwork_url: filterSpacerGif(artwork.artwork_url),
-        discogs_url: artwork.release_url ?? null,
-        // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
-        // render literal "0". Mirrors metadata.service.ts (#1002).
-        release_year: artwork.release_year || null,
-        // Prefer LML-supplied streaming URLs; fall back to synthesized.
-        // Apple Music has no fallback — null is load-bearing "no verified
-        // iTunes match" signal (BS#1192).
-        spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
-        apple_music_url: artwork.apple_music_url ?? null,
-        youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
-        bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
-        soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
-        artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
-        artist_wikipedia_url: artwork.wikipedia_url ?? null,
-        // LML-only enrichment fields (BS#1336). Present on `artwork` only
-        // because handler.ts now sets `extended: true`; without it these
-        // would all write null. Persisting them lets the BS#1331 cache-first
-        // read path emit the artist+release subtree on a hit instead of
-        // shedding it. `profile_tokens` maps to the `bio_tokens` column
-        // (iOS's `bioTokens`). No cleanup/synthesis here — raw passthroughs
-        // of what LML resolved for the top-1 release match; the read side
-        // (`buildLocalMetadataResponse`) projects + filters to match the
-        // cold-fallthrough wire shape.
-        discogs_artist_id: artwork.discogs_artist_id ?? null,
-        label: artwork.label ?? null,
-        full_release_date: artwork.full_release_date ?? null,
-        genres: artwork.genres ?? null,
-        styles: artwork.styles ?? null,
-        tracklist: artwork.tracklist ?? null,
-        artist_image_url: artwork.artist_image_url ?? null,
-        bio_tokens: artwork.profile_tokens ?? null,
-      };
-      await db
-        .insert(album_metadata)
-        .values({ album_id: row.album_id, ...payload, updated_at: sql`NOW()` })
-        .onConflictDoUpdate({
-          target: album_metadata.album_id,
-          set: { ...payload, updated_at: sql`NOW()` },
-          setWhere: sql`${album_metadata.updated_at} < NOW()`,
-        });
+      // Linked + match: the 10(+3 streaming-status +1 attempts)-col payload
+      // lands in album_metadata; flowsheet UPDATE only flips status. See
+      // `upsertMatchedAlbumMetadata` for the merge + UPSERT (BS#1915 also
+      // calls it directly from the hourly streaming-reask sweep, which has
+      // no flowsheet row to finalize).
+      await upsertMatchedAlbumMetadata(row.album_id, artwork, searchUrls);
       const updated = await db
         .update(flowsheet)
         // composer rides the flowsheet UPDATE, not the album_metadata UPSERT

--- a/apps/enrichment-worker/precheck.ts
+++ b/apps/enrichment-worker/precheck.ts
@@ -30,30 +30,62 @@
  * complete load-bearing set here. The four search-URL columns are
  * deliberately excluded: they are synthesized locally on every no-match and
  * so never distinguish a real match from a poisoned shell.
+ *
+ * BS#1915 (bounded self-heal of unresolved streaming links) layers a second
+ * gate on top: even with load-bearing artwork/discogs present, a row is NOT
+ * "done" while a streaming field (`spotify_status` / `apple_music_status` /
+ * `bandcamp_status`) is `'unresolved'` AND the album is still under
+ * `STREAMING_REASK_ATTEMPT_CAP` — that combination re-calls LML too, so a
+ * transient "couldn't check" null self-heals instead of freezing forever.
+ * `'absent'` stays terminal (never re-asked — preserves #1747's amplifier
+ * fix) and a NULL status (never-consulted) does not force a re-ask; only an
+ * explicit `'unresolved'` does. See `enrich.ts` for the merge logic that
+ * writes these columns and the shared per-album `streaming_reask_attempts`
+ * counter.
  */
 
-import { and, eq, isNotNull, or } from 'drizzle-orm';
+import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
 
-import { resolveComposer, type EnrichRow } from './enrich.js';
+import { resolveComposer, STREAMING_REASK_ATTEMPT_CAP, type EnrichRow } from './enrich.js';
 
 /**
  * True when the album already has a persisted, load-bearing Discogs match in
- * `album_metadata` — i.e. `artwork_url` OR `discogs_url` is non-null. False
- * when the row is missing, all-null, or a search-URL-only shell, so the
- * caller re-calls LML and the false no-match self-heals (BS#1089 guard).
+ * `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND no
+ * streaming field is still bounded-re-ask-eligible (BS#1915 — see file
+ * header). False when the row is missing, all-null, a search-URL-only shell
+ * (BS#1089 guard), or carries an `'unresolved'` streaming field under the
+ * attempt cap, so the caller re-calls LML and the row self-heals.
  *
  * Only linked rows (flowsheet `album_id` non-null) have an `album_metadata`
  * row to consult; the caller gates on that before invoking this.
  */
 export async function hasLoadBearingAlbumMetadata(albumId: number): Promise<boolean> {
+  // COALESCE(..., false) is load-bearing, not decorative: SQL's
+  // three-valued logic makes `col = 'unresolved'` evaluate to NULL (not
+  // false) when `col` is NULL, so for the common case of all three status
+  // columns still NULL (never consulted), the un-coalesced expression would
+  // evaluate to NULL — and negating a NULL WHERE-clause term excludes the
+  // row, silently breaking the base BS#1747 skip for every plain
+  // load-bearing row. COALESCE pins the "nothing to re-ask" default to an
+  // explicit false before negating.
+  const needsStreamingReask = sql<boolean>`COALESCE(
+    ${album_metadata.streaming_reask_attempts} < ${STREAMING_REASK_ATTEMPT_CAP}
+    AND (
+      ${album_metadata.spotify_status} = 'unresolved'
+      OR ${album_metadata.apple_music_status} = 'unresolved'
+      OR ${album_metadata.bandcamp_status} = 'unresolved'
+    ),
+    false
+  )`;
   const rows = await db
     .select({ album_id: album_metadata.album_id })
     .from(album_metadata)
     .where(
       and(
         eq(album_metadata.album_id, albumId),
-        or(isNotNull(album_metadata.artwork_url), isNotNull(album_metadata.discogs_url))
+        or(isNotNull(album_metadata.artwork_url), isNotNull(album_metadata.discogs_url)),
+        sql`NOT ${needsStreamingReask}`
       )
     )
     .limit(1);

--- a/apps/enrichment-worker/streaming-reask.ts
+++ b/apps/enrichment-worker/streaming-reask.ts
@@ -1,0 +1,162 @@
+/**
+ * Hourly bounded self-heal sweep for unresolved streaming links (BS#1915).
+ *
+ * The CDC handler (`handler.ts` -> `enrich.ts#finalizeRow`) already re-asks
+ * LML for an album whose streaming field is `unresolved` under the attempt
+ * cap the next time that album is PLAYED (`precheck.ts`'s gate keeps the row
+ * "not done"). But CDC only fires on a new flowsheet INSERT — an album that
+ * isn't played again may never get another chance to self-heal. This module
+ * is the other half of the bound: a periodic sweep that finds every
+ * `album_metadata` row still carrying an `unresolved` streaming field and
+ * re-asks LML directly, independent of play activity.
+ *
+ * Driven on an hourly cadence from `worker.ts` (mirrors `sweep.ts`'s
+ * in-process interval pattern for the stranded-claim recovery sweep — see
+ * that file's header for why an in-process interval beats a sibling cron
+ * container at this frequency). "Hourly" is also the natural backoff
+ * spacing BS#1915 specifies: no per-row `next_retry_at` column, no
+ * exponential schedule — an unresolved field simply gets re-asked at most
+ * once per sweep tick, and the sweep tick is hourly.
+ *
+ * Re-ask dispatch reuses `enrichmentBulkLookup` (`lookup-batcher.ts`) — the
+ * SAME call already tagged `caller: 'enrichment-worker'`, which
+ * `shared/lml-client/src/policy.ts` (BS#1826) registers as class 5
+ * (batch/backfill), i.e. the low-priority lane per the #1819 isolation
+ * contract. No new caller label or lane-selection logic is needed: this
+ * sweep is just another source of `enrichmentBulkLookup` calls, batched and
+ * rate-limited exactly like the live CDC path's.
+ *
+ * Write-back reuses `enrich.ts`'s `upsertMatchedAlbumMetadata` (merge +
+ * UPSERT, never overwriting a verified URL, `absent` terminal) on a fresh
+ * match, or `bumpStreamingReaskAttempts` (attempt spent, no other write)
+ * when LML responds with no artwork at all for a candidate that previously
+ * matched. A candidate whose LML call THROWS (transient failure or a shed)
+ * spends nothing — it stays eligible for the next sweep tick, exactly like
+ * the live CDC path's C6 stranded-claim treatment of a throw.
+ */
+
+import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
+import { album_metadata, db, library } from '@wxyc/database';
+
+import {
+  bumpStreamingReaskAttempts,
+  extractArtwork,
+  STREAMING_REASK_ATTEMPT_CAP,
+  synthesizeSearchUrls,
+  upsertMatchedAlbumMetadata,
+} from './enrich.js';
+import { enrichmentBulkLookup } from './lookup-batcher.js';
+
+/** One album still eligible for a bounded streaming re-ask. */
+export interface StreamingReaskCandidate {
+  album_id: number;
+  artist_name: string;
+  album_title: string | null;
+}
+
+/**
+ * Find up to `limit` albums that still carry a load-bearing Discogs match
+ * (`artwork_url` OR `discogs_url` non-null — this sweep only upgrades
+ * already-matched albums, never mints a new match) AND have at least one
+ * streaming field `'unresolved'` under `STREAMING_REASK_ATTEMPT_CAP`.
+ * Mirrors `precheck.ts`'s gate predicate (the two must stay in lockstep —
+ * this is the positive form of that negative gate) including the same
+ * `COALESCE(..., false)` guard against SQL's three-valued logic silently
+ * dropping rows whose status columns are all still NULL... except here
+ * NULL columns correctly never qualify a row (a never-consulted service
+ * isn't a reason to re-ask), so the guard only matters for the base
+ * artwork/discogs predicate interacting with an all-NULL streaming state —
+ * kept for defense-in-depth and literal parity with precheck.ts.
+ */
+export async function findUnresolvedStreamingCandidates(limit: number): Promise<StreamingReaskCandidate[]> {
+  const needsStreamingReask = sql<boolean>`COALESCE(
+    ${album_metadata.streaming_reask_attempts} < ${STREAMING_REASK_ATTEMPT_CAP}
+    AND (
+      ${album_metadata.spotify_status} = 'unresolved'
+      OR ${album_metadata.apple_music_status} = 'unresolved'
+      OR ${album_metadata.bandcamp_status} = 'unresolved'
+    ),
+    false
+  )`;
+
+  const rows = await db
+    .select({
+      album_id: album_metadata.album_id,
+      // `library.artist_name` is denormalized and nullable (schema.ts:
+      // "Nullable until A.2"); the WHERE below excludes NULL rows, so this
+      // cast reflects the actual (never-null) shape of the returned rows.
+      artist_name: library.artist_name,
+      album_title: library.album_title,
+    })
+    .from(album_metadata)
+    .innerJoin(library, eq(library.id, album_metadata.album_id))
+    .where(
+      and(
+        isNotNull(library.artist_name),
+        or(isNotNull(album_metadata.artwork_url), isNotNull(album_metadata.discogs_url)),
+        sql`${needsStreamingReask}`
+      )
+    )
+    .limit(limit);
+  return rows as StreamingReaskCandidate[];
+}
+
+export interface StreamingReaskSweepResult {
+  /** Albums selected as re-ask-eligible this tick. */
+  candidates: number;
+  /** Candidates whose LML call resolved (match or no-match) and were written back. */
+  succeeded: number;
+  /** Candidates whose LML call threw — spent nothing, stay eligible for the next tick. */
+  failed: number;
+}
+
+/**
+ * Run one streaming-reask sweep tick. Dispatches every candidate's
+ * `enrichmentBulkLookup` call concurrently — `lookup-batcher.ts` coalesces
+ * them into as few real HTTP round-trips as its burst window allows, and
+ * the shared client's Semaphore(5)/TokenBucket chokepoint still gates the
+ * actual concurrency, so firing all candidates at once is safe even for a
+ * large sweep batch.
+ */
+export async function reaskUnresolvedStreaming(limit: number): Promise<StreamingReaskSweepResult> {
+  const candidates = await findUnresolvedStreamingCandidates(limit);
+  if (candidates.length === 0) {
+    return { candidates: 0, succeeded: 0, failed: 0 };
+  }
+
+  const outcomes = await Promise.allSettled(candidates.map((candidate) => reaskOne(candidate)));
+  const succeeded = outcomes.filter((outcome) => outcome.status === 'fulfilled').length;
+  return { candidates: candidates.length, succeeded, failed: outcomes.length - succeeded };
+}
+
+async function reaskOne(candidate: StreamingReaskCandidate): Promise<void> {
+  const response = await enrichmentBulkLookup({
+    artist_name: candidate.artist_name,
+    album_title: candidate.album_title,
+    // Album-level re-ask — no specific playcut track is driving this
+    // sweep, so there is no track title to narrow the lookup with.
+    track_title: null,
+  });
+  const artwork = extractArtwork(response);
+  if (artwork) {
+    // Reuse the ONE canonical search-URL synthesizer (parity-tested against
+    // the shared `@wxyc/metadata` module — see enrich.ts's file header)
+    // rather than duplicating its per-service precedence rules here. `id`
+    // and `album_id` are unused by `synthesizeSearchUrls` (it only reads
+    // artist_name/album_title/track_title); album_id doubles as a stable
+    // placeholder id since there's no flowsheet row driving this sweep.
+    const searchUrls = synthesizeSearchUrls({
+      id: candidate.album_id,
+      artist_name: candidate.artist_name,
+      album_title: candidate.album_title,
+      track_title: null,
+      album_id: candidate.album_id,
+    });
+    await upsertMatchedAlbumMetadata(candidate.album_id, artwork, searchUrls);
+    return;
+  }
+  // LML answered but returned no artwork at all for an album that
+  // previously matched (a rare Discogs-side flap). Still spends an
+  // attempt — see the module header.
+  await bumpStreamingReaskAttempts(candidate.album_id);
+}

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -28,6 +28,7 @@ import { envInt } from '@wxyc/lml-client';
 import { drainInFlightCandidates, makeEnrichmentHandler } from './handler.js';
 import { startHealthcheckServer, type HealthState } from './healthcheck.js';
 import { sweepStrandedClaims } from './sweep.js';
+import { reaskUnresolvedStreaming } from './streaming-reask.js';
 
 /**
  * Stranded-claim sweep cadence (BS#1225). The C6 contract is "recover any
@@ -38,6 +39,24 @@ import { sweepStrandedClaims } from './sweep.js';
  * deploy-config typo can't produce a tight-loop `setInterval(fn, 0)`.
  */
 const SWEEP_INTERVAL_MS = envInt('ENRICHMENT_SWEEP_INTERVAL_MS', 60_000);
+
+/**
+ * Streaming self-heal sweep cadence (BS#1915). Hourly is the backoff
+ * spacing the design specifies — no per-row `next_retry_at` column, no
+ * exponential schedule; an unresolved streaming field is re-asked at most
+ * once per tick, bounded overall by `STREAMING_REASK_ATTEMPT_CAP`
+ * (`enrich.ts`). Override via env for shorter-cycle integration runs.
+ */
+const STREAMING_REASK_SWEEP_INTERVAL_MS = envInt('ENRICHMENT_STREAMING_REASK_SWEEP_INTERVAL_MS', 3_600_000);
+
+/**
+ * Per-tick cap on how many albums one streaming-reask sweep re-asks. Bounds
+ * the worst-case LML call burst from a single tick (a large unresolved
+ * backlog drains over several hourly ticks rather than one large burst);
+ * `enrichmentBulkLookup`'s burst coalescing plus the shared client's
+ * Semaphore(5)/TokenBucket chokepoint further smooth the actual dispatch.
+ */
+const STREAMING_REASK_SWEEP_BATCH_SIZE = envInt('ENRICHMENT_STREAMING_REASK_SWEEP_BATCH_SIZE', 200);
 
 /**
  * Per-step bound for the shutdown path so SIGTERM never hangs if PG (or
@@ -132,10 +151,16 @@ const main = async (): Promise<void> => {
   // tear the in-flight UPDATE's connection.
   let shuttingDown = false;
   let activeSweep: Promise<void> | null = null;
+  // BS#1915: the streaming-reask sweep gets its own overlap latch + timer
+  // ref, mirroring the stranded-claim sweep above but independent of it —
+  // an hourly tick running long must not block (or be blocked by) the 60s
+  // stranded-claim tick.
+  let activeStreamingReaskSweep: Promise<void> | null = null;
   // Mutable holder so the shutdown closure (declared next) can clear the
   // timer that's only assigned later, after the initial sweep. Holding via
   // a ref keeps the binding `const` and survives `prefer-const`.
   const sweepTimerRef: { current: NodeJS.Timeout | undefined } = { current: undefined };
+  const streamingReaskSweepTimerRef: { current: NodeJS.Timeout | undefined } = { current: undefined };
 
   const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
     if (shuttingDown) return;
@@ -144,14 +169,16 @@ const main = async (): Promise<void> => {
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
       if (sweepTimerRef.current !== undefined) clearInterval(sweepTimerRef.current);
+      if (streamingReaskSweepTimerRef.current !== undefined) clearInterval(streamingReaskSweepTimerRef.current);
       // Each step is bounded + best-effort via runShutdownStep so a hang
       // or throw in one (e.g. a wedged CDC LISTEN socket — BS#1014 lists
       // the exact failure modes) doesn't skip the cleanup steps that
       // follow. The ordering still matters:
       //   1. Stop CDC dispatches first so new `handleCandidate` calls
       //      don't fire fresh DB writes during the sweep wait.
-      //   2. Drain any in-flight sweep so closeDatabaseConnection
-      //      doesn't tear its UPDATE.
+      //   2. Drain any in-flight sweep (both the stranded-claim sweep and
+      //      the BS#1915 streaming-reask sweep) so closeDatabaseConnection
+      //      doesn't tear an in-flight UPDATE.
       //   3. Drain in-flight `handleCandidate` invocations (BS#1108) so
       //      pending LML lookups can finalize their `metadata_status`
       //      write before the pool closes. Bounded by
@@ -163,6 +190,9 @@ const main = async (): Promise<void> => {
       await runShutdownStep('stop_cdc', stopCdcListener);
       if (activeSweep !== null) {
         await runShutdownStep('drain_sweep', activeSweep);
+      }
+      if (activeStreamingReaskSweep !== null) {
+        await runShutdownStep('drain_streaming_reask_sweep', activeStreamingReaskSweep);
       }
       // BS#1108: signal-driven count of candidates that didn't finish in
       // time. Mirrors the backend's `metric: 'in_flight_dropped'` tag
@@ -290,6 +320,17 @@ const main = async (): Promise<void> => {
     void scheduleSweep();
   }, SWEEP_INTERVAL_MS);
 
+  // BS#1915: bounded self-heal of unresolved streaming links. Unlike the
+  // stranded-claim sweep above, this does NOT fire an immediate first tick
+  // on startup — an unresolved streaming field isn't "stranded" the way a
+  // half-claimed row is, it's just waiting its next hourly turn, and firing
+  // on every deploy would correlate a burst of re-ask LML calls with
+  // deploy frequency. The first tick fires after one full
+  // STREAMING_REASK_SWEEP_INTERVAL_MS.
+  streamingReaskSweepTimerRef.current = setInterval(() => {
+    void scheduleStreamingReaskSweep();
+  }, STREAMING_REASK_SWEEP_INTERVAL_MS);
+
   /**
    * Schedule a sweep tick with overlap and shutdown guards. The
    * `activeSweep` latch causes a tick to skip cleanly if the previous one
@@ -306,6 +347,21 @@ const main = async (): Promise<void> => {
       activeSweep = null;
     });
     await activeSweep;
+  }
+
+  /**
+   * Schedule a streaming-reask sweep tick (BS#1915), with the same
+   * overlap + shutdown guards as `scheduleSweep` above, on its own
+   * independent latch so a long-running hourly tick can't starve (or be
+   * starved by) the 60s stranded-claim tick.
+   */
+  async function scheduleStreamingReaskSweep(): Promise<void> {
+    if (shuttingDown) return;
+    if (activeStreamingReaskSweep !== null) return;
+    activeStreamingReaskSweep = runStreamingReaskSweep().finally(() => {
+      activeStreamingReaskSweep = null;
+    });
+    await activeStreamingReaskSweep;
   }
 };
 
@@ -327,6 +383,32 @@ async function runSweep(): Promise<void> {
       tags: { component: 'enrichment-worker', step: 'stranded_claim_sweep' },
     });
     console.error('[enrichment-worker] sweep failed', { error: message });
+  }
+}
+
+/**
+ * Wrap one streaming-reask sweep tick (BS#1915). Same defensive shape as
+ * `runSweep` above: catch DB/LML errors here so an unhealthy tick can't
+ * unhandled-reject and tear down the worker via setInterval's fire-and-forget
+ * callback. `reaskUnresolvedStreaming` itself already isolates per-candidate
+ * failures (`Promise.allSettled`); this catch is for a failure in the
+ * candidate-selection query itself.
+ */
+async function runStreamingReaskSweep(): Promise<void> {
+  try {
+    const result = await reaskUnresolvedStreaming(STREAMING_REASK_SWEEP_BATCH_SIZE);
+    if (result.candidates > 0) {
+      console.log(
+        `[enrichment-worker] streaming-reask sweep processed ${result.candidates} candidate(s): ` +
+          `${result.succeeded} succeeded, ${result.failed} failed (stay eligible for the next tick)`
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    Sentry.captureException(err, {
+      tags: { component: 'enrichment-worker', step: 'streaming_reask_sweep' },
+    });
+    console.error('[enrichment-worker] streaming-reask sweep failed', { error: message });
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@sentry/node": "^10.68.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^2.3.0",
+        "@wxyc/shared": "^3.1.0",
         "better-auth": "^1.6.23",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^2.6.0",
+        "@wxyc/shared": "^3.1.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -6828,9 +6828,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "2.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.6.0/9473a3aef11e99a8b0a0cee2f39064b228407c7e",
-      "integrity": "sha512-AXarRgyHvISrGtijbB/RqGBwBZZw+2fACi7aZZMq4GO7TG+1s/y4Zjkp9q2TZKOHHB0xLyYCUorB71qipfIhMQ==",
+      "version": "3.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.1.0/e6b6c1794ef0e00d956c1c21bffd355d5c848118",
+      "integrity": "sha512-pHo39RYSFlIXp2h9IIiR6zftT6fWGQtK9VhqzpA+Vp82/FcqFBZsj+HtfAWl1/ErXKuxX/qq+MhfUo4WLaFJdw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -15076,7 +15076,7 @@
         "@aws-sdk/client-ses": "^3.1096.0",
         "@sentry/node": "^10.68.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^2.3.0",
+        "@wxyc/shared": "^3.1.0",
         "better-auth": "^1.6.23",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15366,7 +15366,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.68.0",
-        "@wxyc/shared": "^2.4.0"
+        "@wxyc/shared": "^3.1.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1096.0",
     "@sentry/node": "^10.68.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^2.3.0",
+    "@wxyc/shared": "^3.1.0",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/database/src/migrations/0135_album-metadata-streaming-reask.sql
+++ b/shared/database/src/migrations/0135_album-metadata-streaming-reask.sql
@@ -1,0 +1,38 @@
+-- 0135 — WXYC/Backend-Service#1915: bounded self-heal of unresolved
+-- streaming links, consuming LML#1053's per-service verdict
+-- (verified/absent/unresolved) on `DiscogsMatchResult.streaming_status`.
+--
+-- Problem: a `*_url` column alone can't distinguish "consulted, genuinely
+-- absent" from "couldn't check, transient" — both leave it NULL, so the
+-- pre-#1915 enrichment worker either re-asked every null forever
+-- (resurrecting the #1747 per-play LML-call amplifier) or froze a
+-- transient Apple/Spotify null permanently. These 4 columns give the
+-- worker the substrate to tell the two apart and bound the retry:
+--
+--   - `spotify_status` / `apple_music_status` / `bandcamp_status` — TEXT
+--     with a documented vocabulary rather than a pgEnum (the 0109 lesson:
+--     enum-value additions cost their own migration), mirroring this
+--     file's `source`-style columns. Values: 'verified' | 'absent' |
+--     'unresolved'. NULL = never consulted (LML's key-omission
+--     convention) and must NOT be treated as 'absent'.
+--   - `streaming_reask_attempts` — ONE shared per-album counter, not
+--     per-service: a single LML re-ask resolves all three services'
+--     verdicts at once. Bounds the re-ask loop (see
+--     `apps/enrichment-worker/enrich.ts`'s `STREAMING_REASK_ATTEMPT_CAP`).
+--
+-- Operationally: four `ADD COLUMN`s on an existing table, three plain
+-- nullable TEXT (no default, no constraint) and one `INTEGER DEFAULT 0
+-- NOT NULL` — every existing row gets the default at add time, so the
+-- `NOT NULL` is provably safe with no precondition guard needed
+-- (`scripts/validate-migrations.mjs` Check 8's documented exception:
+-- DEFAULT paired with NOT NULL). PG11+ metadata-only add-column for a
+-- constant default — no table rewrite, no long lock.
+--
+-- @no-precondition-needed: all four columns are additive (nullable TEXT,
+-- or NOT NULL with a DEFAULT applied to existing rows at add time); no
+-- data invariant on current rows can be violated.
+
+ALTER TABLE "wxyc_schema"."album_metadata" ADD COLUMN "spotify_status" text;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."album_metadata" ADD COLUMN "apple_music_status" text;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."album_metadata" ADD COLUMN "bandcamp_status" text;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."album_metadata" ADD COLUMN "streaming_reask_attempts" integer DEFAULT 0 NOT NULL;

--- a/shared/database/src/migrations/meta/0135_snapshot.json
+++ b/shared/database/src/migrations/meta/0135_snapshot.json
@@ -1,0 +1,6240 @@
+{
+  "id": "1d0a33a0-c159-4c03-8d6b-18a0d3fb2700",
+  "prevId": "abe3c243-5db2-42dc-b0ed-4682c8e38558",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_status": {
+          "name": "spotify_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_status": {
+          "name": "apple_music_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_status": {
+          "name": "bandcamp_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_reask_attempts": {
+          "name": "streaming_reask_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concert_performers": {
+      "name": "concert_performers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "concert_id": {
+          "name": "concert_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "concert_performer_role_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id_source": {
+          "name": "discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concert_performers_concert_role_raw_name_idx": {
+          "name": "concert_performers_concert_role_raw_name_idx",
+          "columns": [
+            {
+              "expression": "concert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concert_performers_concert_id_concerts_id_fk": {
+          "name": "concert_performers_concert_id_concerts_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "concerts",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "concert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "concert_performers_artist_id_artists_id_fk": {
+          "name": "concert_performers_artist_id_artists_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "has_resolved_support": {
+          "name": "has_resolved_support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"has_resolved_support\") AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_rotation_no_match_idx": {
+          "name": "flowsheet_rotation_no_match_idx",
+          "columns": [
+            {
+              "expression": "rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriched_no_match' AND \"wxyc_schema\".\"flowsheet\".\"rotation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unresolved_attempted_at": {
+          "name": "unresolved_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "discogs_release_id_resolve_attempted_at": {
+          "name": "discogs_release_id_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_performer_role_enum": {
+      "name": "concert_performer_role_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "headliner",
+        "support"
+      ]
+    },
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\", \"wxyc_schema\".\"library\".\"discogs_unavailable\", \"wxyc_schema\".\"library\".\"discogs_unavailable_note\", \"wxyc_schema\".\"library\".\"last_discogs_recheck_at\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -925,6 +925,13 @@
       "when": 1785512607328,
       "tag": "0134_fold-artist-name",
       "breakpoints": true
+    },
+    {
+      "idx": 135,
+      "version": "7",
+      "when": 1785618408696,
+      "tag": "0135_album-metadata-streaming-reask",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -130,5 +130,6 @@
   "0131_rotation-discogs-release-id-resolve-attempted-at": "29ea34283bb7dc1d541c441e4941ede3a4249e4742e0ce83adde94f2a60935b6",
   "0132_flowsheet-metadata-status-cutover-idx": "29ba784c8f1ab1eebe62f3a4fd605630a7f1c26ca7f0a4ee77b2c91db7150d2b",
   "0133_1895-serialize-discogs-unavailable": "af5ec3f4a1028819cb47301c4ff939cbf766fdfd5399685ea671c2c471e65620",
-  "0134_fold-artist-name": "fd865d83c820b9437ae31073f3d30eced23b874b076256c2db1c0dcac3829a5b"
+  "0134_fold-artist-name": "fd865d83c820b9437ae31073f3d30eced23b874b076256c2db1c0dcac3829a5b",
+  "0135_album-metadata-streaming-reask": "ee0309ccc3e4ded44d7dfd9f301f1f2b905c2fd2f36f31a99837356aee1327e5"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -1362,6 +1362,34 @@ export const album_metadata = wxyc_schema.table('album_metadata', {
   tracklist: jsonb('tracklist'),
   artist_image_url: varchar('artist_image_url', { length: 512 }),
   bio_tokens: jsonb('bio_tokens'),
+  // BS#1915 (bounded self-heal of unresolved streaming links, consuming
+  // LML#1053's per-service verdict). A `*_url` column alone can't
+  // distinguish "checked, genuinely absent" from "couldn't check, transient"
+  // — both leave it NULL. These three carry LML's disambiguating verdict per
+  // service. TEXT with a documented vocabulary rather than a pgEnum (the
+  // 0109 lesson: enum-value additions cost their own migration) — mirrors
+  // the `source`-style columns elsewhere in this file (e.g.
+  // `album_review_submissions.source`, `concerts.headlining_discogs_artist_id_source`).
+  // Values: 'verified' (URL present, terminal) | 'absent' (consulted, no
+  // match, terminal — negative-cached, never re-asked, preserving #1747's
+  // amplifier fix) | 'unresolved' (couldn't check — transient, re-ask
+  // eligible while under the attempt cap). NULL = never consulted (LML's
+  // key-omission convention, mirrored here) and must NOT be treated as
+  // `absent` — `apps/enrichment-worker/precheck.ts` only re-asks a service
+  // currently `unresolved`, never a NULL or `absent` one.
+  spotify_status: text('spotify_status'),
+  apple_music_status: text('apple_music_status'),
+  bandcamp_status: text('bandcamp_status'),
+  // Shared per-album re-ask attempt counter — NOT per-service. A single LML
+  // re-ask resolves all three services' verdicts in one call, so the bound
+  // is naturally per-album, not per-(album, service). Incremented only on a
+  // genuine re-ask (an UPSERT against an EXISTING row via
+  // `apps/enrichment-worker/enrich.ts`'s `onConflictDoUpdate`); a fresh
+  // album's first-ever write leaves this at its DEFAULT 0. Gated at
+  // `STREAMING_REASK_ATTEMPT_CAP` (`enrich.ts`, default 3) so a
+  // persistently-unresolved field eventually stops being re-probed — the
+  // "no unbounded re-ask loop" half of the #1747 amplifier guard.
+  streaming_reask_attempts: integer('streaming_reask_attempts').notNull().default(0),
   updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.68.0",
-    "@wxyc/shared": "^2.4.0"
+    "@wxyc/shared": "^3.1.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -39,6 +39,12 @@ export type {
   StreamingCheckResponse,
   StreamingSourceMatch,
   StreamingCheckSources,
+  // BS#1915: LML#1053's per-service streaming resolution verdict on
+  // DiscogsMatchResult.streaming_status. Re-exported here (not just left
+  // nested inside DiscogsMatchResult) so consumers like the enrichment
+  // worker's bounded self-heal can name the status union directly.
+  StreamingResolution,
+  StreamingResolutionStatus,
 } from '@wxyc/shared/dtos';
 
 // BS#1710: streaming-URL host guard. Enforces "a `spotify_url` field must

--- a/tests/integration/enrichment-worker-cache-precheck.spec.js
+++ b/tests/integration/enrichment-worker-cache-precheck.spec.js
@@ -160,3 +160,116 @@ describe('enrichment-worker cache-first pre-check predicate (real PG)', () => {
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
   });
 });
+
+/**
+ * BS#1915 — bounded self-heal of unresolved streaming links. Load-bearing
+ * artwork/discogs alone is no longer sufficient to call a row "done": a
+ * streaming field still `unresolved` and under the attempt cap must ALSO
+ * keep the predicate false so the worker re-asks LML. `absent` stays
+ * terminal (never re-asked, preserving #1747), and NULL (never-consulted)
+ * must not be mistaken for a re-ask-eligible `unresolved`.
+ *
+ * @see WXYC/Backend-Service#1915
+ * @see WXYC/library-metadata-lookup#1053
+ */
+describe('enrichment-worker cache-first pre-check predicate — BS#1915 streaming self-heal gate (real PG)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('SELF-HEAL: load-bearing artwork present but apple_music unresolved under the cap → false (worker re-asks)', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-unresolved-under-cap');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 0, NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('BOUNDED: the same unresolved field stops being re-ask-eligible once the attempt cap is hit → true', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-unresolved-at-cap');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 3, NOW())
+    `;
+
+    // No unbounded re-ask loop: attempts >= STREAMING_REASK_ATTEMPT_CAP (3)
+    // means the worker accepts the frozen null and stops asking.
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('TERMINAL: an absent streaming field is never re-asked, regardless of the attempt count', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-absent');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'absent', 0, NOW())
+    `;
+
+    // 'absent' is terminal — negative-cached, never re-asked, preserving the
+    // #1747 amplifier fix. True even with zero prior attempts.
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('NEVER-CONSULTED: a NULL streaming status (not unresolved, not absent) does not force a re-ask', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-never-consulted');
+    insertedAlbumIds.push(albumId);
+    // apple_music_status left NULL — the key-omission convention for
+    // "never consulted." Must NOT be treated as re-ask-eligible the way
+    // 'unresolved' is.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('ANY-FIELD: one unresolved-under-cap field blocks "done" even when the other two are resolved', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-mixed-verdicts');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, spotify_status, bandcamp_status, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'verified', 'absent', 'unresolved', 1, NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('SELF-HEAL flip: unresolved-under-cap flips to verified → predicate flips false → true', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'streaming-heal-flip');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 1, NOW())
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET apple_music_status = 'verified',
+             apple_music_url = 'https://music.apple.com/album/healed',
+             updated_at = NOW()
+       WHERE album_id = ${albumId}
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+});

--- a/tests/integration/enrichment-worker-streaming-reask.spec.js
+++ b/tests/integration/enrichment-worker-streaming-reask.spec.js
@@ -1,0 +1,261 @@
+/**
+ * Integration test for the enrichment worker's bounded self-heal of
+ * unresolved streaming links (BS#1915).
+ *
+ * Pure SQL against the live `album_metadata` table — does NOT import
+ * `apps/enrichment-worker/{enrich,streaming-reask}.ts`. Same rationale as
+ * every other enrichment-worker integration spec in this directory (see
+ * `enrichment-worker-cache-precheck.spec.js` header): the integration
+ * runner is babel-jest with no TS support (drizzle-orm + ts-jest
+ * incompatibility). `findCandidateAlbumIds` mirrors
+ * `streaming-reask.ts#findUnresolvedStreamingCandidates`'s WHERE (the
+ * positive form of `precheck.ts`'s negative gate — see that spec's
+ * mirror), and `applyReaskVerdict` mirrors `enrich.ts`'s
+ * `mergeStreamingField` + `inferIncomingStreamingStatus` + the
+ * `upsertMatchedAlbumMetadata` write. When any of those TS functions are
+ * hand-edited, the mirrors here must follow.
+ *
+ * Covers the BS#1915 acceptance criteria end to end against real Postgres:
+ *   (a) an `unresolved` field self-heals to `verified` on a later re-ask
+ *   (b) an `absent` field is never selected for re-ask again (terminal)
+ *   (c) the candidate query + write loop is bounded — no unbounded re-ask
+ *   (d) a verified URL is never overwritten, even by a later flapping verdict
+ *
+ * @see WXYC/Backend-Service#1915
+ * @see WXYC/library-metadata-lookup#1053
+ * @see WXYC/Backend-Service#1747, #1089
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/** Mirrors `STREAMING_REASK_ATTEMPT_CAP` in `apps/enrichment-worker/enrich.ts`. */
+const STREAMING_REASK_ATTEMPT_CAP = 3;
+
+/**
+ * Mirrors `enrich.ts#mergeStreamingField` + `#inferIncomingStreamingStatus`.
+ * `current` is `{status, url}`; `incoming` is `{status, url}` or undefined
+ * (the service's key omitted from this round's verdict — never consulted).
+ */
+function mergeStreamingField(current, incoming) {
+  if (current.status === 'verified') return current;
+  const incomingStatus = incoming ? incoming.status || (incoming.url ? 'verified' : undefined) : undefined;
+  if (incomingStatus === undefined) return current;
+  if (incomingStatus === 'verified') return { status: 'verified', url: incoming.url ?? null };
+  if (incomingStatus === 'absent') return { status: 'absent', url: null };
+  return { status: 'unresolved', url: current.url };
+}
+
+/**
+ * Mirrors `streaming-reask.ts#findUnresolvedStreamingCandidates`'s WHERE —
+ * the positive form of `precheck.ts`'s negative gate (see
+ * `enrichment-worker-cache-precheck.spec.js`'s mirror for the same
+ * COALESCE(..., false) three-valued-logic guard, load-bearing there for the
+ * same reason here).
+ */
+async function findCandidateAlbumIds(sql, albumIds) {
+  const rows = await sql`
+    SELECT album_id
+      FROM ${sql(SCHEMA)}.album_metadata
+     WHERE album_id = ANY(${albumIds})
+       AND (artwork_url IS NOT NULL OR discogs_url IS NOT NULL)
+       AND COALESCE(
+         streaming_reask_attempts < ${STREAMING_REASK_ATTEMPT_CAP}
+         AND (
+           spotify_status = 'unresolved'
+           OR apple_music_status = 'unresolved'
+           OR bandcamp_status = 'unresolved'
+         ),
+         false
+       )
+     ORDER BY album_id
+  `;
+  return rows.map((r) => r.album_id);
+}
+
+async function readStreamingState(sql, albumId) {
+  const [row] = await sql`
+    SELECT spotify_status, spotify_url, apple_music_status, apple_music_url,
+           bandcamp_status, bandcamp_url, streaming_reask_attempts
+      FROM ${sql(SCHEMA)}.album_metadata
+     WHERE album_id = ${albumId}
+  `;
+  return row;
+}
+
+/**
+ * Mirrors `enrich.ts#upsertMatchedAlbumMetadata`'s merge + write for the
+ * three streaming fields only (the album-identity columns are out of scope
+ * for this spec — `enrichment-worker-cache-precheck.spec.js` already covers
+ * the load-bearing artwork/discogs shell distinctions). `verdict` is
+ * `{ spotify?: {status, url}, apple_music?: {status, url}, bandcamp?: {status, url} }`
+ * — an absent key means that service's key was omitted from this round's
+ * LML response (never consulted this round).
+ */
+async function applyReaskVerdict(sql, albumId, verdict) {
+  const prior = await readStreamingState(sql, albumId);
+  const spotify = mergeStreamingField({ status: prior.spotify_status, url: prior.spotify_url }, verdict.spotify);
+  const appleMusic = mergeStreamingField(
+    { status: prior.apple_music_status, url: prior.apple_music_url },
+    verdict.apple_music
+  );
+  const bandcamp = mergeStreamingField({ status: prior.bandcamp_status, url: prior.bandcamp_url }, verdict.bandcamp);
+
+  await sql`
+    UPDATE ${sql(SCHEMA)}.album_metadata
+       SET spotify_status = ${spotify.status},
+           spotify_url = ${spotify.url},
+           apple_music_status = ${appleMusic.status},
+           apple_music_url = ${appleMusic.url},
+           bandcamp_status = ${bandcamp.status},
+           bandcamp_url = ${bandcamp.url},
+           streaming_reask_attempts = streaming_reask_attempts + 1,
+           updated_at = NOW()
+     WHERE album_id = ${albumId}
+  `;
+}
+
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'bs1915-reask-test-' + suffix}, 9998, 'Chuquimamani-Condori')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+describe('enrichment-worker streaming self-heal — BS#1915 candidate query + write mirror (real PG)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('(a) SELF-HEAL: an unresolved apple_music field flips to verified on a later re-ask', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'self-heal');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/x.jpg', 'unresolved', 0, NOW())
+    `;
+
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([albumId]);
+
+    await applyReaskVerdict(sql, albumId, {
+      apple_music: { status: 'verified', url: 'https://music.apple.com/album/healed' },
+    });
+
+    const row = await readStreamingState(sql, albumId);
+    expect(row.apple_music_status).toBe('verified');
+    expect(row.apple_music_url).toBe('https://music.apple.com/album/healed');
+    expect(row.streaming_reask_attempts).toBe(1);
+
+    // Now resolved — no longer a candidate for a future re-ask.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+
+  test('(b) TERMINAL: an absent field is never selected for re-ask again', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'absent-terminal');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/x.jpg', 'absent', 0, NOW())
+    `;
+
+    // Never a candidate in the first place — 'absent' is terminal from the
+    // moment it's written, regardless of attempt count.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+
+    const row = await readStreamingState(sql, albumId);
+    expect(row.apple_music_status).toBe('absent');
+    expect(row.streaming_reask_attempts).toBe(0);
+  });
+
+  test('(c) BOUNDED: the candidate query + write loop caps at STREAMING_REASK_ATTEMPT_CAP — no unbounded re-ask', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'bounded-cap');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/x.jpg', 'unresolved', 0, NOW())
+    `;
+
+    // LML keeps returning "still can't tell" every round — the realistic
+    // case a bound has to protect against. Loop more times than the cap
+    // allows; each iteration mirrors the production flow: the sweep only
+    // re-asks a row the candidate query STILL returns.
+    let reaskCount = 0;
+    for (let i = 0; i < STREAMING_REASK_ATTEMPT_CAP + 3; i++) {
+      const candidates = await findCandidateAlbumIds(sql, [albumId]);
+      if (candidates.length === 0) break; // matches production: no candidate, no LML call
+      await applyReaskVerdict(sql, albumId, { apple_music: { status: 'unresolved', url: null } });
+      reaskCount++;
+    }
+
+    expect(reaskCount).toBe(STREAMING_REASK_ATTEMPT_CAP);
+    const row = await readStreamingState(sql, albumId);
+    expect(row.streaming_reask_attempts).toBe(STREAMING_REASK_ATTEMPT_CAP);
+    expect(row.apple_music_status).toBe('unresolved');
+    // Past the cap, the row drops out of candidacy — the frozen null is
+    // accepted rather than re-asked forever.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+
+  test('(d) NEVER OVERWRITE: a verified URL survives a later flapping verdict', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'never-overwrite');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, spotify_status, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'verified', 'https://open.spotify.com/album/PRE-EXISTING', 'unresolved', 0, NOW())
+    `;
+
+    // Still a candidate — apple_music is the pending field, even though
+    // spotify is already verified.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([albumId]);
+
+    // A flapping response: this round says spotify is 'absent' (would
+    // normally null the url out) and apple_music stays unresolved.
+    await applyReaskVerdict(sql, albumId, {
+      spotify: { status: 'absent', url: null },
+      apple_music: { status: 'unresolved', url: null },
+    });
+
+    const row = await readStreamingState(sql, albumId);
+    // The pre-existing verified URL is untouched — never downgraded.
+    expect(row.spotify_status).toBe('verified');
+    expect(row.spotify_url).toBe('https://open.spotify.com/album/PRE-EXISTING');
+  });
+
+  test('(d cont.) a never-consulted service (key omitted from the verdict) preserves prior state, never invents a verdict', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'never-consulted-preserve');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_status, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/x.jpg', 'unresolved', 'unresolved', 0, NOW())
+    `;
+
+    // This round's verdict only carries apple_music — bandcamp's key is
+    // omitted (never consulted this round).
+    await applyReaskVerdict(sql, albumId, {
+      apple_music: { status: 'verified', url: 'https://music.apple.com/album/x' },
+    });
+
+    const row = await readStreamingState(sql, albumId);
+    expect(row.apple_music_status).toBe('verified');
+    // bandcamp's prior 'unresolved' is preserved verbatim, not reset.
+    expect(row.bandcamp_status).toBe('unresolved');
+  });
+});

--- a/tests/integration/enrichment-worker-streaming-reask.spec.js
+++ b/tests/integration/enrichment-worker-streaming-reask.spec.js
@@ -43,6 +43,9 @@ function mergeStreamingField(current, incoming) {
   const incomingStatus = incoming ? incoming.status || (incoming.url ? 'verified' : undefined) : undefined;
   if (incomingStatus === undefined) return current;
   if (incomingStatus === 'verified') return { status: 'verified', url: incoming.url ?? null };
+  // Terminal `absent` is never downgraded by an `unresolved`/`absent` flap
+  // (BS#1747/#1089) — only the `verified` above may supersede it.
+  if (current.status === 'absent') return current;
   if (incomingStatus === 'absent') return { status: 'absent', url: null };
   return { status: 'unresolved', url: current.url };
 }
@@ -257,5 +260,38 @@ describe('enrichment-worker streaming self-heal — BS#1915 candidate query + wr
     expect(row.apple_music_status).toBe('verified');
     // bandcamp's prior 'unresolved' is preserved verbatim, not reset.
     expect(row.bandcamp_status).toBe('unresolved');
+  });
+
+  test('(e) TERMINAL under sibling heal: a terminal absent field is not resurrected when the row is re-merged to heal an unresolved sibling (BS#1747/#1089)', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'absent-survives-sibling-heal');
+    insertedAlbumIds.push(albumId);
+    // spotify is terminal-absent; apple_music is the pending field that keeps
+    // the row a re-ask candidate. The whole row gets re-merged for apple's
+    // sake — spotify must not ride along back into 'unresolved'.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, spotify_status, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'absent', NULL, 'unresolved', 0, NOW())
+    `;
+
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([albumId]);
+
+    // LML's fresh probe this round flaps the already-absent spotify to
+    // 'unresolved' while apple heals to verified.
+    await applyReaskVerdict(sql, albumId, {
+      spotify: { status: 'unresolved', url: null },
+      apple_music: { status: 'verified', url: 'https://music.apple.com/album/healed' },
+    });
+
+    const row = await readStreamingState(sql, albumId);
+    // The terminal absent is preserved — NOT downgraded to unresolved.
+    expect(row.spotify_status).toBe('absent');
+    expect(row.spotify_url).toBeNull();
+    expect(row.apple_music_status).toBe('verified');
+
+    // Row is fully resolved now (apple verified, spotify terminal-absent) —
+    // it drops out of candidacy rather than re-asking the resurrected spotify.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
   });
 });

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -249,6 +249,21 @@ export const album_metadata = {
   soundcloud_url: 'soundcloud_url',
   artist_bio: 'artist_bio',
   artist_wikipedia_url: 'artist_wikipedia_url',
+  discogs_artist_id: 'discogs_artist_id',
+  label: 'label',
+  full_release_date: 'full_release_date',
+  genres: 'genres',
+  styles: 'styles',
+  tracklist: 'tracklist',
+  artist_image_url: 'artist_image_url',
+  bio_tokens: 'bio_tokens',
+  // BS#1915: per-service streaming resolution status + shared re-ask
+  // attempt counter — see shared/database/src/schema.ts and
+  // apps/enrichment-worker/enrich.ts (mergeStreamingField).
+  spotify_status: 'spotify_status',
+  apple_music_status: 'apple_music_status',
+  bandcamp_status: 'bandcamp_status',
+  streaming_reask_attempts: 'streaming_reask_attempts',
   updated_at: 'updated_at',
 };
 export const artist_metadata = {

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -758,6 +758,26 @@ describe('mergeStreamingField + inferIncomingStreamingStatus (BS#1915)', () => {
       });
     });
 
+    it('never downgrades a terminal absent field — a later unresolved/absent flap is ignored (BS#1747/#1089)', () => {
+      // Reachable when the album is pulled in to heal a SIBLING unresolved
+      // field: the whole row is re-merged, and if LML's fresh probe flaps the
+      // already-absent service to 'unresolved', the field must NOT be
+      // resurrected for re-ask (that is the negative-cache amplifier
+      // BS#1747/#1089 killed).
+      const current: StreamingFieldState = { status: 'absent', url: null };
+      expect(mergeStreamingField(current, asStatus('unresolved'), null)).toEqual(current);
+      expect(mergeStreamingField(current, asStatus('absent'), null)).toEqual(current);
+      expect(mergeStreamingField(current, undefined, undefined)).toEqual(current);
+    });
+
+    it('absent → verified: a genuine resolved url supersedes a prior absent (a release that finally appeared)', () => {
+      const current: StreamingFieldState = { status: 'absent', url: null };
+      expect(mergeStreamingField(current, asStatus('verified'), 'https://example.com/new')).toEqual({
+        status: 'verified',
+        url: 'https://example.com/new',
+      });
+    });
+
     it('unresolved: transient — status flips to unresolved; url carries forward from current, never fabricated', () => {
       expect(mergeStreamingField(FRESH, asStatus('unresolved'), null)).toEqual({ status: 'unresolved', url: null });
       const current: StreamingFieldState = { status: 'unresolved', url: null };

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -16,8 +16,15 @@
 import { jest } from '@jest/globals';
 
 import { album_metadata, db, flowsheet } from '@wxyc/database';
-import type { LookupResponse } from '@wxyc/lml-client';
-import { extractArtwork, finalizeRow, synthesizeSearchUrls } from '../../../../apps/enrichment-worker/enrich';
+import type { LookupResponse, StreamingResolutionStatus } from '@wxyc/lml-client';
+import {
+  extractArtwork,
+  finalizeRow,
+  inferIncomingStreamingStatus,
+  mergeStreamingField,
+  synthesizeSearchUrls,
+  type StreamingFieldState,
+} from '../../../../apps/enrichment-worker/enrich';
 
 const mockDb = db as unknown as {
   insert: jest.Mock;
@@ -277,6 +284,11 @@ describe('finalizeRow (BS#892 PR-2)', () => {
 describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // BS#1915: the linked-match arm now reads prior per-service streaming
+    // state before merging (see `mergeStreamingField`). Default: no prior
+    // album_metadata row (a fresh album) — tests that need an existing row
+    // override with `mockDb._chain.limit.mockReturnValueOnce(...)`.
+    mockDb._chain.limit.mockReturnValue(Promise.resolve([]));
   });
 
   it('on match: UPSERTs the 10-column payload into album_metadata', async () => {
@@ -505,6 +517,252 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
 
     expect(outcome).toBe('enriched_match_raced');
     expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+  });
+});
+
+/**
+ * BS#1915 — bounded self-heal of unresolved streaming links, consuming
+ * LML#1053's per-service `verified` / `absent` / `unresolved` verdict on
+ * `DiscogsMatchResult.streaming_status`.
+ *
+ * The linked-match arm now reads the album's PRIOR persisted streaming
+ * state before writing, and merges it with the fresh LML verdict via
+ * `mergeStreamingField` — never downgrading an already-`verified` field,
+ * treating `absent` as terminal (url forced null), and leaving `unresolved`
+ * transient (retry-eligible). `streaming_reask_attempts` — the shared
+ * per-album bound, not per-service — increments ONLY on the conflict-update
+ * branch (a genuine re-ask against an existing row); a fresh album's
+ * first-ever write leaves it at the schema DEFAULT 0.
+ */
+describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-match arm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.limit.mockReturnValue(Promise.resolve([]));
+  });
+
+  it('fresh album: persists a verified/absent/unresolved per-service status alongside each url', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const response = {
+      results: [
+        {
+          artwork: {
+            artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+            release_url: 'https://discogs.com/release/123',
+            spotify_url: 'https://open.spotify.com/album/x',
+            apple_music_url: null,
+            bandcamp_url: null,
+            streaming_status: { spotify: 'verified', apple_music: 'unresolved', bandcamp: 'absent' },
+          },
+        },
+      ],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(LINKED_ROW, response);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.spotify_status).toBe('verified');
+    expect(insertPayload.spotify_url).toBe('https://open.spotify.com/album/x');
+    expect(insertPayload.apple_music_status).toBe('unresolved');
+    expect(insertPayload.apple_music_url).toBeNull();
+    expect(insertPayload.bandcamp_status).toBe('absent');
+    // Bandcamp (unlike Apple Music) keeps its pre-#1915 synthesized
+    // search-URL fallback for any non-verified status — status='absent' is
+    // tracked, but the displayed url still falls back so the UX doesn't
+    // regress. Only Apple Music has no fallback (BS#1192).
+    expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+  });
+
+  it('infers verified from a bare non-null url when streaming_status is entirely absent (pre-LML#1053 compatibility)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    // matchResponse carries real spotify_url/apple_music_url but no
+    // streaming_status object at all (an LML predating the LML#1053
+    // producer rollout, or a path that doesn't resolve one).
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.spotify_status).toBe('verified');
+    expect(insertPayload.spotify_url).toBe('https://open.spotify.com/album/x');
+    expect(insertPayload.apple_music_status).toBe('verified');
+    expect(insertPayload.apple_music_url).toBe('https://music.apple.com/album/y');
+  });
+
+  it('never overwrites a previously verified URL, even when a later re-ask flaps to unresolved or absent', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(
+      Promise.resolve([
+        {
+          spotify_status: 'verified',
+          spotify_url: 'https://open.spotify.com/album/PRIOR',
+          apple_music_status: 'verified',
+          apple_music_url: 'https://music.apple.com/album/PRIOR',
+          bandcamp_status: null,
+          bandcamp_url: null,
+        },
+      ])
+    );
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const flappyResponse = {
+      results: [
+        {
+          artwork: {
+            artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+            release_url: 'https://discogs.com/release/123',
+            spotify_url: null,
+            apple_music_url: null,
+            streaming_status: { spotify: 'unresolved', apple_music: 'absent' },
+          },
+        },
+      ],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(LINKED_ROW, flappyResponse);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(conflictCfg.set.spotify_status).toBe('verified');
+    expect(conflictCfg.set.spotify_url).toBe('https://open.spotify.com/album/PRIOR');
+    expect(conflictCfg.set.apple_music_status).toBe('verified');
+    expect(conflictCfg.set.apple_music_url).toBe('https://music.apple.com/album/PRIOR');
+  });
+
+  it('absent is terminal: url stays null and status is absent regardless of prior unresolved state', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(
+      Promise.resolve([
+        {
+          apple_music_status: 'unresolved',
+          apple_music_url: null,
+          spotify_status: null,
+          spotify_url: null,
+          bandcamp_status: null,
+          bandcamp_url: null,
+        },
+      ])
+    );
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const response = {
+      results: [
+        {
+          artwork: {
+            artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+            release_url: 'https://discogs.com/release/123',
+            apple_music_url: null,
+            streaming_status: { apple_music: 'absent' },
+          },
+        },
+      ],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(LINKED_ROW, response);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(conflictCfg.set.apple_music_status).toBe('absent');
+    expect(conflictCfg.set.apple_music_url).toBeNull();
+  });
+
+  it('bumps streaming_reask_attempts only on the conflict-update branch, never on the fresh-insert branch', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload).not.toHaveProperty('streaming_reask_attempts');
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(conflictCfg.set.streaming_reask_attempts).toBeDefined();
+  });
+
+  it('a never-consulted service (key omitted, no url) preserves whatever prior state existed — never invents a verdict', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(
+      Promise.resolve([
+        {
+          bandcamp_status: 'unresolved',
+          bandcamp_url: null,
+          spotify_status: null,
+          spotify_url: null,
+          apple_music_status: null,
+          apple_music_url: null,
+        },
+      ])
+    );
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const response = {
+      results: [
+        {
+          artwork: {
+            artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+            release_url: 'https://discogs.com/release/123',
+            spotify_url: null,
+            apple_music_url: null,
+            bandcamp_url: null,
+            // bandcamp key deliberately omitted from streaming_status —
+            // never consulted this round.
+            streaming_status: { spotify: 'unresolved' },
+          },
+        },
+      ],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(LINKED_ROW, response);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(conflictCfg.set.bandcamp_status).toBe('unresolved');
+    // The prior unresolved status is preserved (not reset to null/absent),
+    // and — same fallback rule as above — the displayed bandcamp_url stays
+    // the synthesized search URL since the status still isn't 'verified'.
+    expect(conflictCfg.set.bandcamp_url).toContain('bandcamp.com/search');
+  });
+});
+
+describe('mergeStreamingField + inferIncomingStreamingStatus (BS#1915)', () => {
+  const FRESH: StreamingFieldState = { status: null, url: null };
+
+  describe('inferIncomingStreamingStatus', () => {
+    it('trusts an explicit status over url presence', () => {
+      expect(inferIncomingStreamingStatus('unresolved', 'https://example.com/x')).toBe('unresolved');
+    });
+
+    it('infers verified from a bare non-null url when no explicit status is given', () => {
+      expect(inferIncomingStreamingStatus(undefined, 'https://example.com/x')).toBe('verified');
+    });
+
+    it('returns undefined (genuinely unknown) when there is neither an explicit status nor a url', () => {
+      expect(inferIncomingStreamingStatus(undefined, null)).toBeUndefined();
+      expect(inferIncomingStreamingStatus(undefined, undefined)).toBeUndefined();
+    });
+  });
+
+  describe('mergeStreamingField', () => {
+    const asStatus = (s: StreamingResolutionStatus) => s;
+
+    it('never-consulted this round (incomingStatus undefined) preserves the current state exactly', () => {
+      const current: StreamingFieldState = { status: 'unresolved', url: null };
+      expect(mergeStreamingField(current, undefined, undefined)).toEqual(current);
+    });
+
+    it('never overwrites an already-verified field — not with a fresh url, not with absent, not with unresolved', () => {
+      const current: StreamingFieldState = { status: 'verified', url: 'https://example.com/PRIOR' };
+      expect(mergeStreamingField(current, asStatus('verified'), 'https://example.com/NEW')).toEqual(current);
+      expect(mergeStreamingField(current, asStatus('absent'), null)).toEqual(current);
+      expect(mergeStreamingField(current, asStatus('unresolved'), null)).toEqual(current);
+    });
+
+    it('verified: adopts the incoming url and status', () => {
+      expect(mergeStreamingField(FRESH, asStatus('verified'), 'https://example.com/x')).toEqual({
+        status: 'verified',
+        url: 'https://example.com/x',
+      });
+    });
+
+    it('absent: terminal — url forced null regardless of any stray incoming url', () => {
+      expect(mergeStreamingField(FRESH, asStatus('absent'), 'https://example.com/should-be-ignored')).toEqual({
+        status: 'absent',
+        url: null,
+      });
+    });
+
+    it('unresolved: transient — status flips to unresolved; url carries forward from current, never fabricated', () => {
+      expect(mergeStreamingField(FRESH, asStatus('unresolved'), null)).toEqual({ status: 'unresolved', url: null });
+      const current: StreamingFieldState = { status: 'unresolved', url: null };
+      expect(mergeStreamingField(current, asStatus('unresolved'), null)).toEqual({ status: 'unresolved', url: null });
+    });
   });
 });
 

--- a/tests/unit/apps/enrichment-worker/streaming-reask.test.ts
+++ b/tests/unit/apps/enrichment-worker/streaming-reask.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the enrichment worker's hourly streaming self-heal sweep
+ * (BS#1915).
+ *
+ * `findUnresolvedStreamingCandidates` selects `album_metadata` rows that
+ * still carry a load-bearing Discogs match but have a streaming field stuck
+ * `unresolved` under `STREAMING_REASK_ATTEMPT_CAP`. `reaskUnresolvedStreaming`
+ * is the driver: for each candidate it re-asks LML through the SAME class-5
+ * `enrichmentBulkLookup` pipeline the live CDC path uses (already tagged
+ * `caller: 'enrichment-worker'` — the batch/low-priority lane, BS#1826), and
+ * on a fresh artwork response reuses `upsertMatchedAlbumMetadata`'s merge +
+ * UPSERT (never overwriting a verified URL, treating `absent` as terminal).
+ * A candidate whose re-ask comes back with no artwork at all still spends an
+ * attempt (`bumpStreamingReaskAttempts`) so a persistently-unmatchable album
+ * doesn't retry forever; a candidate whose LML call THROWS (transient
+ * failure/shed) spends nothing and stays eligible for the next sweep.
+ *
+ * Real-Postgres coverage of the candidate-selection WHERE and the
+ * merge/write contract (an `unresolved` field healing to `verified`,
+ * `absent` staying terminal, the attempt cap holding, a verified URL never
+ * overwritten) lives in
+ * tests/integration/enrichment-worker-streaming-reask.spec.js.
+ */
+import { jest } from '@jest/globals';
+
+jest.mock('@sentry/node', () => ({
+  startSpan: jest.fn((_opts: unknown, fn: (span: { setAttribute: jest.Mock }) => unknown) =>
+    fn({ setAttribute: jest.fn() })
+  ),
+  captureException: jest.fn(),
+}));
+
+const mockEnrichmentBulkLookup = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('../../../../apps/enrichment-worker/lookup-batcher.js', () => ({
+  enrichmentBulkLookup: mockEnrichmentBulkLookup,
+}));
+
+const mockUpsertMatchedAlbumMetadata = jest.fn<(...args: unknown[]) => Promise<void>>();
+const mockBumpStreamingReaskAttempts = jest.fn<(...args: unknown[]) => Promise<void>>();
+jest.mock('../../../../apps/enrichment-worker/enrich.js', () => {
+  const actual = jest.requireActual<typeof import('../../../../apps/enrichment-worker/enrich')>(
+    '../../../../apps/enrichment-worker/enrich'
+  );
+  return {
+    ...actual,
+    upsertMatchedAlbumMetadata: mockUpsertMatchedAlbumMetadata,
+    bumpStreamingReaskAttempts: mockBumpStreamingReaskAttempts,
+  };
+});
+
+import { db } from '@wxyc/database';
+import {
+  findUnresolvedStreamingCandidates,
+  reaskUnresolvedStreaming,
+} from '../../../../apps/enrichment-worker/streaming-reask';
+
+const mockDb = db as unknown as {
+  select: jest.Mock;
+  _chain: { from: jest.Mock; innerJoin: jest.Mock; where: jest.Mock; limit: jest.Mock };
+};
+
+const CANDIDATE = { album_id: 7, artist_name: 'Sessa', album_title: 'Pequena Vertigem de Amor' };
+
+describe('findUnresolvedStreamingCandidates (BS#1915)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries album_metadata and passes the caller limit through to .limit()', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+
+    await findUnresolvedStreamingCandidates(25);
+
+    expect(mockDb.select).toHaveBeenCalled();
+    expect(mockDb._chain.limit).toHaveBeenCalledWith(25);
+  });
+
+  it('returns the rows the query resolves', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([CANDIDATE]));
+
+    const candidates = await findUnresolvedStreamingCandidates(100);
+
+    expect(candidates).toEqual([CANDIDATE]);
+  });
+});
+
+describe('reaskUnresolvedStreaming (BS#1915)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('short-circuits with zero counts when there are no candidates — never calls LML', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+
+    const result = await reaskUnresolvedStreaming(100);
+
+    expect(mockEnrichmentBulkLookup).not.toHaveBeenCalled();
+    expect(result).toEqual({ candidates: 0, succeeded: 0, failed: 0 });
+  });
+
+  it('dispatches enrichmentBulkLookup per candidate through the shared batch-lane batcher, and upserts a fresh match', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([CANDIDATE]));
+    mockEnrichmentBulkLookup.mockResolvedValueOnce({
+      results: [
+        { artwork: { artwork_url: 'https://i.discogs.com/x.jpg', release_url: 'https://discogs.com/release/1' } },
+      ],
+    });
+
+    const result = await reaskUnresolvedStreaming(100);
+
+    expect(mockEnrichmentBulkLookup).toHaveBeenCalledWith(
+      expect.objectContaining({ artist_name: 'Sessa', album_title: 'Pequena Vertigem de Amor', track_title: null })
+    );
+    expect(mockUpsertMatchedAlbumMetadata).toHaveBeenCalledTimes(1);
+    expect(mockUpsertMatchedAlbumMetadata.mock.calls[0]?.[0]).toBe(7);
+    expect(mockBumpStreamingReaskAttempts).not.toHaveBeenCalled();
+    expect(result).toEqual({ candidates: 1, succeeded: 1, failed: 0 });
+  });
+
+  it('bumps the attempt counter (no album_metadata write) when LML answers with no artwork at all', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([CANDIDATE]));
+    mockEnrichmentBulkLookup.mockResolvedValueOnce({ results: [] });
+
+    const result = await reaskUnresolvedStreaming(100);
+
+    expect(mockBumpStreamingReaskAttempts).toHaveBeenCalledWith(7);
+    expect(mockUpsertMatchedAlbumMetadata).not.toHaveBeenCalled();
+    expect(result).toEqual({ candidates: 1, succeeded: 1, failed: 0 });
+  });
+
+  it('spends nothing when the LML call itself throws — bounded, but a transient failure never costs an attempt', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([CANDIDATE]));
+    mockEnrichmentBulkLookup.mockRejectedValueOnce(new Error('shed_limiter_saturated'));
+
+    const result = await reaskUnresolvedStreaming(100);
+
+    expect(mockBumpStreamingReaskAttempts).not.toHaveBeenCalled();
+    expect(mockUpsertMatchedAlbumMetadata).not.toHaveBeenCalled();
+    expect(result).toEqual({ candidates: 1, succeeded: 0, failed: 1 });
+  });
+
+  it('processes multiple candidates independently — one failure does not block the others', async () => {
+    const second = { album_id: 8, artist_name: 'Chuquimamani-Condori', album_title: 'Edits' };
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([CANDIDATE, second]));
+    mockEnrichmentBulkLookup.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce({
+      results: [
+        { artwork: { artwork_url: 'https://i.discogs.com/y.jpg', release_url: 'https://discogs.com/release/2' } },
+      ],
+    });
+
+    const result = await reaskUnresolvedStreaming(100);
+
+    expect(mockUpsertMatchedAlbumMetadata).toHaveBeenCalledTimes(1);
+    expect(mockUpsertMatchedAlbumMetadata.mock.calls[0]?.[0]).toBe(8);
+    expect(result).toEqual({ candidates: 2, succeeded: 1, failed: 1 });
+  });
+});

--- a/tests/utils/enrichment-precheck.js
+++ b/tests/utils/enrichment-precheck.js
@@ -1,6 +1,6 @@
 /**
  * Shared test helper for the enrichment worker's cache-first pre-check
- * (B1 / BS#1747).
+ * (B1 / BS#1747, extended by BS#1915's bounded streaming self-heal gate).
  *
  * `hasLoadBearingMetadata` is the ONE canonical mirror of the SELECT in
  * `apps/enrichment-worker/precheck.ts#hasLoadBearingAlbumMetadata`. The
@@ -11,17 +11,34 @@
  * predicate is chased through one file.
  *
  * The predicate is the load-bearing test the worker uses to decide whether to
- * skip the LML call: skip only when `artwork_url` OR `discogs_url` is
- * non-null. The four synthesized search-URL columns are deliberately NOT part
- * of the predicate — a search-URL-only shell is the BS#1089 poisoned-null
- * shape that must keep re-calling LML to self-heal.
+ * skip the LML call. Skip (return true) requires BOTH:
+ *   1. A confirmed load-bearing Discogs match — `artwork_url` OR
+ *      `discogs_url` is non-null. The four synthesized search-URL columns
+ *      are deliberately NOT part of this — a search-URL-only shell is the
+ *      BS#1089 poisoned-null shape that must keep re-calling LML to
+ *      self-heal.
+ *   2. BS#1915: no streaming field is still `unresolved` under the attempt
+ *      cap. `spotify_status` / `apple_music_status` / `bandcamp_status`
+ *      `= 'unresolved'` AND `streaming_reask_attempts < STREAMING_REASK_ATTEMPT_CAP`
+ *      on ANY of the three blocks the skip (re-ask instead), so a transient
+ *      "couldn't check" null self-heals on a later sweep instead of freezing
+ *      forever. `absent` is terminal (never re-asked — preserves the #1747
+ *      amplifier fix) and NULL (never-consulted) does not force a re-ask —
+ *      only the field's key ever being explicitly `unresolved` does.
+ *      STREAMING_REASK_ATTEMPT_CAP mirrors `apps/enrichment-worker/enrich.ts`'s
+ *      exported constant of the same name; keep the literal `3` here in
+ *      lockstep with that file.
  */
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
+/** Mirrors `STREAMING_REASK_ATTEMPT_CAP` in `apps/enrichment-worker/enrich.ts` (BS#1915). */
+const STREAMING_REASK_ATTEMPT_CAP = 3;
+
 /**
  * Return true iff the album already has a persisted load-bearing Discogs
- * match in `album_metadata` (`artwork_url` OR `discogs_url` non-null).
+ * match in `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND no
+ * streaming field is still bounded-re-ask-eligible (BS#1915).
  *
  * @param {import('postgres').Sql} sql - the shared test pool from `getTestDb()`.
  * @param {number} albumId - the `album_metadata.album_id` (== `library.id`).
@@ -34,9 +51,26 @@ async function hasLoadBearingMetadata(sql, albumId) {
       FROM ${sql(SCHEMA)}.album_metadata
      WHERE album_id = ${albumId}
        AND (artwork_url IS NOT NULL OR discogs_url IS NOT NULL)
+       -- COALESCE(..., false) is load-bearing, not decorative: SQL's
+       -- three-valued logic makes NULL = 'unresolved' evaluate to NULL
+       -- (not false), so for the common case of all three status columns
+       -- still NULL (never consulted), the un-coalesced OR/AND chain would
+       -- evaluate to NULL, NOT(NULL) is ALSO NULL, and a NULL WHERE clause
+       -- excludes the row -- silently breaking the base BS#1747 skip for
+       -- every plain load-bearing row. COALESCE pins the "nothing to
+       -- re-ask" default to an explicit false before negating.
+       AND NOT COALESCE(
+         streaming_reask_attempts < ${STREAMING_REASK_ATTEMPT_CAP}
+         AND (
+           spotify_status = 'unresolved'
+           OR apple_music_status = 'unresolved'
+           OR bandcamp_status = 'unresolved'
+         ),
+         false
+       )
      LIMIT 1
   `;
   return rows.length > 0;
 }
 
-module.exports = { hasLoadBearingMetadata };
+module.exports = { hasLoadBearingMetadata, STREAMING_REASK_ATTEMPT_CAP };


### PR DESCRIPTION
## Summary

Closes #1915.

Implements the recommended Option A from the issue: when LML's per-service status marks a streaming field `unresolved` (couldn't-check, transient), the enrichment worker bounded-re-asks LML on later sweeps — attempt cap + backoff — until the field resolves to a `verified` URL or LML flips it to `absent`. An `absent` field is terminal and is never re-asked, preserving #1747's amplifier fix and the #1089 negative-cache-poisoning discipline.

Consumes the per-service `streaming_status` (`verified` / `absent` / `unresolved`) that WXYC/library-metadata-lookup#1053 adds to `DiscogsMatchResult`, per the parent PRD WXYC/Backend-Service#1819.

### Substrate (migration 0135)

`album_metadata` gains four columns: `spotify_status` / `apple_music_status` / `bandcamp_status` (nullable text, LML#1053's vocabulary — NULL means never-consulted and must not be treated as `absent`) and a single shared `streaming_reask_attempts` counter (one LML re-ask resolves all three services at once, so the bound is per-album, not per-service).

### Logic

- `apps/enrichment-worker/enrich.ts` — `mergeStreamingField` + `inferIncomingStreamingStatus` decide, per service, whether a fresh LML verdict may overwrite persisted state: a `verified` URL is never downgraded; `absent` forces the url to null and is terminal; `unresolved` stays transient. The linked-match write path is extracted into `upsertMatchedAlbumMetadata` (shared by the live CDC finalize path and the new sweep) plus `bumpStreamingReaskAttempts` for a no-artwork re-ask. `streaming_reask_attempts` increments only on the `onConflictDoUpdate` branch, so a fresh album's first write is never counted as a re-ask.
- `apps/enrichment-worker/precheck.ts` — `hasLoadBearingAlbumMetadata` now also gates on any streaming field still `unresolved` under `STREAMING_REASK_ATTEMPT_CAP` (default 3), so a CDC replay of a played-again album re-asks too, not just the sweep.
- `apps/enrichment-worker/streaming-reask.ts` (new) — `findUnresolvedStreamingCandidates` + the hourly `reaskUnresolvedStreaming` driver, wired into `worker.ts` alongside the existing stranded-claim sweep. Re-asks dispatch through the existing `enrichmentBulkLookup` batcher, already tagged `caller: 'enrichment-worker'` — registered class 5 (batch/low-priority lane) in `shared/lml-client/src/policy.ts` per the #1819 isolation contract, so no new lane-selection logic was needed. A candidate whose LML call throws spends no attempt and stays eligible for the next tick; one that answers with no artwork still spends one so a persistently-unmatchable album isn't retried forever.
- `shared/lml-client` re-exports `StreamingResolution`/`StreamingResolutionStatus` so downstream consumers can name the verdict union directly.

Both `precheck.ts`'s gate and `streaming-reask.ts`'s candidate query build on a `COALESCE(..., false)` guard against SQL's three-valued logic — an unguarded `col = 'unresolved'` over an all-NULL row evaluates to NULL rather than false, which silently excluded ordinary load-bearing rows from the base #1747 skip during development (caught by the test suite, not shipped).

## Test plan

- [x] TDD throughout: failing tests written first for the merge rules, the precheck gate, and the sweep orchestration, confirmed red, then implemented.
- [x] Unit coverage: `mergeStreamingField`/`inferIncomingStreamingStatus` pure-logic rules; `finalizeRow`'s linked-match arm (never-overwrite-verified, absent-terminal, attempt-bump-only-on-conflict, never-consulted preserved); `streaming-reask.ts`'s dispatch/write orchestration (mocked DB + LML).
- [x] Integration coverage (real Postgres): `precheck.ts`'s gate predicate across unresolved/absent/never-consulted/mixed states and the bounded cap; the candidate-selection query + merge/write contract covering self-heal, absent-is-terminal, the bounded attempt cap, and never overwriting a verified URL.
- [x] The real TS implementations (`hasLoadBearingAlbumMetadata`, `findUnresolvedStreamingCandidates`, `upsertMatchedAlbumMetadata`) were also smoke-verified directly against live Postgres to confirm they match the integration specs' SQL mirrors byte-for-byte.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run lint:migrations`, `npm run test:unit` (5908 tests) all pass locally.
- [x] Migration 0135 applies cleanly against the local dev Postgres.

Not merging/deploying — final unit of a hand-gated ship chain; a human owns the merge/deploy.