### PR TITLE
fix(library-etl): fold Unicode forms at the artist-match boundary

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -19,6 +19,16 @@ import {
 const legacyDB = MirrorSQL.instance();
 const JOB_NAME = 'library-etl';
 
+// Schema-qualified reference to the `fold_artist_name(text)` SQL function
+// (migration 0134 / BS#1095, mirroring the `artistIdFromName` runtime-path
+// fix in `apps/backend/services/library.service.ts` for BS#1897). Derived
+// from `WXYC_SCHEMA_NAME` the same way the `@wxyc/database` `pgSchema` object
+// and the other job SQL builders are, so the per-worker test-isolation
+// schema resolves correctly. `""`-escaped for the (theoretical)
+// quoted-identifier case.
+const FOLD_SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const FOLD_ARTIST_NAME_FN = sql.raw(`"${FOLD_SCHEMA}"."fold_artist_name"`);
+
 type LegacyReleaseRow = {
   release_id: number;
   release_title: string;
@@ -381,14 +391,25 @@ const ensureArtist = async (
   const cached = artistCache.get(artistKey);
   if (cached) return cached;
 
-  const nameLower = artistName.toLowerCase().trim();
   const lettersLower = normalizedLetters.toLowerCase().trim();
   const query = isVarious
     ? dbClient
         .select({ id: artists.id, artist_name: artists.artist_name })
         .from(artists)
         .where(
-          and(sql`lower(${artists.artist_name}) = ${nameLower}`, sql`lower(${artists.code_letters}) = ${lettersLower}`)
+          and(
+            // Unicode-form + diacritic + case insensitive match (BS#1095,
+            // mirroring the BS#1897 runtime-path fix). The former
+            // `lower(artist_name) = lower($name)` is collation-aware but NOT
+            // Unicode-form aware: `Nilüfer Yanya` in NFC (`ü` = U+00FC) vs
+            // NFD (`u` + U+0308) is byte-distinct and misses, so this ETL
+            // inserted a duplicate `artists` row per composition form.
+            // `fold_artist_name` (migration 0134) folds NFC/NFD/ASCII-fold/
+            // case onto one key on BOTH sides — an app-side `.toLowerCase()`
+            // on the input alone can't match an NFD-stored row.
+            sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artistName})`,
+            sql`lower(${artists.code_letters}) = ${lettersLower}`
+          )
         )
         .limit(1)
     : dbClient
@@ -397,7 +418,7 @@ const ensureArtist = async (
         .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
         .where(
           and(
-            sql`lower(${artists.artist_name}) = ${nameLower}`,
+            sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artistName})`,
             sql`lower(${artists.code_letters}) = ${lettersLower}`,
             eq(genre_artist_crossreference.genre_id, genreId),
             eq(genre_artist_crossreference.artist_genre_code, artistGenreCode)
@@ -482,7 +503,11 @@ const findArtistId = async (
     .from(artists)
     .where(
       and(
-        sql`lower(${artists.artist_name}) = ${artistName.toLowerCase().trim()}`,
+        // Unicode-form + diacritic + case insensitive match (BS#1095,
+        // mirroring the BS#1897 runtime-path fix + this file's `ensureArtist`
+        // above). See the comment there for the byte-distinct NFC/NFD
+        // collision this replaces.
+        sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artistName})`,
         sql`lower(${artists.code_letters}) = ${codeLetters.toLowerCase().trim()}`
       )
     )
@@ -1177,6 +1202,8 @@ export {
   buildAlbumCacheKey,
   buildLegacySourcedSetMap,
   buildLegacySourcedSetWhere,
+  ensureArtist,
+  findArtistId,
 };
 
 run().catch((error) => {

--- a/tests/integration/library-etl-artist-fold-match.spec.js
+++ b/tests/integration/library-etl-artist-fold-match.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Integration tests for library-etl's Unicode-form artist matcher (BS#1095).
+ *
+ * `jobs/library-etl/job.ts`'s `ensureArtist` (both branches) and
+ * `findArtistId` matched existing `artists` rows via
+ * `lower(artist_name) = lower($name)`, which is collation-aware but NOT
+ * Unicode-form aware: 'Nilüfer Yanya' in NFC ('ü' = U+00FC) vs NFD ('u' +
+ * U+0308) is byte-distinct and misses, so the ETL inserted a duplicate
+ * `artists` row per composition form. The fix swaps both predicates to
+ * `fold_artist_name(artist_name) = fold_artist_name($name)` (migration 0134),
+ * mirroring the BS#1897 runtime-path fix already pinned against real Postgres
+ * in `artist-unicode-dedup.spec.js` (the `artistIdFromName` matcher there has
+ * the exact same shape as this file's genre-agnostic branch).
+ *
+ * Pure SQL — does NOT import the TS job (the integration runner is babel-jest
+ * with no TS support). The queries here mirror `ensureArtist`'s two branches
+ * and `findArtistId` in `jobs/library-etl/job.ts`; when any of those is
+ * hand-edited, the SQL here must follow.
+ *
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+// Genre id that exists in the integration fixture (used across
+// library.spec.js POST /library tests and artist-unicode-dedup.spec.js).
+const GENRE_ID = 11;
+
+// NFC vs NFD spellings of the same name, from explicit codepoints.
+const NILUFER_NFC = 'ZZ1095 Nilüfer'; // ü = U+00FC
+const NILUFER_NFD = 'ZZ1095 Nilüfer'; // u + U+0308
+const NILUFER_ASCII = 'ZZ1095 Nilufer';
+
+async function insertArtist(sql, name, codeLetters) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+    VALUES (${name}, ${name}, ${codeLetters})
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+async function insertGenreCrossref(sql, artistId, genreId, artistGenreCode) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+    VALUES (${artistId}, ${genreId}, ${artistGenreCode})
+  `;
+}
+
+/**
+ * Mirror of `ensureArtist`'s various-artist branch (name + code_letters, no
+ * genre scoping) and `findArtistId` — both use this exact predicate shape.
+ */
+async function matchByNameAndCodeLetters(sql, name, codeLetters) {
+  const rows = await sql`
+    SELECT a.id
+    FROM ${sql(SCHEMA)}.artists a
+    WHERE ${sql(SCHEMA)}.fold_artist_name(a.artist_name) = ${sql(SCHEMA)}.fold_artist_name(${name})
+      AND lower(a.code_letters) = lower(${codeLetters})
+    LIMIT 1
+  `;
+  return rows.length ? rows[0].id : 0;
+}
+
+/**
+ * Mirror of `ensureArtist`'s non-various (genre-scoped) match branch.
+ */
+async function matchEnsureArtistGenreScoped(sql, name, codeLetters, genreId, artistGenreCode) {
+  const rows = await sql`
+    SELECT a.id
+    FROM ${sql(SCHEMA)}.artists a
+    JOIN ${sql(SCHEMA)}.genre_artist_crossreference g ON g.artist_id = a.id
+    WHERE ${sql(SCHEMA)}.fold_artist_name(a.artist_name) = ${sql(SCHEMA)}.fold_artist_name(${name})
+      AND lower(a.code_letters) = lower(${codeLetters})
+      AND g.genre_id = ${genreId}
+      AND g.artist_genre_code = ${artistGenreCode}
+    LIMIT 1
+  `;
+  return rows.length ? rows[0].id : 0;
+}
+
+describe('library-etl artist Unicode-form fold match (real PG, BS#1095)', () => {
+  let sql;
+  const artistIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    for (const id of artistIds) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.genre_artist_crossreference WHERE artist_id = ${id}`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${id}`;
+    }
+  });
+
+  describe('various-artist branch / findArtistId shape (name + code_letters only)', () => {
+    let seededId;
+
+    beforeAll(async () => {
+      seededId = await insertArtist(sql, NILUFER_NFC, 'ZN');
+      artistIds.push(seededId);
+    });
+
+    test('matches the NFC-stored artist from an NFD input', async () => {
+      expect(await matchByNameAndCodeLetters(sql, NILUFER_NFD, 'ZN')).toBe(seededId);
+    });
+
+    test('matches the NFC-stored artist from an ASCII-fold input', async () => {
+      expect(await matchByNameAndCodeLetters(sql, NILUFER_ASCII, 'ZN')).toBe(seededId);
+    });
+
+    test('matches the NFC input itself', async () => {
+      expect(await matchByNameAndCodeLetters(sql, NILUFER_NFC, 'ZN')).toBe(seededId);
+    });
+
+    test('does NOT match a genuinely-different name (no false-merge)', async () => {
+      expect(await matchByNameAndCodeLetters(sql, 'ZZ1095 Jessica Pratt', 'ZN')).toBe(0);
+    });
+
+    test('does NOT match with different code_letters (scoping preserved)', async () => {
+      expect(await matchByNameAndCodeLetters(sql, NILUFER_NFD, 'XX')).toBe(0);
+    });
+  });
+
+  describe('ensureArtist genre-scoped branch', () => {
+    let seededId;
+    const artistGenreCode = 90021;
+
+    beforeAll(async () => {
+      seededId = await insertArtist(sql, NILUFER_NFC, 'ZG');
+      artistIds.push(seededId);
+      await insertGenreCrossref(sql, seededId, GENRE_ID, artistGenreCode);
+    });
+
+    test('matches the NFC-stored artist from an NFD input, scoped by genre + artist_genre_code', async () => {
+      expect(await matchEnsureArtistGenreScoped(sql, NILUFER_NFD, 'ZG', GENRE_ID, artistGenreCode)).toBe(seededId);
+    });
+
+    test('matches the NFC input itself', async () => {
+      expect(await matchEnsureArtistGenreScoped(sql, NILUFER_NFC, 'ZG', GENRE_ID, artistGenreCode)).toBe(seededId);
+    });
+
+    test('does NOT match in a different genre (genre scoping preserved)', async () => {
+      expect(await matchEnsureArtistGenreScoped(sql, NILUFER_NFD, 'ZG', GENRE_ID + 1, artistGenreCode)).toBe(0);
+    });
+
+    test('does NOT match with a different artist_genre_code (scoping preserved)', async () => {
+      expect(await matchEnsureArtistGenreScoped(sql, NILUFER_NFD, 'ZG', GENRE_ID, artistGenreCode + 1)).toBe(0);
+    });
+  });
+});

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -76,6 +76,7 @@ jest.mock('drizzle-orm', () => {
   };
 });
 
