### PR TITLE
refactor(catalog-popularity-freetext-resolve): extract enumerate query into @wxyc/database

### DIFF
--- a/jobs/catalog-popularity-freetext-resolve/job.ts
+++ b/jobs/catalog-popularity-freetext-resolve/job.ts
@@ -41,6 +41,8 @@ import {
   requireNonNegativeInt,
   requirePositiveInt,
   freetextPairKey,
+  enumerateFreetextPairs,
+  type RawPair,
 } from '@wxyc/database';
 import { bulkLookupMetadata, type BulkLookupItem, type BulkLookupResponse } from '@wxyc/lml-client';
 import * as Sentry from '@sentry/node';
@@ -133,16 +135,15 @@ export const STOP_BY_UTC_DEFAULT = '11:00';
 
 // -- Source query ------------------------------------------------------------
 
-/** A raw free-text pair as the DJ typed it, with a representative track title.
- * `song` is trimmed at the enumerate boundary (empty string when no usable
- * track exists for the pair) — it is the single place the "usable track?" rule
- * is applied, so every downstream consumer can treat a truthy `song` as ready
- * to send. */
-export interface RawPair {
-  artist: string;
-  album: string;
-  song: string;
-}
+/** `enumerateFreetextPairs` (and its `RawPair` shape) moved to
+ * `@wxyc/database` (BS#1799) so the `tests/integration` babel-jest harness —
+ * which can't import this job directly (no TS transform registered for
+ * `jest.config.json`) — can import the SAME statement the job runs instead of
+ * hand-duplicating a SQL mirror. Imported above (for use in `runResolve`
+ * below) and re-exported here so any existing import site of this job still
+ * resolves; see `shared/database/src/freetext-enumerate.ts` for the
+ * implementation and full rationale. */
+export { enumerateFreetextPairs, type RawPair };
 
 /** A normalized dedup key + the representative raw pair to send to LML. */
 export interface NormalizedPair {
@@ -152,70 +153,6 @@ export interface NormalizedPair {
   album: string;
   song: string;
 }
-
-/** SELECT one row per unlinked `(artist, album)` pair, carrying the pair's
- * MOST-PLAYED non-empty `track_title` as its representative track.
- *
- * The most-played track (not the alphabetically-first) is the album's
- * canonical track — an 'A…' bonus/intro title is an arbitrary, low-signal
- * representative that resolves to the wrong release (or no release) far more
- * often. Picking the modal track reduces both wrong-release matches and missed
- * matches; the A/B probe behind BS#1767 showed track-aware matching lifting the
- * match rate ~3.7x over album-only with zero regressions.
- *
- * Shape: an inner `GROUP BY (artist_name, album_title, track_title)` counts
- * plays per distinct track, then `DISTINCT ON (artist_name, album_title)` with
- * an `ORDER BY` that (1) prefers a non-empty track
- * (`btrim(coalesce(track_title, '')) = ''` sorts false-before-true, so
- * non-empty first), (2) then most-played (`play_count DESC`), (3) then a
- * deterministic `track_title ASC` tiebreak, keeps exactly the modal
- * representative per pair. Cardinality is UNCHANGED — still one row per
- * distinct `(artist, album)` pair; the GROUP BY only picks a better
- * representative track, it does not change which pairs are enumerated. There is
- * NO `track_title IS NOT NULL` filter — a pair whose plays are all track-less
- * still enumerates and resolves album-only, exactly as before this change.
- *
- * The `normalizePairs` determinism contract still holds: rows remain ordered by
- * `(artist_name, album_title)` first, so the first-encountered representative
- * per normalized key is stable across runs.
- *
- * The inner GROUP BY subquery measured ~17s on prod (within the raised
- * `statement_timeout`). Wrapped in `db.transaction` + `SET LOCAL
- * statement_timeout` because the `album_id IS NULL` partition isn't covered by
- * the metadata-drain partial indexes; the planner falls back to a scan that can
- * exceed the backend's default `statement_timeout`. `SET LOCAL` only scopes
- * inside an explicit transaction with the postgres-js driver. Mirrors
- * `album-level-backfill#enumeratePendingAlbumIds`. */
-export const enumerateFreetextPairs = async (timeoutMs: number = READ_TIMEOUT_DEFAULT): Promise<RawPair[]> => {
-  return await db.transaction(async (tx) => {
-    await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
-    const rows = (await tx.execute(sql`
-      SELECT DISTINCT ON ("artist_name", "album_title")
-             "artist_name", "album_title", "track_title"
-      FROM (
-        SELECT "artist_name", "album_title", "track_title", count(*) AS play_count
-        FROM "wxyc_schema"."flowsheet"
-        WHERE "entry_type" = 'track'
-          AND "album_id" IS NULL
-          AND "artist_name" IS NOT NULL
-          AND "album_title" IS NOT NULL
-        GROUP BY "artist_name", "album_title", "track_title"
-      ) g
-      ORDER BY "artist_name", "album_title",
-               (btrim(coalesce("track_title", '')) = '') ASC,
-               play_count DESC,
-               "track_title" ASC
-    `)) as unknown as Array<{ artist_name: string; album_title: string; track_title: string | null }>;
-    return rows.map((r) => ({
-      artist: String(r.artist_name),
-      album: String(r.album_title),
-      // Trim the representative track once, HERE, at the single "usable track?"
-      // boundary. Downstream (`buildBulkItems`) treats a truthy `song` as
-      // ready-to-send with no further trimming.
-      song: (r.track_title ?? '').trim(),
-    }));
-  });
-};
 
 /** Fold raw pairs into normalized dedup keys, keeping one representative raw
  * pair per key (the first encountered — `enumerateFreetextPairs` returns them

--- a/shared/database/src/freetext-enumerate.ts
+++ b/shared/database/src/freetext-enumerate.ts
@@ -1,0 +1,100 @@
+/**
+ * The catalog-popularity-freetext-resolve ENUMERATE statement (BS#1767 /
+ * BS#1799 — extracted to `@wxyc/database` from
+ * `jobs/catalog-popularity-freetext-resolve/job.ts` so it is a single
+ * importable source of truth for both the job's TS runtime and the
+ * `tests/integration` babel-jest harness, which can't import the job
+ * directly (no TS transform registered for `jest.config.json`; see BS#1799).
+ *
+ * `jobs/catalog-popularity-freetext-resolve/job.ts` is now a thin re-export
+ * shim pointing here (à la the `@wxyc/legacy-mirror` BS#1707 extraction and
+ * `jobs/concerts-artist-resolver/recompute.ts`'s BS#1763 shim), so its
+ * existing import site stays untouched.
+ *
+ * SELECT one row per unlinked `(artist, album)` pair, carrying the pair's
+ * MOST-PLAYED non-empty `track_title` as its representative track.
+ *
+ * The most-played track (not the alphabetically-first) is the album's
+ * canonical track — an 'A…' bonus/intro title is an arbitrary, low-signal
+ * representative that resolves to the wrong release (or no release) far more
+ * often. Picking the modal track reduces both wrong-release matches and missed
+ * matches; the A/B probe behind BS#1767 showed track-aware matching lifting the
+ * match rate ~3.7x over album-only with zero regressions.
+ *
+ * Shape: an inner `GROUP BY (artist_name, album_title, track_title)` counts
+ * plays per distinct track, then `DISTINCT ON (artist_name, album_title)` with
+ * an `ORDER BY` that (1) prefers a non-empty track
+ * (`btrim(coalesce(track_title, '')) = ''` sorts false-before-true, so
+ * non-empty first), (2) then most-played (`play_count DESC`), (3) then a
+ * deterministic `track_title ASC` tiebreak, keeps exactly the modal
+ * representative per pair. Cardinality is UNCHANGED — still one row per
+ * distinct `(artist, album)` pair; the GROUP BY only picks a better
+ * representative track, it does not change which pairs are enumerated. There is
+ * NO `track_title IS NOT NULL` filter — a pair whose plays are all track-less
+ * still enumerates and resolves album-only, exactly as before this change.
+ *
+ * The `normalizePairs` determinism contract (in the job) still holds: rows
+ * remain ordered by `(artist_name, album_title)` first, so the
+ * first-encountered representative per normalized key is stable across runs.
+ *
+ * The inner GROUP BY subquery measured ~17s on prod (within the raised
+ * `statement_timeout`). Wrapped in `db.transaction` + `SET LOCAL
+ * statement_timeout` because the `album_id IS NULL` partition isn't covered by
+ * the metadata-drain partial indexes; the planner falls back to a scan that can
+ * exceed the backend's default `statement_timeout`. `SET LOCAL` only scopes
+ * inside an explicit transaction with the postgres-js driver. Mirrors
+ * `album-level-backfill#enumeratePendingAlbumIds`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from './client.js';
+
+/** A raw free-text pair as the DJ typed it, with a representative track title.
+ * `song` is trimmed at the enumerate boundary (empty string when no usable
+ * track exists for the pair) — it is the single place the "usable track?" rule
+ * is applied, so every downstream consumer can treat a truthy `song` as ready
+ * to send. */
+export interface RawPair {
+  artist: string;
+  album: string;
+  song: string;
+}
+
+/** Default statement timeout (ms) for the enumerate scan when the caller
+ * doesn't pass one explicitly. Mirrors
+ * `jobs/catalog-popularity-freetext-resolve/job.ts`'s
+ * `READ_TIMEOUT_DEFAULT` (5 minutes) — kept as a separate literal here since
+ * that job's constant is env-var-driven (`FREETEXT_RESOLVE_READ_TIMEOUT_MS`)
+ * and this default only matters for a bare no-arg call (unit tests). */
+const DEFAULT_READ_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const enumerateFreetextPairs = async (timeoutMs: number = DEFAULT_READ_TIMEOUT_MS): Promise<RawPair[]> => {
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
+    const rows = (await tx.execute(sql`
+      SELECT DISTINCT ON ("artist_name", "album_title")
+             "artist_name", "album_title", "track_title"
+      FROM (
+        SELECT "artist_name", "album_title", "track_title", count(*) AS play_count
+        FROM "wxyc_schema"."flowsheet"
+        WHERE "entry_type" = 'track'
+          AND "album_id" IS NULL
+          AND "artist_name" IS NOT NULL
+          AND "album_title" IS NOT NULL
+        GROUP BY "artist_name", "album_title", "track_title"
+      ) g
+      ORDER BY "artist_name", "album_title",
+               (btrim(coalesce("track_title", '')) = '') ASC,
+               play_count DESC,
+               "track_title" ASC
+    `)) as unknown as Array<{ artist_name: string; album_title: string; track_title: string | null }>;
+    return rows.map((r) => ({
+      artist: String(r.artist_name),
+      album: String(r.album_title),
+      // Trim the representative track once, HERE, at the single "usable track?"
+      // boundary. Downstream (`buildBulkItems`) treats a truthy `song` as
+      // ready-to-send with no further trimming.
+      song: (r.track_title ?? '').trim(),
+    }));
+  });
+};

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -15,3 +15,4 @@ export * from './ny-time.js';
 export * from './concerts-sql.js';
 export * from './concerts-recompute.js';
 export * from './album-resolve.js';
