### PR TITLE
fix(enrichment-worker): atomic-CASE streaming UPSERT closes self-heal TOCTOU + shell-match re-ask miscount

### DIFF
--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -42,21 +42,42 @@
  *   - tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts (BS#889 / BS#1189)
  *
  * BS#1915 (bounded self-heal of unresolved streaming links). The linked-match
- * arm now reads the album's PRIOR persisted spotify/apple_music/bandcamp
- * status+url before writing, and merges each field with the fresh LML
- * verdict via `mergeStreamingField` (never downgrading an already-`verified`
- * field, forcing `absent` fields' url to null and terminal, and leaving
- * `unresolved` fields transient/retry-eligible). `streaming_reask_attempts`
- * — one shared per-album counter, not per-service, since a single LML
- * re-ask resolves all three services' verdicts at once — increments ONLY on
- * the `onConflictDoUpdate` branch (a genuine re-ask against an EXISTING
- * row); a fresh album's first-ever write leaves the column at its schema
- * DEFAULT 0, because the first ask is not a re-ask. Migration 0135 (schema)
- * carries the full design rationale; `precheck.ts` is the read side that
- * gates further re-asks at `STREAMING_REASK_ATTEMPT_CAP`.
+ * arm merges each of the three per-service streaming fields (spotify,
+ * apple_music, bandcamp) with the fresh LML verdict via `mergeStreamingField`
+ * (never downgrading an already-`verified` field, forcing `absent` fields'
+ * url to null and terminal, and leaving `unresolved` fields transient/
+ * retry-eligible). `streaming_reask_attempts` — one shared per-album counter,
+ * not per-service, since a single LML re-ask resolves all three services'
+ * verdicts at once — increments ONLY on a genuine re-ask against an EXISTING,
+ * already-matched row (see BS#1924 below); a fresh album's first-ever write
+ * leaves the column at its schema DEFAULT 0, because the first ask is not a
+ * re-ask. Migration 0135 (schema) carries the full design rationale;
+ * `precheck.ts` is the read side that gates further re-asks at
+ * `STREAMING_REASK_ATTEMPT_CAP`.
+ *
+ * BS#1923 (TOCTOU fix). The original merge read the album's PRIOR persisted
+ * streaming state via a separate SELECT *before* the LML round-trip, then
+ * wrote the merge verdict computed against that now-stale snapshot. A live
+ * CDC verify landing during the round-trip (rare, but real) could get
+ * silently clobbered back to `unresolved` plus a search URL — the write
+ * never looked at the row as it actually stood at write time. The fix folds
+ * the merge directly into the UPSERT's `onConflictDoUpdate` `set` clause as
+ * SQL `CASE` expressions over the LIVE `album_metadata` columns
+ * (`buildStreamingFieldConflictSet`), so the read and the write are the same
+ * atomic statement — there is no longer a separate read to go stale. The
+ * INSERT branch (a genuinely fresh album) still merges in plain JS against
+ * an all-NULL state, since there is no live row to race against there.
+ *
+ * BS#1924 (re-ask counter miscount fix). The counter used to increment
+ * whenever the write hit the `onConflictDoUpdate` branch — but a BS#1089
+ * no-match SHELL row (search-URL-only) already has an `album_metadata` row,
+ * so its first REAL match also hits that branch and miscounted 0->1 before
+ * any actual re-ask happened. The increment is now gated on the row already
+ * carrying a load-bearing match (`artwork_url` OR `discogs_url` present)
+ * *before* this write — a shell->matched transition leaves the counter at 0.
  */
 
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql, type AnyColumn, type SQL } from 'drizzle-orm';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { DiscogsMatchResult, LookupResponse, StreamingResolutionStatus } from '@wxyc/lml-client';
 import { cleanDiscogsBio, filterSpacerGif } from '@wxyc/metadata';
@@ -143,62 +164,111 @@ export function mergeStreamingField(
   return { status: 'unresolved', url: current.url };
 }
 
+/** A field with no synthesized search-URL fallback (Apple Music, BS#1192) never falls back — its non-verified branches keep/null the live URL directly instead of substituting a fresh search URL. */
+const NO_FALLBACK = null;
+
+/** A never-persisted album: `mergeStreamingField` treats this identically to a row whose streaming columns are all still NULL. */
+const FRESH_STREAMING_STATE: StreamingFieldState = { status: null, url: null };
+
 /**
- * Read the album's prior persisted per-service streaming state before a
- * (re-)write. Returns all-null state for an album with no `album_metadata`
- * row yet (a fresh first-ever match) — `mergeStreamingField` treats that
- * identically to a row whose columns are all still NULL.
+ * One field's `onConflictDoUpdate` `set` fragments (BS#1923): SQL `CASE`
+ * expressions over the LIVE `statusCol`/`urlCol` values, translating
+ * `mergeStreamingField`'s rules so the merge and the write are the same
+ * atomic statement — no separate SELECT that could go stale during the LML
+ * round-trip.
+ *
+ * `incomingStatus`/`incomingUrl` are plain JS values fixed for this call
+ * (this round's LML verdict) — only the "current persisted state" side of
+ * the merge needs to become SQL, since that is the side a concurrent writer
+ * could have changed since this call started. Per incoming verdict:
+ *
+ *   - `undefined` (never consulted this round): status is left unchanged
+ *     (whatever the live row already holds). A field WITH a search-URL
+ *     fallback still recomputes it fresh whenever the live status isn't
+ *     `'verified'` — unrelated to whether this field was asked this round;
+ *     that mirrors the pre-#1915 last-writer-wins fallback recompute. A
+ *     field with no fallback (Apple Music) leaves its url unchanged too.
+ *   - `'verified'`: status becomes `'verified'` unconditionally (rule 3 of
+ *     `mergeStreamingField` supersedes a prior `'absent'`); url adopts
+ *     `incomingUrl` UNLESS the live row is already `'verified'`, in which
+ *     case the live url is kept — a verified field is never downgraded,
+ *     evaluated against the row as it stands at write time, not a stale
+ *     snapshot.
+ *   - `'absent'`: status becomes `'absent'` unless the live row is already
+ *     `'verified'` (kept). url becomes the fallback (or NULL with no
+ *     fallback) in that same non-verified branch — `current.status ===
+ *     'absent'` (keep) and adopting `'absent'` fresh collapse to the same
+ *     final url here, so one branch covers both.
+ *   - `'unresolved'`: status becomes `'unresolved'` unless the live row is
+ *     already `'verified'` OR already `'absent'` (both terminal, kept). url
+ *     recomputes the fresh fallback in the non-verified branch for a field
+ *     WITH a fallback (same recompute as the `undefined` case); for Apple
+ *     Music (no fallback) the url never changes for an `'unresolved'`
+ *     verdict, in every reachable branch — so it is left as the live column
+ *     untouched.
+ *
+ * Every `${statusCol} = 'verified'` (and `'absent'`) comparison below is
+ * written out at its use site rather than factored into a shared
+ * sub-fragment — a flat template per branch, directly inspectable by a test
+ * via `.sql`/`.values` without needing to recurse through nested `SQL`
+ * objects (see `buildStreamingFieldConflictSet`'s unit tests). These
+ * predicates read the LIVE row (evaluated by Postgres against the
+ * pre-UPDATE row, same as every other `set` expression in an
+ * `ON CONFLICT DO UPDATE`) — this is exactly what closes the TOCTOU window:
+ * whatever a concurrent CDC verify wrote before this UPDATE commits is what
+ * these CASEs see.
  */
-async function selectPriorStreamingState(albumId: number): Promise<{
-  spotify: StreamingFieldState;
-  apple_music: StreamingFieldState;
-  bandcamp: StreamingFieldState;
-}> {
-  const rows = await db
-    .select({
-      spotify_status: album_metadata.spotify_status,
-      spotify_url: album_metadata.spotify_url,
-      apple_music_status: album_metadata.apple_music_status,
-      apple_music_url: album_metadata.apple_music_url,
-      bandcamp_status: album_metadata.bandcamp_status,
-      bandcamp_url: album_metadata.bandcamp_url,
-    })
-    .from(album_metadata)
-    .where(eq(album_metadata.album_id, albumId))
-    .limit(1);
-  const prior = rows[0] as
-    | {
-        spotify_status: string | null;
-        spotify_url: string | null;
-        apple_music_status: string | null;
-        apple_music_url: string | null;
-        bandcamp_status: string | null;
-        bandcamp_url: string | null;
-      }
-    | undefined;
+export function buildStreamingFieldConflictSet(
+  statusCol: AnyColumn,
+  urlCol: AnyColumn,
+  incomingStatus: StreamingResolutionStatus | undefined,
+  incomingUrl: string | null,
+  fallbackUrl: string | null
+): { status: SQL; url: SQL } {
+  const hasFallback = fallbackUrl !== NO_FALLBACK;
+
+  if (incomingStatus === undefined) {
+    return {
+      status: sql`${statusCol}`,
+      url: hasFallback
+        ? sql`CASE WHEN ${statusCol} = 'verified' THEN ${urlCol} ELSE ${fallbackUrl} END`
+        : sql`${urlCol}`,
+    };
+  }
+
+  if (incomingStatus === 'verified') {
+    return {
+      status: sql`'verified'`,
+      url: sql`CASE WHEN ${statusCol} = 'verified' THEN ${urlCol} ELSE ${incomingUrl} END`,
+    };
+  }
+
+  if (incomingStatus === 'absent') {
+    return {
+      status: sql`CASE WHEN ${statusCol} = 'verified' THEN ${statusCol} ELSE 'absent' END`,
+      url: sql`CASE WHEN ${statusCol} = 'verified' THEN ${urlCol} ELSE ${fallbackUrl} END`,
+    };
+  }
+
+  // incomingStatus === 'unresolved'
   return {
-    spotify: {
-      status: (prior?.spotify_status ?? null) as StreamingResolutionStatus | null,
-      url: prior?.spotify_url ?? null,
-    },
-    apple_music: {
-      status: (prior?.apple_music_status ?? null) as StreamingResolutionStatus | null,
-      url: prior?.apple_music_url ?? null,
-    },
-    bandcamp: {
-      status: (prior?.bandcamp_status ?? null) as StreamingResolutionStatus | null,
-      url: prior?.bandcamp_url ?? null,
-    },
+    status: sql`CASE WHEN ${statusCol} = 'verified' OR ${statusCol} = 'absent' THEN ${statusCol} ELSE 'unresolved' END`,
+    url: hasFallback ? sql`CASE WHEN ${statusCol} = 'verified' THEN ${urlCol} ELSE ${fallbackUrl} END` : sql`${urlCol}`,
   };
 }
 
 /**
- * UPSERT a matched album's full metadata payload into `album_metadata`,
- * merging the three streaming-verdict fields against the album's prior
- * state (BS#1915 — see `mergeStreamingField` / `inferIncomingStreamingStatus`
- * above) and bumping the shared `streaming_reask_attempts` counter on a
- * genuine re-ask (the `onConflictDoUpdate` branch, which fires only when a
- * row already existed for this album).
+ * UPSERT a matched album's full metadata payload into `album_metadata`.
+ *
+ * The re-ask (`onConflictDoUpdate`) branch merges the three streaming-verdict
+ * fields against the LIVE row via SQL `CASE` expressions
+ * (`buildStreamingFieldConflictSet`, BS#1923) instead of a separate
+ * SELECT-then-merge-then-write — closing the TOCTOU window a concurrent CDC
+ * verify could land in during the LML round-trip. It also bumps the shared
+ * `streaming_reask_attempts` counter, but ONLY when the row already carried a
+ * load-bearing match before this write (BS#1924) — a fresh album's INSERT
+ * (below) and a BS#1089 no-match shell's first real match both leave the
+ * counter at its schema DEFAULT 0.
  *
  * Extracted from `finalizeRow`'s linked-match arm so BOTH callers share one
  * write path: the live CDC handler (via `finalizeRow`, which also owns the
@@ -211,22 +281,23 @@ export async function upsertMatchedAlbumMetadata(
   artwork: DiscogsMatchResult,
   searchUrls: { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string }
 ): Promise<void> {
-  const prior = await selectPriorStreamingState(albumId);
-  const spotify = mergeStreamingField(
-    prior.spotify,
-    inferIncomingStreamingStatus(artwork.streaming_status?.spotify, artwork.spotify_url),
-    artwork.spotify_url
-  );
-  const appleMusic = mergeStreamingField(
-    prior.apple_music,
-    inferIncomingStreamingStatus(artwork.streaming_status?.apple_music, artwork.apple_music_url),
+  const spotifyIncomingStatus = inferIncomingStreamingStatus(artwork.streaming_status?.spotify, artwork.spotify_url);
+  const appleMusicIncomingStatus = inferIncomingStreamingStatus(
+    artwork.streaming_status?.apple_music,
     artwork.apple_music_url
   );
-  const bandcamp = mergeStreamingField(
-    prior.bandcamp,
-    inferIncomingStreamingStatus(artwork.streaming_status?.bandcamp, artwork.bandcamp_url),
-    artwork.bandcamp_url
-  );
+  const bandcampIncomingStatus = inferIncomingStreamingStatus(artwork.streaming_status?.bandcamp, artwork.bandcamp_url);
+  const spotifyIncomingUrl = artwork.spotify_url ?? null;
+  const appleMusicIncomingUrl = artwork.apple_music_url ?? null;
+  const bandcampIncomingUrl = artwork.bandcamp_url ?? null;
+
+  // INSERT branch (a genuinely fresh album — no live row to race against):
+  // merge in plain JS against an all-NULL prior state. This is a pure
+  // computation over this call's own incoming verdict, with no DB read
+  // involved, so there is no snapshot that could go stale.
+  const freshSpotify = mergeStreamingField(FRESH_STREAMING_STATE, spotifyIncomingStatus, spotifyIncomingUrl);
+  const freshAppleMusic = mergeStreamingField(FRESH_STREAMING_STATE, appleMusicIncomingStatus, appleMusicIncomingUrl);
+  const freshBandcamp = mergeStreamingField(FRESH_STREAMING_STATE, bandcampIncomingStatus, bandcampIncomingUrl);
 
   // The album_metadata UPSERT is idempotent (same album_id → same row) and
   // guarded by `updated_at < NOW()` so a concurrent stale write (e.g. a
@@ -240,18 +311,20 @@ export async function upsertMatchedAlbumMetadata(
     // A verified streaming URL wins outright; anything else (absent /
     // unresolved / never-consulted) falls back to the synthesized search
     // URL for Spotify and Bandcamp — unchanged from pre-#1915 behavior, and
-    // never a downgrade of a prior verified URL (merged above). Apple Music
-    // has NO fallback — null is load-bearing "no verified iTunes match"
-    // (BS#1192), now disambiguated by `apple_music_status` instead of
-    // silently freezing a transient null (BS#1915 — the whole point of
-    // this ticket).
-    spotify_url: spotify.status === 'verified' ? spotify.url : searchUrls.spotify_url,
-    spotify_status: spotify.status,
-    apple_music_url: appleMusic.url,
-    apple_music_status: appleMusic.status,
+    // never a downgrade of a prior verified URL. Apple Music has NO
+    // fallback — null is load-bearing "no verified iTunes match" (BS#1192),
+    // disambiguated by `apple_music_status` instead of silently freezing a
+    // transient null (BS#1915). This INSERT-branch payload only ever runs
+    // against a fresh (all-NULL) prior, so there is nothing to downgrade
+    // here — the conflict branch below is where that guarantee is load-
+    // bearing.
+    spotify_url: freshSpotify.status === 'verified' ? freshSpotify.url : searchUrls.spotify_url,
+    spotify_status: freshSpotify.status,
+    apple_music_url: freshAppleMusic.url,
+    apple_music_status: freshAppleMusic.status,
     youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
-    bandcamp_url: bandcamp.status === 'verified' ? bandcamp.url : searchUrls.bandcamp_url,
-    bandcamp_status: bandcamp.status,
+    bandcamp_url: freshBandcamp.status === 'verified' ? freshBandcamp.url : searchUrls.bandcamp_url,
+    bandcamp_status: freshBandcamp.status,
     soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
     artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
     artist_wikipedia_url: artwork.wikipedia_url ?? null,
@@ -273,6 +346,33 @@ export async function upsertMatchedAlbumMetadata(
     artist_image_url: artwork.artist_image_url ?? null,
     bio_tokens: artwork.profile_tokens ?? null,
   };
+
+  // BS#1923: the conflict (re-ask) branch replaces the plain-JS merged
+  // values above with CASE expressions over the LIVE row — see
+  // `buildStreamingFieldConflictSet`'s header for the rule-by-rule
+  // translation from `mergeStreamingField`.
+  const spotifyConflict = buildStreamingFieldConflictSet(
+    album_metadata.spotify_status,
+    album_metadata.spotify_url,
+    spotifyIncomingStatus,
+    spotifyIncomingUrl,
+    searchUrls.spotify_url
+  );
+  const appleMusicConflict = buildStreamingFieldConflictSet(
+    album_metadata.apple_music_status,
+    album_metadata.apple_music_url,
+    appleMusicIncomingStatus,
+    appleMusicIncomingUrl,
+    NO_FALLBACK
+  );
+  const bandcampConflict = buildStreamingFieldConflictSet(
+    album_metadata.bandcamp_status,
+    album_metadata.bandcamp_url,
+    bandcampIncomingStatus,
+    bandcampIncomingUrl,
+    searchUrls.bandcamp_url
+  );
+
   await db
     .insert(album_metadata)
     .values({ album_id: albumId, ...payload, updated_at: sql`NOW()` })
@@ -280,12 +380,27 @@ export async function upsertMatchedAlbumMetadata(
       target: album_metadata.album_id,
       set: {
         ...payload,
-        // BS#1915: bump the shared per-album re-ask counter ONLY on a
-        // genuine re-ask — this conflict branch fires exactly when a row
-        // already existed for this album. A fresh album's first-ever
-        // INSERT above leaves the column at its schema DEFAULT 0; the
-        // first ask is not a re-ask.
-        streaming_reask_attempts: sql`${album_metadata.streaming_reask_attempts} + 1`,
+        spotify_status: spotifyConflict.status,
+        spotify_url: spotifyConflict.url,
+        apple_music_status: appleMusicConflict.status,
+        apple_music_url: appleMusicConflict.url,
+        bandcamp_status: bandcampConflict.status,
+        bandcamp_url: bandcampConflict.url,
+        // BS#1924: bump the shared per-album re-ask counter ONLY when the
+        // row already carried a load-bearing match (artwork_url OR
+        // discogs_url present) BEFORE this write — a genuine re-ask of an
+        // already-enriched album. Both column refs read the PRE-UPDATE row
+        // (Postgres evaluates every `SET` expression in one UPDATE against
+        // the row as it stood before the statement, same as the streaming
+        // CASEs above), so a BS#1089 no-match SHELL row (search-URL only,
+        // both those columns still NULL) resolving its first REAL match
+        // does NOT miscount as a re-ask — that shell->matched transition
+        // leaves the counter at 0, same as a brand-new INSERT.
+        streaming_reask_attempts: sql`CASE
+          WHEN ${album_metadata.artwork_url} IS NOT NULL OR ${album_metadata.discogs_url} IS NOT NULL
+          THEN ${album_metadata.streaming_reask_attempts} + 1
+          ELSE ${album_metadata.streaming_reask_attempts}
+        END`,
         updated_at: sql`NOW()`,
       },
       setWhere: sql`${album_metadata.updated_at} < NOW()`,

--- a/tests/integration/enrichment-worker-streaming-toctou.spec.js
+++ b/tests/integration/enrichment-worker-streaming-toctou.spec.js
@@ -1,0 +1,294 @@
+/**
+ * Integration test for the atomic CASE-based streaming UPSERT (BS#1923 +
+ * BS#1924), replacing the old read-then-merge-then-write flow in
+ * `apps/enrichment-worker/enrich.ts#upsertMatchedAlbumMetadata`.
+ *
+ * Pure SQL against the live `album_metadata` table — does NOT import
+ * `apps/enrichment-worker/enrich.ts`. Same rationale as every other
+ * enrichment-worker integration spec in this directory (see
+ * `enrichment-worker-cache-precheck.spec.js` / `enrichment-worker-streaming-
+ * reask.spec.js` headers): the integration runner is babel-jest with no TS
+ * support (drizzle-orm + ts-jest incompatibility). `fieldConflictSql` mirrors
+ * `enrich.ts#buildStreamingFieldConflictSet` field-for-field — when that
+ * function is hand-edited, this mirror must follow (the unit suite,
+ * `tests/unit/apps/enrichment-worker/enrich.test.ts`, pins its exact CASE
+ * text/values against the real module; this spec pins the *behavior* those
+ * CASEs produce against a real row, including the race #1923 closes).
+ *
+ * BS#1923 (TOCTOU): the old flow read the album's prior streaming state via
+ * a separate SELECT *before* the LML round-trip, then wrote the merge
+ * verdict computed against that now-stale snapshot. A live CDC verify
+ * landing during the round-trip could get silently clobbered. The fix folds
+ * the merge into the UPDATE itself as CASE expressions over the LIVE
+ * columns, so there is no separate read to go stale — whatever the row
+ * holds AT THE MOMENT this statement executes is what the CASE sees, no
+ * matter how a JS-side verdict (computed independently, from LML, with no
+ * knowledge of concurrent writes) says to merge it.
+ *
+ * Test (a) simulates the race directly: a concurrent write lands (mimicking
+ * a live CDC verify landing during the sweep's LML round-trip) BEFORE the
+ * atomic conflict-update statement executes, carrying a verdict that would
+ * downgrade the field if it were being merged against a stale snapshot. The
+ * verified state must survive — proving the CASE evaluates the row as it
+ * stands at execution time, not an earlier read.
+ *
+ * BS#1924 (re-ask counter miscount): the shared `streaming_reask_attempts`
+ * counter must increment only on a GENUINE re-ask of an album that already
+ * carried a load-bearing match (`artwork_url` OR `discogs_url` present)
+ * BEFORE this write — never on a BS#1089 no-match shell row's first real
+ * match, even though that write also hits the same UPDATE (the row already
+ * existed as a shell). Tests (b)/(c) cover both sides of that gate.
+ *
+ * @see WXYC/Backend-Service#1923
+ * @see WXYC/Backend-Service#1924
+ * @see WXYC/Backend-Service#1915 (the self-heal mechanism these two harden)
+ * @see WXYC/Backend-Service#1089 (the no-match shell row BS#1924 protects)
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Mirrors `enrich.ts#buildStreamingFieldConflictSet` for ONE streaming
+ * field. `incoming` is `{status, url}` or undefined (the service's key was
+ * omitted from this round's LML verdict — never consulted this round).
+ * `fallbackUrl` is the synthesized search-URL fallback for a field that has
+ * one (spotify/bandcamp), or `null` for Apple Music (BS#1192, no fallback).
+ * Returns `{status, url}` postgres.js SQL fragments built from the LIVE
+ * `statusCol`/`urlCol` — nested directly into the caller's UPDATE (postgres.js
+ * "Building queries" — `${ sql`` }` for sql fragments), never a JS value
+ * computed from a prior SELECT.
+ */
+function fieldConflictSql(sql, statusCol, urlCol, incoming, fallbackUrl) {
+  const incomingStatus = incoming ? incoming.status : undefined;
+  const incomingUrl = incoming ? (incoming.url ?? null) : null;
+  const hasFallback = fallbackUrl !== null;
+
+  if (incomingStatus === undefined) {
+    return {
+      status: sql`${sql(statusCol)}`,
+      url: hasFallback
+        ? sql`CASE WHEN ${sql(statusCol)} = 'verified' THEN ${sql(urlCol)} ELSE ${fallbackUrl} END`
+        : sql`${sql(urlCol)}`,
+    };
+  }
+  if (incomingStatus === 'verified') {
+    return {
+      status: sql`'verified'`,
+      url: sql`CASE WHEN ${sql(statusCol)} = 'verified' THEN ${sql(urlCol)} ELSE ${incomingUrl} END`,
+    };
+  }
+  if (incomingStatus === 'absent') {
+    return {
+      status: sql`CASE WHEN ${sql(statusCol)} = 'verified' THEN ${sql(statusCol)} ELSE 'absent' END`,
+      url: sql`CASE WHEN ${sql(statusCol)} = 'verified' THEN ${sql(urlCol)} ELSE ${fallbackUrl} END`,
+    };
+  }
+  // incomingStatus === 'unresolved'
+  return {
+    status: sql`CASE WHEN ${sql(statusCol)} = 'verified' OR ${sql(statusCol)} = 'absent' THEN ${sql(statusCol)} ELSE 'unresolved' END`,
+    url: hasFallback
+      ? sql`CASE WHEN ${sql(statusCol)} = 'verified' THEN ${sql(urlCol)} ELSE ${fallbackUrl} END`
+      : sql`${sql(urlCol)}`,
+  };
+}
+
+/**
+ * Mirrors the `onConflictDoUpdate` `set` clause of
+ * `enrich.ts#upsertMatchedAlbumMetadata` (BS#1923 + BS#1924) as ONE atomic
+ * UPDATE: the three streaming fields' CASEs (BS#1923) plus the
+ * `streaming_reask_attempts` gate (BS#1924), which reads `artwork_url`/
+ * `discogs_url` as they stood BEFORE this same statement's writes — Postgres
+ * evaluates every `SET` expression in an UPDATE against the pre-statement
+ * row, exactly like every other `set` expression here.
+ */
+async function atomicConflictUpdate(sql, albumId, { artworkUrl, discogsUrl, verdict, searchUrls }) {
+  const spotify = fieldConflictSql(sql, 'spotify_status', 'spotify_url', verdict.spotify, searchUrls.spotify_url);
+  const appleMusic = fieldConflictSql(sql, 'apple_music_status', 'apple_music_url', verdict.apple_music, null);
+  const bandcamp = fieldConflictSql(sql, 'bandcamp_status', 'bandcamp_url', verdict.bandcamp, searchUrls.bandcamp_url);
+
+  await sql`
+    UPDATE ${sql(SCHEMA)}.album_metadata
+       SET artwork_url = ${artworkUrl},
+           discogs_url = ${discogsUrl},
+           spotify_status = ${spotify.status},
+           spotify_url = ${spotify.url},
+           apple_music_status = ${appleMusic.status},
+           apple_music_url = ${appleMusic.url},
+           bandcamp_status = ${bandcamp.status},
+           bandcamp_url = ${bandcamp.url},
+           streaming_reask_attempts = CASE
+             WHEN artwork_url IS NOT NULL OR discogs_url IS NOT NULL
+             THEN streaming_reask_attempts + 1
+             ELSE streaming_reask_attempts
+           END,
+           updated_at = NOW()
+     WHERE album_id = ${albumId}
+       AND updated_at < NOW()
+  `;
+}
+
+async function readRow(sql, albumId) {
+  const [row] = await sql`
+    SELECT artwork_url, discogs_url,
+           spotify_status, spotify_url,
+           apple_music_status, apple_music_url,
+           bandcamp_status, bandcamp_url,
+           streaming_reask_attempts
+      FROM ${sql(SCHEMA)}.album_metadata
+     WHERE album_id = ${albumId}
+  `;
+  return row;
+}
+
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'bs1923-1924-toctou-test-' + suffix}, 9997, 'Chuquimamani-Condori')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+describe('enrichment-worker streaming UPSERT — atomic CASE merge (BS#1923) + re-ask counter gate (BS#1924), real PG', () => {
+  let sql;
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('(a) TOCTOU CLOSED: a concurrent verify landing before the atomic write executes survives a flapping re-ask verdict', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'toctou-race');
+    insertedAlbumIds.push(albumId);
+    // Starting state: spotify is 'unresolved' — the state a hypothetical
+    // stale read (the old code's SELECT, taken before the LML round-trip)
+    // would have captured.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, discogs_url, spotify_status, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'https://discogs.com/release/1', 'unresolved', 0, NOW())
+    `;
+
+    // A live CDC verify lands NOW — mimicking it landing during the sweep's
+    // LML round-trip, i.e. AFTER a stale read would have already captured
+    // 'unresolved', but BEFORE the atomic write below executes.
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET spotify_status = 'verified', spotify_url = 'https://open.spotify.com/album/CONCURRENTLY-VERIFIED', updated_at = NOW()
+       WHERE album_id = ${albumId}
+    `;
+
+    // The atomic write's own JS-side verdict — LML's fresh probe flapping
+    // spotify to 'absent', unaware of the concurrent verify. Under the OLD
+    // read-then-merge-then-write flow this would have clobbered the
+    // just-verified row (the merge would have run against the STALE
+    // 'unresolved' snapshot). The atomic CASE evaluates the row as it
+    // stands right now instead.
+    await atomicConflictUpdate(sql, albumId, {
+      artworkUrl: 'https://i.discogs.com/x.jpg',
+      discogsUrl: 'https://discogs.com/release/1',
+      verdict: { spotify: { status: 'absent', url: null } },
+      searchUrls: { spotify_url: 'https://open.spotify.com/search/should-not-be-used', bandcamp_url: null },
+    });
+
+    const row = await readRow(sql, albumId);
+    expect(row.spotify_status).toBe('verified');
+    expect(row.spotify_url).toBe('https://open.spotify.com/album/CONCURRENTLY-VERIFIED');
+  });
+
+  test('(b) COUNTER GATE: a no-match shell album resolving its first REAL match leaves streaming_reask_attempts at 0', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'shell-to-matched');
+    insertedAlbumIds.push(albumId);
+    // A BS#1089 no-match shell: search-URLs only, artwork_url/discogs_url
+    // both still NULL. This row already exists, so the write below hits
+    // the UPDATE (conflict) branch even though it is this album's first
+    // REAL match.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, spotify_url, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://open.spotify.com/search/shell-fallback', 0, NOW())
+    `;
+
+    await atomicConflictUpdate(sql, albumId, {
+      artworkUrl: 'https://i.discogs.com/first-real-match.jpg',
+      discogsUrl: 'https://discogs.com/release/2',
+      verdict: { spotify: { status: 'verified', url: 'https://open.spotify.com/album/real' } },
+      searchUrls: { spotify_url: 'https://open.spotify.com/search/fallback', bandcamp_url: null },
+    });
+
+    const row = await readRow(sql, albumId);
+    expect(row.artwork_url).toBe('https://i.discogs.com/first-real-match.jpg');
+    expect(row.spotify_status).toBe('verified');
+    // The load-bearing point: the counter is gated on the PRE-update
+    // artwork_url/discogs_url (both NULL going into this statement), so the
+    // shell's first real match does NOT miscount as a re-ask.
+    expect(row.streaming_reask_attempts).toBe(0);
+  });
+
+  test('(c) COUNTER GATE: a genuine re-ask of an already-matched album DOES increment the counter', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'already-matched-reask');
+    insertedAlbumIds.push(albumId);
+    // Already carries a load-bearing match from a prior enrichment.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, discogs_url, spotify_status, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/existing.jpg', 'https://discogs.com/release/3', 'unresolved', 0, NOW())
+    `;
+
+    await atomicConflictUpdate(sql, albumId, {
+      artworkUrl: 'https://i.discogs.com/existing.jpg',
+      discogsUrl: 'https://discogs.com/release/3',
+      verdict: { spotify: { status: 'unresolved', url: null } },
+      searchUrls: { spotify_url: 'https://open.spotify.com/search/fallback', bandcamp_url: null },
+    });
+
+    const row = await readRow(sql, albumId);
+    expect(row.streaming_reask_attempts).toBe(1);
+
+    // A SECOND genuine re-ask increments again — not a one-time fluke.
+    await atomicConflictUpdate(sql, albumId, {
+      artworkUrl: 'https://i.discogs.com/existing.jpg',
+      discogsUrl: 'https://discogs.com/release/3',
+      verdict: { spotify: { status: 'unresolved', url: null } },
+      searchUrls: { spotify_url: 'https://open.spotify.com/search/fallback', bandcamp_url: null },
+    });
+    const row2 = await readRow(sql, albumId);
+    expect(row2.streaming_reask_attempts).toBe(2);
+  });
+
+  test('(d) never downgrades a verified field even on a genuinely fresh (non-racy) absent re-ask — same CASE, no concurrency involved', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'verified-no-race-control');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, discogs_url, spotify_status, spotify_url, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'https://discogs.com/release/4', 'verified', 'https://open.spotify.com/album/ALREADY-VERIFIED', 0, NOW())
+    `;
+
+    await atomicConflictUpdate(sql, albumId, {
+      artworkUrl: 'https://i.discogs.com/x.jpg',
+      discogsUrl: 'https://discogs.com/release/4',
+      verdict: { spotify: { status: 'absent', url: null } },
+      searchUrls: { spotify_url: 'https://open.spotify.com/search/should-not-be-used', bandcamp_url: null },
+    });
+
+    const row = await readRow(sql, albumId);
+    expect(row.spotify_status).toBe('verified');
+    expect(row.spotify_url).toBe('https://open.spotify.com/album/ALREADY-VERIFIED');
+  });
+});

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -18,6 +18,7 @@ import { jest } from '@jest/globals';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { LookupResponse, StreamingResolutionStatus } from '@wxyc/lml-client';
 import {
+  buildStreamingFieldConflictSet,
   extractArtwork,
   finalizeRow,
   inferIncomingStreamingStatus,
@@ -38,6 +39,25 @@ const mockDb = db as unknown as {
     onConflictDoNothing: jest.Mock;
   };
 };
+
+/**
+ * Renders a mocked drizzle-orm `sql` fragment's template text back to a
+ * string, splicing `<col>` at each interpolation point — same convention as
+ * `tests/unit/shared/database/concerts-sql.test.ts` /
+ * `tests/unit/jobs/rotation-release-id-backfill/writer.test.ts`. Works here
+ * because `buildStreamingFieldConflictSet` (BS#1923) writes each CASE
+ * comparison out at its use site rather than nesting sub-fragments — every
+ * returned `SQL` is a single flat `{ sql, values }` under the
+ * `tests/__mocks__/drizzle-orm.ts` mock, never a `values` entry that is
+ * itself another `sql` fragment.
+ */
+type SqlLike = { sql?: readonly string[]; values?: unknown[] };
+const renderSql = (value: unknown): string => {
+  const frag = value as SqlLike | null | undefined;
+  if (!frag?.sql) return '';
+  return frag.sql.join('<col>');
+};
+const sqlValues = (value: unknown): unknown[] => (value as SqlLike | null | undefined)?.values ?? [];
 
 // Default row is UNLINKED (album_id=null) — preserves pre-D3 behavior for the
 // existing assertions below. Linked-path tests use LINKED_ROW.
@@ -284,11 +304,6 @@ describe('finalizeRow (BS#892 PR-2)', () => {
 describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // BS#1915: the linked-match arm now reads prior per-service streaming
-    // state before merging (see `mergeStreamingField`). Default: no prior
-    // album_metadata row (a fresh album) — tests that need an existing row
-    // override with `mockDb._chain.limit.mockReturnValueOnce(...)`.
-    mockDb._chain.limit.mockReturnValue(Promise.resolve([]));
   });
 
   it('on match: UPSERTs the 10-column payload into album_metadata', async () => {
@@ -521,6 +536,169 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
 });
 
 /**
+ * BS#1923 — `buildStreamingFieldConflictSet` builds the `onConflictDoUpdate`
+ * `set` fragments for one streaming field as SQL `CASE` expressions over the
+ * LIVE `album_metadata` columns, closing the TOCTOU window the old
+ * read-then-merge-then-write flow left open (a concurrent CDC verify landing
+ * during the LML round-trip could get clobbered by a write computed against
+ * a now-stale JS snapshot). These tests pin the exact CASE text and column
+ * bindings per `mergeStreamingField` rule/incoming-verdict combination —
+ * independent of `finalizeRow`/`upsertMatchedAlbumMetadata`, which the
+ * describe blocks further below exercise end to end (still via the mocked
+ * `db`, asserting the SAME fragments land in the real `set` object).
+ */
+describe('buildStreamingFieldConflictSet (BS#1923)', () => {
+  // A field WITH a synthesized search-URL fallback (spotify/bandcamp).
+  const FALLBACK = 'https://open.spotify.com/search/fallback';
+
+  describe('a field with a search-URL fallback (spotify/bandcamp shape)', () => {
+    it('incoming undefined (never consulted): status left unchanged; url recomputes the fresh fallback unless already verified', () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.spotify_status,
+        album_metadata.spotify_url,
+        undefined,
+        null,
+        FALLBACK
+      );
+
+      expect(renderSql(frag.status)).toBe('<col>');
+      expect(sqlValues(frag.status)).toEqual([album_metadata.spotify_status]);
+
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([album_metadata.spotify_status, album_metadata.spotify_url, FALLBACK]);
+    });
+
+    it("incoming 'verified': status becomes 'verified' unconditionally; url adopts incomingUrl unless the live row is already verified", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.spotify_status,
+        album_metadata.spotify_url,
+        'verified',
+        'https://open.spotify.com/album/NEW',
+        FALLBACK
+      );
+
+      expect(renderSql(frag.status)).toBe("'verified'");
+      expect(sqlValues(frag.status)).toEqual([]);
+
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([
+        album_metadata.spotify_status,
+        album_metadata.spotify_url,
+        'https://open.spotify.com/album/NEW',
+      ]);
+    });
+
+    it("incoming 'absent': status becomes 'absent' unless already verified; url falls back to the fresh search URL in that same branch", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.bandcamp_status,
+        album_metadata.bandcamp_url,
+        'absent',
+        null,
+        FALLBACK
+      );
+
+      expect(renderSql(frag.status)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE 'absent' END");
+      expect(sqlValues(frag.status)).toEqual([album_metadata.bandcamp_status, album_metadata.bandcamp_status]);
+
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([album_metadata.bandcamp_status, album_metadata.bandcamp_url, FALLBACK]);
+    });
+
+    it("incoming 'unresolved': status becomes 'unresolved' unless already verified OR already absent (both terminal); url recomputes the fresh fallback in the same non-verified branch", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.bandcamp_status,
+        album_metadata.bandcamp_url,
+        'unresolved',
+        null,
+        FALLBACK
+      );
+
+      expect(renderSql(frag.status)).toBe(
+        "CASE WHEN <col> = 'verified' OR <col> = 'absent' THEN <col> ELSE 'unresolved' END"
+      );
+      expect(sqlValues(frag.status)).toEqual([
+        album_metadata.bandcamp_status,
+        album_metadata.bandcamp_status,
+        album_metadata.bandcamp_status,
+      ]);
+
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([album_metadata.bandcamp_status, album_metadata.bandcamp_url, FALLBACK]);
+    });
+  });
+
+  describe('a field with NO fallback (Apple Music shape, BS#1192)', () => {
+    it('incoming undefined: status AND url both left completely unchanged (no CASE at all)', () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.apple_music_status,
+        album_metadata.apple_music_url,
+        undefined,
+        null,
+        null
+      );
+
+      expect(renderSql(frag.status)).toBe('<col>');
+      expect(sqlValues(frag.status)).toEqual([album_metadata.apple_music_status]);
+      // No fallback → no CASE at all; the url column is left as a bare
+      // self-reference (a structural no-op UPDATE, not a search-URL guess).
+      expect(renderSql(frag.url)).toBe('<col>');
+      expect(sqlValues(frag.url)).toEqual([album_metadata.apple_music_url]);
+    });
+
+    it("incoming 'verified': same shape as a fallback field — adopts incomingUrl unless already verified (no fallback needed on this branch)", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.apple_music_status,
+        album_metadata.apple_music_url,
+        'verified',
+        'https://music.apple.com/album/NEW',
+        null
+      );
+
+      expect(renderSql(frag.status)).toBe("'verified'");
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([
+        album_metadata.apple_music_status,
+        album_metadata.apple_music_url,
+        'https://music.apple.com/album/NEW',
+      ]);
+    });
+
+    it("incoming 'absent': url's non-verified branch is forced NULL (the fallback param), not a search URL", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.apple_music_status,
+        album_metadata.apple_music_url,
+        'absent',
+        null,
+        null
+      );
+
+      expect(renderSql(frag.status)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE 'absent' END");
+      expect(renderSql(frag.url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      expect(sqlValues(frag.url)).toEqual([album_metadata.apple_music_status, album_metadata.apple_music_url, null]);
+    });
+
+    it("incoming 'unresolved': url is left as the bare live column in EVERY branch — never changes for an unresolved verdict", () => {
+      const frag = buildStreamingFieldConflictSet(
+        album_metadata.apple_music_status,
+        album_metadata.apple_music_url,
+        'unresolved',
+        null,
+        null
+      );
+
+      expect(renderSql(frag.status)).toBe(
+        "CASE WHEN <col> = 'verified' OR <col> = 'absent' THEN <col> ELSE 'unresolved' END"
+      );
+      // No CASE for the url at all — matches `mergeStreamingField` rule 6
+      // (carry `current.url` forward unchanged) with no post-merge fallback
+      // ternary layered on top (unlike spotify/bandcamp).
+      expect(renderSql(frag.url)).toBe('<col>');
+      expect(sqlValues(frag.url)).toEqual([album_metadata.apple_music_url]);
+    });
+  });
+});
+
+/**
  * BS#1915 — bounded self-heal of unresolved streaming links, consuming
  * LML#1053's per-service `verified` / `absent` / `unresolved` verdict on
  * `DiscogsMatchResult.streaming_status`.
@@ -533,11 +711,18 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
  * per-album bound, not per-service — increments ONLY on the conflict-update
  * branch (a genuine re-ask against an existing row); a fresh album's
  * first-ever write leaves it at the schema DEFAULT 0.
+ *
+ * BS#1923 folds that merge directly into the UPSERT as CASE expressions
+ * over the LIVE row (`buildStreamingFieldConflictSet`, tested independently
+ * above) — the describe block below exercises `finalizeRow` end to end and
+ * asserts the resulting `set` fragments structurally (their rendered CASE
+ * text + bound values), since they are no longer plain merged JS values.
+ * BS#1924 gates the `streaming_reask_attempts` bump on a pre-existing
+ * load-bearing match, tested further below.
  */
 describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-match arm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDb._chain.limit.mockReturnValue(Promise.resolve([]));
   });
 
   it('fresh album: persists a verified/absent/unresolved per-service status alongside each url', async () => {
@@ -586,19 +771,7 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
     expect(insertPayload.apple_music_url).toBe('https://music.apple.com/album/y');
   });
 
-  it('never overwrites a previously verified URL, even when a later re-ask flaps to unresolved or absent', async () => {
-    mockDb._chain.limit.mockReturnValueOnce(
-      Promise.resolve([
-        {
-          spotify_status: 'verified',
-          spotify_url: 'https://open.spotify.com/album/PRIOR',
-          apple_music_status: 'verified',
-          apple_music_url: 'https://music.apple.com/album/PRIOR',
-          bandcamp_status: null,
-          bandcamp_url: null,
-        },
-      ])
-    );
+  it('never overwrites a previously verified URL, even when a later re-ask flaps to unresolved or absent (BS#1923: checked against the LIVE row, not a stale read)', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
     const flappyResponse = {
       results: [
@@ -616,26 +789,38 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
 
     await finalizeRow(LINKED_ROW, flappyResponse);
 
+    // There is no more prior-state mock to flap against — the write no
+    // longer reads a snapshot at all. The invariant instead has to hold
+    // structurally: the CASE's FIRST branch, evaluated by Postgres against
+    // whatever the row actually holds at write time, is always "is the live
+    // status already verified — if so, keep the live status/url verbatim."
+    // A concurrently-verified row can therefore never be downgraded by this
+    // write, regardless of what LML's flappy verdict says.
     const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
-    expect(conflictCfg.set.spotify_status).toBe('verified');
-    expect(conflictCfg.set.spotify_url).toBe('https://open.spotify.com/album/PRIOR');
-    expect(conflictCfg.set.apple_music_status).toBe('verified');
-    expect(conflictCfg.set.apple_music_url).toBe('https://music.apple.com/album/PRIOR');
+    expect(renderSql(conflictCfg.set.spotify_status)).toBe(
+      "CASE WHEN <col> = 'verified' OR <col> = 'absent' THEN <col> ELSE 'unresolved' END"
+    );
+    expect(sqlValues(conflictCfg.set.spotify_status)).toEqual([
+      album_metadata.spotify_status,
+      album_metadata.spotify_status,
+      album_metadata.spotify_status,
+    ]);
+    expect(renderSql(conflictCfg.set.spotify_url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+    // The THEN branch (live status IS verified) reads the LIVE spotify_url
+    // column, not a fabricated/stale value — that is what makes the prior
+    // verified URL survive a flappy re-ask.
+    expect(sqlValues(conflictCfg.set.spotify_url)[0]).toBe(album_metadata.spotify_status);
+    expect(sqlValues(conflictCfg.set.spotify_url)[1]).toBe(album_metadata.spotify_url);
+
+    expect(renderSql(conflictCfg.set.apple_music_status)).toBe(
+      "CASE WHEN <col> = 'verified' THEN <col> ELSE 'absent' END"
+    );
+    expect(renderSql(conflictCfg.set.apple_music_url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+    expect(sqlValues(conflictCfg.set.apple_music_url)[0]).toBe(album_metadata.apple_music_status);
+    expect(sqlValues(conflictCfg.set.apple_music_url)[1]).toBe(album_metadata.apple_music_url);
   });
 
-  it('absent is terminal: url stays null and status is absent regardless of prior unresolved state', async () => {
-    mockDb._chain.limit.mockReturnValueOnce(
-      Promise.resolve([
-        {
-          apple_music_status: 'unresolved',
-          apple_music_url: null,
-          spotify_status: null,
-          spotify_url: null,
-          bandcamp_status: null,
-          bandcamp_url: null,
-        },
-      ])
-    );
+  it('absent is terminal: the non-verified branch forces status=absent/url=NULL, whether the live row was already absent or newly flapping there', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
     const response = {
       results: [
@@ -653,35 +838,21 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
     await finalizeRow(LINKED_ROW, response);
 
     const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
-    expect(conflictCfg.set.apple_music_status).toBe('absent');
-    expect(conflictCfg.set.apple_music_url).toBeNull();
-  });
-
-  it('bumps streaming_reask_attempts only on the conflict-update branch, never on the fresh-insert branch', async () => {
-    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
-
-    await finalizeRow(LINKED_ROW, matchResponse);
-
-    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(insertPayload).not.toHaveProperty('streaming_reask_attempts');
-
-    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
-    expect(conflictCfg.set.streaming_reask_attempts).toBeDefined();
-  });
-
-  it('a never-consulted service (key omitted, no url) preserves whatever prior state existed — never invents a verdict', async () => {
-    mockDb._chain.limit.mockReturnValueOnce(
-      Promise.resolve([
-        {
-          bandcamp_status: 'unresolved',
-          bandcamp_url: null,
-          spotify_status: null,
-          spotify_url: null,
-          apple_music_status: null,
-          apple_music_url: null,
-        },
-      ])
+    expect(renderSql(conflictCfg.set.apple_music_status)).toBe(
+      "CASE WHEN <col> = 'verified' THEN <col> ELSE 'absent' END"
     );
+    // Apple Music has no search-URL fallback (BS#1192) — the non-verified
+    // branch's url is the literal NULL fallback param, not a live-column
+    // carry-forward.
+    expect(renderSql(conflictCfg.set.apple_music_url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+    expect(sqlValues(conflictCfg.set.apple_music_url)).toEqual([
+      album_metadata.apple_music_status,
+      album_metadata.apple_music_url,
+      null,
+    ]);
+  });
+
+  it('a never-consulted service (key omitted, no url) is left as a bare self-reference — structurally cannot invent a verdict', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
     const response = {
       results: [
@@ -692,8 +863,9 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
             spotify_url: null,
             apple_music_url: null,
             bandcamp_url: null,
-            // bandcamp key deliberately omitted from streaming_status —
-            // never consulted this round.
+            // bandcamp key deliberately omitted from streaming_status, and
+            // its url is null — inferIncomingStreamingStatus returns
+            // undefined (genuinely never consulted this round).
             streaming_status: { spotify: 'unresolved' },
           },
         },
@@ -703,11 +875,71 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
     await finalizeRow(LINKED_ROW, response);
 
     const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
-    expect(conflictCfg.set.bandcamp_status).toBe('unresolved');
-    // The prior unresolved status is preserved (not reset to null/absent),
-    // and — same fallback rule as above — the displayed bandcamp_url stays
-    // the synthesized search URL since the status still isn't 'verified'.
-    expect(conflictCfg.set.bandcamp_url).toContain('bandcamp.com/search');
+    // status is a bare column self-reference — whatever the live row holds
+    // survives untouched, never overwritten with an invented verdict.
+    expect(renderSql(conflictCfg.set.bandcamp_status)).toBe('<col>');
+    expect(sqlValues(conflictCfg.set.bandcamp_status)).toEqual([album_metadata.bandcamp_status]);
+    // bandcamp DOES have a search-URL fallback (unlike Apple Music), so its
+    // url still recomputes the fresh synthesized search URL whenever the
+    // live status isn't verified — same recompute rule as every other
+    // non-verified branch, unrelated to this round's never-consulted status.
+    expect(renderSql(conflictCfg.set.bandcamp_url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+    const bandcampUrlValues = sqlValues(conflictCfg.set.bandcamp_url);
+    expect(bandcampUrlValues[0]).toBe(album_metadata.bandcamp_status);
+    expect(bandcampUrlValues[1]).toBe(album_metadata.bandcamp_url);
+    expect(bandcampUrlValues[2]).toContain('bandcamp.com/search');
+  });
+});
+
+/**
+ * BS#1924 — the shared per-album `streaming_reask_attempts` counter must
+ * increment only on a GENUINE re-ask of an already-enriched album, never on
+ * a BS#1089 no-match shell row's first real match (a shell already has an
+ * `album_metadata` row — search-URLs only — so its first real match also
+ * hits the `onConflictDoUpdate` branch and used to miscount 0->1 before any
+ * actual re-ask happened). The gate gets checked against the LIVE
+ * `artwork_url`/`discogs_url` columns as they stood BEFORE this write (the
+ * same pre-UPDATE-row evaluation every other `set` expression in this
+ * statement relies on) — composes with the BS#1923 CASE rewrite in the same
+ * `set` clause. The actual VALUE this CASE resolves to at conflict time (0
+ * for a shell's first match, N+1 for a genuine re-ask) is a real-Postgres
+ * fact, pinned by the integration spec
+ * (tests/integration/enrichment-worker-streaming-toctou.spec.js); this
+ * suite pins the CASE's structure and its wiring into `finalizeRow`.
+ */
+describe('finalizeRow (BS#1924) — re-ask counter gated on a pre-existing load-bearing match', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('never appears in the fresh-INSERT branch — a brand-new row leaves the counter at its schema DEFAULT 0', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload).not.toHaveProperty('streaming_reask_attempts');
+  });
+
+  it('the conflict-update CASE only increments when the live row already carries artwork_url OR discogs_url', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(renderSql(conflictCfg.set.streaming_reask_attempts)).toBe(
+      'CASE\n' +
+        '          WHEN <col> IS NOT NULL OR <col> IS NOT NULL\n' +
+        '          THEN <col> + 1\n' +
+        '          ELSE <col>\n' +
+        '        END'
+    );
+    expect(sqlValues(conflictCfg.set.streaming_reask_attempts)).toEqual([
+      album_metadata.artwork_url,
+      album_metadata.discogs_url,
+      album_metadata.streaming_reask_attempts,
+      album_metadata.streaming_reask_attempts,
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Rewrites `upsertMatchedAlbumMetadata`'s `onConflictDoUpdate` `set` clause in `apps/enrichment-worker/enrich.ts` to fix two related bugs surfaced in review of the BS#1915 streaming self-heal mechanism. Both fixes touch the same `set` clause, so they're delivered together in one PR.

### BS#1923 — TOCTOU: a stale-read sweep write can clobber a concurrently-verified URL

The old flow was read -> (LML round-trip, 1-5s) -> merge against the stale read -> write. A live CDC verify landing during the round-trip could get silently clobbered back to `unresolved` plus a search URL, because the write never looked at the row as it actually stood at write time — only at the `updated_at < NOW()` guard, which doesn't protect against this.

Fix: fold the merge directly into the UPSERT as SQL `CASE` expressions over the live `album_metadata` columns (`buildStreamingFieldConflictSet`), so the read and the write are the same atomic statement. There is no longer a separate SELECT to go stale. The INSERT branch (a genuinely fresh album) still merges in plain JS against an all-NULL prior state, since there's no live row to race against there.

Preserves every BS#1915 invariant: a `verified` field is never downgraded, `absent` stays terminal, and `unresolved` stays retry-eligible under the bounded cap — all evaluated against the live row now, not a snapshot.

### BS#1924 — no-match shell album counts its first real match as a re-ask

`streaming_reask_attempts` incremented on every `onConflictDoUpdate` branch, on the premise that "conflict branch fired = a row already existed = this is a re-ask." But a BS#1089 no-match shell row (search-URLs only, `artwork_url`/`discogs_url` both NULL) already has an `album_metadata` row, so its first REAL match also hits the conflict branch and miscounted 0->1 before any actual re-ask happened.

Fix: gate the increment on the row already carrying a load-bearing match (`artwork_url` OR `discogs_url` present) *before* this write — both column refs read the pre-UPDATE row (Postgres evaluates every `SET` expression in one UPDATE against the row as it stood before the statement), so a shell -> matched transition correctly leaves the counter at 0.

## Test plan

- [x] Unit tests (ran locally, `npm run test:unit`): new `buildStreamingFieldConflictSet` describe block pins the exact CASE text + bound columns for every incoming-verdict x fallback-presence combination; `finalizeRow` describe blocks updated to assert the conflict branch's CASE structure (verified-never-downgraded, absent-terminal, never-consulted-preserved) and the BS#1924 counter-gate CASE shape.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
- [ ] Integration test (`tests/integration/enrichment-worker-streaming-toctou.spec.js`) — CI-verified only; cannot run locally in a parallel worktree (needs exclusive Docker Postgres). Simulates a concurrent CDC verify landing before the atomic write executes and asserts the verified URL/status survive a flapping re-ask verdict, plus both sides of the BS#1924 counter gate (shell -> matched leaves the counter at 0; a genuine re-ask of an already-matched album increments it).

Closes #1923
Closes #1924