### PR TITLE
docs(auth): document intentional double Sentry capture in fallback handler

### DIFF
--- a/apps/auth/fallback-error-handler.ts
+++ b/apps/auth/fallback-error-handler.ts
@@ -10,6 +10,17 @@ import * as Sentry from '@sentry/node';
 import type { Request, Response, NextFunction } from 'express';
 
 export function fallbackErrorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+  // Deliberately unconditional (BS#1221) — this intentionally overrides
+  // `shouldCaptureAuthExpressError` (`./sentry-error-filter.ts`, BS#1387),
+  // which only governs `Sentry.setupExpressErrorHandler`'s own capture.
+  // An error reaching this generic Express fallback is itself unexpected
+  // (every status-carrying error path is handled upstream), so it's worth
+  // capturing here regardless of what the predicate would have decided.
+  // Sentry dedupes by event hash server-side, so a case where the
+  // integration also captured the same error does not double-count as a
+  // distinct issue. This call is also load-bearing for
+  // `tests/unit/auth/fallback-error-handler.test.ts` — do not remove it as
+  // a "redundant Sentry call" cleanup without re-reading BS#1221.
   Sentry.captureException(err);
 
   if (process.env.NODE_ENV === 'production') {

--- a/apps/auth/sentry-error-filter.ts
+++ b/apps/auth/sentry-error-filter.ts
@@ -32,6 +32,12 @@
  * The auth service has no equivalent of `LmlClientError` to special-case —
  * better-auth's plugin errors propagate as `APIError` instances with `status`
  * codes that the default predicate already filters correctly.
+ *
+ * NOTE (BS#1221): `./fallback-error-handler.ts` calls `Sentry.captureException`
+ * unconditionally, deliberately overriding this predicate for anything that
+ * reaches the generic Express fallback chain. The two files are not
+ * contradictory — this predicate governs only `setupExpressErrorHandler`'s
+ * own capture.
  */
 export function shouldCaptureAuthExpressError(error: Error): boolean {
   const raw = (error as { statusCode?: number | string }).statusCode ?? (error as { status?: number | string }).status;


### PR DESCRIPTION
Closes #1221

## Summary

The auth service's fallback Express error handler (`apps/auth/fallback-error-handler.ts`) calls `Sentry.captureException(err)` unconditionally, even though `Sentry.setupExpressErrorHandler` (wired in `apps/auth/app.ts`) already captures errors per the `shouldCaptureAuthExpressError` predicate in `apps/auth/sentry-error-filter.ts` (BS#1387). An error that reaches the generic fallback can therefore be captured twice — once by the Sentry Express integration, once by the explicit call.

Per the decision in #1221, this keeps the explicit call (option a) rather than removing it: an error bubbling all the way to the generic fallback is itself unexpected and worth capturing regardless of status, and Sentry dedupes by event hash server-side so the double capture doesn't show up as two distinct issues. This PR only adds documentation making that intent explicit in both files so a future reader doesn't file a "redundant Sentry call" cleanup that removes the wrong one (the explicit call is also load-bearing for the existing unit test that mocks `@sentry/node` and asserts on it).

No behavior change. `apps/auth/app.ts`'s `setupExpressErrorHandler` wiring is untouched.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; pre-existing warnings only)
- [x] `npm run format:check`
- [x] `npm run test:unit` (390 suites / 5955 tests passed, including `tests/unit/auth/fallback-error-handler.test.ts`'s existing Sentry-asserting cases, unchanged)