### PR TITLE
fix(conditionalGet): If-None-Match regression test + randomize the no-etag sentinel

### DIFF
--- a/apps/backend/middleware/conditionalGet.ts
+++ b/apps/backend/middleware/conditionalGet.ts
@@ -38,8 +38,16 @@ export type WatermarkProvider = () => Promise<Date>;
  * Sentinel written to the `ETag` header before the route handler runs, so
  * that Express's own per-body ETag generation never fires (see below), then
  * stripped again right before the response is flushed.
+ *
+ * Randomized per process (BS#1800 hardening) rather than a fixed literal: a
+ * conforming client can never legitimately echo this value back (it's
+ * stripped before flush, so no client ever observes it), but a fixed literal
+ * left a theoretical bypass — a client that happened to send
+ * `If-None-Match` equal to the exact literal would trip Express's internal
+ * freshness match and get an empty-body 304 that skipped `conditionalGet`
+ * entirely. Computed once here at module load, not per-request.
  */
-const ETAG_SUPPRESSED = 'wxyc-no-etag';
+const ETAG_SUPPRESSED = `wxyc-no-etag-${crypto.randomUUID()}`;
 
 /**
  * Forces `conditionalGet`'s watermark `Last-Modified` to be the SINGLE

--- a/tests/unit/middleware/conditionalGet.singleValidator.test.ts
+++ b/tests/unit/middleware/conditionalGet.singleValidator.test.ts
@@ -56,4 +56,47 @@ describe('singleValidatorCache middleware', () => {
 
     expect(res.headers.etag).toBeDefined();
   });
+
+  // BS#1800: the dj-site#983 regression this middleware exists to prevent.
+  // Before #1689, a watermarked route carried two independent freshness
+  // validators — this middleware's `Last-Modified` and Express's own
+  // body-hash `ETag`. A client that had cached the body-hash ETag from an
+  // earlier response could echo it back as `If-None-Match`; Express's
+  // internal `res.send` freshness check matched it and converted the
+  // response to an empty-body 304 without ever going through
+  // `conditionalGet`'s watermark decision. This test captures the ETag
+  // Express's default weak-etag generator assigns to this exact body (via
+  // the sibling `/unwrapped` route, which renders identical content without
+  // `singleValidatorCache`) and echoes it back as `If-None-Match` on the
+  // watermarked route. If a future change re-enables a body-hash ETag on a
+  // watermarked route, this captured value WOULD match it and this test
+  // would fail with a 304 + empty body — exactly reproducing the bug.
+  it('returns 200 + full body on If-None-Match, not an Express-internal empty-body 304 (dj-site#983 regression)', async () => {
+    const app = buildApp();
+
+    const control = await request(app).get('/unwrapped');
+    const bodyHashEtag = control.headers.etag;
+    expect(bodyHashEtag).toBeDefined();
+
+    const res = await request(app).get('/watermarked').set('If-None-Match', bodyHashEtag);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ hello: 'world' });
+  });
+
+  // BS#1800 sentinel hardening. The suppression sentinel written to `ETag`
+  // before the route handler runs used to be the fixed literal
+  // `wxyc-no-etag`. It is stripped before the response flushes, so a
+  // conforming client can never legitimately have cached it — but if a
+  // client (buggy, stale, or probing) echoed that exact literal back as
+  // `If-None-Match`, Express's internal freshness check would match it and
+  // produce the same empty-body 304 bypass, skipping `conditionalGet`
+  // entirely. The sentinel is now randomized per process, so the old
+  // literal must no longer match.
+  it('does not bypass on the literal legacy sentinel value "wxyc-no-etag"', async () => {
+    const res = await request(buildApp()).get('/watermarked').set('If-None-Match', 'wxyc-no-etag');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ hello: 'world' });
+  });
 });


### PR DESCRIPTION
## Summary

Two follow-up hardening items from the #1800 tracker (originally surfaced against #1689 / PR #1791):

- **Regression test.** `conditionalGet.singleValidator.test.ts` had no test asserting the core behavior the #1689 fix protects: an `If-None-Match` conditional request against a `singleValidatorCache` route must return `200` with the full body, not an Express-internal empty-body `304`. That empty-body 304 is the dj-site#983 bug. The new test captures the ETag Express's default weak-etag generator would assign to the response body (via a sibling `/unwrapped` route with identical content but without `singleValidatorCache`) and echoes it back as `If-None-Match` on the watermarked route. If a future change re-enables a body-hash ETag on a watermarked route, this captured value would match it and the test would fail with a 304 + empty body, reproducing the bug.

- **Sentinel hardening.** The ETag suppression sentinel written before the route handler runs (and stripped again before the response flushes) was the fixed literal `wxyc-no-etag`. Practically unreachable — a conforming client never observes it, since it's stripped before flush — but a client that happened to echo that exact literal back as `If-None-Match` would trip Express's internal freshness match and get the same empty-body 304 bypass, skipping `conditionalGet` entirely. The sentinel is now suffixed with `crypto.randomUUID()`, computed once at module load (a top-level `const`, so it only evaluates once per process thanks to Node's module cache), so the old literal - or any other guess - no longer matches. Added a test asserting a client echoing the old literal `wxyc-no-etag` gets a normal 200 + body.

No other `conditionalGet` behavior changed.

Refs #1800

## Test plan

- [x] `npm run typecheck` - clean
- [x] `npm run lint` - 0 errors (pre-existing warnings only, unrelated to this diff)
- [x] `npm run format:check` - clean
- [x] `npm run test:unit` - 391 suites / 6039 tests passing, including the two new tests in `tests/unit/middleware/conditionalGet.singleValidator.test.ts`