+import { sql } from 'drizzle-orm';
 import {
   parseTabRow,
   toNullableString,
@@ -95,6 +96,8 @@ import {
   buildLegacySourcedSetMap,
   buildLegacySourcedSetWhere,
   buildAlbumCacheKey,
+  ensureArtist,
+  findArtistId,
 } from '../../../jobs/library-etl/job';
 
 describe('library-etl job helpers', () => {
@@ -666,6 +669,110 @@ describe('library-etl job helpers', () => {
         .filter((k): k is string => Boolean(k))
         .sort();
       expect(whereKeys).toEqual(setKeys);
+    });
+  });
+
+  // BS#1095: `ensureArtist` + `findArtistId` matched existing `artists` rows
+  // via `lower(artist_name) = lower($name)`, which is collation-aware but not
+  // Unicode-form aware — 'Nilüfer Yanya' in NFC ('ü' = U+00FC) vs NFD ('u' +
+  // U+0308) is byte-distinct and misses, so the ETL inserted a duplicate row
+  // per composition form. The fix swaps both predicates to
+  // `fold_artist_name(artist_name) = fold_artist_name($name)` (migration
+  // 0134), mirroring the BS#1897 runtime-path fix in
+  // `apps/backend/services/library.service.ts` `artistIdFromName`. These are
+  // structural regression guards over the fully-mocked `sql` tag (the actual
+  // NFC/NFD collapse behavior is PG-side and is pinned by an integration spec
+  // against real Postgres — the mocked DB here can't execute `fold_artist_name`
+  // itself).
+  describe('ensureArtist / findArtistId Unicode-form fold match (BS#1095)', () => {
+    // 'ü' precomposed (U+00FC) vs decomposed ('u' + combining diaeresis
+    // U+0308) — same visual name, byte-distinct strings, mixed case so a
+    // regression to `.toLowerCase()` pre-processing would also be caught.
+    const NILUFER_NFC = 'Nilüfer Yanya'.normalize('NFC');
+    const NILUFER_NFD = NILUFER_NFC.normalize('NFD');
+
+    const sqlMock = sql as unknown as jest.Mock;
+
+    /**
+     * Find `sql` tagged-template calls shaped like
+     * `sql\`${FOLD_FN}(${artists.artist_name}) = ${FOLD_FN}(${name})\`` —
+     * i.e. the 2nd and 4th interpolated values are equal (the same
+     * schema-qualified `fold_artist_name` SQL-function reference used on both
+     * sides) and the 4th is the exact, untouched `name` argument.
+     */
+    const findFoldNameCalls = (name: string) =>
+      sqlMock.mock.calls.filter(
+        (args) =>
+          args[4] === name &&
+          args[1] != null &&
+          typeof args[1] === 'object' &&
+          'raw' in (args[1] as object) &&
+          args[1] === args[3]
+      );
+
+    const makeSelectOnlyDbClient = (existingRows: Array<{ id: number; artist_name: string }>) => {
+      const limitMock = jest.fn().mockResolvedValue(existingRows);
+      const whereMock = jest.fn(() => ({ limit: limitMock }));
+      const innerJoinMock = jest.fn(() => ({ where: whereMock }));
+      const fromMock = jest.fn(() => ({ where: whereMock, innerJoin: innerJoinMock }));
+      const selectMock = jest.fn(() => ({ from: fromMock }));
+      return { select: selectMock } as any;
+    };
+
+    it('ensureArtist (various-artist branch) compares fold_artist_name(column) = fold_artist_name(name), not a pre-lowered value, for both NFC and NFD spellings', async () => {
+      const dbClientNfc = makeSelectOnlyDbClient([{ id: 42, artist_name: NILUFER_NFC }]);
+      const resultNfc = await ensureArtist(dbClientNfc, NILUFER_NFC, NILUFER_NFC, true, 1, 'NY', 0, new Map());
+      expect(resultNfc.id).toBe(42);
+
+      const dbClientNfd = makeSelectOnlyDbClient([{ id: 42, artist_name: NILUFER_NFC }]);
+      const resultNfd = await ensureArtist(dbClientNfd, NILUFER_NFD, NILUFER_NFD, true, 1, 'NY', 0, new Map());
+      expect(resultNfd.id).toBe(42);
+
+      const nfcCalls = findFoldNameCalls(NILUFER_NFC);
+      const nfdCalls = findFoldNameCalls(NILUFER_NFD);
+      expect(nfcCalls.length).toBeGreaterThan(0);
+      expect(nfdCalls.length).toBeGreaterThan(0);
+      expect((nfcCalls[0][1] as { raw: string }).raw).toContain('fold_artist_name');
+      // Same fold-function reference used for both the NFC and NFD lookups —
+      // the DB-side function is what collapses the two forms, not app code.
+      expect(nfcCalls[0][1]).toBe(nfdCalls[0][1]);
+    });
+
+    it('ensureArtist (genre-scoped branch) compares fold_artist_name(column) = fold_artist_name(name)', async () => {
+      const dbClient = makeSelectOnlyDbClient([{ id: 7, artist_name: NILUFER_NFC }]);
+      const result = await ensureArtist(dbClient, NILUFER_NFD, NILUFER_NFD, false, 11, 'NY', 3, new Map());
+      expect(result.id).toBe(7);
+
+      const calls = findFoldNameCalls(NILUFER_NFD);
+      expect(calls.length).toBeGreaterThan(0);
+      expect((calls[0][1] as { raw: string }).raw).toContain('fold_artist_name');
+    });
+
+    it('findArtistId compares fold_artist_name(column) = fold_artist_name(name) for both NFC and NFD spellings', async () => {
+      const dbClientNfc = makeSelectOnlyDbClient([{ id: 99 }]);
+      const idNfc = await findArtistId(dbClientNfc, NILUFER_NFC, 'NY', new Map());
+      expect(idNfc).toBe(99);
+
+      const dbClientNfd = makeSelectOnlyDbClient([{ id: 99 }]);
+      const idNfd = await findArtistId(dbClientNfd, NILUFER_NFD, 'NY', new Map());
+      expect(idNfd).toBe(99);
+
+      const nfcCalls = findFoldNameCalls(NILUFER_NFC);
+      const nfdCalls = findFoldNameCalls(NILUFER_NFD);
+      expect(nfcCalls.length).toBeGreaterThan(0);
+      expect(nfdCalls.length).toBeGreaterThan(0);
+      expect((nfcCalls[0][1] as { raw: string }).raw).toContain('fold_artist_name');
+      expect(nfcCalls[0][1]).toBe(nfdCalls[0][1]);
+    });
+
+    it('leaves the code_letters comparison on lower() (not folded)', async () => {
+      const dbClient = makeSelectOnlyDbClient([{ id: 5 }]);
+      await findArtistId(dbClient, NILUFER_NFC, 'NY', new Map());
+
+      // The code_letters predicate is a plain `sql` call carrying a bare
+      // lowercased string value, not a { raw } fold-function reference.
+      const codeLettersCalls = sqlMock.mock.calls.filter((args) => args.includes('ny'));
+      expect(codeLettersCalls.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

`ensureArtist` and `findArtistId` in `jobs/library-etl/job.ts` matched existing `artists` rows via `lower(artist_name) = lower($name)`, which is collation-aware but not Unicode-form aware: an NFC-composed name (e.g. `Nilüfer Yanya`, `ü` = U+00FC) and its NFD-decomposed spelling (`u` + U+0308) are byte-distinct and miss the match, so the ETL would insert a duplicate `artists` row per composition form (a third for the ASCII-fold spelling).

This swaps both predicates to `fold_artist_name(artist_name) = fold_artist_name($name)` (migration 0134's SQL function), mirroring the BS#1897 runtime-path fix already shipped for the `POST /library` add-album write boundary's `artistIdFromName` matcher — same fix, same function, applied to the catalog ETL's two match sites instead. `code_letters` comparisons are left on `lower()` unchanged (ASCII, no Unicode concern).

The two prerequisites this issue originally blocked on (the canonical `fold_artist_name` function + the `jobs/artist-unicode-dedup` one-shot cleanup for existing duplicates) already shipped via BS#1897, so this closes out the residual: the catalog-ETL write path that was still creating new duplicates.

Closes #1095

## Changes

- `jobs/library-etl/job.ts`: `ensureArtist` (both the various-artist and genre-scoped branches) and `findArtistId` now match on `fold_artist_name(...)` instead of `lower(...)` for `artist_name`.
- `tests/unit/jobs/library-etl.test.ts`: exports `ensureArtist`/`findArtistId` for testing and adds structural regression-guard tests over the mocked `sql` tag, confirming both predicates reference the schema-qualified `fold_artist_name` function (not a pre-lowered JS value) for NFC and NFD spellings of the same name, and that `code_letters` is untouched.
- `tests/integration/library-etl-artist-fold-match.spec.js` (new): pins the actual NFC/NFD/ASCII-fold collapse against real Postgres for both `ensureArtist` branches and the `findArtistId` shape, mirroring the existing `artist-unicode-dedup.spec.js` precedent for the sibling runtime-path fix. This is a new integration spec — it requires the Docker `pg` tier and was not run locally per project convention; it will be exercised by CI's integration-tests job.

## Scope notes

- Left `code_letters` comparisons on `lower()` deliberately (ASCII values, no Unicode-form concern) per the issue's decided scope.
- Did not touch the in-memory `artistCache`/`buildArtistCacheKey` key hashing (still plain `.toLowerCase()`) — it's a same-run memoization optimization only; correctness now comes from the fixed DB-side predicate, so a cache miss across Unicode forms just costs one extra (now-correct) query, not a duplicate insert.

## Test plan

- `npx tsc --noEmit -p jobs/library-etl/tsconfig.json` — clean
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (814 pre-existing warnings, none newly introduced by this change)
- `npm run format:check` — clean
- `npm run test:unit` — 5959/5959 passed across 390 suites
- `test:integration` / `ci:testmock` not run locally (Docker+ports, per project convention for parallel worktrees); the new integration spec is correct-by-construction and mirrors the existing `artist-unicode-dedup.spec.js` pattern — CI will exercise it.