### PR TITLE
chore(backend): correct stale cron-tracing doc comments + artwork-agg + span-attr polish

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -46,7 +46,7 @@
  *                         in-memory buffer to read synchronously).
  */
 import { db, flowsheet, album_metadata, rotation, library, artists } from '@wxyc/database';
-import { sql, inArray, and, isNotNull, eq, desc } from 'drizzle-orm';
+import { sql, inArray, and, isNotNull, eq, desc, asc } from 'drizzle-orm';
 
 const MAX_ENTRIES = 200;
 const HOUR_MS = 3_600_000;
@@ -426,11 +426,15 @@ interface PlaycutCandidate {
  * the same album, each with its own artwork_url) — including rows the
  * candidate's own `flowsheet.album_id` doesn't point at, since a sibling
  * format's flowsheet row may carry artwork this one's album_id lacks. The
- * deterministic tie-break, preserved verbatim from the pre-Phase-3
- * implementation (commit d0b8317d, closes #1105): aggregate every matching
- * artwork_url into an array ordered by album_id ascending and take the
- * first element — deterministically the lowest album_id's artwork,
- * independent of scan/plan order.
+ * deterministic tie-break — lowest album_id wins, independent of scan/plan
+ * order — was originally an `array_agg(artwork_url ORDER BY album_id ASC)[1]`
+ * (commit d0b8317d, closes #1105), which materializes every matching
+ * artwork_url per group just to discard all but the first. BS#1800 replaced
+ * it with `SELECT DISTINCT ON (lookup key)` ordered by the same
+ * `(lookup key, album_id ASC)`: Postgres still scans every matching row but
+ * never builds the intermediate array, and — since a tie on `album_id` can
+ * only occur for rows sharing the same `album_metadata` row, hence the same
+ * `artwork_url` — the selected value is identical to the array_agg form.
  */
 async function enrichPlaycuts(candidates: PlaycutCandidate[]): Promise<Map<number, string>> {
   if (candidates.length === 0) return new Map();
@@ -447,11 +451,14 @@ async function enrichPlaycuts(candidates: PlaycutCandidate[]): Promise<Map<numbe
 
   try {
     const rows = await db
-      .select({
-        key: flowsheetLookupKey,
+      .selectDistinctOn([flowsheetLookupKey], {
         // See the enrichPlaycuts docstring above for the split-format
-        // tie-break rationale (BS#1105).
-        artwork_url: sql<string>`(array_agg(${album_metadata.artwork_url} order by ${album_metadata.album_id} asc))[1]`,
+        // tie-break rationale (BS#1105 / BS#1800): DISTINCT ON the lookup
+        // key, ordered by the same key then album_id ASC, picks the
+        // lowest-album_id row's artwork_url per group without materializing
+        // an array.
+        key: flowsheetLookupKey,
+        artwork_url: album_metadata.artwork_url,
       })
       .from(flowsheet)
       // INNER JOIN to album_metadata drops `flowsheet.album_id IS NULL` rows
@@ -464,7 +471,7 @@ async function enrichPlaycuts(candidates: PlaycutCandidate[]): Promise<Map<numbe
       // migration 0082 — this query never relied on it.
       .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
       .where(and(inArray(flowsheetLookupKey, keys), isNotNull(album_metadata.artwork_url)))
-      .groupBy(flowsheetLookupKey);
+      .orderBy(flowsheetLookupKey, asc(album_metadata.album_id));
 
     const map = new Map<number, string>();
     for (const row of rows) {

--- a/apps/backend/services/ses-events/emit-span.ts
+++ b/apps/backend/services/ses-events/emit-span.ts
@@ -17,10 +17,13 @@ import type { SesEvent } from './types.js';
  *     email.bounce_subtype:   (Bounce only)
  *     email.delay_type:       (DeliveryDelay only)
  *     email.reject_reason:    (Reject only) trimmed to 500 chars
- *
- *   measurements:
- *     ses.delivery_latency_ms: (Delivery only) ms from mail.timestamp to delivery.timestamp
- *     ses.processing_time_ms:  (Delivery only) delivery.processingTimeMillis
+ *     ses.delivery_latency_ms: (Delivery only) ms from mail.timestamp to
+ *                             delivery.timestamp — folded into the same
+ *                             creation-time attributes bag (not a separate
+ *                             `measurements` block) so Sentry indexes it
+ *                             numerically for avg/percentile aggregation
+ *     ses.processing_time_ms:  (Delivery only) delivery.processingTimeMillis,
+ *                             folded in alongside ses.delivery_latency_ms
  *
  *   span status:
  *     ok                 on Send/Delivery

--- a/jobs/album-reviews-etl/logger.ts
+++ b/jobs/album-reviews-etl/logger.ts
@@ -77,9 +77,10 @@ export const captureError = (error: unknown, step: string, extra: Record<string,
 
 /** Warning-level Sentry message (no exception object) — used for the
  *  source-staleness signal, which is a condition, not a thrown error.
- *  Message-based, so it needs no tracing (BS crons default
- *  SENTRY_TRACES_SAMPLE_RATE=0; span-attribute alerts would be
- *  dead-on-arrival here, see BS#1457). */
+ *  Message-based, so it needs no tracing either way — BS crons now
+ *  default `SENTRY_TRACES_SAMPLE_RATE` to 1.0 (BS#1299/PR#1782 flipped
+ *  the earlier 0 default); see BS#1457 for why span-attribute-only
+ *  alerts needed explicit tracing before that flip. */
 export const captureWarning = (message: string, step: string, extra: Record<string, unknown> = {}): void => {
   Sentry.captureMessage(message, { level: 'warning', tags: { step }, extra });
 };

--- a/jobs/library-identity-consumer/job.ts
+++ b/jobs/library-identity-consumer/job.ts
@@ -21,7 +21,7 @@ import * as Sentry from '@sentry/node';
 
 import { closeDatabaseConnection } from '@wxyc/database';
 
-import { runConsumer } from './orchestrate.js';
+import { runConsumer, type Totals } from './orchestrate.js';
 import { bulkResolveLibraries } from './lml-fetch.js';
 import { writeSingleArtist, stampUnresolvedAttemptedAt } from './writer.js';
 import {
@@ -42,6 +42,28 @@ const requireLmlConfigured = (): void => {
     throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
   }
 };
+
+/**
+ * Project a run's totals onto the flat `consumer.*` span-attribute shape
+ * (BS#1086: `rows_skipped.lml_untrusted_library_id` must mirror its sibling
+ * `rows_skipped.lml_cardinality_mismatch` here — both are cardinality-class
+ * skip buckets from `orchestrate.ts`, and only one being surfaced left the
+ * other invisible to trace-explorer pivots). Extracted to a pure function so
+ * the mapping is unit-testable without invoking Sentry or the DB.
+ */
+export const buildSpanAttributes = (totals: Totals): Record<string, number> => ({
+  'consumer.scanned': totals.scanned,
+  'consumer.rows_resolved': totals.rows_resolved,
+  'consumer.rows_unresolved': totals.rows_unresolved,
+  'consumer.rows_skipped.compilation': totals.rows_skipped.compilation,
+  'consumer.rows_skipped.lml_error': totals.rows_skipped.lml_error,
+  'consumer.rows_skipped.writer_error': totals.rows_skipped.writer_error,
+  'consumer.rows_skipped.lml_cardinality_mismatch': totals.rows_skipped.lml_cardinality_mismatch,
+  'consumer.rows_skipped.lml_untrusted_library_id': totals.rows_skipped.lml_untrusted_library_id,
+  'consumer.source_rows_skipped_null_confidence': totals.source_rows_skipped_null_confidence,
+  'consumer.lml_total_calls': totals.lml_total_calls,
+  'consumer.lml_total_latency_ms': totals.lml_total_latency_ms,
+});
 
 const main = async (): Promise<void> => {
   initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
@@ -65,18 +87,7 @@ const main = async (): Promise<void> => {
 
       // Surface the run totals as span attributes so trace explorer can
       // pivot on them without scraping the JSON log.
-      span.setAttributes({
-        'consumer.scanned': result.totals.scanned,
-        'consumer.rows_resolved': result.totals.rows_resolved,
-        'consumer.rows_unresolved': result.totals.rows_unresolved,
-        'consumer.rows_skipped.compilation': result.totals.rows_skipped.compilation,
-        'consumer.rows_skipped.lml_error': result.totals.rows_skipped.lml_error,
-        'consumer.rows_skipped.writer_error': result.totals.rows_skipped.writer_error,
-        'consumer.rows_skipped.lml_cardinality_mismatch': result.totals.rows_skipped.lml_cardinality_mismatch,
-        'consumer.source_rows_skipped_null_confidence': result.totals.source_rows_skipped_null_confidence,
-        'consumer.lml_total_calls': result.totals.lml_total_calls,
-        'consumer.lml_total_latency_ms': result.totals.lml_total_latency_ms,
-      });
+      span.setAttributes(buildSpanAttributes(result.totals));
     } catch (error) {
       log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
       captureError(error, 'failed');
@@ -88,4 +99,10 @@ const main = async (): Promise<void> => {
   });
 };
 
-void main();
+// Guard the auto-invoke so importing this module (e.g. to unit-test
+// buildSpanAttributes) doesn't fire a stray run against a live DB/LML.
+// Mirrors `jobs/album-level-backfill/job.ts`; Jest sets NODE_ENV='test' by
+// default, production runs leave it unset.
+if (process.env.NODE_ENV !== 'test') {
+  void main();
+}

--- a/jobs/triangle-shows-etl/logger.ts
+++ b/jobs/triangle-shows-etl/logger.ts
@@ -77,9 +77,10 @@ export const captureError = (error: unknown, step: string, extra: Record<string,
 
 /** Warning-level Sentry message (no exception object) — used for the
  *  source-staleness signal, which is a condition, not a thrown error.
- *  Message-based, so it needs no tracing (BS crons default
- *  SENTRY_TRACES_SAMPLE_RATE=0; span-attribute alerts would be
- *  dead-on-arrival here, see BS#1457). */
+ *  Message-based, so it needs no tracing either way — BS crons now
+ *  default `SENTRY_TRACES_SAMPLE_RATE` to 1.0 (BS#1299/PR#1782 flipped
+ *  the earlier 0 default); see BS#1457 for why span-attribute-only
+ *  alerts needed explicit tracing before that flip. */
 export const captureWarning = (message: string, step: string, extra: Record<string, unknown> = {}): void => {
   Sentry.captureMessage(message, { level: 'warning', tags: { step }, extra });
 };

--- a/tests/unit/jobs/library-identity-consumer/job.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/job.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for jobs/library-identity-consumer/job.ts's span-attribute
+ * projection (BS#1086).
+ *
+ * The run-totals span only surfaced `rows_skipped.lml_cardinality_mismatch`
+ * as a `consumer.*` attribute — its sibling cardinality-class skip bucket,
+ * `rows_skipped.lml_untrusted_library_id` (BS#1094, the result-validation
+ * skip added to `orchestrate.ts`), was silently absent from every run's
+ * trace, even though both buckets are populated the same way. `main()`
+ * itself isn't unit-tested (mirrors the rest of the jobs/* fleet: the
+ * `NODE_ENV !== 'test'` guard exists purely so this module can be imported
+ * safely, per `jobs/album-level-backfill/job.ts`) — this file pins the
+ * extracted, pure `buildSpanAttributes` mapping instead, so a future skip
+ * bucket added to `Totals` without a matching span-attribute entry is
+ * caught without needing to drive the whole job through Sentry/DB mocks.
+ */
+import { buildSpanAttributes } from '../../../../jobs/library-identity-consumer/job';
+import type { Totals } from '../../../../jobs/library-identity-consumer/orchestrate';
+
+const totals: Totals = {
+  scanned: 500,
+  rows_resolved: 300,
+  rows_unresolved: 50,
+  rows_skipped: {
+    compilation: 40,
+    lml_error: 20,
+    writer_error: 5,
+    lml_cardinality_mismatch: 3,
+    lml_untrusted_library_id: 7,
+  },
+  source_rows_skipped_null_confidence: 2,
+  lml_total_calls: 25,
+  lml_total_latency_ms: 123456,
+};
+
+describe('buildSpanAttributes (BS#1086)', () => {
+  it('surfaces rows_skipped.lml_untrusted_library_id as a span attribute, mirroring its lml_cardinality_mismatch sibling', () => {
+    const attrs = buildSpanAttributes(totals);
+
+    expect(attrs['consumer.rows_skipped.lml_cardinality_mismatch']).toBe(3);
+    expect(attrs['consumer.rows_skipped.lml_untrusted_library_id']).toBe(7);
+  });
+
+  it('projects every Totals field onto its consumer.* span attribute', () => {
+    const attrs = buildSpanAttributes(totals);
+
+    expect(attrs).toEqual({
+      'consumer.scanned': 500,
+      'consumer.rows_resolved': 300,
+      'consumer.rows_unresolved': 50,
+      'consumer.rows_skipped.compilation': 40,
+      'consumer.rows_skipped.lml_error': 20,
+      'consumer.rows_skipped.writer_error': 5,
+      'consumer.rows_skipped.lml_cardinality_mismatch': 3,
+      'consumer.rows_skipped.lml_untrusted_library_id': 7,
+      'consumer.source_rows_skipped_null_confidence': 2,
+      'consumer.lml_total_calls': 25,
+      'consumer.lml_total_latency_ms': 123456,
+    });
+  });
+
+  it('emits every attribute as a number (Sentry indexes non-numeric values as strings, breaking avg/percentile aggregation)', () => {
+    const attrs = buildSpanAttributes(totals);
+
+    for (const value of Object.values(attrs)) {
+      expect(typeof value).toBe('number');
+    }
+  });
+});

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -6,25 +6,28 @@
  * query builder and exercise: entry_type -> tubafrenzy wire-vocabulary
  * mapping, hour/chronOrderID/timeCreated synthesis, rotation/request string
  * coercion, playcut slicing vs. unsliced talksets/breakpoints, and artwork
- * enrichment (including the BS#1105 split-format tie-break, preserved from
- * the pre-Phase-3 implementation).
+ * enrichment (including the BS#1105 split-format tie-break, rewritten from
+ * an `array_agg(...)[1]` to a `DISTINCT ON` by BS#1800).
  */
 import { jest } from '@jest/globals';
 
 // --- Mocks ---
 
-// Mock the database module. A single shared chain object is reused for both
-// query shapes getRecentEntries issues:
-//   1. main entries query:   select().from(flowsheet).leftJoin(rotation, ...).orderBy(...).limit(...)
-//   2. artwork batch query:  select().from(flowsheet).innerJoin(album_metadata, ...).where(...).groupBy(...)
-// The two are distinguished by their terminal method: `.limit()` resolves
-// the main entries rows, `.groupBy()` resolves the artwork rows.
+// Mock the database module. A single shared chain object is reused for the
+// main entries query shape getRecentEntries issues:
+//   select().from(flowsheet).leftJoin(rotation, ...).orderBy(...).limit(...)
+// resolved by its terminal `.limit()`. The artwork batch query is a separate
+// entry point/chain (BS#1800 rewrote it from `.select()...groupBy()` to
+// `.selectDistinctOn()...orderBy()`, and `.orderBy()` is also a *non-terminal*
+// link in the main chain above, so it needs its own mock chain to avoid the
+// two meanings colliding):
+//   selectDistinctOn().from(flowsheet).innerJoin(album_metadata, ...).where(...).orderBy(...)
+// resolved by its terminal `.orderBy()`.
 const mockSelect = jest.fn();
 const mockFrom = jest.fn();
 const mockLeftJoin = jest.fn();
 const mockInnerJoin = jest.fn();
 const mockWhere = jest.fn();
-const mockGroupBy = jest.fn();
 const mockOrderBy = jest.fn();
 const mockLimit = jest.fn();
 // db.execute(sql`...`) resolves the batched rotation-fallback query (BS#1862).
@@ -36,7 +39,6 @@ const mockDbChain = {
   leftJoin: mockLeftJoin,
   innerJoin: mockInnerJoin,
   where: mockWhere,
-  groupBy: mockGroupBy,
   orderBy: mockOrderBy,
   limit: mockLimit,
 };
@@ -45,19 +47,40 @@ mockFrom.mockReturnValue(mockDbChain);
 mockLeftJoin.mockReturnValue(mockDbChain);
 mockInnerJoin.mockReturnValue(mockDbChain);
 mockWhere.mockReturnValue(mockDbChain);
-mockGroupBy.mockResolvedValue([]);
 mockOrderBy.mockReturnValue(mockDbChain);
 mockLimit.mockResolvedValue([]);
 mockExecute.mockResolvedValue([]); // rotation fallback: no matches by default
 
+// Separate chain for the artwork `db.selectDistinctOn(...)` query (BS#1105 /
+// BS#1800) — kept apart from mockDbChain because its terminal call is
+// `.orderBy()`, which mockDbChain's main-entries chain also uses, but
+// non-terminally (before `.limit()`).
+const mockSelectDistinctOn = jest.fn();
+const mockArtworkFrom = jest.fn();
+const mockArtworkInnerJoin = jest.fn();
+const mockArtworkWhere = jest.fn();
+const mockArtworkOrderBy = jest.fn();
+
+const artworkChain = {
+  from: mockArtworkFrom,
+  innerJoin: mockArtworkInnerJoin,
+  where: mockArtworkWhere,
+  orderBy: mockArtworkOrderBy,
+};
+mockSelectDistinctOn.mockReturnValue(artworkChain);
+mockArtworkFrom.mockReturnValue(artworkChain);
+mockArtworkInnerJoin.mockReturnValue(artworkChain);
+mockArtworkWhere.mockReturnValue(artworkChain);
+mockArtworkOrderBy.mockResolvedValue([]); // artwork query default: no matches
+
 jest.mock('@wxyc/database', () => ({
   db: {
     select: (...args: unknown[]) => mockSelect(...args),
+    selectDistinctOn: (...args: unknown[]) => mockSelectDistinctOn(...args),
     from: (...args: unknown[]) => mockFrom(...args),
     leftJoin: (...args: unknown[]) => mockLeftJoin(...args),
     innerJoin: (...args: unknown[]) => mockInnerJoin(...args),
     where: (...args: unknown[]) => mockWhere(...args),
-    groupBy: (...args: unknown[]) => mockGroupBy(...args),
     orderBy: (...args: unknown[]) => mockOrderBy(...args),
     limit: (...args: unknown[]) => mockLimit(...args),
     execute: (...args: unknown[]) => mockExecute(...args),
@@ -108,6 +131,7 @@ jest.mock('drizzle-orm', () => ({
   and: jest.fn(),
   eq: jest.fn(),
   desc: jest.fn(),
+  asc: jest.fn(),
 }));
 
 // Suppress console output in tests
@@ -268,9 +292,13 @@ describe('playlist-proxy.service', () => {
     mockInnerJoin.mockReturnValue(mockDbChain);
     mockWhere.mockReturnValue(mockDbChain);
     mockOrderBy.mockReturnValue(mockDbChain);
-    mockGroupBy.mockResolvedValue([]); // artwork query default: no matches
     mockLimit.mockResolvedValue([]); // main entries query default: empty
     mockExecute.mockResolvedValue([]); // rotation fallback default: no matches
+    mockSelectDistinctOn.mockReturnValue(artworkChain);
+    mockArtworkFrom.mockReturnValue(artworkChain);
+    mockArtworkInnerJoin.mockReturnValue(artworkChain);
+    mockArtworkWhere.mockReturnValue(artworkChain);
+    mockArtworkOrderBy.mockResolvedValue([]); // artwork query default: no matches
   });
 
   describe('getRecentEntries — grouping and entry_type mapping', () => {
@@ -538,7 +566,7 @@ describe('playlist-proxy.service', () => {
   describe('getRecentEntries — artwork enrichment', () => {
     it('enriches playcuts with artwork from DB', async () => {
       mockLimit.mockResolvedValue([jessicaPrattRow]);
-      mockGroupBy.mockResolvedValue([
+      mockArtworkOrderBy.mockResolvedValue([
         { key: 'jessica pratt-on your own love again', artwork_url: 'https://i.discogs.com/jessica.jpg' },
       ]);
 
@@ -549,7 +577,7 @@ describe('playlist-proxy.service', () => {
 
     it('omits artworkURL when there is no metadata match', async () => {
       mockLimit.mockResolvedValue([jessicaPrattRow]);
-      mockGroupBy.mockResolvedValue([]);
+      mockArtworkOrderBy.mockResolvedValue([]);
 
       const result = await getRecentEntries(50);
 
@@ -558,7 +586,7 @@ describe('playlist-proxy.service', () => {
 
     it('degrades to no artwork (rather than throwing) when the artwork query fails', async () => {
       mockLimit.mockResolvedValue([jessicaPrattRow]);
-      mockGroupBy.mockRejectedValue(new Error('DB connection lost'));
+      mockArtworkOrderBy.mockRejectedValue(new Error('DB connection lost'));
 
       const result = await getRecentEntries(50);
 
@@ -570,7 +598,7 @@ describe('playlist-proxy.service', () => {
 
       await getRecentEntries(50);
 
-      expect(mockGroupBy).not.toHaveBeenCalled();
+      expect(mockArtworkOrderBy).not.toHaveBeenCalled();
     });
 
     it('only enriches the sliced playcuts, not the full 200-row window', async () => {
@@ -579,7 +607,7 @@ describe('playlist-proxy.service', () => {
         id: 4000 + i,
       }));
       mockLimit.mockResolvedValue(manyPlaycuts);
-      mockGroupBy.mockResolvedValue([]);
+      mockArtworkOrderBy.mockResolvedValue([]);
 
       await getRecentEntries(3);
 
@@ -587,7 +615,7 @@ describe('playlist-proxy.service', () => {
       // `and(...)` to `.where(...)` — drizzle-orm is mocked, so we can only
       // assert the query executed once (batched), not literally introspect
       // the key list through the mocked `and`/`inArray`.
-      expect(mockGroupBy).toHaveBeenCalledTimes(1);
+      expect(mockArtworkOrderBy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -611,12 +639,13 @@ describe('playlist-proxy.service', () => {
       'utf-8'
     );
 
-    it('imports `and`, `isNotNull`, `eq`, and `desc` from drizzle-orm', () => {
+    it('imports `and`, `isNotNull`, `eq`, `desc`, and `asc` from drizzle-orm', () => {
       expect(proxySource).toMatch(/from\s+'drizzle-orm'/);
       expect(proxySource).toMatch(/\band\b/);
       expect(proxySource).toMatch(/\bisNotNull\b/);
       expect(proxySource).toMatch(/\beq\b/);
       expect(proxySource).toMatch(/\bdesc\b/);
+      expect(proxySource).toMatch(/\basc\b/);
     });
 
     it('imports album_metadata, rotation, library, and artists alongside flowsheet from @wxyc/database', () => {
@@ -628,7 +657,7 @@ describe('playlist-proxy.service', () => {
     });
 
     it('the flowsheet artwork SELECT inner-joins album_metadata on album_id and filters isNotNull(album_metadata.artwork_url)', () => {
-      const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*groupBy\([\s\S]*?\)\s*;/g) ?? [];
+      const chains = proxySource.match(/db\s*\.\s*selectDistinctOn[\s\S]*?\.\s*orderBy\([\s\S]*?\)\s*;/g) ?? [];
       const artworkChains = chains.filter((c) => /flowsheetLookupKey/.test(c));
       expect(artworkChains.length).toBe(1);
       for (const chain of artworkChains) {
@@ -649,9 +678,11 @@ describe('playlist-proxy.service', () => {
   });
 
   describe('artwork tie-break: split-format albums (BS#1105)', () => {
-    // Preserved verbatim from the pre-Phase-3 implementation (commit
-    // d0b8317d, closes #1105). See enrichPlaycuts' docstring in the service
-    // file for the full rationale.
+    // Originally an `array_agg(... ORDER BY album_id ASC)[1]` preserved
+    // verbatim from the pre-Phase-3 implementation (commit d0b8317d, closes
+    // #1105). BS#1800 replaced the array-materializing aggregate with a
+    // `DISTINCT ON` selecting the same (lowest-album_id) row directly — see
+    // enrichPlaycuts' docstring in the service file for the full rationale.
     const fs = jest.requireActual<typeof import('fs')>('fs');
     const path = jest.requireActual<typeof import('path')>('path');
 
@@ -660,20 +691,19 @@ describe('playlist-proxy.service', () => {
       'utf-8'
     );
 
-    it('groups by lookup key alone and aggregates artwork_url deterministically by lowest album_id', () => {
-      const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*groupBy\([\s\S]*?\)\s*;/g) ?? [];
+    it('selects DISTINCT ON the lookup key, ordered by lookup key then album_id ascending, without array_agg', () => {
+      const chains = proxySource.match(/db\s*\.\s*selectDistinctOn[\s\S]*?\.\s*orderBy\([\s\S]*?\)\s*;/g) ?? [];
       const batchChain = chains.find((c) => /flowsheetLookupKey/.test(c));
       expect(batchChain).toBeDefined();
-      expect(batchChain).toMatch(/\.groupBy\(\s*flowsheetLookupKey\s*\)/);
-      expect(batchChain).not.toMatch(/\.groupBy\(\s*flowsheetLookupKey\s*,\s*album_metadata\.artwork_url\s*\)/);
-      expect(batchChain).toMatch(
-        /array_agg\(\s*\$\{album_metadata\.artwork_url\}\s*order by\s*\$\{album_metadata\.album_id\}\s*asc\s*\)\)\[1\]/
-      );
+      expect(batchChain).toMatch(/\.selectDistinctOn\(\s*\[\s*flowsheetLookupKey\s*\]\s*,/);
+      expect(batchChain).toMatch(/\.orderBy\(\s*flowsheetLookupKey\s*,\s*asc\(\s*album_metadata\.album_id\s*\)\s*\)/);
+      expect(batchChain).not.toMatch(/array_agg/);
+      expect(batchChain).not.toMatch(/\.groupBy\(/);
     });
 
     it('behaviorally resolves the artwork the mocked tie-break query returns onto the matching playcut', async () => {
       mockLimit.mockResolvedValue([juanaMolinaRow]);
-      mockGroupBy.mockResolvedValue([
+      mockArtworkOrderBy.mockResolvedValue([
         { key: 'juana molina-doga', artwork_url: 'https://i.discogs.com/lowest-album-id.jpg' },
       ]);
 
@@ -775,7 +805,7 @@ describe('playlist-proxy.service', () => {
 
       expect('artworkURL' in entry).toBe(false);
       expect(entry.playcut).not.toHaveProperty('imageURL');
-      expect(mockGroupBy).not.toHaveBeenCalled();
+      expect(mockArtworkOrderBy).not.toHaveBeenCalled();
     });
 
     it('bounds the window to n TOTAL entries (min(n, 200)), not n playcuts', async () => {


### PR DESCRIPTION
## Summary

Small polish/doc-accuracy batch from tracker #1800 (the two "Stale cron-logger doc comments" items plus #1105, #1081, #1086 under "Minor polish").

- **Stale cron-logger doc comments (#1299 residue).** `jobs/album-reviews-etl/logger.ts` and `jobs/triangle-shows-etl/logger.ts`'s `captureWarning` doc comment asserted "BS crons default `SENTRY_TRACES_SAMPLE_RATE=0`" — PR #1782 flipped that default to 1.0, and the stale text risked a maintainer re-disabling tracing believing 0 was still the fleet convention. Updated both comments to state the current 1.0 default and why message-based warnings need no tracing either way. Docs only — the tracesSampler cost-cap idea mentioned in the same tracker bullet is explicitly out of scope (conditional on prod ingest-cost telemetry that doesn't exist yet).
- **#1105.** `enrichPlaycuts`'s artwork tie-break in `playlist-proxy.service.ts` used `array_agg(artwork_url ORDER BY album_id ASC)[1]`, materializing every matching `artwork_url` per lookup-key group just to discard all but the first. Replaced with `SELECT DISTINCT ON (lookup key)` ordered by the same `(lookup key, album_id ASC)`. Value-identical to the old query: a tie on `album_id` can only occur for rows sharing the same `album_metadata` row (hence the same `artwork_url`), so DISTINCT ON picks the same value the array_agg form did, without building the intermediate array. Extended the existing unit test coverage (mock harness now models `db.selectDistinctOn(...)` as its own chain, separate from the shared `.select()` chain, since both end in `.orderBy()` but only one is terminal).
- **#1081.** `emit-span.ts`'s JSDoc header still documented a separate `measurements:` block for `ses.delivery_latency_ms`/`ses.processing_time_ms`, though PR #1783 already folded those fields into the creation-time `attributes` bag. Updated the doc to list them under `attributes:` and explain why (Sentry numeric-aggregation indexing). Docs only.
- **#1086.** `jobs/library-identity-consumer/job.ts`'s run-totals span surfaced `consumer.rows_skipped.lml_cardinality_mismatch` but not its sibling `consumer.rows_skipped.lml_untrusted_library_id` (the BS#1094 result-validation skip bucket) — added it, mirroring the sibling exactly. Extracted the totals→span-attributes mapping into an exported `buildSpanAttributes` so it's unit-testable, and added the `NODE_ENV !== 'test'` auto-invoke guard already used elsewhere in `jobs/*` so the module can be imported safely by the new test.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (824 pre-existing warnings, none new)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 393 suites / 6087 tests passing
- [x] `npx tsc --noEmit -p jobs/album-reviews-etl/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p jobs/triangle-shows-etl/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p jobs/library-identity-consumer/tsconfig.json` — clean
- [x] Extended `tests/unit/services/playlist-proxy.service.test.ts` for the DISTINCT ON rewrite
- [x] Added `tests/unit/jobs/library-identity-consumer/job.test.ts` pinning `buildSpanAttributes`' full key set including the new attribute

Refs #1800