### PR TITLE
refactor(lml-client): extract shared search_type trust predicate; delegate coordinator + jobs (BS#1356)

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1052,17 +1052,22 @@ export const updateArtworkUrl = async (id: number, artwork_url: string | null) =
  * a coarse band kept around so future analyses can re-judge weak matches
  * once LML exposes a real signal.
  *
- * The non-direct rows are load-bearing for `flowsheet-linkage.service.ts`,
- * which calls `mapLookupToCanonicalEntity` on the raw (non-gated) lookup
- * response and uses the band to gate auto-link vs. gray-zone-review.
- * `library.controller.fireAndForgetCanonicalEntity` instead gates with
- * `requireSearchType: 'direct'` at the coordinator (BS#1355) — a deliberate
- * tightening, not a refactor: the old caller path persisted canonical
- * entities for non-direct matches (fallback / alternative / compilation /
- * song_as_artist) with their banded confidence; the gated path persists
- * only `search_type === 'direct'` (band 0.9). The non-direct bands stay
- * here for flowsheet-linkage; do not reuse them on the librarian-write
- * path without re-opening the BS#1355 decision.
+ * BS#1356: these bands are DESCRIPTIVE audit metadata, not a write gate.
+ * The only auto-accept authority for a `LookupResponse` is the
+ * `isTrustedLmlAlbumMatch` predicate (`@wxyc/lml-client`, `src/trust.ts`) —
+ * every live write path (the coordinator's `applyTrustGate`, which every
+ * `fireAndForgetCanonicalEntity` call goes through via
+ * `requireSearchType: 'direct'`, BS#1355) sits behind that predicate before
+ * `mapLookupToCanonicalEntity` below ever runs, so only `search_type ===
+ * 'direct'` (band 0.9) reaches this table on any reachable path today. The
+ * non-direct bands (0.3 / 0.5) stay for retroactive analysis and for
+ * `flowsheet-linkage.service.ts`, which reads this same table but has had
+ * **no production caller since PR #894** (the enrichment-worker superseded
+ * its inline fire-and-forget wiring) — it is dormant, not load-bearing.
+ * Do not treat a non-direct band as license to auto-persist; if
+ * flowsheet-linkage is ever revived, route it through
+ * `isTrustedLmlAlbumMatch` (or, for track-context callers, the reserved
+ * `isTrustedLmlTrackContextMatch`) rather than reading this table directly.
  */
 const SEARCH_TYPE_CONFIDENCE: Record<LookupResponse['search_type'], number | null> = {
   direct: 0.9,

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -55,6 +55,7 @@ import {
   lookupMetadata,
   shedReasonOf,
   LimiterShedError,
+  isTrustedLmlAlbumMatch,
   type GatedLookupResponse,
   type LookupOptions,
   type LookupResponse,
@@ -217,7 +218,12 @@ export class LmlLookupCoordinator {
     span: ReturnType<typeof Sentry.getActiveSpan>
   ): LookupResponse | null {
     if (!options?.requireSearchType) return response;
-    if (response.search_type === options.requireSearchType) return response;
+    // BS#1356: delegates to the shared predicate instead of re-deriving the
+    // `search_type === 'direct'` comparison inline. `requireSearchType`'s
+    // only literal value is `'direct'`, so this is behavior-identical to the
+    // prior direct comparison — including the fail-closed-on-absent case,
+    // which strict equality inside the predicate already handles.
+    if (isTrustedLmlAlbumMatch(response)) return response;
     if (span) {
       try {
         span.setAttribute('lml.coordinator.trust_reject_reason', `search_type:${response.search_type}`);

--- a/jobs/library-canonical-entity-backfill/resolve.ts
+++ b/jobs/library-canonical-entity-backfill/resolve.ts
@@ -17,7 +17,17 @@
  *   - no_match — empty result set, OR a direct match whose top result has no
  *     pinable Discogs release_id. The orchestrator does not stamp anything
  *     so the next sweep retries.
+ *
+ * BS#1356: the `search_type === 'direct'` check delegates to the shared
+ * `isTrustedLmlAlbumMatch` predicate (`@wxyc/lml-client`) instead of
+ * re-deriving the comparison locally. This converts the absent-`search_type`
+ * case from a branch-order accident (falling through to `review` because
+ * `undefined !== 'direct'`) to an explicit fail-closed call — same verdict
+ * (still `review`, never `auto_accept`), now backed by a documented,
+ * shared contract instead of an implicit fallthrough.
  */
+
+import { isTrustedLmlAlbumMatch } from '@wxyc/lml-client';
 
 import type { LmlLookupResponse } from './lml-types.js';
 
@@ -48,7 +58,7 @@ export const resolveCanonicalEntity = (response: LmlLookupResponse): Resolution 
 
   const releaseId = top.artwork?.release_id;
 
-  if (response.search_type === 'direct') {
+  if (isTrustedLmlAlbumMatch(response)) {
     if (typeof releaseId !== 'number') {
       return { status: 'no_match' };
     }

--- a/jobs/rotation-release-id-backfill/lml-fetch.ts
+++ b/jobs/rotation-release-id-backfill/lml-fetch.ts
@@ -18,9 +18,15 @@
  * `search_type` and must not be persisted; BS#1516). Mirrors the runtime
  * tier-3 path's extraction plus its BS#1351/BS#1355 trust gate so the SAME
  * entity is persisted whether the resolution happened at runtime or offline.
+ *
+ * BS#1356: the trust check now delegates to the shared `isTrustedLmlAlbumMatch`
+ * predicate (`@wxyc/lml-client`) instead of re-deriving the `search_type ===
+ * 'direct'` comparison locally — the same predicate the coordinator's
+ * `applyTrustGate` uses, so this offline path and the runtime path can no
+ * longer drift on what counts as trusted. No verdict change.
  */
 
-import { lookupMetadata as sharedLookupMetadata } from '@wxyc/lml-client';
+import { lookupMetadata as sharedLookupMetadata, isTrustedLmlAlbumMatch } from '@wxyc/lml-client';
 
 import { defaultLmlLimiter } from './lml-limiter.js';
 import type { LookupOutcome } from './orchestrate.js';
@@ -100,9 +106,11 @@ export const lookupReleaseId = async (
   // BS#1515), and a persisted wrong id is served by tier 1 forever; the
   // runtime BS#1351 gate never re-checks stored ids. Fail closed when
   // `search_type` is absent: no trust signal, no persist. Mirrors the
-  // coordinator's `requireSearchType: 'direct'` (BS#1355), which this job
-  // can't use because it imports `@wxyc/lml-client` directly.
-  if (response.search_type !== 'direct') {
+  // coordinator's `requireSearchType: 'direct'` (BS#1355) via the shared
+  // `isTrustedLmlAlbumMatch` predicate (BS#1356) — this job imports
+  // `@wxyc/lml-client` directly rather than going through the coordinator,
+  // but both now delegate to the same gate.
+  if (!isTrustedLmlAlbumMatch(response)) {
     return { kind: 'trust_rejected', searchType: response.search_type ?? 'absent' };
   }
   // `release_id: 0` (BS#1185 streaming-only sentinel) intentionally passes

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -56,6 +56,15 @@ export type {
 import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from './streaming-url-guard.js';
 export { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls };
 
+// BS#1356: shared search_type trust predicates. `isTrustedLmlAlbumMatch` is
+// the single authority every album-context write gate delegates to (the
+// coordinator's `applyTrustGate` in `apps/backend/services/lml/
+// lookup-coordinator.ts`, plus the two offline job gates); no in-package
+// callsite needs it, so it's re-exported only. `isTrustedLmlTrackContextMatch`
+// is reserved for BS#1359 and likewise has no callsite yet.
+export { isTrustedLmlAlbumMatch, isTrustedLmlTrackContextMatch } from './trust.js';
+export type { LmlTrustGateInput } from './trust.js';
+
 // BS#1826: per-caller traffic-class policy layer. `policy.ts` imports
 // `envInt` back from this module (below) — a deliberate circular import
 // that's safe because `envInt` is a hoisted `function` declaration, not a

--- a/shared/lml-client/src/trust.ts
+++ b/shared/lml-client/src/trust.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared LML `search_type` trust predicates (BS#1356).
+ *
+ * LML's `search_type` discriminator tells a caller HOW a result was found:
+ * `direct` confirms the literal (artist, album) pair typed by the caller
+ * exists in Discogs as typed. Every other value (`fallback`, `alternative`,
+ * `compilation`, `song_as_artist`, `none`) is a candidate LML offers when the
+ * typed pair wasn't found outright — `results[0]` may name a DIFFERENT album
+ * by the same artist (the Yenbett -> Tzenni recurrence, BS#1515 / BS#1516).
+ * Whether that candidate is trustworthy enough to auto-persist depends on
+ * WHAT is being persisted:
+ *
+ *   - An **album-context** write — a librarian typed this exact release
+ *     (addAlbum, the rotation picker, canonical-entity linkage) — can only
+ *     trust `direct`. See `isTrustedLmlAlbumMatch`.
+ *   - A **track-context** write — a DJ played this track and LML confirms it
+ *     lives on the returned release — can also trust `compilation`: a V/A
+ *     comp genuinely carrying that track is a correct match, not a
+ *     same-artist substitution. See `isTrustedLmlTrackContextMatch`,
+ *     reserved for BS#1359 (PR 3 of this reconciliation) and not wired into
+ *     any callsite yet.
+ *
+ * Both predicates fail closed on an absent/undefined `search_type`: no trust
+ * signal means no auto-accept. Neither bundles payload extraction (e.g.
+ * pulling `results[0].artwork.release_id`) — trust ("is this match
+ * believable") stays orthogonal to extraction ("is there a usable id"),
+ * because callers disagree on how to read a usable id out of an already-
+ * trusted response (the rotation picker treats a `release_id: 0` sentinel as
+ * "no Discogs id, but the inline tracklist is still valid"; the
+ * `rotation-release-id-backfill` orchestrator counts that same sentinel
+ * separately from a real id). Bundling extraction here couldn't serve both.
+ * See the BS#1356 decision memo §3 for the full reasoning.
+ *
+ * `SEARCH_TYPE_CONFIDENCE` in `apps/backend/services/library.service.ts`
+ * stays descriptive audit metadata (BS#1356 memo §4) — it is NOT a second
+ * write gate. These two predicates are the only auto-accept authority; every
+ * write-gate callsite (the coordinator's `applyTrustGate`, and the two
+ * offline job gates in `jobs/rotation-release-id-backfill/lml-fetch.ts` and
+ * `jobs/library-canonical-entity-backfill/resolve.ts`) delegates to
+ * `isTrustedLmlAlbumMatch` rather than re-deriving the `direct` comparison.
+ */
+import type { LookupResponse } from '@wxyc/shared/dtos';
+
+/**
+ * Minimal response shape both predicates need. Deliberately narrower than
+ * the full `LookupResponse` so a caller that maintains its own trimmed
+ * response type — e.g. `jobs/library-canonical-entity-backfill`'s
+ * `LmlLookupResponse`, which mirrors `LookupResponse` without importing
+ * `@wxyc/shared` types directly — can pass its own object structurally, with
+ * no cast. `search_type` is optional here even though the SSOT schema marks
+ * it required-with-a-default: a defensively-typed absent case is exactly
+ * what "fail closed" means, and strict equality against a literal handles
+ * `undefined` for free.
+ */
+export type LmlTrustGateInput = {
+  search_type?: LookupResponse['search_type'];
+};
+
+/**
+ * True iff `response` is a `direct` search_type match — LML confirmed the
+ * literal (artist, album) pair typed by the caller. Fails closed (`false`)
+ * on any non-`direct` value, including an absent or `undefined`
+ * `search_type`.
+ *
+ * Deliberately does NOT conjoin a `confidence >= threshold` check: today
+ * confidence is *derived from* `search_type` (see `SEARCH_TYPE_CONFIDENCE`
+ * in `library.service.ts`), so `direct` <=> the top band <=> passes — a
+ * hard-coded conjunct here would imply an independent signal LML doesn't
+ * emit yet. When LML ships per-result confidence (LML#158), add the floor
+ * INSIDE this predicate, in this one place — not as a second conjunct
+ * duplicated at each callsite.
+ */
+export function isTrustedLmlAlbumMatch(response: LmlTrustGateInput): boolean {
+  return response.search_type === 'direct';
+}
+
+/**
+ * True iff `response` is a `direct` OR `compilation` search_type match.
+ * Reserved for BS#1359 (PR 3 of the trust-gate reconciliation) — a
+ * DJ-played *track*, not a librarian-typed album, is the context here: LML
+ * confirms the typed track appears on the returned release, and a V/A
+ * compilation genuinely carrying that track is a correct match, not the
+ * same-artist substitution `isTrustedLmlAlbumMatch` guards against.
+ * `alternative` stays excluded even in track context — it's LML's
+ * closest-match fallback when neither the artist nor the album was
+ * confirmed, carrying no track-level confirmation at all.
+ *
+ * | search_type      | album match (`isTrustedLmlAlbumMatch`) | track-context match (this fn) | why |
+ * |------------------|:---------------------------------------:|:------------------------------:|-----|
+ * | direct           | trusted                                  | trusted                         | typed pair confirmed |
+ * | compilation      | rejected                                 | trusted                          | V/A comp track-confirmed; different album by design, not a substitution |
+ * | alternative      | rejected                                 | rejected                         | closest-match fallback, no track confirmation |
+ * | fallback         | rejected                                 | rejected                         | artist-only fallback answer |
+ * | song_as_artist   | rejected                                 | rejected                         | title matched as an artist name, not this track |
+ * | none / absent    | rejected                                 | rejected                         | no result / no trust signal |
+ *
+ * Not wired into any callsite in this PR — BS#1359 lands the
+ * `metadata.service.ts` migration (and the wider track-context job family)
+ * on its own option-A approval.
+ */
+export function isTrustedLmlTrackContextMatch(response: LmlTrustGateInput): boolean {
+  return response.search_type === 'direct' || response.search_type === 'compilation';
+}

--- a/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
@@ -114,6 +114,21 @@ describe('resolveCanonicalEntity', () => {
         expect(resolveCanonicalEntity(response).status).toBe('review');
       }
     });
+
+    it('routes an absent search_type to review, not auto_accept (BS#1356 fail-closed)', () => {
+      // Pre-BS#1356 this fell through to `review` by branch-order accident
+      // (`undefined !== 'direct'`); the resolver now delegates to the shared
+      // `isTrustedLmlAlbumMatch` predicate, which explicitly fails closed on
+      // an absent search_type. Same verdict, no longer an accident.
+      const response = responseFor({
+        results: [itemWithReleaseId(33)],
+        search_type: undefined,
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      expect(result.status).toBe('review');
+    });
   });
 
   describe('no_match branch', () => {

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -17,6 +17,9 @@ const loadModule = async (
   }));
   jest.doMock('@wxyc/lml-client', () => ({
     lookupMetadata: mockLookup,
+    // BS#1356: faithful stand-in for the shared trust predicate lml-fetch.ts
+    // now delegates to, mirroring its real (and only) rule.
+    isTrustedLmlAlbumMatch: (r: { search_type?: string }) => r.search_type === 'direct',
   }));
   return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
 };

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -26,11 +26,18 @@ class FakeLimiterShedError extends Error {
 const fakeShedReasonOf = (r: { outcome?: string }): string | undefined =>
   r.outcome === 'shed_limiter_saturated' || r.outcome === 'shed_breaker_open' ? r.outcome : undefined;
 
+// Faithful stand-in for the BS#1356 predicate `applyTrustGate` now delegates
+// to. Mirrors `isTrustedLmlAlbumMatch`'s real (and only) rule — fail closed
+// on anything but a `direct` search_type — so these tests keep asserting the
+// coordinator's actual gating behavior rather than a mocked verdict.
+const fakeIsTrustedLmlAlbumMatch = (r: { search_type?: string }): boolean => r.search_type === 'direct';
+
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   envInt: (_name: string, fallback: number) => fallback,
   shedReasonOf: fakeShedReasonOf,
   LimiterShedError: FakeLimiterShedError,
+  isTrustedLmlAlbumMatch: fakeIsTrustedLmlAlbumMatch,
 }));
 
 // Capture span attribute writes so the requireSearchType tests can assert

--- a/tests/unit/shared/lml-client/trust.test.ts
+++ b/tests/unit/shared/lml-client/trust.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the shared search_type trust predicates (BS#1356).
+ *
+ * `isTrustedLmlAlbumMatch` is the single authority every album-context write
+ * gate delegates to (the coordinator's `applyTrustGate`, plus the two offline
+ * job gates in `jobs/rotation-release-id-backfill` and
+ * `jobs/library-canonical-entity-backfill`). `isTrustedLmlTrackContextMatch`
+ * is reserved for BS#1359 (PR 3) and not wired into any callsite yet — these
+ * tests still pin its standalone contract so the reservation is verifiable
+ * ahead of that wiring.
+ */
+import { isTrustedLmlAlbumMatch, isTrustedLmlTrackContextMatch } from '@wxyc/lml-client';
+
+describe('isTrustedLmlAlbumMatch', () => {
+  it('trusts a direct match', () => {
+    expect(isTrustedLmlAlbumMatch({ search_type: 'direct' })).toBe(true);
+  });
+
+  it.each<string>(['fallback', 'alternative', 'compilation', 'song_as_artist', 'none'])(
+    'rejects a %s match',
+    (search_type) => {
+      expect(isTrustedLmlAlbumMatch({ search_type: search_type as never })).toBe(false);
+    }
+  );
+
+  it('fails closed on an absent search_type', () => {
+    expect(isTrustedLmlAlbumMatch({})).toBe(false);
+  });
+
+  it('fails closed on an undefined search_type', () => {
+    expect(isTrustedLmlAlbumMatch({ search_type: undefined })).toBe(false);
+  });
+});
+
+describe('isTrustedLmlTrackContextMatch', () => {
+  it('trusts a direct match', () => {
+    expect(isTrustedLmlTrackContextMatch({ search_type: 'direct' })).toBe(true);
+  });
+
+  it('trusts a compilation match', () => {
+    expect(isTrustedLmlTrackContextMatch({ search_type: 'compilation' })).toBe(true);
+  });
+
+  it.each<string>(['alternative', 'fallback', 'song_as_artist', 'none'])('rejects a %s match', (search_type) => {
+    expect(isTrustedLmlTrackContextMatch({ search_type: search_type as never })).toBe(false);
+  });
+
+  it('fails closed on an absent search_type', () => {
+    expect(isTrustedLmlTrackContextMatch({})).toBe(false);
+  });
+
+  it('fails closed on an undefined search_type', () => {
+    expect(isTrustedLmlTrackContextMatch({ search_type: undefined })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The `search_type === 'direct'` LML trust check had drifted into three separate copies (the coordinator's `applyTrustGate`, `rotation-release-id-backfill/lml-fetch.ts`, `library-canonical-entity-backfill/resolve.ts`), and the `SEARCH_TYPE_CONFIDENCE` table in `library.service.ts` described a conflicting policy (banded confidence for non-direct matches) that no longer matches any live write path. This is PR 1 of a 3-PR reconciliation, per the decision memo on #1356 (section 8 sequencing, section 9 approved asks a-f).

- Adds `shared/lml-client/src/trust.ts` exporting two predicates, both fail-closed on an absent/undefined `search_type`:
  - `isTrustedLmlAlbumMatch` — `search_type === 'direct'` only. The single auto-accept authority for album-context writes (a librarian typed this exact release).
  - `isTrustedLmlTrackContextMatch` — `direct` or `compilation`. Reserved for #1359 (PR 3); not wired into any callsite in this PR.
- Re-exports both from the package index.
- `applyTrustGate` (`apps/backend/services/lml/lookup-coordinator.ts`) now delegates to `isTrustedLmlAlbumMatch` instead of re-deriving the comparison inline.
- `jobs/rotation-release-id-backfill/lml-fetch.ts` and `jobs/library-canonical-entity-backfill/resolve.ts` both migrate to the shared predicate. For `resolve.ts` this converts its absent-`search_type` handling from an implicit branch-order fallthrough to an explicit fail-closed call — same verdict (still routes to `review`, never `auto_accept`).
- Rewrites the stale doc comment on `SEARCH_TYPE_CONFIDENCE` in `library.service.ts`: the non-direct bands are descriptive audit metadata only, the only auto-accept authority is `isTrustedLmlAlbumMatch`, and `flowsheet-linkage.service.ts` (the module the old comment called load-bearing) has had no production caller since PR #894.

## Behavior-neutral by construction

- All four coordinator callsites (rotation-picker tier-3, `enrichWithArtwork`, addAlbum artwork, `fireAndForgetCanonicalEntity`) keep their existing verdicts — `requireSearchType`'s only literal value is `'direct'`, so delegating to the predicate is the same comparison.
- Both job gates keep their existing verdicts, including fail-closed-on-absent.
- `SEARCH_TYPE_CONFIDENCE` and `mapLookupToCanonicalEntity` are untouched — the table still returns banded confidence for whatever passes the gate above it.

Not in this PR: `isTrustedLmlTrackContextMatch` is defined but not wired anywhere (reserved for #1359); the freetext-resolve cron (#1518) is untouched; no prod audit or `canonical_entity_confidence` remediation; no id-namespace changes; no migration.

## Test plan

- [x] `tests/unit/shared/lml-client/trust.test.ts` (new) — both predicates against every `search_type` value plus absent/undefined
- [x] Extended `tests/unit/services/lml/lookup-coordinator.test.ts` mock to provide a faithful `isTrustedLmlAlbumMatch` stand-in; existing `requireSearchType gate` suite (29 tests) passes unchanged
- [x] Extended `tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts` mock the same way; existing trust-gate suite passes unchanged
- [x] Added a case to `tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts` pinning the absent-`search_type` → `review` verdict
- [x] `npm run typecheck` (root workspaces)
- [x] `npx tsc --noEmit -p jobs/rotation-release-id-backfill/tsconfig.json`
- [x] `npx tsc --noEmit -p jobs/library-canonical-entity-backfill/tsconfig.json`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` (391 suites / 5979 tests passing)

Closes #1356