### PR TITLE
fix(artist-identity-etl): NFC-normalize both sides of the artist-name match

### DIFF
--- a/jobs/artist-identity-etl/job.ts
+++ b/jobs/artist-identity-etl/job.ts
@@ -6,11 +6,21 @@
  *   node dist/job.js          one-shot incremental (default)
  *   node dist/job.js --poll   continuous polling
  *
- * Matching: exact case-sensitive equality on
- * `entity.identity.library_name = artists.artist_name`. Both sides treat
- * `library_name` as the canonical artist key so exact match covers most
- * real entries; mismatches surface in the run log as unmatched and can
- * inform a follow-up normalization pass.
+ * Matching: NFC-normalized, otherwise case-sensitive, equality on
+ * `entity.identity.library_name = artists.artist_name` (BS#521). Both
+ * sides are normalized to Unicode NFC (canonical composition) before
+ * comparison, so an LML-supplied name and its `artists` row still match
+ * when one is stored in a different composition form (e.g. NFD) -- the
+ * dominant defect in the initial full-scan reconciliation match rate
+ * (see BS#521). This is deliberately NFC-only: no case-fold, no
+ * diacritic-strip, no "The " strip. `artists.artist_name` has no unique
+ * constraint, so a broader fold (as the catalog-write matcher applies
+ * post-#1897, see #1095) risks COALESCE-ing external ids across two rows
+ * a human might be deliberately keeping distinct (e.g. `Wire` vs
+ * `WIRE`). NFC normalization alone can't cause that kind of collision --
+ * it only collapses byte-distinct encodings of the identical character
+ * sequence. Remaining mismatches (case, diacritic-fold, punctuation,
+ * etc.) still surface in the run log as unmatched.
  *
  * Update strategy: only fills nulls. Each column on `artists` keeps its
  * existing value if non-null (so any value entered by the library staff

--- a/jobs/artist-identity-etl/runIncremental.ts
+++ b/jobs/artist-identity-etl/runIncremental.ts
@@ -48,7 +48,24 @@ export const runIncremental = async (): Promise<SyncResult> => {
   // multiple rows. We keep the first match per name for conflict
   // detection (preserving the previous loadExisting semantic), but the
   // bulk UPDATE below applies COALESCE across every matching row.
-  const names = identities.map((i) => i.library_name);
+  //
+  // Both sides of the name match are NFC-normalized (BS#521): an LML
+  // `library_name` and the corresponding `artists.artist_name` can be
+  // byte-distinct while visually and semantically identical -- e.g. NFC
+  // `Nilüfer` (precomposed ü, U+00FC) vs NFD `Nilüfer` ("u" + combining
+  // diaeresis, U+0308) -- which silently defeated the previous exact
+  // `=` match. This is deliberately NFC-only: no case-fold, no
+  // diacritic-strip, no "The " strip. `artists.artist_name` has no
+  // unique constraint and the artist-unicode-dedup one-shot (BS#1897)
+  // is not confirmed run on prod, so a broader fold here (as the
+  // catalog-write matcher does post-#1897, see #1095) risks COALESCE-ing
+  // external ids across two rows a human might be deliberately keeping
+  // distinct (e.g. `Wire` vs `WIRE`). NFC normalization alone can't
+  // cause that kind of cross-artist collision -- it only collapses
+  // byte-distinct encodings of the identical character sequence -- so
+  // it's provably collision-free while still fixing the dominant
+  // NFC/NFD-drift defect.
+  const names = identities.map((i) => i.library_name.normalize('NFC'));
   const existingRows = await db
     .select({
       artist_name: artists.artist_name,
@@ -60,12 +77,13 @@ export const runIncremental = async (): Promise<SyncResult> => {
       bandcamp_id: artists.bandcamp_id,
     })
     .from(artists)
-    .where(inArray(artists.artist_name, names));
+    .where(inArray(sql`normalize(${artists.artist_name}, NFC)`, names));
 
   const firstByName = new Map<string, ExistingArtistIdentity>();
   for (const row of existingRows) {
-    if (!firstByName.has(row.artist_name)) {
-      firstByName.set(row.artist_name, row);
+    const key = row.artist_name.normalize('NFC');
+    if (!firstByName.has(key)) {
+      firstByName.set(key, row);
     }
   }
 
@@ -75,7 +93,7 @@ export const runIncremental = async (): Promise<SyncResult> => {
   const fillCandidates: LmlIdentity[] = [];
 
   for (const lml of identities) {
-    const existing = firstByName.get(lml.library_name);
+    const existing = firstByName.get(lml.library_name.normalize('NFC'));
     if (!existing) continue;
     matched++;
 
@@ -113,9 +131,14 @@ export const runIncremental = async (): Promise<SyncResult> => {
   // Per-cell type casts are required because postgres-js infers VALUES
   // column types from the first row and several columns can legitimately
   // be NULL there.
+  //
+  // v.library_name is NFC-normalized here (same rule as the SELECT
+  // above) so the join predicate below can compare it directly against
+  // `normalize(a.artist_name, NFC)` -- both sides land in the same
+  // canonical composed form.
   const valuesRows = fillCandidates.map(
     (v) =>
-      sql`(${v.library_name}::text, ${v.discogs_artist_id}::integer, ${v.musicbrainz_artist_id}::varchar(64), ${v.wikidata_qid}::varchar(32), ${v.spotify_artist_id}::varchar(64), ${v.apple_music_artist_id}::varchar(64), ${v.bandcamp_id}::varchar(255))`
+      sql`(${v.library_name.normalize('NFC')}::text, ${v.discogs_artist_id}::integer, ${v.musicbrainz_artist_id}::varchar(64), ${v.wikidata_qid}::varchar(32), ${v.spotify_artist_id}::varchar(64), ${v.apple_music_artist_id}::varchar(64), ${v.bandcamp_id}::varchar(255))`
   );
 
   const updated = await db.execute(sql`
@@ -136,7 +159,7 @@ export const runIncremental = async (): Promise<SyncResult> => {
       apple_music_artist_id,
       bandcamp_id
     )
-    WHERE a.artist_name = v.library_name
+    WHERE normalize(a.artist_name, NFC) = v.library_name
       AND (
         (a.discogs_artist_id     IS NULL AND v.discogs_artist_id     IS NOT NULL) OR
         (a.musicbrainz_artist_id IS NULL AND v.musicbrainz_artist_id IS NOT NULL) OR

--- a/tests/unit/jobs/artist-identity-etl/runIncremental.test.ts
+++ b/tests/unit/jobs/artist-identity-etl/runIncremental.test.ts
@@ -214,6 +214,52 @@ describe('runIncremental', () => {
     expect(mockExecuteUpdate).toHaveBeenCalledTimes(1);
   });
 
+  test('matches an NFD-form artists row to an NFC-form LML library_name (BS#521)', async () => {
+    // Precomposed ü (U+00FC) vs the NFD form ("u" + combining diaeresis,
+    // U+0308) -- byte-distinct, visually and semantically identical.
+    const nfcName = 'Nilüfer Yanya';
+    const nfdName = nfcName.normalize('NFD');
+    expect(nfdName).not.toBe(nfcName); // sanity: the two forms really are byte-distinct
+
+    mockFetchLml.mockResolvedValue([lmlRow(nfcName, { discogs_artist_id: 42 })]);
+    mockSelectExisting.mockReturnValue([existingRow(nfdName)]);
+    mockExecuteUpdate.mockResolvedValue([{ id: 1 }]);
+
+    const result = await runIncremental();
+
+    expect(result.matched).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.columnsWritten).toBe(1);
+  });
+
+  test('matches an NFC-form artists row to an NFD-form LML library_name (symmetric)', async () => {
+    const nfcName = 'Csillagrablók';
+    const nfdName = nfcName.normalize('NFD');
+    expect(nfdName).not.toBe(nfcName);
+
+    mockFetchLml.mockResolvedValue([lmlRow(nfdName, { discogs_artist_id: 7 })]);
+    mockSelectExisting.mockReturnValue([existingRow(nfcName)]);
+    mockExecuteUpdate.mockResolvedValue([{ id: 1 }]);
+
+    const result = await runIncremental();
+
+    expect(result.matched).toBe(1);
+    expect(result.updated).toBe(1);
+  });
+
+  test('does NOT collapse a case-different name (NFC-only, never case-fold)', async () => {
+    // Guards the Wire/WIRE distinct-artist trap the issue calls out: NFC
+    // normalization must never widen into a case fold.
+    mockFetchLml.mockResolvedValue([lmlRow('Wire', { discogs_artist_id: 99 })]);
+    mockSelectExisting.mockReturnValue([existingRow('WIRE')]);
+
+    const result = await runIncremental();
+
+    expect(result.matched).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(mockExecuteUpdate).not.toHaveBeenCalled();
+  });
+
   test('updates the last-run timestamp on every successful path', async () => {
     // empty path
     mockFetchLml.mockResolvedValue([]);


### PR DESCRIPTION
Closes #521

## Summary

The artist-identity ETL's LML-vs-`artists` name join used exact byte equality (`entity.identity.library_name = artists.artist_name`), so an LML-supplied name and its corresponding `artists` row silently failed to match whenever one was stored in a different Unicode composition form -- e.g. NFD `Nilüfer` ("u" + combining diaeresis, U+0308) vs NFC `Nilüfer` (precomposed ü, U+00FC) -- even though the two strings are visually and semantically identical. The 2026-04-27 full-scan reconciliation run flagged this as the dominant cause behind an 82.8% no-match rate on the Discogs stage (see issue comments for the sample no-match names).

This change normalizes both sides of the match to Unicode NFC before comparing:

- The batch `SELECT ... WHERE artist_name IN (...)` now matches on `normalize(artists.artist_name, NFC)` against a batch of JS-side `.normalize('NFC')`'d `library_name`s.
- The JS-side `firstByName` match map (and its lookup in the per-row loop) keys on the NFC form of `artists.artist_name` / `library_name`.
- The bulk `UPDATE ... FROM (VALUES ...)` join predicate compares `normalize(a.artist_name, NFC) = v.library_name`, where `v.library_name` is the pre-normalized JS value.

This is deliberately **NFC-only**, not a full case/diacritic fold: `artists.artist_name` has no unique constraint, and the `artist-unicode-dedup` one-shot (#1897) that would clean up any pre-existing Unicode-duplicate rows is not confirmed run on prod. A broader fold here (matching the catalog-write matcher's post-#1897 behavior, see #1095) would risk COALESCE-ing external ids across two `artists` rows a human might be deliberately keeping distinct (e.g. `Wire` vs `WIRE`). NFC normalization alone can only collapse byte-distinct encodings of the *identical* character sequence, so it carries no such cross-artist collision risk while still fixing the dominant NFC/NFD-drift defect.

Out of scope (tracked separately, not touched here): case folding, diacritic stripping, "The " prefix stripping, punctuation cleanup -- all still surface as unmatched in the run log, same as before.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/jobs/artist-identity-etl` -- 18/18 passing (15 existing + 3 new: NFD→NFC match, NFC→NFD match (symmetric), and a case-different-name-does-NOT-collapse regression guard)
- [x] `npm run test:unit` -- 390 suites / 5958 tests passing
- [x] `npm run typecheck`
- [x] `npx tsc --noEmit -p jobs/artist-identity-etl/tsconfig.json`
- [x] `npm run lint` -- 0 errors (pre-existing warnings only, none in changed files)
- [x] `npm run format:check`