### PR TITLE
fix(flowsheet-metadata-backfill): fail fast on LML auth rejection instead of looping forever (BS#1094 Layer 3)

### DIFF
--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -52,7 +52,10 @@
  *     BS#1011) — is logged, counted, and the loop continues. The row stays
  *     `metadata_status = 'pending'`, so the next sweep retries it; the
  *     in-run cursor still advances, so one bad row can never wedge the
- *     drain.
+ *     drain. BS#1094 Layer 3 carve-out: an `LmlAuthError` (401/403 — the
+ *     shared `LML_API_KEY` bearer was rejected) is NOT treated as a
+ *     per-row `lml_error` — it aborts the whole run instead. See
+ *     `processRow`'s doc comment for the full rationale.
  *   - Cooperative pause: WXYC has no quiet hours — there is always a DJ in
  *     the booth. Before the work-list build and before each batch, the
  *     orchestrator probes `flowsheet` for
@@ -107,7 +110,7 @@ import {
   requirePositiveInt,
   type CheckLiveActivityFn,
 } from '@wxyc/database';
-import type { LookupResponse } from '@wxyc/lml-client';
+import { LmlAuthError, lmlApiKeyFingerprint, type LookupResponse } from '@wxyc/lml-client';
 import type { EnrichRow, EnrichOutcome } from './enrich.js';
 import { applyEnrichment as defaultApplyEnrichment, stampDeadLetter as defaultStampDeadLetter } from './enrich.js';
 import type { LookupResult } from './lml-fetch.js';
@@ -550,6 +553,23 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * `stampDeadLetter` so it leaves the cohort. Genuinely transient failures
  * (deadlock, serialization, connection drop, or an unreadable code) are left
  * unstamped and retryable, exactly as before.
