### PR TITLE
docs(library): clarify caller contexts for the three library-search endpoints

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -190,6 +190,45 @@ type AlbumQueryParams = {
   on_streaming?: string;
 };
 
+/**
+ * GET /library/ — legacy-shape catalog search.
+ *
+ * Canonical caller: dj-site's "classic" experience catalog panel
+ * (`useSearchCatalogQuery`, `experiences/classic/catalog/SearchResults.tsx`)
+ * — Search-by-Artist / Search-by-Album / Search-Both modes, plus the
+ * streaming-only "Browse Exclusive Albums" view (`on_streaming` alone, no
+ * text query — see #872). Still live alongside `GET /library/query`; the
+ * modern experience's query-builder panel (`experiences/modern/catalog/`)
+ * uses `/query` instead, so the two coexist by UI generation rather than one
+ * superseding the other. `code_letters`/`code_artist_number` lookup is
+ * accepted as a query shape but not implemented (throws 501 — see
+ * `TODO: Library Code Lookup` below).
+ *
+ * Auth: `requirePermissions({ catalog: ['read'] })` — DJ role or above.
+ *
+ * Delegates to `libraryService.fuzzySearchLibrary(artist_name, album_title,
+ * n, on_streaming)`: both fields identical (dj-site's Search-Both mode)
+ * routes through the full tsvector + trigram + CTA/LML cascade
+ * (`searchLibraryBothMode`, same cascade `GET /library/search` uses); both
+ * fields set but different keeps the legacy OR-of-trigrams semantics
+ * (`artist_name % :artist OR album_title % :album`, `<->` distance order);
+ * either field alone is a single-column trigram search. Cascade fallback
+ * stages are gated by `CATALOG_TRACK_SEARCH_CTA_ENABLED` /
+ * `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED`; alias-aware trigram matching is
+ * gated by `CATALOG_SEARCH_ALIAS_ENABLED`.
+ *
+ * Artwork enrichment (`enrichWithArtwork`) runs fire-and-forget after the
+ * response is computed — a slow/rate-limited LML artwork lookup never adds
+ * to this endpoint's latency; an un-warmed album's artwork appears on the
+ * *next* search instead (BS#1828).
+ *
+ * Response shape: a bare `LibraryArtistViewResponse[]` (serialized
+ * `library_artist_view` rows, `matched_via`/`matched_via_alias` present when
+ * the row came from a fallback cascade stage) — no envelope, no pagination
+ * metadata. Contrast `GET /library/search`'s `{ success, results, total,
+ * query }` envelope and `GET /library/query`'s `{ results, total, page,
+ * totalPages }` page.
+ */
 export const searchForAlbum: RequestHandler = async (req: Request<object, object, object, AlbumQueryParams>, res) => {
   const { query } = req;
   // `on_streaming` is sufficient on its own to scope the result set (used by
@@ -970,6 +1009,46 @@ const VALID_CATALOG_ORDERS: CatalogOrder[] = ['asc', 'desc'];
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
+/**
+ * GET /library/query — query-builder catalog search (Catalog Track Search
+ * project, WXYC/projects/30).
+ *
+ * Canonical caller: dj-site's "modern" experience catalog panel
+ * (`useSearchLibraryQueryQuery` / `useSearchLibraryQueryInfiniteQuery`,
+ * `lib/features/catalog/api.ts`), gated client-side behind dj-site's
+ * `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` flag. Distinct from the
+ * legacy `GET /library/` search this coexists with — see that handler's
+ * docstring and `library.route.ts`'s header comment for how the two split
+ * by UI generation.
+ *
+ * Auth: `requirePermissions({ catalog: ['read'] })` — DJ role or above.
+ *
+ * Query semantics: `q` is parsed by `search-parser.service.ts`
+ * (`parseSearchQuery` + `CATALOG_PARSER_CONFIG`) into field-scoped
+ * conditions (`artist:`, `album:`, `label:`, bare `all`-field terms,
+ * negation, AND/OR) rather than the plain artist/title split `GET
+ * /library/` and `GET /library/search` use. Offset-paginated
+ * (`page`/`limit`, default limit 50, max 100 — see `DEFAULT_LIMIT` /
+ * `MAX_LIMIT` above); sortable by `artist` | `album` | `plays` | `date` in
+ * either `order`; filterable by `on_streaming`, `missing`,
+ * `genres`/`genre`, `formats`/`format`, and `rotation_bins`.
+ *
+ * Ranking/filter semantics live in `librarySearchService.searchLibrary`
+ * (`library-search.service.ts`): a plain-text, non-negated, ≤6-condition
+ * query of at least `MIN_CASCADE_QUERY_LENGTH` (4) characters
+ * (`passesCascadeGate`) reaches the same tsvector + trigram + CTA/LML
+ * cascade the other two endpoints use; anything else (field-scoped,
+ * negated, or too short) is a pure SQL filter/sort with no cascade.
+ * `CATALOG_TRACK_SEARCH_CTA_ENABLED` / `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED`
+ * gate the cascade's fallback stages; `CATALOG_SEARCH_ALIAS_ENABLED` gates
+ * alias-aware matching via `artist_search_alias`.
+ *
+ * Response shape: `{ results: AlbumSearchResultRow[], total, page,
+ * totalPages }` — an offset-paginated page with a richer per-row shape than
+ * `GET /library/` (adds `label`, `rotation_bin`, `plays`,
+ * `discogsUnavailable`, etc.). Contrast `GET /library/`'s bare array and
+ * `GET /library/search`'s `{ success, results, total, query }` envelope.
+ */
 export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown, LibraryQueryParams> = async (
   req,
   res

--- a/apps/backend/controllers/requestLine.controller.ts
+++ b/apps/backend/controllers/requestLine.controller.ts
@@ -190,8 +190,38 @@ export const parseMessage: RequestHandler<object, unknown, { message: string }> 
 };
 
 /**
- * Search the library.
- * GET /library/search
+ * GET /library/search — public catalog search backing the request line.
+ *
+ * Canonical caller: the request-line flow (`POST /request`), where a
+ * listener names a song and the DJ (or an automated matcher) looks up the
+ * closest catalog hit to attach to the request before submitting it. Lives
+ * in `requestLine.controller.ts` but is mounted under `/library` in
+ * `library.route.ts` — see that file's header comment for how this sits
+ * alongside `GET /library/` and `GET /library/query`. Not to be confused
+ * with `GET /proxy/library/search` (`proxy.controller.ts`), which proxies
+ * straight through to LML's own `/library/search` for dj-site's flowsheet
+ * autocomplete; this endpoint reads BS's own catalog via `searchLibrary` in
+ * `library.service.ts`.
+ *
+ * Auth: `requirePermissions({})` — any authenticated JWT, including an
+ * anonymous better-auth session. No `catalog:read`/`catalog:write` role is
+ * required, which makes this the only one of the three library-search
+ * variants a bare listener session can call.
+ *
+ * Query semantics: at least one of `artist`, `title`, or `query` is
+ * required (400 otherwise). A free-text `query` routes through
+ * `searchLibrary`'s tsvector + trigram + CTA/LML cascade
+ * (`searchLibraryBothMode`); `artist` and/or `title` alone route through the
+ * trigram-only `fuzzySearchLibrary` path. See `searchLibrary` in
+ * `library.service.ts` for the full cascade and the
+ * `CATALOG_TRACK_SEARCH_CTA_ENABLED` / `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED`
+ * / `CATALOG_SEARCH_ALIAS_ENABLED` flags that gate its fallback stages.
+ *
+ * Response shape: `{ success: true, results: EnrichedLibraryResult[], total,
+ * query: { artist, title, query, limit } }` — the only one of the three
+ * that wraps its rows in a `{ success, ... }` envelope, rather than
+ * returning a bare array (`GET /library/`) or an offset-paginated
+ * `{ results, total, page, totalPages }` object (`GET /library/query`).
  */
 export const searchLibraryEndpoint: RequestHandler<object, unknown, unknown, LibrarySearchQuery> = async (
   req,

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -8,6 +8,37 @@ import { getCatalogLastModifiedAt } from '../services/library.service.js';
 
 export const library_route = Router();
 
+// -----------------------------------------------------------------------
+// Three library-search variants (BS#980)
+// -----------------------------------------------------------------------
+//
+// This router mounts three GET endpoints that all search the catalog but
+// serve different callers with different auth, query shapes, and response
+// shapes. Read the docstring on each handler before adding a fourth or
+// changing one of these three:
+//
+//   - `GET /search` -> `requestLineController.searchLibraryEndpoint`. Public
+//     (any JWT, no `catalog:*` permission) — backs the request-line flow.
+//     Free-text `query` and/or `artist`/`title`; returns a `{ success,
+//     results, total, query }` envelope.
+//   - `GET /` -> `libraryController.searchForAlbum`. `catalog:read` —
+//     backs dj-site's "classic" experience catalog search (plus the
+//     streaming-only "Browse Exclusive Albums" view). `artist_name` /
+//     `album_title` / `on_streaming`; returns a bare result array.
+//   - `GET /query` -> `libraryController.searchLibraryQueryEndpoint`.
+//     `catalog:read` — backs dj-site's "modern" experience query-builder
+//     panel (Catalog Track Search project, WXYC/projects/30), client-gated
+//     there by `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED`. Field-scoped
+//     `q` syntax (`artist:`, `album:`, `label:`) plus sort/filter/offset
+//     pagination; returns a `{ results, total, page, totalPages }` page.
+//
+// All three ultimately share the same tsvector + trigram + CTA/LML fallback
+// cascade for plain-text queries (`searchLibraryBothMode` /
+// `library-search.service.ts`'s cascade gate) — they differ in how a caller
+// reaches that cascade and how the result is shaped on the wire, not in the
+// underlying catalog data. As of this writing all three are live production
+// surfaces for distinct callers; none is a deprecated shim.
+
 // Public library search endpoint (for request line feature)
 // Requires JWT auth but no specific role/permissions
 library_route.get('/search', requirePermissions({}), trackActivity, requestLineController.searchLibraryEndpoint);


### PR DESCRIPTION
## Summary

`apps/backend/routes/library.route.ts` mounts three overlapping library-search endpoints with no documentation of who calls each one, what auth it requires, how it ranks/filters, or what feature flags affect it. This adds a JSDoc block to each controller plus a header comment on the route file so a reader doesn't have to reverse-engineer the boundaries from three separate controllers and a search-service cascade.

- `searchLibraryEndpoint` (`GET /library/search`, `requestLine.controller.ts`) — public (any JWT, no `catalog:*` permission), backs the request-line flow. Free-text `query` and/or `artist`/`title`; returns a `{ success, results, total, query }` envelope. Documented the distinction from the separately-mounted `GET /proxy/library/search` (proxies straight to LML), since the names collide.
- `searchForAlbum` (`GET /library/`, `library.controller.ts`) — `catalog:read`, backs dj-site's "classic" experience catalog search plus the streaming-only "Browse Exclusive Albums" view. Bare result array; fire-and-forget artwork enrichment.
- `searchLibraryQueryEndpoint` (`GET /library/query`, `library.controller.ts`) — `catalog:read`, backs dj-site's "modern" experience query-builder panel (Catalog Track Search project), client-gated there by `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED`. Field-scoped `q` syntax, sort/filter/offset pagination, `{ results, total, page, totalPages }` page.

Each docstring covers caller context, auth scope, query/ranking semantics (including which reach the shared tsvector + trigram + CTA/LML fallback cascade and under what `CATALOG_TRACK_SEARCH_*` / `CATALOG_SEARCH_ALIAS_ENABLED` flags), and response shape, with cross-references to the other two so the differences read as one picture instead of three.

Verified via the checked-out dj-site tree that both `GET /library/` (`useSearchCatalogQuery`) and `GET /library/query` (`useSearchLibraryQuery`/`useSearchLibraryQueryInfiniteQuery`) are live, actively-consumed endpoints today (classic vs. modern experience) — neither is a deprecated shim, so no follow-up deprecation ticket is filed per the issue's acceptance criteria.

Pure documentation pass — no behavior, route, or type changes.

Closes #980

## Test plan

- [x] `npm run typecheck` — passes, no errors
- [x] `npm run lint` — 0 errors, 812 pre-existing warnings (unrelated to this change)
- [x] `npm run format:check` — all files formatted
- [x] `npm run test:unit` — 387 suites / 5915 tests passed
- Not run: `test:integration` / `ci:testmock` (Docker Postgres, excluded per this change being a comment-only diff with no runtime behavior to exercise)