### PR TITLE
feat(library): capture LML streaming-check errored_sources to telemetry

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -1,4 +1,5 @@
 import { Request, RequestHandler } from 'express';
+import * as Sentry from '@sentry/node';
 import {
   Album,
   Artist,
@@ -19,6 +20,7 @@ import type { CatalogSort, CatalogOrder } from '../services/library-search.servi
 import { checkStreamingAvailability, isLmlConfigured } from '@wxyc/lml-client';
 import { lmlLookupCoordinator } from '../services/lml/index.js';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
+import { getPostHogClient } from '../utils/posthog.js';
 import WxycError from '../utils/error.js';
 
 // BS#1826 PR 2: `LIBRARY_LML_BUDGET_MS` retired. Budget for the add-album
@@ -125,6 +127,42 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
       }
     } else if (streamingResult.status === 'rejected') {
       console.warn('Streaming check failed for new album:', streamingResult.reason);
+    }
+
+    // BS#1228 (LML#376 follow-up): capture which streaming services errored
+    // out so a future retry-policy decision can be data-driven. Pure
+    // observability — never persisted to `library.*`, independent of the
+    // on_streaming verdict above (a service can error while others still
+    // resolve a match). Each emit is its own try/catch so a PostHog outage
+    // can't suppress the Sentry span projection or vice versa.
+    if (streamingResult.status === 'fulfilled' && streamingResult.value.errored_sources?.length) {
+      try {
+        getPostHogClient().capture({
+          distinctId: String(inserted_album.id),
+          event: 'streaming_check_partial_error',
+          properties: {
+            album_id: inserted_album.id,
+            artist: artistName,
+            title: body.album_title,
+            on_streaming_verdict: streamingResult.value.on_streaming,
+            errored_sources: streamingResult.value.errored_sources,
+          },
+        });
+      } catch (e) {
+        console.warn('Failed to emit streaming-check telemetry:', (e as Error).message);
+      }
+
+      try {
+        // `on_streaming` is `boolean | null`; Sentry's SpanAttributeValue has
+        // no `null` member, so a null verdict (LML's "inconclusive" case)
+        // omits the attribute entirely rather than coercing it to a string.
+        Sentry.getActiveSpan()?.setAttributes({
+          'streaming_check.errored_sources': streamingResult.value.errored_sources,
+          'streaming_check.on_streaming': streamingResult.value.on_streaming ?? undefined,
+        });
+      } catch (e) {
+        console.warn('Failed to project streaming-check telemetry onto span:', (e as Error).message);
+      }
     }
 
     if (artworkResult.status === 'rejected') {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -130,6 +130,23 @@ jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
   },
 }));
 
