### PR TITLE
feat(healthcheck): surface classified DB failure cause from /healthcheck probe

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -38,14 +38,14 @@ import { startSseMetrics, stopSseMetrics } from './services/sse/sse-metrics.js';
 import { serverEventsMgr } from './utils/serverEvents.js';
 import { startRotationTracksCacheWarm } from './services/rotation-tracks-cache-warm.service.js';
 import { drainInFlightEnrichments } from './services/metadata/enrichment.service.js';
+import { checkDatabase } from './services/health/database-check.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
 import { shouldCaptureExpressError } from './middleware/sentryErrorFilter.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { responseMetricsMiddleware } from './middleware/responseMetrics.js';
 import { requirePermissions, resolveCorsOrigin } from '@wxyc/authentication';
-import { closeDatabaseConnection, db } from '@wxyc/database';
-import { sql } from 'drizzle-orm';
+import { closeDatabaseConnection } from '@wxyc/database';
 import type { HealthCheckResponse } from '@wxyc/shared/dtos';
 
 const port = process.env.PORT || 8080;
@@ -133,15 +133,31 @@ app.get('/testAuth', requirePermissions({ flowsheet: ['read'] }), async (req, re
 // WXYC service exposes the same status enum + per-dependency `services`
 // map. wxyc-canary checks `r.ok` only, so the body change is non-breaking
 // for the alarm. See WXYC/Backend-Service#804.
+//
+// The DB probe itself is classified by `checkDatabase()` (BS#662, epic
+// #665): a bare `catch {}` around `SELECT 1` used to collapse every
+// failure — auth, timeout, connection refused — into the same hardcoded
+// "unavailable" string, so an operator reading the response body couldn't
+// tell why it was failing without pulling logs. `services.database` now
+// carries the classified vocabulary (`auth-error | rate-limited |
+// upstream-error | network-error | error`), mirroring LML's `/health`
+// `discogs_api` probe (WXYC/library-metadata-lookup#226) so dashboards and
+// smoke tests can pattern-match across both endpoints, plus a top-level
+// `cause` with the underlying message. Status codes are unchanged (200/503).
 app.get('/healthcheck', async (req, res) => {
-  try {
-    await db.execute(sql`SELECT 1`);
+  const result = await checkDatabase();
+  if (result.status === 'ok') {
     const body: HealthCheckResponse = { status: 'healthy', services: { database: 'ok' } };
     res.json(body);
-  } catch {
-    const body: HealthCheckResponse = { status: 'unhealthy', services: { database: 'unavailable' } };
-    res.status(503).json(body);
+    return;
   }
+  console.error(`[HEALTHCHECK] database check failed (${result.status}): ${result.cause}`);
+  const body: HealthCheckResponse = {
+    status: 'unhealthy',
+    services: { database: result.status },
+    cause: result.cause,
+  };
+  res.status(503).json(body);
 });
 
 // SNS subscriber for SES Configuration Set events (`ses-delivery-events-prod`

--- a/apps/backend/services/health/database-check.ts
+++ b/apps/backend/services/health/database-check.ts
@@ -1,0 +1,138 @@
+/**
+ * DB failure classification for the `/healthcheck` probe (BS#662, epic #665).
+ *
+ * `db.execute(sql`SELECT 1`)` fails through drizzle-orm's postgres-js
+ * session (`drizzle-orm/pg-core/session.js`), which wraps every driver
+ * error in a `DrizzleQueryError` whose `.cause` is the original error:
+ *   - a `PostgresError` (the `postgres` package) for anything the server
+ *     itself rejected — postgres-js parses the wire `ErrorResponse`'s `C`
+ *     field straight onto `.code`, so `.code` is the raw Postgres SQLSTATE
+ *     (see `postgres/src/connection.js`'s `errorFields` / `parseError`).
+ *   - a raw Node socket error (`ECONNREFUSED`, `ENOTFOUND`, `EHOSTUNREACH`,
+ *     `ECONNRESET`, `ETIMEDOUT`) or one of postgres-js's own
+ *     `Errors.connection(...)` codes (`CONNECT_TIMEOUT`, `CONNECTION_CLOSED`,
+ *     `CONNECTION_DESTROYED`, `CONNECTION_ENDED`) for anything that failed
+ *     before, or without, a Postgres wire response.
+ *
+ * Classification checks both `error.cause.code` and `error.code` — the same
+ * dual-path idiom as `extractSqlState` in
+ * `jobs/flowsheet-metadata-backfill/orchestrate.ts` and
+ * `apps/backend/routes/internal-bans.route.ts` — so a test that throws a
+ * bare `{code}` error and a prod run that throws the real
+ * `DrizzleQueryError` wrapper both classify identically. The reported
+ * `cause` string prefers `error.cause.message` for the same reason: the
+ * wrapper's own message is just `"Failed query: ..."`, not the useful part.
+ *
+ * Vocabulary mirrors LML's `/health` `discogs_api` probe
+ * (WXYC/library-metadata-lookup#226) per Epic #665 §Ordering, so operators
+ * can pattern-match `services.database` against `services.discogs_api`
+ * across both endpoints: `auth-error | rate-limited | upstream-error |
+ * network-error | error`. Postgres has no probe-timeout bucket distinct
+ * from "couldn't get a response" the way LML's httpx client does, so a
+ * canceled statement (SQLSTATE 57014 — includes `statement_timeout`
+ * cancels, see `shared/database/src/client.ts`'s `DB_STATEMENT_TIMEOUT_MS`)
+ * is grouped under `network-error`, mirroring LML's own "connection /
+ * timeout" grouping for `NETWORK_ERROR`.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+export type DbCheckStatus = 'auth-error' | 'rate-limited' | 'upstream-error' | 'network-error' | 'error';
+
+export type DbCheckResult = { status: 'ok' } | { status: DbCheckStatus; cause: string };
+
+// SQLSTATE class 28 — Invalid Authorization Specification (bad password,
+// unknown role, rejected by pg_hba.conf).
+const AUTH_ERROR_CODES = new Set(['28000', '28P01']);
+
+// SQLSTATE class 53 — Insufficient Resources. The DB is refusing more work
+// (too many connections, out of memory/disk) — the closest Postgres analog
+// to an HTTP 429.
+const RATE_LIMITED_CODES = new Set(['53000', '53100', '53200', '53300', '53400']);
+
+// SQLSTATE class 57 — Operator Intervention. The server itself is shutting
+// down, crashed, or not accepting connections yet — the closest Postgres
+// analog to an HTTP 5xx from an upstream.
+const UPSTREAM_ERROR_CODES = new Set(['57000', '57P01', '57P02', '57P03', '57P04']);
+
+// SQLSTATE class 08 — Connection Exception. The wire connection itself
+// failed, whether or not it round-tripped the server first.
+const CONNECTION_EXCEPTION_CODES = new Set(['08000', '08001', '08003', '08004', '08006', '08P01']);
+
+// SQLSTATE 57014 — query_canceled, which covers `statement_timeout` cancels.
+const STATEMENT_TIMEOUT_CODE = '57014';
+
+// Raw Node socket error codes surfaced before any Postgres wire handshake.
+const NETWORK_ERROR_NODE_CODES = new Set(['ECONNREFUSED', 'ENOTFOUND', 'EHOSTUNREACH', 'ECONNRESET', 'ETIMEDOUT']);
+
+// postgres-js's own `Errors.connection(...)` codes (see
+// `postgres/src/errors.js` + its call sites in `postgres/src/connection.js`
+// and `postgres/src/index.js`).
+const NETWORK_ERROR_DRIVER_CODES = new Set([
+  'CONNECT_TIMEOUT',
+  'CONNECTION_CLOSED',
+  'CONNECTION_DESTROYED',
+  'CONNECTION_ENDED',
+]);
+
+/**
+ * Extract the SQLSTATE / driver error code, preferring the wrapped
+ * `DrizzleQueryError.cause` shape and falling back to a bare `error.code` —
+ * see the module doc comment.
+ */
+const extractErrorCode = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const cause = (error as { cause?: unknown }).cause;
+  const causeCode = typeof cause === 'object' && cause !== null ? (cause as { code?: unknown }).code : undefined;
+  const code = causeCode ?? (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+};
+
+/**
+ * Extract a human-readable message, preferring the wrapped
+ * `DrizzleQueryError.cause`'s message (the underlying driver/server error)
+ * over the wrapper's own generic `"Failed query: ..."` message.
+ */
+const extractErrorMessage = (error: unknown): string => {
+  if (typeof error === 'object' && error !== null) {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause instanceof Error) return cause.message;
+    if (typeof cause === 'object' && cause !== null && typeof (cause as { message?: unknown }).message === 'string') {
+      return (cause as { message: string }).message;
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+/** Classify a `db.execute` failure into the shared cross-service health-check vocabulary. */
+export const classifyDatabaseError = (error: unknown): DbCheckResult => {
+  const code = extractErrorCode(error);
+  const cause = extractErrorMessage(error);
+
+  if (code) {
+    if (AUTH_ERROR_CODES.has(code)) return { status: 'auth-error', cause };
+    if (RATE_LIMITED_CODES.has(code)) return { status: 'rate-limited', cause };
+    if (UPSTREAM_ERROR_CODES.has(code)) return { status: 'upstream-error', cause };
+    if (
+      code === STATEMENT_TIMEOUT_CODE ||
+      CONNECTION_EXCEPTION_CODES.has(code) ||
+      NETWORK_ERROR_NODE_CODES.has(code) ||
+      NETWORK_ERROR_DRIVER_CODES.has(code)
+    ) {
+      return { status: 'network-error', cause };
+    }
+  }
+
+  return { status: 'error', cause };
+};
+
+/** Probe the database with `SELECT 1`, classifying any failure. */
+export const checkDatabase = async (): Promise<DbCheckResult> => {
+  try {
+    await db.execute(sql`SELECT 1`);
+    return { status: 'ok' };
+  } catch (error) {
+    return classifyDatabaseError(error);
+  }
+};

--- a/tests/unit/config/healthcheck-shape.test.ts
+++ b/tests/unit/config/healthcheck-shape.test.ts
@@ -15,6 +15,15 @@
  * exercises the live request/response path.
  *
  * Background: WXYC/Backend-Service#804, WXYC/wxyc-shared#108.
+ *
+ * BS#662 / epic #665: the backend failure branch no longer hardcodes
+ * `database: 'unavailable'` — `checkDatabase()` (see
+ * `apps/backend/services/health/database-check.ts`, unit-tested directly in
+ * `tests/unit/services/health/database-check.test.ts`) classifies the actual
+ * DB failure into `auth-error | rate-limited | upstream-error |
+ * network-error | error`, mirroring LML's `/health` `discogs_api` probe
+ * vocabulary, and the response gains a top-level `cause` string. Status
+ * codes (200/503) are unchanged.
  */
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -38,9 +47,20 @@ describe('/healthcheck response shape (HealthCheckResponse from @wxyc/shared)', 
       expect(backendAppSource).toMatch(/database\s*:\s*['"]ok['"]/);
     });
 
-    it('failure body uses status: "unhealthy" with services.database: "unavailable" and 503 status', () => {
+    it('delegates the DB probe to checkDatabase() from the health-check module (BS#662)', () => {
+      expect(backendAppSource).toMatch(
+        /import\s+\{\s*checkDatabase\s*\}\s+from\s+['"]\.\/services\/health\/database-check\.js['"]/
+      );
+      expect(backendAppSource).toMatch(/checkDatabase\s*\(\s*\)/);
+    });
+
+    it('failure body uses status: "unhealthy" with a classified services.database + cause, and 503 status', () => {
       expect(backendAppSource).toMatch(/status\s*:\s*['"]unhealthy['"]/);
-      expect(backendAppSource).toMatch(/database\s*:\s*['"]unavailable['"]/);
+      // services.database now carries the classified result (BS#662), not a
+      // hardcoded 'unavailable' literal.
+      expect(backendAppSource).toMatch(/database\s*:\s*result\.status/);
+      expect(backendAppSource).toMatch(/cause\s*:\s*result\.cause/);
+      expect(backendAppSource).not.toMatch(/database\s*:\s*['"]unavailable['"]/);
       // The catch branch must still set 503 (canary alarm depends on it).
       expect(backendAppSource).toMatch(/\.status\(\s*503\s*\)/);
     });

--- a/tests/unit/services/health/database-check.test.ts
+++ b/tests/unit/services/health/database-check.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the `/healthcheck` DB failure classifier (BS#662).
+ *
+ * `classifyDatabaseError` is pure and covers every branch directly.
+ * `checkDatabase` is covered through the mocked `db.execute` (moduleNameMapper
+ * routes `@wxyc/database` to `tests/mocks/database.mock.ts` for the unit
+ * suite — see `jest.unit.config.ts`).
+ *
+ * Test doubles mirror the dual shape a real failure can take — see
+ * `jobs/flowsheet-metadata-backfill/orchestrate.test.ts`'s `withCode` /
+ * `withCauseCode` precedent:
+ *   - `withCauseCode(code)` — the real `DrizzleQueryError` wrapper shape,
+ *     `error.cause.code` (drizzle-orm/pg-core/session.js wraps every driver
+ *     error this way).
+ *   - `withCode(code)` — a bare `error.code`, for callers/tests that throw
+ *     the unwrapped driver error directly.
+ */
+import { db } from '../../../mocks/database.mock';
+import { classifyDatabaseError, checkDatabase } from '../../../../apps/backend/services/health/database-check';
+
+const withCauseCode = (code: string, message = 'drizzle wrapper'): Error =>
+  Object.assign(new Error('Failed query: SELECT 1'), { cause: Object.assign(new Error(message), { code }) });
+const withCode = (code: string, message = 'db error'): Error => Object.assign(new Error(message), { code });
+
+describe('classifyDatabaseError', () => {
+  it('classifies SQLSTATE 28P01/28000 (invalid password / auth spec) as auth-error', () => {
+    expect(classifyDatabaseError(withCauseCode('28P01', 'password authentication failed for user "wxyc"'))).toEqual({
+      status: 'auth-error',
+      cause: 'password authentication failed for user "wxyc"',
+    });
+    expect(classifyDatabaseError(withCauseCode('28000', 'role "wxyc" does not exist'))).toEqual({
+      status: 'auth-error',
+      cause: 'role "wxyc" does not exist',
+    });
+  });
+
+  it('classifies SQLSTATE class 53 (insufficient resources) as rate-limited', () => {
+    expect(classifyDatabaseError(withCauseCode('53300', 'sorry, too many clients already'))).toEqual({
+      status: 'rate-limited',
+      cause: 'sorry, too many clients already',
+    });
+    expect(classifyDatabaseError(withCauseCode('53400'))).toEqual({ status: 'rate-limited', cause: 'drizzle wrapper' });
+  });
+
+  it('classifies SQLSTATE class 57 (operator intervention) as upstream-error', () => {
+    expect(
+      classifyDatabaseError(withCauseCode('57P01', 'terminating connection due to administrator command'))
+    ).toEqual({ status: 'upstream-error', cause: 'terminating connection due to administrator command' });
+    expect(classifyDatabaseError(withCauseCode('57P03', 'the database system is starting up'))).toEqual({
+      status: 'upstream-error',
+      cause: 'the database system is starting up',
+    });
+  });
+
+  it('classifies SQLSTATE 57014 (statement timeout / query_canceled) as network-error', () => {
+    expect(classifyDatabaseError(withCauseCode('57014', 'canceling statement due to statement timeout'))).toEqual({
+      status: 'network-error',
+      cause: 'canceling statement due to statement timeout',
+    });
+  });
+
+  it('classifies SQLSTATE class 08 (connection exception) as network-error', () => {
+    expect(classifyDatabaseError(withCauseCode('08006', 'connection to server was lost'))).toEqual({
+      status: 'network-error',
+      cause: 'connection to server was lost',
+    });
+  });
+
+  it('classifies raw Node socket error codes as network-error', () => {
+    expect(classifyDatabaseError(withCauseCode('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:5432'))).toEqual({
+      status: 'network-error',
+      cause: 'connect ECONNREFUSED 127.0.0.1:5432',
+    });
+    expect(classifyDatabaseError(withCauseCode('ENOTFOUND', 'getaddrinfo ENOTFOUND db.internal'))).toEqual({
+      status: 'network-error',
+      cause: 'getaddrinfo ENOTFOUND db.internal',
+    });
+    expect(classifyDatabaseError(withCauseCode('EHOSTUNREACH'))).toEqual({
+      status: 'network-error',
+      cause: 'drizzle wrapper',
+    });
+  });
+
+  it("classifies postgres-js's own connection-error codes as network-error", () => {
+    expect(classifyDatabaseError(withCauseCode('CONNECT_TIMEOUT'))).toEqual({
+      status: 'network-error',
+      cause: 'drizzle wrapper',
+    });
+    expect(classifyDatabaseError(withCauseCode('CONNECTION_CLOSED'))).toEqual({
+      status: 'network-error',
+      cause: 'drizzle wrapper',
+    });
+  });
+
+  it('falls back to generic error for an unrecognized or missing SQLSTATE', () => {
+    expect(classifyDatabaseError(withCauseCode('42501', 'permission denied for table flowsheet'))).toEqual({
+      status: 'error',
+      cause: 'permission denied for table flowsheet',
+    });
+    expect(classifyDatabaseError(new Error('something unexpected'))).toEqual({
+      status: 'error',
+      cause: 'something unexpected',
+    });
+    expect(classifyDatabaseError('just a string')).toEqual({ status: 'error', cause: 'just a string' });
+    expect(classifyDatabaseError(null)).toEqual({ status: 'error', cause: 'null' });
+  });
+
+  it('reads the code off error.code when there is no cause (bare error shape)', () => {
+    expect(classifyDatabaseError(withCode('28P01', 'password authentication failed'))).toEqual({
+      status: 'auth-error',
+      cause: 'password authentication failed',
+    });
+  });
+
+  it('prefers cause.code over a top-level code (drizzle wrapper shape)', () => {
+    const wrapped = Object.assign(new Error('wrapper'), {
+      code: 'ECONNREFUSED',
+      cause: { code: '28P01', message: 'password authentication failed' },
+    });
+    expect(classifyDatabaseError(wrapped)).toEqual({ status: 'auth-error', cause: 'password authentication failed' });
+  });
+
+  it("prefers the wrapped cause's message over the DrizzleQueryError wrapper's own 'Failed query: ...' message", () => {
+    const wrapped = withCauseCode('57P01', 'terminating connection due to administrator command');
+    expect(wrapped.message).toBe('Failed query: SELECT 1');
+    expect(classifyDatabaseError(wrapped).cause).toBe('terminating connection due to administrator command');
+  });
+});
+
+describe('checkDatabase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns { status: "ok" } when db.execute resolves', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([{ '?column?': 1 }]);
+    await expect(checkDatabase()).resolves.toEqual({ status: 'ok' });
+  });
+
+  it('returns the classified failure when db.execute rejects', async () => {
+    (db.execute as jest.Mock).mockRejectedValue(withCauseCode('28P01', 'password authentication failed'));
+    await expect(checkDatabase()).resolves.toEqual({
+      status: 'auth-error',
+      cause: 'password authentication failed',
+    });
+  });
+
+  it('classifies a connection-refused failure as network-error', async () => {
+    (db.execute as jest.Mock).mockRejectedValue(withCauseCode('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:5432'));
+    await expect(checkDatabase()).resolves.toEqual({
+      status: 'network-error',
+      cause: 'connect ECONNREFUSED 127.0.0.1:5432',
+    });
+  });
+});


### PR DESCRIPTION
Closes #662

## Summary

`GET /healthcheck` previously wrapped its `SELECT 1` probe in a bare `catch {}` and collapsed every DB failure — auth error, statement timeout, connection refused, permission denied — into the same hardcoded `services.database: 'unavailable'` string, so an operator reading the response body couldn't tell why it was failing without pulling application logs.

This adds `checkDatabase()` (`apps/backend/services/health/database-check.ts`), which classifies the error caught from `db.execute(sql\`SELECT 1\`)` by its SQLSTATE / driver error code — checking both the wrapped `DrizzleQueryError.cause.code` shape and a bare `error.code`, the same dual-path idiom already used in `apps/backend/routes/internal-bans.route.ts` and `jobs/flowsheet-metadata-backfill/orchestrate.ts` — into one of:

- `auth-error` — SQLSTATE class 28 (invalid password / role)
- `rate-limited` — SQLSTATE class 53 (insufficient resources — too many connections, out of memory/disk)
- `upstream-error` — SQLSTATE class 57 (operator intervention — admin shutdown, database starting up)
- `network-error` — SQLSTATE class 08 (connection exception), SQLSTATE 57014 (statement timeout / query_canceled), raw Node socket errors (`ECONNREFUSED`, `ENOTFOUND`, etc.), and postgres-js's own connection-error codes
- `error` — anything else

This vocabulary mirrors LML's `/health` `discogs_api` probe (WXYC/library-metadata-lookup#226) per the parent epic's (#665) ordering rationale, so operators can pattern-match `services.database` against `services.discogs_api` across both endpoints.

`/healthcheck` now surfaces the classified value in `services.database` plus a new top-level `cause` string with the underlying message. Status codes are unchanged (200 healthy / 503 unhealthy) — `HealthCheckResponse`'s `services` map has a loose `[key: string]: unknown` index signature (not the stricter `ReadinessResponse` `ok|unavailable|timeout` union), so this doesn't require a `@wxyc/shared` schema change.

## Scope notes

- Single-dependency probe only, per the issue's explicit out-of-scope note — no new dependencies (auth, LML, SES) added to the probe.
- No schema/migration change.
- `apps/auth/app.ts`'s healthcheck is untouched (separate probe, not in scope).

## Test plan

Ran locally (all green):
- `npm run typecheck`
- `npm run lint` (0 errors; pre-existing warnings only, none in touched files)
- `npm run format:check`
- `npm run test:unit` (388 suites / 5930 tests, including 25 new/updated tests: `tests/unit/services/health/database-check.test.ts` covers every classification branch — both the wrapped `DrizzleQueryError.cause.code` shape and the bare `error.code` shape — plus `checkDatabase()` end-to-end via a mocked `db.execute`; `tests/unit/config/healthcheck-shape.test.ts` updated to pin the new response shape instead of the retired `'unavailable'` literal)

Not run (per task instructions — needs Docker Postgres, can't run in a parallel worktree): `npm run test:integration`, `npm run ci:testmock`. This PR doesn't touch any integration spec.