### PR TITLE
fix(flowsheet): reject out-of-int4-range range ids with 400 instead of 500

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -99,6 +99,10 @@ export interface IFSEntry extends Omit<
 
 const MAX_ITEMS = 200;
 const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual number of tracks due to deletions
+// flowsheet.id is a Postgres int4 column; a value outside this range parses
+// fine as a JS integer (passing Number.isInteger) but blows up downstream as
+// an unhandled "value out of range for type integer" Postgres error (BS#1800).
+const INT4_MAX = 2147483647;
 
 /**
  * Project a page of flowsheet entries to their V2 wire shape, tolerating — but
@@ -167,6 +171,15 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     }
     if (!Number.isInteger(endId)) {
       throw new WxycError('end_id must be a valid integer', 400);
+    }
+    // BS#1800: a value that parses as a valid JS integer can still exceed the
+    // flowsheet.id int4 column's range (e.g. start_id=2200000000), which
+    // Number.isInteger alone doesn't catch. Reject before it reaches Postgres.
+    if (startId < 0 || startId > INT4_MAX) {
+      throw new WxycError('start_id must be within the valid integer range', 400);
+    }
+    if (endId < 0 || endId > INT4_MAX) {
+      throw new WxycError('end_id must be within the valid integer range', 400);
     }
     // end_id < start_id would compute a negative-length range; reject rather
     // than silently returning an empty/inverted result from getEntriesByRange.

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -330,6 +330,86 @@ describe('flowsheet.controller', () => {
       });
     });
 
+    // BS#1800 (follow-up to BS#1110 / PR #1788): start_id/end_id values that
+    // parse as valid JS integers but exceed the flowsheet.id int4 column's
+    // range used to sail past the Number.isInteger guard and reach Postgres,
+    // which raised "value out of range for type integer" as an unhandled 500.
+    // These must 400 with a message naming the bad parameter, same as the
+    // NaN case above.
+    describe('range mode int4-bounds validation (BS#1800)', () => {
+      it('rejects a start_id above INT4_MAX with 400 naming start_id', async () => {
+        const req = createMockReq({ start_id: '2200000000', end_id: '2200000100' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'start_id must be within the valid integer range'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects an end_id above INT4_MAX with 400 naming end_id', async () => {
+        const req = createMockReq({ start_id: '100', end_id: '2200000100' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'end_id must be within the valid integer range'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects a negative start_id with 400', async () => {
+        const req = createMockReq({ start_id: '-1', end_id: '105' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'start_id must be within the valid integer range'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects a negative end_id with 400', async () => {
+        const req = createMockReq({ start_id: '100', end_id: '-5' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'end_id must be within the valid integer range'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects with a WxycError (400) rather than throwing an unhandled error', async () => {
+        const req = createMockReq({ start_id: '2200000000', end_id: '2200000100' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('still accepts a normal in-range request (no regression)', async () => {
+        mockGetEntriesByRange.mockResolvedValue([createMockEntry(100)]);
+
+        const req = createMockReq({ start_id: '100', end_id: '105' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(mockGetEntriesByRange).toHaveBeenCalledWith(100, 105);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('accepts start_id/end_id exactly at INT4_MAX and 0 boundaries', async () => {
+        mockGetEntriesByRange.mockResolvedValue([createMockEntry(0)]);
+
+        const req = createMockReq({ start_id: '0', end_id: '5' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(mockGetEntriesByRange).toHaveBeenCalledWith(0, 5);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+
     it('calculates offset from page and limit', async () => {
       mockGetEntriesByPage.mockResolvedValue([]);
       mockGetEntryCount.mockResolvedValue(100);


### PR DESCRIPTION
## Summary

`GET /flowsheet` range queries (`start_id`/`end_id`) still 500 on out-of-int4-range ids. #1110 (PR #1788) added a `Number.isInteger` guard that fixed the `NaN` case, but a value like `start_id=2200000000` parses to a valid JS integer, passes every existing guard, and then Postgres raises `value out of range for type integer` on the `flowsheet.id` column (`int4`), which surfaces as an unhandled 500. This is the same input-validation class PR #1788 closed — it just missed the overflow bound.

## Fix

Adds an int4-bounds check (`0` to `INT4_MAX = 2147483647`) alongside the existing `Number.isInteger` guard for both `start_id` and `end_id` in `apps/backend/controllers/flowsheet.controller.ts`, throwing via the same `WxycError(..., 400)` mechanism the sibling guards already use — no new error path.

There is currently only one range-query code path (`getEntries` in `flowsheet.controller.ts`, mounted at `GET /flowsheet`), so this single guard covers it.

## Test plan

- [x] Added failing tests first (confirmed red), then implemented the guard (confirmed green)
- [x] `start_id` above `INT4_MAX` -> 400 naming `start_id`
- [x] `end_id` above `INT4_MAX` -> 400 naming `end_id`
- [x] negative `start_id` / negative `end_id` -> 400
- [x] error is a `WxycError` (400), not an unhandled exception
- [x] normal in-range request still succeeds (no regression)
- [x] boundary case (`start_id=0`) still succeeds
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test:unit` all pass locally

Refs #1800