+ *
+ * BS#1094 Layer 3 carve-out: an `LmlAuthError` (401/403 — the shared
+ * `LML_API_KEY` bearer was rejected) is NOT swallowed into the `lml_error`
+ * bucket. Every other LML throw is a per-row, plausibly-transient failure
+ * that the next sweep should simply retry; an auth rejection means EVERY
+ * row in this run (and the next, and the next) will fail identically until
+ * an operator re-coordinates the bearer rotation across consumers — looping
+ * on it just produces thousands of individually-unremarkable `lml_error`
+ * Sentry events with no aggregated signal that auth, specifically, is
+ * broken (the silent-stall failure mode BS#1094 was filed to close). So
+ * this branch logs + captures with a bearer fingerprint for triage, then
+ * RETHROWS — the throw propagates out of this run's batch loop, out of
+ * `runBackfill`, to `job.ts`'s top-level catch, which sets
+ * `process.exitCode = 1`. A loud, visible cron failure in GHA / Railway
+ * beats an invisible per-row loop. Acceptable per BS#1094's documented
+ * tradeoff: a brief auth blip kills one hourly run; the cron retries next
+ * cycle regardless.
  */
 export const processRow = async (
   row: EnrichRow,
@@ -563,6 +583,30 @@ export const processRow = async (
   try {
     result = await deps.lookup(artist, album, track, row.discogs_unavailable);
   } catch (error) {
+    if (error instanceof LmlAuthError) {
+      const bearerFingerprint = lmlApiKeyFingerprint() ?? 'unset';
+      Sentry.addBreadcrumb({
+        category: 'lml.auth',
+        message: `LML rejected the shared bearer with ${error.statusCode}`,
+        level: 'error',
+        data: { bearer_fingerprint: bearerFingerprint, status_code: error.statusCode, flowsheet_id: row.id },
+      });
+      log(
+        'error',
+        'lml_auth_error',
+        `LML rejected the shared LML_API_KEY bearer (status ${error.statusCode}) on flowsheet.id=${row.id} — aborting run instead of looping`,
+        { flowsheet_id: row.id, status_code: error.statusCode, bearer_fingerprint: bearerFingerprint }
+      );
+      captureError(error, 'lml_auth_error', {
+        flowsheet_id: row.id,
+        artist,
+        album,
+        track,
+        status_code: error.statusCode,
+        bearer_fingerprint: bearerFingerprint,
+      });
+      throw error;
+    }
     log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
       flowsheet_id: row.id,
       error_message: (error as Error).message,

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -101,6 +101,59 @@ class LmlClientError extends Error {
 export { LmlClientError };
 
 /**
+ * BS#1094 Layer 3: thrown in place of a bare `LmlClientError` when LML
+ * rejects a request with 401 or 403. Extends `LmlClientError` (not a
+ * sibling class) so every pre-existing `catch (err) { if (err instanceof
+ * LmlClientError) ... }` site keeps working unchanged, while callers that
+ * need to fail fast on the auth class specifically — the flowsheet-metadata
+ * backfill orchestrator, see `jobs/flowsheet-metadata-backfill/orchestrate.ts`
+ * — can `instanceof LmlAuthError` to distinguish "the shared LML_API_KEY
+ * bearer was rejected" from every other transient LML failure (timeout,
+ * 5xx, saturation shed, ...).
+ *
+ * Why this matters: before this class existed, `lmlFetch` mapped every
+ * `status < 500` verbatim onto a generic `LmlClientError`, so a rotated (or
+ * dropped) bearer looked identical to any other 4xx to every catch site.
+ * The backfill orchestrator bucketed all of them as the same retryable
+ * `lml_error`, leaving the row `metadata_status = 'pending'` — the next
+ * hourly sweep re-asked LML, got rejected again, and repeated forever. A
+ * distinct class lets a caller opt into fail-fast behavior for auth
+ * specifically without reinterpreting HTTP status codes at every call site.
+ */
+export class LmlAuthError extends LmlClientError {
+  constructor(message: string, statusCode: 401 | 403) {
+    super(message, statusCode);
+    this.name = 'LmlAuthError';
+  }
+}
+
+/**
+ * Minimum key length before `lmlApiKeyFingerprint` will render a
+ * first-4/last-4 fingerprint. Below this, first-4 + last-4 would overlap or
+ * cover most of the secret, so the fingerprint would leak more of the key
+ * than it's meant to.
+ */
+const MIN_FINGERPRINTABLE_KEY_LENGTH = 8;
+
+/**
+ * First/last 4 characters of the configured `LML_API_KEY`, joined by an
+ * ellipsis (e.g. `sk_l...7890`) — never the full key. BS#1094 acceptance:
+ * "Sentry breadcrumb on auth-class failures includes the bearer fingerprint
+ * ... so post-incident triage knows whether it's a rotation issue or a
+ * different auth path." Lives here (not in a job's own logger) because this
+ * module is the sole reader of `LML_API_KEY` (see the chokepoint comment in
+ * `lmlFetch` below).
+ *
+ * Returns `undefined` when the key is unset, or shorter than
+ * `MIN_FINGERPRINTABLE_KEY_LENGTH` — a short key's first-4/last-4 would
+ * leak most or all of the secret rather than merely identifying it.
+ */
+export function lmlApiKeyFingerprint(apiKey: string | undefined = process.env.LML_API_KEY): string | undefined {
+  if (!apiKey || apiKey.length < MIN_FINGERPRINTABLE_KEY_LENGTH) return undefined;
+  return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
+}
+
+/**
  * Discriminator for a runtime-lookup call the BS#1748 limiter shed rather than
  * sent to LML: either the pre-admission queue wait exceeded
  * `LML_LIMITER_MAX_QUEUE_WAIT_MS` (`shed_limiter_saturated`) or the per-limiter
@@ -613,6 +666,12 @@ async function lmlFetch(path: string, init?: RequestInit, timeoutMs?: number): P
     });
 
     if (!response.ok) {
+      // BS#1094 Layer 3: classify 401/403 distinctly from every other
+      // status. Everything else keeps the pre-existing mapping (5xx -> 502,
+      // other 4xx verbatim).
+      if (response.status === 401 || response.status === 403) {
+        throw new LmlAuthError(`LML responded with ${response.status}: ${response.statusText}`, response.status);
+      }
       throw new LmlClientError(
         `LML responded with ${response.status}: ${response.statusText}`,
         response.status >= 500 ? 502 : response.status

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -130,19 +130,23 @@ export class LmlAuthError extends LmlClientError {
 /**
  * Minimum key length before `lmlApiKeyFingerprint` will render a
  * first-4/last-4 fingerprint. Below this, first-4 + last-4 would overlap or
- * cover most of the secret, so the fingerprint would leak more of the key
- * than it's meant to.
+ * cover the whole secret, so the fingerprint would leak more of the key than
+ * it's meant to. At exactly 8 the two 4-char slices are edge-to-edge and
+ * expose every character (`abcd...efgh` for `abcdefgh`), so 9 is the smallest
+ * length that keeps at least one character hidden.
  */
-const MIN_FINGERPRINTABLE_KEY_LENGTH = 8;
+const MIN_FINGERPRINTABLE_KEY_LENGTH = 9;
 
 /**
  * First/last 4 characters of the configured `LML_API_KEY`, joined by an
  * ellipsis (e.g. `sk_l...7890`) — never the full key. BS#1094 acceptance:
  * "Sentry breadcrumb on auth-class failures includes the bearer fingerprint
  * ... so post-incident triage knows whether it's a rotation issue or a
- * different auth path." Lives here (not in a job's own logger) because this
- * module is the sole reader of `LML_API_KEY` (see the chokepoint comment in
- * `lmlFetch` below).
+ * different auth path." Lives here — the same module that attaches the bearer
+ * in `lmlFetch` — so the fingerprint is derived at the point of use and every
+ * caller shares one rendering. (Other jobs read `LML_API_KEY` directly for
+ * their own LML fetches; this is not the sole reader, just the canonical
+ * fingerprint helper.)
  *
  * Returns `undefined` when the key is unset, or shorter than
  * `MIN_FINGERPRINTABLE_KEY_LENGTH` — a short key's first-4/last-4 would
@@ -669,6 +673,17 @@ async function lmlFetch(path: string, init?: RequestInit, timeoutMs?: number): P
       // BS#1094 Layer 3: classify 401/403 distinctly from every other
       // status. Everything else keeps the pre-existing mapping (5xx -> 502,
       // other 4xx verbatim).
+      //
+      // Both 401 and 403 are auth-fatal here, and deliberately so: LML's
+      // `core/auth.py` returns 401 only when the Authorization header is
+      // *missing* (dropped bearer), and 403 when the header is present but the
+      // bearer is *wrong* — a rotated or revoked key (`reason=invalid_token_value`)
+      // or a malformed scheme. A rotated bearer, the primary scenario this
+      // layer exists to catch, is therefore a 403, not a 401; narrowing to
+      // 401-only would blind the classifier to it. LML checks the shared bearer
+      // once per request with no per-resource authorization, so an LML auth
+      // 4xx is global (every row fails identically), never query-dependent —
+      // there is no single "head row" that a spurious per-query 403 could wedge.
       if (response.status === 401 || response.status === 403) {
         throw new LmlAuthError(`LML responded with ${response.status}: ${response.statusText}`, response.status);
       }

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -47,7 +47,7 @@ import * as Sentry from '@sentry/node';
 // behaving exactly as they do today, unmocked.
 jest.mock('@sentry/node', () => {
   const actual = jest.requireActual('@sentry/node');
-  return { ...actual, captureMessage: jest.fn() };
+  return { ...actual, captureMessage: jest.fn(), addBreadcrumb: jest.fn() };
 });
 
 import { db, type CheckLiveActivityFn } from '@wxyc/database';
@@ -80,7 +80,7 @@ import type {
   BuildWorkListFn,
   WorkList,
 } from '../../../../jobs/flowsheet-metadata-backfill/worklist';
-import type { LookupResponse } from '@wxyc/lml-client';
+import { LmlAuthError, LmlClientError, type LookupResponse } from '@wxyc/lml-client';
 
 type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
 const renderSql = (value: unknown): string => {
@@ -512,6 +512,107 @@ describe('processRow', () => {
     await processRow(flaggedRow, { lookup, enrich });
 
     expect(lookup).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise', true);
+  });
+});
+
+describe('processRow — LmlAuthError fail-fast (BS#1094 Layer 3)', () => {
+  const row = {
+    id: 42,
+    artist_name: 'Autechre',
+    album_title: 'Confield',
+    track_title: 'VI Scose Poise',
+    album_id: null,
+  };
+
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, LML_API_KEY: 'sk_live_abcdef1234567890' };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('rethrows an LmlAuthError instead of returning an lml_error outcome — the row is NOT dead-lettered as retryable-forever', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new LmlAuthError('LML responded with 401: Unauthorized', 401));
+    const enrich = jest.fn<EnrichFn>();
+
+    await expect(processRow(row, { lookup, enrich })).rejects.toThrow(LmlAuthError);
+    expect(enrich).not.toHaveBeenCalled();
+  });
+
+  it('propagates a 403 LmlAuthError the same way as a 401', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new LmlAuthError('LML responded with 403: Forbidden', 403));
+    const enrich = jest.fn<EnrichFn>();
+
+    await expect(processRow(row, { lookup, enrich })).rejects.toThrow(LmlAuthError);
+  });
+
+  it('does NOT rethrow a generic LmlClientError (non-auth) — still counted as the retryable lml_error outcome', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new LmlClientError('LML request failed', 502));
+    const enrich = jest.fn<EnrichFn>();
+
+    const result = await processRow(row, { lookup, enrich });
+
+    expect(result).toEqual({ outcome: 'lml_error', cacheHit: false });
+    expect(enrich).not.toHaveBeenCalled();
+  });
+
+  it('adds a Sentry breadcrumb carrying the bearer fingerprint before rethrowing', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new LmlAuthError('LML responded with 401: Unauthorized', 401));
+    const enrich = jest.fn<EnrichFn>();
+
+    await expect(processRow(row, { lookup, enrich })).rejects.toThrow(LmlAuthError);
+
+    const addBreadcrumb = Sentry.addBreadcrumb as jest.MockedFunction<typeof Sentry.addBreadcrumb>;
+    expect(addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'lml.auth',
+        data: expect.objectContaining({ bearer_fingerprint: 'sk_l...7890' }),
+      })
+    );
+  });
+
+  it('logs an lml_auth_error line with the bearer fingerprint (bearer configured)', async () => {
+    const initLogger = (await import('../../../../jobs/flowsheet-metadata-backfill/logger')).initLogger;
+    const closeLogger = (await import('../../../../jobs/flowsheet-metadata-backfill/logger')).closeLogger;
+    initLogger({ repo: 'Backend-Service', tool: 'test', runId: 'run-id-lml-auth-error' });
+    const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const lookup = jest
+        .fn<LookupFn>()
+        .mockRejectedValue(new LmlAuthError('LML responded with 401: Unauthorized', 401));
+      const enrich = jest.fn<EnrichFn>();
+
+      await expect(processRow(row, { lookup, enrich })).rejects.toThrow(LmlAuthError);
+
+      const authErrorLine = writeSpy.mock.calls
+        .map((args) => String(args[0]))
+        .find((l) => l.includes('"step":"lml_auth_error"'));
+      if (!authErrorLine) throw new Error('expected an lml_auth_error log line');
+      const parsed = JSON.parse(authErrorLine.trim());
+      expect(parsed.bearer_fingerprint).toBe('sk_l...7890');
+      expect(parsed.status_code).toBe(401);
+    } finally {
+      writeSpy.mockRestore();
+      await closeLogger();
+    }
+  });
+
+  it('renders bearer_fingerprint as "unset" when LML_API_KEY is not configured', async () => {
+    process.env = { ...originalEnv, LML_API_KEY: undefined };
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new LmlAuthError('LML responded with 403: Forbidden', 403));
+    const enrich = jest.fn<EnrichFn>();
+
+    await expect(processRow(row, { lookup, enrich })).rejects.toThrow(LmlAuthError);
+
+    const addBreadcrumb = Sentry.addBreadcrumb as jest.MockedFunction<typeof Sentry.addBreadcrumb>;
+    expect(addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ bearer_fingerprint: 'unset' }) })
+    );
   });
 });
 

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -1524,6 +1524,48 @@ describe('runBackfill (BS#1591 work-list drain)', () => {
     expect(result.totals.enriched_no_match_raced).toBe(1);
     expect(result.totals.lml_error).toBe(0);
   });
+
+  it('rethrows an LmlAuthError out of the batch loop instead of continuing the drain (BS#1094 Layer 3)', async () => {
+    // The load-bearing propagation claim, verified end-to-end rather than by
+    // inspection: a two-row work-list where the FIRST lookup throws
+    // LmlAuthError (a rotated bearer -> LML 403). processRow rethrows, and
+    // because runBackfill awaits it (orchestrate.ts:1193) with no surrounding
+    // try/catch, the throw must escape the inner for-loop AND the outer
+    // while-loop, rejecting runBackfill entirely. job.ts's top-level catch
+    // (job.ts:78-81) turns that rejection into process.exitCode = 1, so a
+    // rotation fails the cron run instead of stalling forever. A future per-row
+    // try/catch that swallowed the throw would restore the infinite loop this
+    // layer exists to prevent — and would flip this test red.
+    const buildWorkList = injectWorkList([
+      [30, 12],
+      [10, 5],
+    ]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([rowFor(30), rowFor(10)]);
+
+    const authLookup = jest
+      .fn<LookupFn>()
+      .mockRejectedValue(new LmlAuthError('LML responded with 403: Forbidden', 403));
+    const enrichSpy = jest.fn<EnrichFn>().mockResolvedValue('enriched_match');
+
+    await expect(
+      runBackfill({
+        lookup: authLookup,
+        enrich: enrichSpy,
+        batchSize: 2,
+        throttleMs: 0,
+        liveActivityLookbackSeconds: 0,
+        playFloor: 5,
+        floorRecencyDays: 7,
+        buildWorkList,
+      })
+    ).rejects.toThrow(LmlAuthError);
+
+    // Aborted at the very first row: row 2 (id=10) never reached lookup and no
+    // enrichment ran — the drain stopped rather than advancing or looping.
+    expect(authLookup).toHaveBeenCalledTimes(1);
+    expect(authLookup.mock.calls[0]?.[0]).toBe('artist-30');
+    expect(enrichSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('W4 rotation self-heal pass (BS#895 / epic #1810)', () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -694,6 +694,17 @@ describe('lml.client', () => {
     it('returns undefined for a key too short to fingerprint without leaking most of it', () => {
       expect(lmlApiKeyFingerprint('short1')).toBeUndefined();
     });
+
+    it('returns undefined at exactly 8 chars, where first-4/last-4 would expose the whole key', () => {
+      // 'abcdefgh' -> slice(0,4)='abcd', slice(-4)='efgh' — edge to edge, every
+      // character revealed. The guard must reject this boundary, not render it.
+      expect(lmlApiKeyFingerprint('abcdefgh')).toBeUndefined();
+    });
+
+    it('renders at 9 chars, the smallest length that keeps a character hidden', () => {
+      // 'abcdefghi' -> 'abcd...fghi'; the middle char ('e') stays concealed.
+      expect(lmlApiKeyFingerprint('abcdefghi')).toBe('abcd...fghi');
+    });
   });
 
   describe('lookupMetadata discogsUnavailable gate (BS#1293)', () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -37,6 +37,8 @@ import {
   ARTIST_GENRES_BATCH_CAP,
   type ArtistGenresSource,
   LmlClientError,
+  LmlAuthError,
+  lmlApiKeyFingerprint,
   checkStreamingAvailability,
   searchLibrary,
   Semaphore,
@@ -606,6 +608,91 @@ describe('lml.client', () => {
       const result = await lookupMetadata('Autechre', 'Confield');
 
       expect(result.results[0].artwork?.spotify_url).toBe(url);
+    });
+  });
+
+  describe('LmlAuthError classification (BS#1094 Layer 3)', () => {
+    it('throws LmlAuthError (not a bare LmlClientError) on a 401 response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      } as unknown as globalThis.Response);
+
+      await expect(lookupMetadata('Autechre', 'Confield')).rejects.toThrow(LmlAuthError);
+    });
+
+    it('throws LmlAuthError on a 403 response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      } as unknown as globalThis.Response);
+
+      await expect(lookupMetadata('Autechre', 'Confield')).rejects.toThrow(LmlAuthError);
+    });
+
+    it('carries the rejected status code on the thrown LmlAuthError', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      } as unknown as globalThis.Response);
+
+      const caught: LmlAuthError = await lookupMetadata('Autechre', 'Confield').catch(
+        (e: unknown) => e as LmlAuthError
+      );
+      expect(caught).toBeInstanceOf(LmlAuthError);
+      expect(caught.statusCode).toBe(401);
+    });
+
+    it('LmlAuthError is an instanceof LmlClientError so existing catch-all sites keep working', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      } as unknown as globalThis.Response);
+
+      const caught: unknown = await lookupMetadata('Autechre', 'Confield').catch((e: unknown) => e);
+      expect(caught).toBeInstanceOf(LmlClientError);
+    });
+
+    it('does NOT classify a non-auth 4xx (e.g. 404) as LmlAuthError', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      } as unknown as globalThis.Response);
+
+      const caught: unknown = await lookupMetadata('Autechre', 'Confield').catch((e: unknown) => e);
+      expect(caught).toBeInstanceOf(LmlClientError);
+      expect(caught).not.toBeInstanceOf(LmlAuthError);
+    });
+
+    it('does NOT classify a 5xx as LmlAuthError', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+      } as unknown as globalThis.Response);
+
+      const caught: unknown = await lookupMetadata('Autechre', 'Confield').catch((e: unknown) => e);
+      expect(caught).toBeInstanceOf(LmlClientError);
+      expect(caught).not.toBeInstanceOf(LmlAuthError);
+    });
+  });
+
+  describe('lmlApiKeyFingerprint (BS#1094 Layer 3)', () => {
+    it('renders the first 4 and last 4 characters, joined by an ellipsis', () => {
+      expect(lmlApiKeyFingerprint('sk_live_abcdef1234567890')).toBe('sk_l...7890');
+    });
+
+    it('returns undefined when the key is unset', () => {
+      expect(lmlApiKeyFingerprint(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a key too short to fingerprint without leaking most of it', () => {
+      expect(lmlApiKeyFingerprint('short1')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Problem

When the `LML_API_KEY` bearer is rotated or dropped without a coordinated BS rollout, the flowsheet-metadata-backfill cron enters a **silent stall**: `lml-client` mapped 401/403 verbatim into a generic `LmlClientError`, the orchestrator bucketed every throw as the retryable `lml_error` outcome, the row stayed `metadata_status='pending'` / `metadata_attempt_at IS NULL`, and the next sweep re-picked it — looping forever while Sentry fired per-row but no aggregate signal identified auth as the cause.

## Change (BS#1094 Layer 3)

- **`shared/lml-client/src/index.ts`**: `lmlFetch` now throws a distinct `LmlAuthError extends LmlClientError` on 401/403 (all other `status < 500` responses keep their existing verbatim mapping, so catch-all sites are unaffected). Adds `lmlApiKeyFingerprint()` (first/last 4 chars; `undefined` when unset or under 8 chars) for triage context.
- **`jobs/flowsheet-metadata-backfill/orchestrate.ts`**: `processRow`'s lookup catch now detects `instanceof LmlAuthError` — it logs, adds a Sentry breadcrumb, and `captureError`s with the bearer fingerprint, then **rethrows** instead of returning the `lml_error` outcome. The throw propagates through `runBackfill` to `job.ts`'s existing top-level catch (`process.exitCode = 1`), so a rotation aborts the run and surfaces as a failed GHA/Railway cron — reusing the same exit path as `requireLmlConfigured()`. Non-auth `LmlClientError`s are unchanged (still retryable).

## Tests

TDD, 16 new tests (written red-first): 401/403 → `LmlAuthError` with `instanceof LmlClientError` preserved, 404/502 stay non-auth, fingerprint rendering/edge cases; orchestrator rethrow-on-auth, non-auth still swallowed, breadcrumb/log carry the fingerprint + status code.

Local checks green: affected unit suites (246 tests), workspace + jobs typecheck, `format:check`.

## Scope

Part of #1094. Layer 1 (the wxyc-canary `lml-auth` probe) already shipped in WXYC/wxyc-canary#32 / #34. Layer 2 (ship LML's `lml.auth.rejected` log to CloudWatch + an alarm at a sustained rate over 5/min) remains a human-gated infra follow-up — **so this PR does not fully resolve #1094 (Layer 2 tracked there).**