### PR TITLE
fix(middleware): add explicit return after res.json in activeShow and showMemberMiddleware

### DIFF
--- a/apps/backend/middleware/checkActiveShow.ts
+++ b/apps/backend/middleware/checkActiveShow.ts
@@ -5,7 +5,7 @@ export const activeShow: RequestHandler = async (req, res, next) => {
   const latestShow = await getLatestShow();
   if (!latestShow || latestShow.end_time !== null) {
     res.status(400).json({ message: 'Bad Request: No active show' });
-  } else {
-    next();
+    return;
   }
+  next();
 };

--- a/apps/backend/middleware/checkShowMember.ts
+++ b/apps/backend/middleware/checkShowMember.ts
@@ -19,11 +19,11 @@ export const showMemberMiddleware: RequestHandler = async (req, res, next) => {
     const user_id = req.auth?.id || req.auth?.sub || res.locals.decodedJWT?.id || res.locals.decodedJWT?.userId;
     const dj_in_show = show_djs.some((dj) => dj.id === user_id);
 
-    if (dj_in_show) {
-      next();
-    } else {
+    if (!dj_in_show) {
       res.status(400).json({ message: 'Bad Request: DJ not a member of show' });
+      return;
     }
+    next();
   } catch (e) {
     next(e);
   }

--- a/tests/unit/middleware/checkActiveShow.test.ts
+++ b/tests/unit/middleware/checkActiveShow.test.ts
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+import type { Show } from '@wxyc/database';
+
+const mockGetLatestShow = jest.fn<() => Promise<Show | undefined>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: mockGetLatestShow,
+}));
+
+import { activeShow } from '../../../apps/backend/middleware/checkActiveShow';
+
+function createMockReqResNext() {
+  const req = {} as Request;
+
+  const statusMock = jest.fn().mockReturnThis();
+  const jsonMock = jest.fn().mockReturnThis();
+  const res = {
+    status: statusMock,
+    json: jsonMock,
+  } as unknown as Response;
+
+  const next = jest.fn() as unknown as NextFunction;
+
+  return { req, res, next, statusMock, jsonMock };
+}
+
+describe('activeShow', () => {
+  it('rejects when there is no latest show', async () => {
+    mockGetLatestShow.mockResolvedValue(undefined);
+
+    const { req, res, next, statusMock, jsonMock } = createMockReqResNext();
+
+    await activeShow(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: 'Bad Request: No active show',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the latest show has ended', async () => {
+    mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() } as Show);
+
+    const { req, res, next, statusMock } = createMockReqResNext();
+
+    await activeShow(req, res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows the request through when there is an active show', async () => {
+    mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null } as Show);
+
+    const { req, res, next, statusMock } = createMockReqResNext();
+
+    await activeShow(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(statusMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1138

## Summary

`activeShow` and `showMemberMiddleware` each rejected a request via `res.status(400).json(...)` inside an if/else, with `next()` reachable only through the else branch. That's safe today, but the shape is brittle: any future change that adds code after the if/else (a log line, an extra check) would call `next()` after the response was already sent, either crashing Express with "Cannot set headers after they are sent" or silently double-dispatching the request through the route handler.

Both middlewares now use an early-return guard: the rejection branch calls `res.status(400).json(...)` followed by an explicit `return`, and `next()` runs unconditionally afterward. No behavior change on the happy or sad path.

Also adds `tests/unit/middleware/checkActiveShow.test.ts` — no dedicated unit test existed for this middleware before this change — mirroring the mock style already used by `checkShowMember.test.ts`, covering the no-active-show, ended-show, and active-show branches.

## Test plan

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors; pre-existing `security/detect-*` warnings only, unrelated to this diff)
- `npm run format:check` — pass
- `npm run test:unit` — pass (388 suites / 5918 tests, including the new `checkActiveShow.test.ts` and existing `checkShowMember.test.ts`)