+export * from './freetext-enumerate.js';

--- a/tests/integration/catalog-popularity-freetext-resolve-enumerate.spec.js
+++ b/tests/integration/catalog-popularity-freetext-resolve-enumerate.spec.js
@@ -2,24 +2,27 @@
  * Integration test for the catalog-popularity-freetext-resolve ENUMERATE
  * representative-track selection (BS#1767), against real PostgreSQL.
  *
- * The unit suite (job.test.ts) imports the REAL `enumerateFreetextPairs` and
- * pins the exact GROUP BY + DISTINCT ON + ORDER BY it emits (so flipping an
- * ASC/DESC, dropping the btrim non-empty-first term, or changing the GROUP BY
- * fails there). This spec validates that pinned SQL's *runtime semantics*
- * against real PG — which track the modal ordering actually resolves to — the
- * one thing a string assertion can't observe.
+ * The unit suite (tests/unit/database/freetext-enumerate.test.ts) imports the
+ * REAL `enumerateFreetextPairs` and pins the exact GROUP BY + DISTINCT ON +
+ * ORDER BY it emits (so flipping an ASC/DESC, dropping the btrim non-empty-
+ * first term, or changing the GROUP BY fails there). This spec validates
+ * that pinned SQL's *runtime semantics* against real PG — which track the
+ * modal ordering actually resolves to — the one thing a string assertion
+ * can't observe.
  *
- * It cannot import the job directly: the integration runner is babel-jest with
- * no TS transform (the job uses `import type`, which the parser rejects), so
- * this mirrors the enumerate statement verbatim, scoped by an `ILIKE '%bs1767%'`
- * marker. That is the same pure-SQL convention every sibling spec uses
- * (flowsheet-metadata-backfill-worklist / -upsert, flowsheet-artwork-repair):
- * WHEN `enumerateFreetextPairs` is hand-edited, BOTH the unit-suite SQL
- * assertions AND this statement must follow — the unit suite is the drift
- * tripwire on the real query, this is the semantics check on that query's shape.
+ * BS#1799: this spec now imports and executes `enumerateFreetextPairs`
+ * ITSELF (extracted to `@wxyc/database` — see
+ * `shared/database/src/freetext-enumerate.ts`) instead of a hand-duplicated
+ * SQL mirror. There is no drift risk left to manage: this IS the production
+ * statement. Since the production function has no test-scoping predicate
+ * (it scans the whole `flowsheet` table), the seeded rows are marked with a
+ * "bs1767" artist token and the returned pairs are filtered to that token in
+ * JS before asserting cardinality/song — a behavior-preserving equivalent of
+ * the old mirror's `ILIKE '%bs1767%'` WHERE clause, applied client-side
+ * instead of in the statement itself.
  *
- * Seeded matrix (all rows carry a "bs1767" marker so the scoped query, cleanup,
- * and assertions stay hermetic; album_id NULL so they're unlinked):
+ * Seeded matrix (all rows carry a "bs1767" marker so the JS-side filter,
+ * cleanup, and assertions stay hermetic; album_id NULL so they're unlinked):
  *   - Pair A ('bs1767 artist a', 'bs1767 album a'):
  *       NULL   track × 5 plays  (most-played OVERALL, but empty → must NOT win)
  *       'Modal Track' × 3 plays (most-played NON-empty → MUST win)
@@ -31,49 +34,32 @@
  *       ''   track × 1 play
  *     → song === '' (all tracks unusable → album-only fallback, still enumerated).
  *
- * Cardinality: exactly one row per distinct pair (2 pairs → 2 rows). The inner
- * GROUP BY only picks a better representative track; it does not change which
- * pairs are enumerated.
+ * Cardinality: exactly one row per distinct pair among the bs1767-marked rows
+ * (2 pairs → 2 rows). The inner GROUP BY only picks a better representative
+ * track; it does not change which pairs are enumerated.
  *
- * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker tier)
+ * plus a built `@wxyc/database` (`dist/`), same as running the app itself —
+ * `@wxyc/database`'s package.json `require` export resolves to
+ * `./dist/index.js`.
  */
+
+// `@wxyc/database` -> `drizzle-orm`. The repo-wide `tests/__mocks__/drizzle-orm.ts`
+// manual mock (written for the ts-jest unit config, see jest.unit.config.ts) is a
+// Jest node_modules manual mock, which Jest substitutes automatically for ANY
+// test file that requires `drizzle-orm` — no `jest.mock(...)` call needed to
+// trigger it — including this babel-jest-transformed integration spec, where
+// that `.ts` mock file fails to parse (no TypeScript-stripping transform is
+// registered for `jest.config.json`). `jest.unmock` opts this file back into
+// the real `drizzle-orm` package so `@wxyc/database`'s real postgres-js driver
+// runs, which is the entire point of this spec (executing the production
+// `enumerateFreetextPairs` against real PG).
+jest.unmock('drizzle-orm');
 
 const { getTestDb } = require('../utils/db');
+const { enumerateFreetextPairs, closeDatabaseConnection } = require('@wxyc/database');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-
-/**
- * Mirror of the enumerate statement in
- * `jobs/catalog-popularity-freetext-resolve/job.ts:enumerateFreetextPairs`
- * (inner GROUP BY play-count + DISTINCT ON non-empty-first / most-played /
- * deterministic ordering), scoped by an `ILIKE '%bs1767%'` marker so it only
- * sees this spec's rows. Returns `{ artist_name, album_title, track_title }`
- * one row per `(artist, album)` pair.
- */
-async function scopedEnumerate(sql) {
-  return await sql`
-    SELECT DISTINCT ON ("artist_name", "album_title")
-           "artist_name", "album_title", "track_title"
-    FROM (
-      SELECT "artist_name", "album_title", "track_title", count(*) AS play_count
-      FROM ${sql(SCHEMA)}.flowsheet
-      WHERE "entry_type" = 'track'
-        AND "album_id" IS NULL
-        AND "artist_name" IS NOT NULL
-        AND "album_title" IS NOT NULL
-        AND "artist_name" ILIKE '%bs1767%'
-      GROUP BY "artist_name", "album_title", "track_title"
-    ) g
-    ORDER BY "artist_name", "album_title",
-             (btrim(coalesce("track_title", '')) = '') ASC,
-             play_count DESC,
-             "track_title" ASC
-  `;
-}
-
-/** Derive `song` exactly as the enumerate map does: trim once at the boundary,
- * NULL → '' . */
-const songOf = (row) => (row.track_title ?? '').trim();
 
 describe('catalog-popularity-freetext-resolve enumerate representative track (real PG, BS#1767)', () => {
   let sql;
@@ -94,6 +80,12 @@ describe('catalog-popularity-freetext-resolve enumerate representative track (re
     return rows[0].id;
   }
 
+  /** Scope `enumerateFreetextPairs`'s full-table result down to this spec's
+   * own rows — the production function has no test-scoping predicate, so
+   * filtering here is the client-side equivalent of the old mirror's
+   * `ILIKE '%bs1767%'` WHERE clause. */
+  const scopedRows = (rows) => rows.filter((r) => r.artist.includes('bs1767'));
+
   beforeAll(async () => {
     sql = getTestDb();
 
@@ -111,31 +103,36 @@ describe('catalog-popularity-freetext-resolve enumerate representative track (re
     if (flowsheetIds.length > 0) {
       await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${flowsheetIds})`;
     }
+    // `@wxyc/database` opens the shared postgres-js pool as a side effect of
+    // import (shared/database/src/client.ts's module-level
+    // `createPostgresClient()`). That pool is separate from this spec's own
+    // `sql` client above (`getTestDb()`), so it needs its own teardown or the
+    // process has an open handle after the suite finishes.
+    await closeDatabaseConnection();
   });
 
   it('returns exactly one row per distinct (artist, album) pair (cardinality unchanged)', async () => {
-    const rows = await scopedEnumerate(sql);
+    const rows = scopedRows(await enumerateFreetextPairs());
     expect(rows).toHaveLength(2);
-    const pairs = rows.map((r) => `${r.artist_name} | ${r.album_title}`).sort();
+    const pairs = rows.map((r) => `${r.artist} | ${r.album}`).sort();
     expect(pairs).toEqual(['bs1767 artist a | bs1767 album a', 'bs1767 artist b | bs1767 album b']);
   });
 
   it('picks the most-played NON-empty track as the representative song (non-empty-first beats raw play_count)', async () => {
-    const rows = await scopedEnumerate(sql);
-    const pairA = rows.find((r) => r.artist_name === 'bs1767 artist a');
+    const rows = scopedRows(await enumerateFreetextPairs());
+    const pairA = rows.find((r) => r.artist === 'bs1767 artist a');
     expect(pairA).toBeDefined();
     // The NULL track has 5 plays vs 'Modal Track' 3, but non-empty sorts first
     // in the DISTINCT ON ordering, then most-played wins among the non-empty.
-    expect(pairA.track_title).toBe('Modal Track');
-    expect(songOf(pairA)).toBe('Modal Track');
+    expect(pairA.song).toBe('Modal Track');
   });
 
   it("enumerates a track-less pair with song='' (album-only fallback, never dropped)", async () => {
-    const rows = await scopedEnumerate(sql);
-    const pairB = rows.find((r) => r.artist_name === 'bs1767 artist b');
+    const rows = scopedRows(await enumerateFreetextPairs());
+    const pairB = rows.find((r) => r.artist === 'bs1767 artist b');
     // The pair is present (not filtered out by a track_title IS NOT NULL), and
     // its representative track collapses to '' at the enumerate boundary.
     expect(pairB).toBeDefined();
-    expect(songOf(pairB)).toBe('');
+    expect(pairB.song).toBe('');
   });
 });

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -501,6 +501,48 @@ export const selectLinkedFlowsheetRow = jest
 export { requirePositiveInt, requireNonNegativeInt } from '../../shared/database/src/env-parsers.js';
 export type { IntParserOptions } from '../../shared/database/src/env-parsers.js';
 
+// Re-export the pure `RawPair` TYPE from source (type-only — erased at
+// compile time, no runtime import, so it can't pull in the module's `db`
+// dependency below).
+export type { RawPair } from '../../shared/database/src/freetext-enumerate.js';
+
+// Self-contained MOCK of shared/database/src/freetext-enumerate.ts's
+// `enumerateFreetextPairs` (BS#1799 extraction from
+// jobs/catalog-popularity-freetext-resolve/job.ts). Can't re-export the VALUE
+// from source the way the pure normalizers above are (contrast
+// normalizeArtistName/freetextPairKey/etc.): its `./client.js` import is a bare
+// relative specifier that the `^.*/shared/database/src/client(\.js)?$` mapper
+// entry below does NOT match (that regex requires the literal specifier to
+// already contain "/shared/database/src/client", which a same-directory `./`
+// import never does) — re-exporting it would load the REAL
+// shared/database/src/client.ts unconditionally at THIS file's own import
+// time and throw on missing DB env vars for every suite that imports
+// `@wxyc/database`. This mock instead calls straight through THIS file's own
+// `db` mock (the same `db.transaction` -> two `db.execute` calls -> row-
+// mapping shape as the real function) so job.ts's `runResolve` unit tests,
+// which drive `db.execute` with a sequenced `mockResolvedValueOnce` queue,
+// keep consuming it in the same order unchanged. The real SQL-shape contract
+// is pinned against the actual module directly by
+// tests/unit/database/freetext-enumerate.test.ts.
+export const enumerateFreetextPairs = async (
+  _timeoutMs?: number
+): Promise<Array<{ artist: string; album: string; song: string }>> => {
+  return db.transaction(async (tx: unknown) => {
+    const { execute } = tx as { execute: (arg: unknown) => Promise<unknown> };
+    await execute({}); // SET LOCAL statement_timeout placeholder
+    const rows = (await execute({})) as Array<{
+      artist_name: string;
+      album_title: string;
+      track_title: string | null;
+    }>;
+    return rows.map((r) => ({
+      artist: String(r.artist_name),
+      album: String(r.album_title),
+      song: (r.track_title ?? '').trim(),
+    }));
+  }) as unknown as Promise<Array<{ artist: string; album: string; song: string }>>;
+};
+
 // Pure normalizers (no DB dependency) re-exported from source so consumer jobs
 // resolving @wxyc/database via this mock still get the real implementation.
 export { normalizeArtistName } from '../../shared/database/src/normalize-artist-name.js';

--- a/tests/unit/database/freetext-enumerate.test.ts
+++ b/tests/unit/database/freetext-enumerate.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for shared/database/src/freetext-enumerate.ts (BS#1767 SQL
+ * shape; extracted from jobs/catalog-popularity-freetext-resolve/job.ts by
+ * BS#1799 so the tests/integration babel-jest harness — which can't import
+ * the job directly — can import and execute this SAME statement instead of
+ * hand-duplicating a SQL mirror). Tests the REAL module directly (bypassing
+ * the package-level `@wxyc/database` mock, mirroring
+ * tests/unit/database/concerts-recompute.test.ts and live-activity.test.ts)
+ * so the SQL text asserted below is the module's actual output, not a
+ * hand-duplicated stub.
+ *
+ * `jobs/catalog-popularity-freetext-resolve/job.ts` imports + re-exports
+ * `enumerateFreetextPairs` from `@wxyc/database` as a thin pass-through; its
+ * own unit suite (tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts)
+ * no longer tests this function directly.
+ *
+ * SQL-contract test pins: the DISTINCT ON (artist_name, album_title)
+ * selection + its three required predicates, the inner GROUP BY play-count
+ * shape, the full non-empty-first / most-played / deterministic-tiebreak
+ * ORDER BY sequence (the drift tripwire the integration spec's runtime
+ * semantics check depends on), and the SET LOCAL statement_timeout wrapper.
+ * Mapping tests pin the `{ artist, album, song }` shape, including the
+ * track-less-pair-collapses-to-'' rule.
+ */
+jest.mock('../../../shared/database/src/client.js', () => jest.requireActual('../../mocks/database.mock'), {
+  virtual: true,
+});
+
+import { db } from '../../mocks/database.mock';
+import { enumerateFreetextPairs } from '../../../shared/database/src/freetext-enumerate';
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: string | string[]; raw?: string }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined =>
+  (db.execute as jest.Mock).mock.calls.find((call) => pattern.test(renderSql(call[0])));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('enumerateFreetextPairs', () => {
+  it('selects DISTINCT ON (artist_name, album_title) with the three required predicates', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([
+      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: 'Waves' },
+    ]);
+
+    await enumerateFreetextPairs();
+
+    const call = findExecuteCallMatching(/SELECT\s+DISTINCT\s+ON/i);
+    expect(call).toBeDefined();
+    const text = renderSql(call?.[0]);
+    expect(text).toMatch(/DISTINCT\s+ON\s*\(\s*"?artist_name"?\s*,\s*"?album_title"?\s*\)/i);
+    expect(text).toMatch(/FROM\s+"?wxyc_schema"?\."?flowsheet"?/i);
+    expect(text).toMatch(/"?entry_type"?\s*=\s*'track'/i);
+    expect(text).toMatch(/"?album_id"?\s+IS\s+NULL/i);
+    expect(text).toMatch(/"?artist_name"?\s+IS\s+NOT\s+NULL/i);
+    expect(text).toMatch(/"?album_title"?\s+IS\s+NOT\s+NULL/i);
+    // Representative track_title is returned but NEVER filtered — a track-less
+    // pair must still fall back to album-only, not be dropped from the scan.
+    expect(text).toMatch(/"?track_title"?/i);
+    expect(text).not.toMatch(/"?track_title"?\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('groups by (artist, album, track) and orders by non-empty-first, then most-played, then deterministic', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await enumerateFreetextPairs();
+    const call = findExecuteCallMatching(/SELECT\s+DISTINCT\s+ON/i);
+    const text = renderSql(call?.[0]);
+    // Inner GROUP BY counts plays per distinct track so the modal one can win.
+    expect(text).toMatch(/GROUP\s+BY\s+"?artist_name"?\s*,\s*"?album_title"?\s*,\s*"?track_title"?/i);
+    expect(text).toMatch(/count\s*\(\s*\*\s*\)\s+AS\s+play_count/i);
+    // Pin the FULL ORDER BY sequence IN ORDER — this is the drift tripwire on
+    // the real query (the integration spec validates this same shape's runtime
+    // semantics against real PG). A flipped ASC/DESC, a dropped btrim
+    // non-empty-first term, or a reordered tiebreak all fail HERE, on the real
+    // function's emitted SQL. Whitespace is collapsed first so the assertion is
+    // a single flat pattern (avoids a nest of `\s*` quantifiers):
+    //   artist_name, album_title,
+    //   (btrim(coalesce(track_title,'')) = '') ASC,   -- non-empty first
+    //   play_count DESC,                              -- most-played wins
+    //   track_title ASC                               -- deterministic tiebreak
+    const flat = text.replace(/\s+/g, ' ');
+    expect(flat).toContain('ORDER BY "artist_name", "album_title",');
+    expect(flat).toContain(`(btrim(coalesce("track_title", '')) = '') ASC, play_count DESC, "track_title" ASC`);
+  });
+
+  it('wraps the SELECT in a transaction + SET LOCAL statement_timeout', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await enumerateFreetextPairs(99_000);
+    expect((db.transaction as jest.Mock).mock.calls.length).toBe(1);
+    const setLocalCall = findExecuteCallMatching(/SET\s+LOCAL\s+statement_timeout/i);
+    expect(renderSql(setLocalCall?.[0])).toMatch(/99000ms/);
+  });
+
+  it('maps rows to { artist, album, song } using the representative track_title', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([
+      { artist_name: 'Kendrick Lamar', album_title: 'DAMN.', track_title: 'HUMBLE.' },
+    ]);
+    const out = await enumerateFreetextPairs();
+    expect(out).toEqual([{ artist: 'Kendrick Lamar', album: 'DAMN.', song: 'HUMBLE.' }]);
+  });
+
+  it('maps a null/missing track_title to an empty song (track-less pairs still fall back to album-only)', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([{ artist_name: 'J Dilla', album_title: 'Donuts', track_title: null }]);
+    const out = await enumerateFreetextPairs();
+    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: '' }]);
+  });
+
+  it('trims a whitespace-only track_title to an empty song at the enumerate boundary', async () => {
+    // The "usable track?" rule lives HERE (the single trim boundary): a
+    // whitespace-only representative maps to song='' so buildBulkItems can use
+    // a plain truthiness check downstream.
+    (db.execute as jest.Mock).mockResolvedValue([
+      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: '   ' },
+    ]);
+    const out = await enumerateFreetextPairs();
+    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: '' }]);
+  });
+
+  it('trims surrounding whitespace off a usable track_title', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([
+      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: '  Waves  ' },
+    ]);
+    const out = await enumerateFreetextPairs();
+    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: 'Waves' }]);
+  });
+});

--- a/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
+++ b/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
@@ -34,7 +34,6 @@ jest.mock('@sentry/node', () => ({
 
 import { db, flowsheet_freetext_resolution } from '@wxyc/database';
 import {
-  enumerateFreetextPairs,
   normalizePairs,
   loadSkipKeys,
   filterEligible,
@@ -98,9 +97,6 @@ const renderSql = (value: unknown): string => {
   return '';
 };
 
-const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined =>
-  (db.execute as jest.Mock).mock.calls.find((call) => pattern.test(renderSql(call[0])));
-
 const renderInsertChain = (): { valuesArg: unknown; conflictArg: unknown } => {
   const insertChain = (db as unknown as { _chain: Record<string, jest.Mock> })._chain;
   return {
@@ -143,95 +139,11 @@ afterEach(() => {
 
 // ---------------------------------------------------------------------------
 // Source query.
+//
+// `enumerateFreetextPairs`'s SQL-contract + mapping tests moved to
+// tests/unit/database/freetext-enumerate.test.ts (BS#1799 extraction to
+// @wxyc/database — see shared/database/src/freetext-enumerate.ts).
 // ---------------------------------------------------------------------------
-
-describe('enumerateFreetextPairs', () => {
-  it('selects DISTINCT ON (artist_name, album_title) with the three required predicates', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([
-      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: 'Waves' },
-    ]);
-
-    await enumerateFreetextPairs();
-
-    const call = findExecuteCallMatching(/SELECT\s+DISTINCT\s+ON/i);
-    expect(call).toBeDefined();
-    const text = renderSql(call?.[0]);
-    expect(text).toMatch(/DISTINCT\s+ON\s*\(\s*"?artist_name"?\s*,\s*"?album_title"?\s*\)/i);
-    expect(text).toMatch(/FROM\s+"?wxyc_schema"?\."?flowsheet"?/i);
-    expect(text).toMatch(/"?entry_type"?\s*=\s*'track'/i);
-    expect(text).toMatch(/"?album_id"?\s+IS\s+NULL/i);
-    expect(text).toMatch(/"?artist_name"?\s+IS\s+NOT\s+NULL/i);
-    expect(text).toMatch(/"?album_title"?\s+IS\s+NOT\s+NULL/i);
-    // Representative track_title is returned but NEVER filtered — a track-less
-    // pair must still fall back to album-only, not be dropped from the scan.
-    expect(text).toMatch(/"?track_title"?/i);
-    expect(text).not.toMatch(/"?track_title"?\s+IS\s+NOT\s+NULL/i);
-  });
-
-  it('groups by (artist, album, track) and orders by non-empty-first, then most-played, then deterministic', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([]);
-    await enumerateFreetextPairs();
-    const call = findExecuteCallMatching(/SELECT\s+DISTINCT\s+ON/i);
-    const text = renderSql(call?.[0]);
-    // Inner GROUP BY counts plays per distinct track so the modal one can win.
-    expect(text).toMatch(/GROUP\s+BY\s+"?artist_name"?\s*,\s*"?album_title"?\s*,\s*"?track_title"?/i);
-    expect(text).toMatch(/count\s*\(\s*\*\s*\)\s+AS\s+play_count/i);
-    // Pin the FULL ORDER BY sequence IN ORDER — this is the drift tripwire on
-    // the real query (the integration spec validates this same shape's runtime
-    // semantics against real PG). A flipped ASC/DESC, a dropped btrim
-    // non-empty-first term, or a reordered tiebreak all fail HERE, on the real
-    // function's emitted SQL. Whitespace is collapsed first so the assertion is
-    // a single flat pattern (avoids a nest of `\s*` quantifiers):
-    //   artist_name, album_title,
-    //   (btrim(coalesce(track_title,'')) = '') ASC,   -- non-empty first
-    //   play_count DESC,                              -- most-played wins
-    //   track_title ASC                               -- deterministic tiebreak
-    const flat = text.replace(/\s+/g, ' ');
-    expect(flat).toContain('ORDER BY "artist_name", "album_title",');
-    expect(flat).toContain(`(btrim(coalesce("track_title", '')) = '') ASC, play_count DESC, "track_title" ASC`);
-  });
-
-  it('wraps the SELECT in a transaction + SET LOCAL statement_timeout', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([]);
-    await enumerateFreetextPairs(99_000);
-    expect((db.transaction as jest.Mock).mock.calls.length).toBe(1);
-    const setLocalCall = findExecuteCallMatching(/SET\s+LOCAL\s+statement_timeout/i);
-    expect(renderSql(setLocalCall?.[0])).toMatch(/99000ms/);
-  });
-
-  it('maps rows to { artist, album, song } using the representative track_title', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([
-      { artist_name: 'Kendrick Lamar', album_title: 'DAMN.', track_title: 'HUMBLE.' },
-    ]);
-    const out = await enumerateFreetextPairs();
-    expect(out).toEqual([{ artist: 'Kendrick Lamar', album: 'DAMN.', song: 'HUMBLE.' }]);
-  });
-
-  it('maps a null/missing track_title to an empty song (track-less pairs still fall back to album-only)', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([{ artist_name: 'J Dilla', album_title: 'Donuts', track_title: null }]);
-    const out = await enumerateFreetextPairs();
-    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: '' }]);
-  });
-
-  it('trims a whitespace-only track_title to an empty song at the enumerate boundary', async () => {
-    // The "usable track?" rule lives HERE (the single trim boundary): a
-    // whitespace-only representative maps to song='' so buildBulkItems can use
-    // a plain truthiness check downstream.
-    (db.execute as jest.Mock).mockResolvedValue([
-      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: '   ' },
-    ]);
-    const out = await enumerateFreetextPairs();
-    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: '' }]);
-  });
-
-  it('trims surrounding whitespace off a usable track_title', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([
-      { artist_name: 'J Dilla', album_title: 'Donuts', track_title: '  Waves  ' },
-    ]);
-    const out = await enumerateFreetextPairs();
-    expect(out).toEqual([{ artist: 'J Dilla', album: 'Donuts', song: 'Waves' }]);
-  });
-});
 
 // ---------------------------------------------------------------------------
 // Normalized dedup.


### PR DESCRIPTION
Closes #1799

## Summary

`enumerateFreetextPairs` (and its `RawPair` type) — the modal representative-track `SELECT DISTINCT ON` query added in #1767 / PR #1777 — moves out of `jobs/catalog-popularity-freetext-resolve/job.ts` into `shared/database/src/freetext-enumerate.ts`, mirroring the `concerts-recompute.ts` / `jobs/concerts-artist-resolver/recompute.ts` extraction pattern (BS#1763). The job now imports it from `@wxyc/database` and re-exports it for backward-compat import sites. No behavior change to the query itself — this is a pure code move.

This closes the drift risk called out in #1799: the integration test previously ran a hand-copied SQL mirror of the enumerate statement because the babel-jest integration harness can't import the job directly (no TS transform for `import type`). Since `@wxyc/database` builds to `dist/` and is importable as plain JS via its `require` export, the integration spec now imports and executes `enumerateFreetextPairs` itself — the actual production statement, not a copy.

### Test moves

- The SQL-contract + row-mapping unit tests for `enumerateFreetextPairs` moved from `tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts` into a new `tests/unit/database/freetext-enumerate.test.ts`, which imports the real module directly (bypassing the package-level mock), mirroring `tests/unit/database/concerts-recompute.test.ts`.
- `tests/integration/catalog-popularity-freetext-resolve-enumerate.spec.js` drops the `scopedEnumerate`/`songOf` SQL mirror entirely and instead calls the real `enumerateFreetextPairs` from `@wxyc/database` (`jest.unmock('drizzle-orm')`, following `tests/integration/rotation-match.spec.js`'s precedent for real-driver integration specs). Since the production function has no test-scoping predicate (it scans the whole `flowsheet` table), the seeded rows carry a "bs1767" artist marker and the spec filters to that marker in JS before asserting cardinality/song — a behavior-preserving equivalent of the old mirror's `ILIKE '%bs1767%'` WHERE clause, applied client-side instead of in the statement.

### Mock note

The package-level `@wxyc/database` jest mock (`tests/mocks/database.mock.ts`) gets a **self-contained mock implementation** of `enumerateFreetextPairs`, not a re-export from source. The real module's `./client.js` import is a bare relative specifier that isn't caught by the existing `^.*/shared/database/src/client(\.js)?$` moduleNameMapper entry (that regex requires the literal specifier to already contain the full path segment, which a same-directory `./` import never does) — re-exporting the real module from the mock would load the real DB client unconditionally at mock-load time and throw on missing DB env vars for every suite that imports `@wxyc/database`. The mock instead drives the same `db.transaction` → two `db.execute` calls → row-mapping shape as the real function, so the job's `runResolve` unit tests — which sequence `db.execute` mock values expecting the enumerate call to consume the first two in order — keep working unchanged. The real SQL-shape contract is pinned separately against the actual module by the new `freetext-enumerate.test.ts`.

## Test plan

Ran locally (no Docker/Postgres available in this environment, so `test:integration` itself was not executed — the new/edited integration spec is correct-by-construction against the `tests/integration/rotation-match.spec.js` precedent and will be exercised by CI):

- [x] `npm run typecheck` — green (root workspaces + `npx tsc --noEmit -p jobs/catalog-popularity-freetext-resolve/tsconfig.json`)
- [x] `npm run lint` — 0 errors (812 pre-existing warnings, same class as before this change)
- [x] `npm run format` / `npm run format:check` — clean
- [x] `npm run test:unit` — 388 suites / 5915 tests passing, including the new `tests/unit/database/freetext-enumerate.test.ts` and the trimmed `job.test.ts`
- [x] `npm run build` (via `shared/database`) — confirmed `enumerateFreetextPairs` is present in the built `dist/index.js` / `dist/index.d.ts`, which the integration spec depends on

## Caveats for reviewers

- `test:integration` was not run locally (per this repo's workflow: it needs Docker Postgres + exclusive ports, unsafe to run in a parallel worktree). The rewritten integration spec follows `tests/integration/rotation-match.spec.js`'s established "real driver, `jest.unmock('drizzle-orm')`, require `@wxyc/database`'s built dist" pattern exactly, so it should behave the same way in CI.
- CLAUDE.md was intentionally left untouched. `npm run check:doc-budget` already alarms on the current file (123,812 chars vs a 22,000 alarm threshold) — this is pre-existing and out of scope for this issue; adding another inline extraction note would only grow an already-over-budget file further.