### PR TITLE
fix(flowsheet-metadata-backfill): extractArtwork walks results for compilation matches

### DIFF
--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -145,18 +145,28 @@ export const synthesizeSearchUrls = (
 };
 
 /**
- * Pick the first artwork from an LML response, or null on no-match.
+ * Pick the first present artwork from an LML response, or null on no-match.
+ *
+ * Walks `results` in order rather than reading only `results[0].artwork`
+ * (BS#961). LML's `search_type: 'direct'` shape always carries the artwork
+ * on `results[0]`, so the walk resolves on the first iteration there — but
+ * `search_type: 'compilation'` responses can return several `library_item`
+ * rows where an earlier entry's `artwork` is null and a later entry's is
+ * populated (LML's `items_with_artwork` pairs each library item with its own
+ * independently-resolved artwork, or `None`). Reading only index 0 silently
+ * dropped that artwork; walking the array covers both shapes with one code
+ * path, so no `search_type` branching is needed here.
  *
  * "No artwork" covers three LML response shapes that all mean the same
- * thing operationally: empty `results`, a `results[0]` with no `artwork`
- * field, or `artwork: null`. All three end up writing search URLs and
- * stamping the marker.
+ * thing operationally: empty `results`, every result missing an `artwork`
+ * field, or every result's `artwork` explicitly null. All three end up
+ * writing search URLs and stamping the marker.
  */
 export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
-  const first = response.results?.[0];
-  if (!first) return null;
-  if (!first.artwork) return null;
-  return first.artwork;
+  for (const result of response.results ?? []) {
+    if (result.artwork) return result.artwork;
+  }
+  return null;
 };
 
 /**

--- a/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
@@ -120,6 +120,29 @@ const noArtworkResponse: LookupResponse = {
   search_type: 'direct',
 };
 
+// BS#961: a representative `search_type: 'compilation'` response. LML matched
+// the track on a Various-Artists compilation shelf row (results[0]) — a
+// `library_item` with no attached `artwork` — and a later entry carries the
+// track's actual resolved release. Modeled on the "Chambers Brothers / People
+// Get Ready" case from the issue's impact-quantification pass.
+const compilationResponse: LookupResponse = {
+  results: [
+    { library_item: { id: 1 }, artwork: null },
+    {
+      library_item: { id: 2 },
+      artwork: {
+        release_id: 67890,
+        release_url: 'https://www.discogs.com/release/67890',
+        artwork_url: 'https://i.discogs.com/comp-art.jpg',
+        release_year: 1975,
+      },
+    },
+  ],
+  search_type: 'compilation',
+  song_not_found: false,
+  found_on_compilation: true,
+};
+
 describe('applyEnrichment', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -686,5 +709,22 @@ describe('extractArtwork', () => {
   it('returns the first result’s artwork object on success-with-match', () => {
     const got = extractArtwork(matchedResponse);
     expect(got?.release_id).toBe(12345);
+  });
+
+  // BS#961
+  it('walks past a results[0] with no artwork to a later compilation match', () => {
+    const got = extractArtwork(compilationResponse);
+    expect(got).not.toBeNull();
+    expect(got?.release_id).toBe(67890);
+  });
+
+  it('returns null when every result in a compilation response lacks artwork', () => {
+    expect(
+      extractArtwork({
+        results: [{ library_item: { id: 1 }, artwork: null }, { library_item: { id: 2 } }],
+        search_type: 'compilation',
+        found_on_compilation: true,
+      })
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`extractArtwork` in `jobs/flowsheet-metadata-backfill/enrich.ts` only ever read `results[0].artwork`. That works for LML's `search_type: 'direct'` responses, but breaks down for `search_type: 'compilation'` responses, which can return multiple `library_item` rows where an earlier entry has no attached `artwork` and a later entry does (LML resolves artwork independently per item; see `library-metadata-lookup/lookup/artwork.py`'s `fetch_artwork_for_items`, which pairs each library item with its own `DiscogsSearchResult | None`). The n=1000 impact-quantification pass from #916/#888 found 3 rows in this shape (the clearest being Chambers Brothers — "People Get Ready"), extrapolated to ~2,800 rows in the buggy-window population blocked from getting compilation artwork.

Fix: `extractArtwork` now walks `results` in order and returns the first entry whose `artwork` is present, instead of reading only index 0. This still resolves on the first iteration for the `direct` shape (artwork is always at `results[0]` there), so no `search_type` branching is needed — one code path covers both shapes.

## Sibling copies (acceptance criterion 4 audit)

Per the issue's ask, audited for the same blind spot elsewhere. It's duplicated verbatim in:

- `apps/backend/services/metadata/metadata.service.ts:70` (inline `lookupResponse.results?.[0]?.artwork`, the **runtime write path**)
- `apps/enrichment-worker/enrich.ts`
- `jobs/library-artwork-url-backfill/enrich.ts`
- `jobs/flowsheet-artwork-repair/repair.ts`
- `jobs/flowsheet-reenrichment/enrich.ts`

Per the issue's scope notes, these are intentionally left untouched here — likely absorbed by the B4 (#887) LML-client-extraction consolidation, or worth a follow-up ticket if that consolidation doesn't land soon. Noting rather than fixing in lockstep to keep this PR narrowly scoped to the backfill job named in the issue.

Closes #961

## Test plan

Ran locally (mocked DB, no Docker needed):

- `npm run test:unit` — 5917/5917 passed (42/42 in `tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts`, including 2 new cases: a compilation response where `results[0]` has no artwork but a later entry does, and a compilation response where every entry lacks artwork)
- `npm run typecheck` — clean
- `npx tsc --noEmit -p jobs/flowsheet-metadata-backfill/tsconfig.json` — clean (job-scoped, not covered by root typecheck)
- `npm run lint` — 0 errors (pre-existing warn-only findings unrelated to this change)
- `npm run format:check` — clean