### PR TITLE
test(backend): strengthen genres-auth / email / freshness / fatal-handler assertions

### DIFF
--- a/jobs/library-identity-consumer/select.ts
+++ b/jobs/library-identity-consumer/select.ts
@@ -5,20 +5,37 @@
  * (Backend is thin-writer; LML is sole composer):
  *
  *   library.canonical_entity_id IS NOT NULL
- *   AND (
- *     NOT EXISTS (SELECT 1 FROM library_identity WHERE library_id = library.id)
- *     OR EXISTS (
- *       SELECT 1 FROM library_identity
- *       WHERE library_id = library.id
- *         AND last_verified_at < NOW() - interval '7 days'
- *     )
+ *   AND NOT EXISTS (
+ *     SELECT 1 FROM library_identity
+ *     WHERE library_id = library.id
+ *       AND last_verified_at >= NOW() - interval '7 days'
  *   )
  *
  * BS#1144: the predicate used to be `canonical_entity_id IS NOT NULL OR ...`
  * — an unconditional disjunct that re-fetched every canonicalized row on
- * every run regardless of freshness, burning LML quota. The freshness guard
- * above narrows eligibility to rows with no `library_identity` row yet, or
- * whose existing row is stale.
+ * every run regardless of freshness, burning LML quota. The fix narrowed
+ * eligibility to rows with no `library_identity` row yet, or whose existing
+ * row is stale: `NOT EXISTS (SELECT 1 FROM library_identity WHERE library_id
+ * = library.id) OR EXISTS (SELECT 1 FROM library_identity WHERE library_id =
+ * library.id AND last_verified_at < NOW() - interval '7 days')`.
+ *
+ * BS#1800: simplified to the single `NOT EXISTS (... AND last_verified_at
+ * >= ...)` form above. `library_identity.library_id` is a PRIMARY KEY (see
+ * schema.ts), so there is at most one `library_identity` row per library —
+ * call its existence P and its freshness F. The #1144 form was `NOT P OR (P
+ * AND NOT F)`, which is `NOT P OR NOT F` (i.e. "no row yet, or the row
+ * isn't fresh") for exactly the same reason `A OR (A AND B)` reduces to `A
+ * OR B` when `A` and `NOT A` partition the cases — here P and NOT P do. Its
+ * negation, `NOT (NOT P OR NOT F)` = `P AND F` ("a row exists and is
+ * fresh"), is exactly what `EXISTS (... AND last_verified_at >= ...)` tests,
+ * so `NOT EXISTS (... AND last_verified_at >= ...)` is `NOT P OR NOT F` —
+ * the identical predicate in one subquery instead of two. This equivalence
+ * only holds because of the PK (at most one row to reason about); it would
+ * NOT hold for a one-to-many child table. Behavioral coverage (fresh
+ * excluded; absent/stale included) lives in
+ * tests/integration/library-identity-consumer-select.spec.js — see that
+ * file's docstring for why it embeds this predicate literally rather than
+ * importing loadBatch() directly.
  *
  * BS#974: `INCLUDE_NULL_CANONICAL` (default off) expands the predicate to also
  * cover `canonical_entity_id IS NULL` rows — the ~34K never-canonicalized
@@ -178,15 +195,20 @@ export const loadBatch = async (
 ): Promise<LibraryRow[]> => {
   const partitionClause = partitionFilter ?? sql``;
 
-  // The eligibility core. Flag OFF is byte-identical to the post-#1144
-  // predicate (canonicalized rows only: never-resolved OR stale). Flag ON
-  // (BS#974) drops the `canonical_entity_id IS NOT NULL` filter and gates
-  // every first-time candidate on the `unresolved_attempted_at` no-match
-  // marker, so the ~34K NULL-canonical rows come into scope without the
-  // unresolved-row hot-loop (a row LML couldn't resolve isn't re-attempted
-  // until `unresolvedRetryDays` elapse). This also retro-fixes the
-  // pre-existing canonical-unresolved re-attempt, since it too now honors the
-  // marker.
+  // The eligibility core. Flag OFF is byte-identical (post-BS#1800
+  // simplification -- see the module docstring for the equivalence proof) to
+  // the post-#1144 predicate (canonicalized rows only: never-resolved OR
+  // stale). Flag ON (BS#974) drops the `canonical_entity_id IS NOT NULL`
+  // filter and gates every first-time candidate on the
+  // `unresolved_attempted_at` no-match marker, so the ~34K NULL-canonical
+  // rows come into scope without the unresolved-row hot-loop (a row LML
+  // couldn't resolve isn't re-attempted until `unresolvedRetryDays` elapse).
+  // This also retro-fixes the pre-existing canonical-unresolved re-attempt,
+  // since it too now honors the marker. (The flag-ON branch keeps its
+  // separate `NOT EXISTS(any)` subquery rather than the flag-OFF
+  // simplification below -- its NOT-EXISTS arm is further gated by the
+  // no-match-marker AND clause, so it isn't the pure `NOT P OR NOT F` shape
+  // the PK equivalence applies to.)
   const eligibilityCore = includeNullCanonical
     ? sql`
       AND (
@@ -208,16 +230,10 @@ export const loadBatch = async (
       )`
     : sql`
       AND "canonical_entity_id" IS NOT NULL
-      AND (
-        NOT EXISTS (
-          SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
-          WHERE li."library_id" = ${LIBRARY_TABLE}."id"
-        )
-        OR EXISTS (
-          SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
-          WHERE li."library_id" = ${LIBRARY_TABLE}."id"
-            AND li."last_verified_at" < NOW() - (interval '1 day' * ${staleDays})
-        )
+      AND NOT EXISTS (
+        SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
+        WHERE li."library_id" = ${LIBRARY_TABLE}."id"
+          AND li."last_verified_at" >= NOW() - (interval '1 day' * ${staleDays})
       )`;
 
   const rows = (await db.execute(sql`

--- a/jobs/library-identity-consumer/select.ts
+++ b/jobs/library-identity-consumer/select.ts
@@ -30,8 +30,21 @@
  * fresh"), is exactly what `EXISTS (... AND last_verified_at >= ...)` tests,
  * so `NOT EXISTS (... AND last_verified_at >= ...)` is `NOT P OR NOT F` —
  * the identical predicate in one subquery instead of two. This equivalence
- * only holds because of the PK (at most one row to reason about); it would
- * NOT hold for a one-to-many child table. Behavioral coverage (fresh
+ * rests on TWO preconditions, both currently true: the PK (at most one row
+ * to reason about; it would NOT hold for a one-to-many child table), and
+ * `library_identity.last_verified_at` being `NOT NULL` (see schema.ts) — so
+ * `>= threshold` and `< threshold` are true complements (exactly one holds)
+ * for any row that exists. If that column were ever made nullable, a row
+ * with a NULL `last_verified_at` would break the complement: both
+ * `last_verified_at >= threshold` and `last_verified_at < threshold`
+ * evaluate to unknown/false per SQL's three-valued logic, so neither
+ * `EXISTS` clause would match it. The two forms would then diverge on
+ * exactly that row: the old form's `EXISTS(... < threshold)` finds nothing,
+ * falling through to `NOT P` — false, since the row exists — so the row is
+ * EXCLUDED; the new form's `NOT EXISTS(... >= threshold)` also finds
+ * nothing, so `NOT EXISTS(...)` is true and the row is INCLUDED. A future
+ * nullable `last_verified_at` would need to re-derive this predicate rather
+ * than assume the simplification still holds. Behavioral coverage (fresh
  * excluded; absent/stale included) lives in
  * tests/integration/library-identity-consumer-select.spec.js — see that
  * file's docstring for why it embeds this predicate literally rather than

--- a/shared/authentication/src/email.ts
+++ b/shared/authentication/src/email.ts
@@ -139,10 +139,13 @@ function getConfigurationSetName(): string | undefined {
  * SES has a 200-message/month quota. `EMAIL_ENABLED` gates the actual
  * `client.send()` call so test/CI runs (which repeatedly exercise the
  * password-reset / verification / OTP flows) never burn that quota.
- * Defaults to enabled (production behavior) when unset; test/CI
- * environments set `EMAIL_ENABLED=false` explicitly (see
- * `scripts/ci-env.sh`, `tests/setup/unit.setup.ts`, and
- * `.github/workflows/test.yml`).
+ * Defaults to enabled (production behavior) when unset. `scripts/ci-env.sh`
+ * does NOT set this var -- test/CI environments set `EMAIL_ENABLED=false`
+ * explicitly in two other places: `tests/setup/unit.setup.ts` (the jest
+ * unit-test-runner process itself) and, for the separately-spawned auth/
+ * backend servers the integration suite talks to over HTTP, on
+ * `dev_env/docker-compose.yml`'s `auth` service (CI profile, hardcoded) and
+ * `.github/workflows/test.yml`'s Integration-Tests "Start services" step.
  */
 export function isEmailSendingEnabled(): boolean {
   const raw = process.env.EMAIL_ENABLED;

--- a/tests/integration/library-identity-consumer-select.spec.js
+++ b/tests/integration/library-identity-consumer-select.spec.js
@@ -1,0 +1,162 @@
+const postgres = require('postgres');
+
+/**
+ * Integration test for jobs/library-identity-consumer/select.ts's
+ * `loadBatch` SELECT predicate (BS#1144 / BS#1800 follow-up).
+ *
+ * The prior unit-level coverage for this predicate string-matched
+ * `/NOT EXISTS/` against the serialized Drizzle SQL object passed to a
+ * mocked `db.execute` -- it could not distinguish the fixed predicate from
+ * the pre-#1144 bug (`canonical_entity_id IS NOT NULL OR ...`, an
+ * unconditional disjunct that also contains the substring "NOT EXISTS"
+ * deeper in its OR branch), because a mocked db.execute never actually
+ * evaluates the query against real rows. This spec replaces that with a
+ * genuine behavioral fixture, run against a real Postgres:
+ *
+ *   - a canonicalized row with no library_identity row yet -> included
+ *   - a canonicalized row whose library_identity row is FRESH -> excluded
+ *   - a canonicalized row whose library_identity row is STALE -> included
+ *   - a non-canonicalized row (canonical_entity_id IS NULL) -> excluded,
+ *     regardless of identity freshness
+ *
+ * Coverage gap (deliberate, same shape as
+ * tests/integration/library-identity-backfill.spec.js): we don't import
+ * select.ts's `loadBatch` directly from this integration runner. The
+ * integration runner uses babel-jest without TS support, and adding a
+ * ts-jest transform crashes drizzle-orm's `extractTablesRelationalConfig` on
+ * `gin_trgm_ops` indexes (see that file's docstring for the full crash
+ * detail). `loadBatch`'s predicate-construction logic (env-var resolvers,
+ * the flag-off/flag-on branch selection, the BS#1800 single-NOT-EXISTS
+ * simplification's structural shape) is unit-tested against the mocked
+ * `db.execute` in tests/unit/jobs/library-identity-consumer/select.test.ts.
+ * This spec is the SQL-contract half: it embeds the flag-off predicate
+ * literally and verifies its actual selection behavior against a real
+ * database, so the two suites together cover both "the right SQL is built"
+ * and "that SQL selects the right rows."
+ *
+ * Scoped to an isolated `wxyc_test_lib_id_sel_<random>` schema; dropped in
+ * afterAll regardless of pass/fail.
+ */
+describe('library-identity-consumer loadBatch predicate (real DB, BS#1144/BS#1800)', () => {
+  let sql;
+  let schemaName;
+  const staleDays = 7;
+
+  beforeAll(async () => {
+    schemaName = `wxyc_test_lib_id_sel_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6)}`;
+    sql = postgres({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+      database: process.env.DB_NAME || 'wxyc_db',
+      user: process.env.DB_USERNAME || 'test-user',
+      password: process.env.DB_PASSWORD || 'test-pw',
+      onnotice: () => {},
+    });
+
+    await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+    // Minimal standalone tables carrying only the columns the predicate
+    // reads -- no FKs to artists/genres/format (irrelevant to this
+    // predicate, and this is an isolated scratch schema, not the real
+    // `library` table).
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library (
+        id integer PRIMARY KEY,
+        artist_name text,
+        canonical_entity_id text
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library_identity (
+        library_id integer PRIMARY KEY,
+        last_verified_at timestamptz NOT NULL,
+        method text NOT NULL,
+        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      try {
+        await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } finally {
+        await sql.end();
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(`TRUNCATE "${schemaName}".library, "${schemaName}".library_identity RESTART IDENTITY CASCADE`);
+  });
+
+  // The exact flag-off (INCLUDE_NULL_CANONICAL=false) predicate shape built
+  // by jobs/library-identity-consumer/select.ts's loadBatch(), post-BS#1800
+  // simplification: canonicalized AND no fresh library_identity row.
+  const selectEligible = async () => {
+    const rows = await sql.unsafe(
+      `
+      SELECT id
+      FROM "${schemaName}".library
+      WHERE artist_name IS NOT NULL
+        AND canonical_entity_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "${schemaName}".library_identity li
+          WHERE li.library_id = library.id
+            AND li.last_verified_at >= NOW() - (interval '1 day' * $1)
+        )
+      ORDER BY id ASC
+      `,
+      [staleDays]
+    );
+    return rows.map((r) => r.id);
+  };
+
+  test('a canonicalized row with no library_identity row yet is included', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, artist_name, canonical_entity_id) VALUES (1, 'Jessica Pratt', 'discogs:master:1')`
+    );
+    expect(await selectEligible()).toEqual([1]);
+  });
+
+  test('a canonicalized row with a FRESH library_identity row is excluded', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, artist_name, canonical_entity_id) VALUES (2, 'Juana Molina', 'discogs:master:2')`
+    );
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library_identity (library_id, last_verified_at, method, confidence) VALUES (2, NOW(), 'exact_match', 1.0)`
+    );
+    expect(await selectEligible()).toEqual([]);
+  });
+
+  test('a canonicalized row with a STALE library_identity row is included', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, artist_name, canonical_entity_id) VALUES (3, 'Chuquimamani-Condori', 'discogs:master:3')`
+    );
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library_identity (library_id, last_verified_at, method, confidence) VALUES (3, NOW() - interval '30 days', 'exact_match', 1.0)`
+    );
+    expect(await selectEligible()).toEqual([3]);
+  });
+
+  test('a non-canonicalized row is excluded regardless of identity freshness', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, artist_name, canonical_entity_id) VALUES (4, 'Duke Ellington & John Coltrane', NULL)`
+    );
+    expect(await selectEligible()).toEqual([]);
+  });
+
+  test('mixed fixture: only the absent and stale rows are selected, never the fresh one', async () => {
+    await sql.unsafe(`
+      INSERT INTO "${schemaName}".library (id, artist_name, canonical_entity_id) VALUES
+        (10, 'Jessica Pratt', 'discogs:master:10'),
+        (11, 'Juana Molina', 'discogs:master:11'),
+        (12, 'Chuquimamani-Condori', 'discogs:master:12')
+    `);
+    await sql.unsafe(`
+      INSERT INTO "${schemaName}".library_identity (library_id, last_verified_at, method, confidence) VALUES
+        (11, NOW(), 'exact_match', 1.0),
+        (12, NOW() - interval '30 days', 'exact_match', 1.0)
+    `);
+    expect(await selectEligible()).toEqual([10, 12]);
+  });
+});

--- a/tests/setup/integration.setup.js
+++ b/tests/setup/integration.setup.js
@@ -6,9 +6,10 @@ process.env.NODE_ENV = 'test';
 process.env.USE_MOCK_SERVICES = 'true';
 // This only affects the jest test-runner process, not the separately
 // spawned auth/backend servers the integration suite talks to over HTTP —
-// those get EMAIL_ENABLED=false from ci-env.sh / test.yml's "Start
-// services" step. Set here too for parity with any in-process helper that
-// imports shared/authentication directly.
+// those get EMAIL_ENABLED=false from dev_env/docker-compose.yml's `auth`
+// service (CI profile) / test.yml's "Start services" step, NOT from
+// ci-env.sh (which doesn't set this var). Set here too for parity with any
+// in-process helper that imports shared/authentication directly.
 process.env.EMAIL_ENABLED = process.env.EMAIL_ENABLED ?? 'false';
 
 global.primary_dj_id = null;

--- a/tests/unit/jobs/flowsheet-etl/backfill-legacy-ids.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/backfill-legacy-ids.test.ts
@@ -11,11 +11,13 @@
  *  (b) The top-level `main().catch(...).finally(...)` construct must run the
  *      `.finally()` cleanup (legacy SSH/MirrorSQL dispose + close the pg pool)
  *      on a fatal error instead of short-circuiting it via `process.exit(1)`.
- *      The test below exercises that exact construct against the exported
- *      `main()`, attaching its own terminal `.catch()` so the deliberately
- *      rethrown error is handled within the test rather than surfacing as a
- *      real `unhandledRejection` (which the production top-level statement
- *      intentionally lets happen, but which Jest would flag as a failure).
+ *      The test below exercises the REAL construct as written at the bottom
+ *      of backfill-legacy-ids.ts -- not a copy hand-rolled inline in the
+ *      test -- by forcing a fresh module evaluation (jest.resetModules() +
+ *      dynamic import, same idiom as tests/unit/services/email.test.ts) with
+ *      a failing `legacyDB.send`, so a revert to `process.exit(1)` inside
+ *      that construct would actually be caught here instead of silently
+ *      passing.
  */
 
 import { jest } from '@jest/globals';
@@ -44,7 +46,7 @@ jest.mock('@wxyc/database', () => ({
   },
 }));
 
-import { backfillDJInfo, main } from '../../../../jobs/flowsheet-etl/backfill-legacy-ids';
+import { backfillDJInfo } from '../../../../jobs/flowsheet-etl/backfill-legacy-ids';
 
 describe('backfillDJInfo', () => {
   beforeEach(() => {
@@ -82,42 +84,72 @@ describe('backfillDJInfo', () => {
 });
 
 describe('cleanup on a fatal error', () => {
-  it('runs the .finally() (legacy SSH dispose + pg pool close) even though main() rejects, without swallowing the error', async () => {
+  it('the real top-level main().catch(...).finally(...) construct runs cleanup and sets exitCode without calling process.exit', async () => {
     const fatalError = new Error('tubafrenzy connection refused');
-    mockSend.mockReset().mockRejectedValue(fatalError);
-    mockLegacyClose.mockClear();
-    mockCloseDatabaseConnection.mockClear();
 
     const previousExitCode = process.exitCode;
     process.exitCode = 0;
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Belt-and-suspenders: if a regression reverts the construct to
+    // `process.exit(1)`, fail on a clean assertion (`not.toHaveBeenCalled()`)
+    // rather than actually tearing down the Jest worker process.
+    const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
-    // Exercise the exact top-level construct from backfill-legacy-ids.ts
-    // (`main().catch((err) => { process.exitCode = 1; throw err; }).finally(...)`)
-    // against the real exported `main`, with our own terminal `.catch()` so the
-    // rethrown error is consumed here instead of becoming a real
-    // `unhandledRejection` in this test process.
-    await expect(
-      main()
-        .catch((err) => {
-          console.error('[backfill] Fatal error:', err);
-          process.exitCode = 1;
-          throw err;
-        })
-        .finally(async () => {
-          mockLegacyClose();
-          await mockCloseDatabaseConnection();
-        })
-    ).rejects.toBe(fatalError);
+    mockSend.mockReset().mockRejectedValue(fatalError);
+    mockLegacyClose.mockClear();
+    mockCloseDatabaseConnection.mockClear();
 
+    // The production top-level statement (`main().catch(...).finally(...)`
+    // at the bottom of backfill-legacy-ids.ts) is a floating promise chain by
+    // design -- nothing exported hands this test a handle to it, since it
+    // only exists as a side effect of module evaluation. Re-trigger it by
+    // forcing a fresh module evaluation (jest.resetModules() + dynamic
+    // import, same idiom as tests/unit/services/email.test.ts).
+    //
+    // The chain deliberately rethrows after cleanup, so it settles rejected
+    // and unconsumed -- normally a real `unhandledRejection`. That event does
+    // not reach listeners registered from inside a Jest test in this repo's
+    // setup (confirmed: neither `process.on`/`.once` nor
+    // `process.prependOnceListener` ever fire here), so instead this
+    // temporarily patches `Promise.prototype.finally` to capture the exact
+    // promise `.finally()` returns at the moment the fresh module calls it,
+    // then immediately attaches a `.catch()` to it -- consuming it before
+    // Node's unhandled-rejection check ever runs, and giving this test a
+    // real handle to `await`.
+    const originalFinally = Promise.prototype.finally;
+    let capturedChain: Promise<unknown> | undefined;
+    Promise.prototype.finally = function (this: Promise<unknown>, onFinally?: (() => void) | null): Promise<unknown> {
+      const result = originalFinally.call(this, onFinally);
+      capturedChain = result;
+      return result;
+    };
+
+    jest.resetModules();
+    try {
+      await import('../../../../jobs/flowsheet-etl/backfill-legacy-ids');
+    } finally {
+      Promise.prototype.finally = originalFinally;
+    }
+
+    if (capturedChain === undefined) {
+      throw new Error('expected Promise.prototype.finally to have been called during the reimport');
+    }
+    const reason = await capturedChain.catch((e: unknown) => e);
+
+    // The real `.catch()` handler received our fatalError -- confirms this
+    // exercised the actual production construct, not a copy.
+    expect(reason).toBe(fatalError);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[backfill] Fatal error:', fatalError);
     // The cleanup ran despite the fatal error, and exitCode was set — the
     // regression this test guards against is `process.exit(1)` inside the
     // .catch(), which would terminate the process before either of these.
     expect(mockLegacyClose).toHaveBeenCalledTimes(1);
     expect(mockCloseDatabaseConnection).toHaveBeenCalledTimes(1);
     expect(process.exitCode).toBe(1);
+    expect(processExitSpy).not.toHaveBeenCalled();
 
     process.exitCode = previousExitCode;
     consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
   });
 });

--- a/tests/unit/jobs/library-identity-consumer/select.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/select.test.ts
@@ -183,10 +183,21 @@ describe('loadBatch', () => {
     await loadBatch(0, 500, null, 7);
     const call = (db.execute as jest.Mock).mock.calls[0][0];
     const serialized = JSON.stringify(call);
-    // The predicate must gate canonicalized rows behind a freshness check
-    // (NOT EXISTS a library_identity row, or the existing one is stale) —
-    // not just an unconditional `canonical_entity_id IS NOT NULL OR ...`.
+    // Structural regression check only -- this can't distinguish the fixed
+    // predicate from the pre-#1144 bug (`canonical_entity_id IS NOT NULL OR
+    // ...`, an unconditional disjunct that also contains "NOT EXISTS" deeper
+    // in its OR branch), so it's necessary but not sufficient. The genuine
+    // behavioral fixture (a FRESH identity row excluded; an ABSENT or STALE
+    // one included) lives in
+    // tests/integration/library-identity-consumer-select.spec.js against a
+    // real Postgres -- a mocked db.execute here can't observe selection
+    // behavior, only the SQL text passed to it.
     expect(serialized).toMatch(/NOT EXISTS/);
+    // Post-BS#1800 simplification (library_identity.library_id is a PK, so
+    // `NOT EXISTS(any) OR EXISTS(stale)` === `NOT EXISTS(fresh)` -- see the
+    // module docstring): the flag-off branch is now a single NOT EXISTS, not
+    // the two-subquery `OR EXISTS` shape.
+    expect(serialized).not.toMatch(/OR EXISTS/);
   });
 
   it('returns the rows surfaced by db.execute', async () => {

--- a/tests/unit/routes/library-genres-permissions.route.test.ts
+++ b/tests/unit/routes/library-genres-permissions.route.test.ts
@@ -26,13 +26,26 @@ jest.mock('jose', () => ({
 // back in to actually exercise the catalog:read vs public gate.
 jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
 
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
 import express from 'express';
 import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
 
 // Collaborator mocks below mirror tests/unit/routes/library-missing-found-permissions.route.test.ts
 // -- only enough is stubbed here to let library.route's import chain resolve
 // without touching a real DB, LML, or lru-cache.
 const mockGetGenresFromDB = jest.fn<() => Promise<Array<{ id: number; genre: string }>>>();
+const mockInsertGenre = jestGlobals.fn<() => Promise<{ id: number }>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   markAlbumMissing: jest.fn(),
@@ -60,7 +73,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   generateAlbumCodeNumber: jest.fn(),
   generateArtistNumber: jest.fn(),
   getGenresFromDB: mockGetGenresFromDB,
-  insertGenre: jest.fn(),
+  insertGenre: mockInsertGenre,
   insertFormat: jest.fn(),
   getFormatById: jest.fn(),
   isISODate: jest.fn(),
@@ -120,5 +133,45 @@ describe('GET /library/genres — public tier (BS#1682)', () => {
     const res = await request(app).get('/library/genres');
     expect(res.status).toBe(200);
     expect(mockGetGenresFromDB).toHaveBeenCalled();
+  });
+});
+
+/**
+ * BS#1682 relaxed GET /library/genres only. This is the negative-assertion
+ * companion (BS#1800 follow-up): POST /library/genres must stay
+ * catalog:write-gated (musicDirector+) so a future accidental relaxation of
+ * the sibling write route is caught. Mirrors the real-middleware wiring +
+ * mockRole helper from tests/unit/routes/library-missing-found-permissions.route.test.ts.
+ */
+describe('POST /library/genres — stays catalog:write-gated (BS#1682 / BS#1800)', () => {
+  beforeEach(() => {
+    mockedJwtVerify.mockReset();
+    mockInsertGenre.mockReset().mockResolvedValue({ id: 1 });
+  });
+
+  test('a musicDirector-role token (catalog:write) is authorized', async () => {
+    mockRole('musicDirector');
+    const res = await request(app)
+      .post('/library/genres')
+      .set('Authorization', 'Bearer test-token')
+      .send({ name: 'Rock', description: 'Rock music' });
+    expect(res.status).toBe(201);
+    expect(mockInsertGenre).toHaveBeenCalled();
+  });
+
+  test('a dj-role token (catalog:read only) is rejected', async () => {
+    mockRole('dj');
+    const res = await request(app)
+      .post('/library/genres')
+      .set('Authorization', 'Bearer test-token')
+      .send({ name: 'Rock', description: 'Rock music' });
+    expect(res.status).toBe(403);
+    expect(mockInsertGenre).not.toHaveBeenCalled();
+  });
+
+  test('a request with no Authorization header is rejected', async () => {
+    const res = await request(app).post('/library/genres').send({ name: 'Rock', description: 'Rock music' });
+    expect(res.status).toBe(401);
+    expect(mockInsertGenre).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/email.test.ts
+++ b/tests/unit/services/email.test.ts
@@ -199,13 +199,25 @@ describe('EMAIL_ENABLED gating', () => {
     delete process.env.EMAIL_ENABLED;
   });
 
-  it('does not call the SES client send when EMAIL_ENABLED is unset', async () => {
+  it('calls the SES client send when EMAIL_ENABLED is unset (defaults to enabled, the production behavior)', async () => {
     delete process.env.EMAIL_ENABLED;
     const emailModule = await import('../../../shared/authentication/src/email');
 
-    // Unset means "enabled" (production default) — confirm the opposite
-    // gate below instead exercises the disabled path.
     expect(emailModule.isEmailSendingEnabled()).toBe(true);
+
+    // BS#1800: the original version of this test stopped at the boolean
+    // helper check above and never drove sendEmail/asserted mockSend --
+    // which meant it couldn't catch a real regression like the gate inside
+    // sendEmail() being inverted (e.g. `if (isEmailSendingEnabled()) return;`),
+    // which would silently disable all production email since unset is the
+    // production default. Drive the real send path here too.
+    await emailModule.sendEmail({
+      type: 'passwordReset',
+      to: 'user@example.com',
+      url: 'https://example.com/reset',
+    });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the SES client send when EMAIL_ENABLED=false', async () => {


### PR DESCRIPTION
## Summary

Four test-accuracy follow-ups from the "Minor polish (test-accuracy / docs)" section of #1800 (the ship-dag review queue), landed together since they're all small, unrelated test-hardening changes.

- **#1682** — `library-genres-permissions.route.test.ts` adds a negative assertion that `POST /library/genres` stays `catalog:write`-gated: a dj-role token (catalog:read only) gets 403, no-Authorization gets 401, and a musicDirector-role token is authorized (201). Catches an accidental relaxation of the sibling write route alongside BS#1682's GET relaxation.
- **#671** — the `EMAIL_ENABLED` gating test named "does not call the SES client send when EMAIL_ENABLED is unset" only asserted the boolean helper and never drove `sendEmail`/asserted `mockSend`. Checked `email.ts`: unset actually defaults to *enabled* (the production behavior), so the correct strengthened assertion is that `mockSend` **is** called once — renamed and rewrote the test accordingly. Also fixed the `isEmailSendingEnabled` JSDoc (and the same wrong claim in `tests/setup/integration.setup.js`) to stop citing `scripts/ci-env.sh`, which does not set `EMAIL_ENABLED` — it's set on `dev_env/docker-compose.yml`'s `auth` service and the GHA integration-tests "Start services" step.
- **#1144** — the freshness-gate test only string-matched `/NOT EXISTS/` on serialized SQL, which can't distinguish the fixed predicate from the pre-#1144 bug. Verified `library_identity.library_id` is a PRIMARY KEY, so the two-subquery `NOT EXISTS(any) OR EXISTS(stale)` form is provably equivalent to a single `NOT EXISTS(fresh)` (proof in the module docstring); simplified the flag-off predicate in `select.ts` accordingly. Added `tests/integration/library-identity-consumer-select.spec.js` as a genuine behavioral fixture against a real Postgres (fresh excluded; absent/stale included; non-canonicalized excluded regardless) — independently verified against the running dev DB, including a check that the fixture correctly flags the pre-#1144 buggy predicate as wrong. The unit test now also asserts the old two-subquery shape is gone.
- **#1141** — the cleanup-on-fatal-error test hand-rolled the `.catch().finally()` construct inline instead of exercising the real top-level statement, so a revert to `process.exit(1)` wouldn't be caught. Refactored to force a fresh module evaluation (`jest.resetModules()` + dynamic import) with a failing `legacyDB.send`, capturing the real construct's floating promise chain via a scoped `Promise.prototype.finally` patch (Node's `unhandledRejection` event doesn't reach listeners registered from inside a test in this jest setup), and asserting cleanup ran, `exitCode` was set, and `process.exit` was never called.

## Test plan

- Each strengthened/refactored test was verified to genuinely fail against the regression it targets (relaxed route permission, inverted email gate, pre-#1144 buggy SQL predicate, reverted `process.exit(1)`), then pass against the correct code.
- `npm run typecheck` / `npm run lint` / `npm run format:check` / `npm run test:unit` all green (393 suites / 6090 tests).
- `npx tsc --noEmit` clean for the touched `jobs/library-identity-consumer` and `jobs/flowsheet-etl` workspaces.
- The new integration spec was verified independently against a running local Postgres (bypassing the full `test:integration` stack, which wasn't spun up for this change) rather than executed via the standard `npm run test:integration` harness; it follows the same real-DB / scoped-schema pattern as the existing `tests/integration/library-identity-backfill.spec.js`.

Refs #1800