+// BS#1228: streaming-check partial-error telemetry (PostHog capture + Sentry
+// span projection). Mirrors the `getPostHogClient` mock shape in
+// tests/unit/middleware/legacy/mirror.posthog.test.ts and the
+// `Sentry.getActiveSpan()?.setAttributes(...)` span mock shape in
+// tests/unit/services/library-search.cascade-span.test.ts.
+const mockPostHogCapture = jest.fn();
+const mockGetPostHogClient = jest.fn(() => ({ capture: mockPostHogCapture }));
+jest.mock('../../../apps/backend/utils/posthog', () => ({
+  getPostHogClient: mockGetPostHogClient,
+}));
+
+type SpanLike = { setAttributes: jest.Mock };
+const mockSpan: SpanLike = { setAttributes: jest.fn() };
+jest.mock('@sentry/node', () => ({
+  getActiveSpan: () => mockSpan,
+}));
+
 import {
   markMissing,
   markFound,
@@ -550,6 +567,113 @@ describe('library.controller', () => {
           undefined,
           expect.objectContaining({ caller: 'library-add-album', discogsUnavailable: true })
         );
+      });
+    });
+
+    // BS#1228 (LML#376 follow-up): `errored_sources` is thrown on the floor
+    // today — capture it to PostHog + a Sentry span attribute so a future
+    // retry-policy decision can be made from real production patterns.
+    describe('streaming-check partial-error telemetry (BS#1228)', () => {
+      const req = () =>
+        ({
+          body: {
+            album_title: 'DOGA',
+            artist_id: 42,
+            artist_name: 'Juana Molina',
+            label: 'Sonamos',
+            genre_id: 11,
+            format_id: 1,
+          },
+        }) as unknown as Request;
+
+      beforeEach(() => {
+        mockGetArtistNameById.mockResolvedValue('Juana Molina');
+        mockInsertAlbum.mockImplementation((album) => Promise.resolve({ id: 501, ...album }));
+        // Some cases below exercise a non-null on_streaming verdict, which
+        // re-persists via updateOnStreaming and reassigns `inserted_album` in
+        // the controller — give it a resolved value so that reassignment
+        // doesn't collapse to undefined (this mock has no default elsewhere).
+        mockUpdateOnStreaming.mockResolvedValue({ id: 501 });
+        mockIsLmlConfigured.mockReturnValue(true);
+        mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
+        mockMapLookupToCanonicalEntity.mockReturnValue(null);
+      });
+
+      it('emits a streaming_check_partial_error PostHog event when LML reports errored_sources', async () => {
+        mockCheckStreamingAvailability.mockResolvedValue({
+          on_streaming: null,
+          errored_sources: ['spotify', 'apple_music'],
+        });
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockPostHogCapture).toHaveBeenCalledTimes(1);
+        expect(mockPostHogCapture).toHaveBeenCalledWith({
+          distinctId: '501',
+          event: 'streaming_check_partial_error',
+          properties: {
+            album_id: 501,
+            artist: 'Juana Molina',
+            title: 'DOGA',
+            on_streaming_verdict: null,
+            errored_sources: ['spotify', 'apple_music'],
+          },
+        });
+      });
+
+      it('projects streaming_check.errored_sources and streaming_check.on_streaming onto the active Sentry span', async () => {
+        mockCheckStreamingAvailability.mockResolvedValue({
+          on_streaming: false,
+          errored_sources: ['bandcamp'],
+        });
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+          'streaming_check.errored_sources': ['bandcamp'],
+          'streaming_check.on_streaming': false,
+        });
+      });
+
+      it('does not emit telemetry when errored_sources is an empty array', async () => {
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: true, errored_sources: [] });
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockPostHogCapture).not.toHaveBeenCalled();
+        expect(mockSpan.setAttributes).not.toHaveBeenCalled();
+      });
+
+      it('does not emit telemetry when errored_sources is absent (pre-1.8.0 shape / defensive optional chaining)', async () => {
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: true });
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(mockPostHogCapture).not.toHaveBeenCalled();
+        expect(mockSpan.setAttributes).not.toHaveBeenCalled();
+      });
+
+      it('swallows a PostHog capture failure and degrades to console.warn instead of bubbling up', async () => {
+        mockCheckStreamingAvailability.mockResolvedValue({
+          on_streaming: null,
+          errored_sources: ['spotify'],
+        });
+        mockPostHogCapture.mockImplementationOnce(() => {
+          throw new Error('posthog unreachable');
+        });
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(consoleWarnSpy).toHaveBeenCalledWith('Failed to emit streaming-check telemetry:', 'posthog unreachable');
+
+        consoleWarnSpy.mockRestore();
       });
     });
   });


### PR DESCRIPTION
Closes #1228

## Summary

`addAlbum` currently throws `StreamingCheckResponse.errored_sources` on the floor: when LML's streaming check returns a `null`/inconclusive `on_streaming` verdict (or any verdict alongside a partial failure), we have no signal on *which* services (Spotify, Apple Music, Bandcamp, Deezer) errored out, how often, or whether failures cluster around an outage window. This PR adds pure observability capture, per the issue's desired end state:

- When `streamingResult.value.errored_sources?.length > 0`, emit a PostHog `streaming_check_partial_error` event with `{album_id, artist, title, on_streaming_verdict, errored_sources}` via the existing process-wide `getPostHogClient()` singleton (`apps/backend/utils/posthog.ts`).
- The same condition projects `streaming_check.errored_sources` and `streaming_check.on_streaming` onto the active Sentry span (`Sentry.getActiveSpan()?.setAttributes(...)`), mirroring the existing pattern at `library.service.ts`'s `searchLibraryByTrackUncachedOrThrow`.
- Both emits are independently wrapped in try/catch and degrade to `console.warn` on failure — a PostHog outage can't suppress the Sentry projection or vice versa, and neither can ever fail the `addAlbum` request.
- `on_streaming` is `boolean | null`; since Sentry's `SpanAttributeValue` has no `null` member, a null verdict omits the span attribute (`?? undefined`) rather than coercing it to a string.

## Out of scope (by design, per the issue's constraints)

- No retry logic — this ticket is data-capture only; the retry-policy decision is a deliberate follow-up once there's a few weeks of production data.
- No schema migration, no persistence of `errored_sources` to `library.*`.
- `enrichAlbumAfterIdentityChange` (the structurally-identical streaming-check block on the `updateAlbum` identity-change path) is intentionally left untouched — the issue scopes this to `addAlbum` only.

## Test plan

All run locally against this branch:

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors; pre-existing warn-only findings elsewhere in the repo, none touch the changed files' new code)
- `npm run format:check` — pass
- `npm run test:unit` — pass (387 suites / 5920 tests, including 5 new cases in `tests/unit/controllers/library.controller.test.ts` covering: PostHog event shape, Sentry span attribute projection, no-emit when `errored_sources` is empty/absent, and try/catch swallow-on-failure)

Not run (per project convention — needs Docker Postgres, excluded from parallel-worktree agent runs): `test:integration`, `ci:testmock`. This change has no integration-test surface (no schema/migration, no DB interaction beyond the pre-existing `addAlbum` path already covered by unit mocks).