### PR TITLE
fix(authentication): check banned claim in AUTH_BYPASS branch of requirePermissions

### DIFF
--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -120,6 +120,22 @@ export function requirePermissions(required: RequiredPermissions) {
           // now refuses the implicit spread; the cast makes the existing
           // intent explicit without changing runtime behavior.
           req.auth = { ...payload, id: userId } as WXYCAuthJwtPayload;
+
+          // Check if user is banned (BS#1941): this branch skips JWKS
+          // signature verification but a JWT-shaped bypass token still
+          // carries the same `banned`/`banReason` claims better-auth's JWT
+          // plugin spreads onto the payload the production branch verifies
+          // below (~line 184). Without this check, AUTH_BYPASS mode (the
+          // regime CI's Integration-Tests job runs under) let a banned
+          // user's decodable JWT sail straight through to `next()`. Mirrors
+          // the production branch's status code and error shape exactly so
+          // bypass and prod never diverge on ban enforcement.
+          if (req.auth.banned) {
+            return res.status(403).json({
+              message: 'Access denied',
+              reason: req.auth.banReason || 'Account suspended',
+            });
+          }
         }
       } catch {
         req.auth = { id: token } as WXYCAuthJwtPayload;

--- a/tests/integration/requestLine.spec.js
+++ b/tests/integration/requestLine.spec.js
@@ -3,8 +3,6 @@ const postgres = require('postgres');
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
 const { signInAnonymous, unbanUser, BETTER_AUTH_URL } = require('../utils/anonymous_auth');
 
-const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-
 // Helper to get a new anonymous auth token
 const getTestToken = async () => {
   const { token, userId, user } = await signInAnonymous();
@@ -294,11 +292,13 @@ describe('Request Line Endpoint', () => {
       // for its fingerprint case. Cleanup below still goes through the real
       // unbanUser() HTTP flow (no session side effect there), so this test
       // still needs the admin credentials TEST_ADMIN_BAN gates.
+      // better-auth's tables live in the `public` schema, not the per-worker
+      // WXYC_SCHEMA_NAME domain schema (migration 0020 creates auth_user with
+      // no schema qualifier; the domain FKs reference "public"."auth_user").
+      // check-request-ban.spec.js targets ${SCHEMA}.banned_fingerprints — a
+      // domain table — so it does not hit this distinction.
       async function banUserDirectly(sql, userId, reason) {
-        await sql.unsafe(`UPDATE ${SCHEMA}.auth_user SET banned = true, ban_reason = $1 WHERE id = $2`, [
-          reason,
-          userId,
-        ]);
+        await sql.unsafe(`UPDATE public.auth_user SET banned = true, ban_reason = $1 WHERE id = $2`, [reason, userId]);
       }
 
       // Exchanges a still-valid session token for a JWT via better-auth's

--- a/tests/integration/requestLine.spec.js
+++ b/tests/integration/requestLine.spec.js
@@ -1,6 +1,9 @@
 require('dotenv').config({ path: '../../.env' });
+const postgres = require('postgres');
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
-const { signInAnonymous, banUser, unbanUser, getAdminToken } = require('../utils/anonymous_auth');
+const { signInAnonymous, unbanUser, BETTER_AUTH_URL } = require('../utils/anonymous_auth');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
 // Helper to get a new anonymous auth token
 const getTestToken = async () => {
@@ -272,17 +275,51 @@ describe('Request Line Endpoint', () => {
 
   describe('User Banning', () => {
     describe('with admin credentials', () => {
-      // Permanently skipped (independent of TEST_ADMIN_BAN — see BS#1941):
-      // this route is gated by requirePermissions({}), whose AUTH_BYPASS
-      // branch (the regime CI's Integration-Tests job runs under) never
-      // checks payload.banned the way the production JWT-verify branch
-      // does, and the bearer token getTestToken() supplies here is a raw
-      // session token (not a decodable JWT) in the first place — so the
-      // ban can never be observed to 403 through this route as currently
-      // written. The sibling admin-ban test in check-request-ban.spec.js
-      // (POST /auth/check-request-ban, which queries auth_user.banned
-      // directly) is unaffected and is enabled via TEST_ADMIN_BAN.
-      it.skip('should return 403 when user is banned', async () => {
+      // Gated the same way as check-request-ban.spec.js's admin-ban case
+      // (BS#133 / BS#1941): cleanup below still needs the test_station_manager
+      // admin fixture account via unbanUser(), so this test stays opt-in
+      // rather than running by default in local dev.
+      const enableAdminBan = process.env.TEST_ADMIN_BAN === 'true';
+      const itIfAdminBan = enableAdminBan ? it : it.skip;
+
+      // Flips auth_user.banned directly via SQL instead of better-auth's
+      // /admin/ban-user endpoint (BS#1941). banUser() unconditionally calls
+      // internalAdapter.deleteUserSessions(), which would kill the very
+      // session this test needs alive to mint a JWT *after* the ban below —
+      // the whole point of the fix is that AUTH_BYPASS only trusts the
+      // `banned` claim baked into a JWT at mint time, so the JWT has to be
+      // minted post-ban. Direct SQL is the existing project convention for
+      // setup that would otherwise trip an HTTP side effect —
+      // check-request-ban.spec.js's banned_fingerprints INSERT does the same
+      // for its fingerprint case. Cleanup below still goes through the real
+      // unbanUser() HTTP flow (no session side effect there), so this test
+      // still needs the admin credentials TEST_ADMIN_BAN gates.
+      async function banUserDirectly(sql, userId, reason) {
+        await sql.unsafe(`UPDATE ${SCHEMA}.auth_user SET banned = true, ban_reason = $1 WHERE id = $2`, [
+          reason,
+          userId,
+        ]);
+      }
+
+      // Exchanges a still-valid session token for a JWT via better-auth's
+      // /token endpoint (the jwt() plugin) — mirrors
+      // check-request-ban.spec.js's getAnonymousJwt(). Test-scoped: every
+      // other test in this file keeps using getTestToken()'s raw session
+      // token, which AUTH_BYPASS's catch-all also accepts but which
+      // decodeJwt cannot parse into a `banned` claim (see BS#1941).
+      async function mintJwt(sessionToken) {
+        const jwtRes = await fetch(`${BETTER_AUTH_URL}/token`, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${sessionToken}` },
+        });
+        if (!jwtRes.ok) {
+          throw new Error(`Failed to fetch JWT: ${jwtRes.status} ${await jwtRes.text()}`);
+        }
+        const { token } = await jwtRes.json();
+        return token;
+      }
+
+      itIfAdminBan('should return 403 when user is banned', async () => {
         // Get a new anonymous user
         const { token, userId } = await getTestToken();
 
@@ -293,18 +330,37 @@ describe('Request Line Endpoint', () => {
           .send({ message: 'Test before ban' });
         expect(beforeBanResponse.status).toBe(200);
 
-        // Ban the user
-        await banUser(userId, 'Test ban');
+        const sql = postgres({
+          host: process.env.DB_HOST || 'localhost',
+          port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+          database: process.env.DB_NAME || 'wxyc_db',
+          user: process.env.DB_USERNAME || 'test-user',
+          password: process.env.DB_PASSWORD || 'test-pw',
+          onnotice: () => {},
+          max: 1,
+        });
 
-        // Request should now return 403
-        const afterBanResponse = await request
-          .post('/request')
-          .set('Authorization', `Bearer ${token}`)
-          .send({ message: 'Test after ban' });
-        expect(afterBanResponse.status).toBe(403);
+        try {
+          // Ban the user (direct SQL — see banUserDirectly above for why)
+          await banUserDirectly(sql, userId, 'Test ban');
 
-        // Clean up: unban the user
-        await unbanUser(userId);
+          // Mint a fresh JWT *after* the ban so its `banned` claim reflects
+          // the current DB state — better-auth's cookieCache is off, so
+          // /token always round-trips through the database (auth.definition.ts).
+          const bannedJwt = await mintJwt(token);
+
+          // Request should now return 403
+          const afterBanResponse = await request
+            .post('/request')
+            .set('Authorization', `Bearer ${bannedJwt}`)
+            .send({ message: 'Test after ban' });
+          expect(afterBanResponse.status).toBe(403);
+        } finally {
+          // Clean up: unban the user (real admin HTTP flow) and close the
+          // direct SQL client.
+          await unbanUser(userId);
+          await sql.end();
+        }
       });
     });
   });

--- a/tests/unit/authentication/auth.middleware.test.ts
+++ b/tests/unit/authentication/auth.middleware.test.ts
@@ -115,6 +115,100 @@ describe('requirePermissions middleware', () => {
       expect(next).toHaveBeenCalled();
       expect(req.auth?.id).toBe(userId);
     });
+
+    // BS#1941: the bypass branch skips JWKS signature verification but must
+    // still honor a decodable JWT's `banned` claim exactly like the
+    // production JWT-verify branch does (see the "token validation" ->
+    // banned coverage below is production-only today; this pins the bypass
+    // side). Before this fix, a banned user's JWT sailed straight through to
+    // next() under AUTH_BYPASS (the regime CI's Integration-Tests job runs
+    // under).
+    describe('banned claim', () => {
+      it('should return 403 with the same shape as the production branch when the JWT-shaped bypass token has banned: true', async () => {
+        mockedDecodeJwt.mockReturnValue({
+          sub: 'banned-user-id',
+          email: 'banned@wxyc.org',
+          banned: true,
+          banReason: 'spamming slurs',
+        });
+        const { req, res, next } = createMocks('Bearer some.jwt.token');
+        const middleware = requirePermissions({ bin: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({
+          message: 'Access denied',
+          reason: 'spamming slurs',
+        });
+      });
+
+      it('should fall back to "Account suspended" when banned: true but banReason is absent', async () => {
+        mockedDecodeJwt.mockReturnValue({
+          sub: 'banned-user-id',
+          email: 'banned@wxyc.org',
+          banned: true,
+        });
+        const { req, res, next } = createMocks('Bearer some.jwt.token');
+        const middleware = requirePermissions({ bin: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({
+          message: 'Access denied',
+          reason: 'Account suspended',
+        });
+      });
+
+      it('should call next() when the JWT-shaped bypass token has banned: false', async () => {
+        mockedDecodeJwt.mockReturnValue({
+          sub: 'clean-user-id',
+          email: 'clean@wxyc.org',
+          banned: false,
+        });
+        const { req, res, next } = createMocks('Bearer some.jwt.token');
+        const middleware = requirePermissions({ bin: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+        expect(req.auth?.id).toBe('clean-user-id');
+      });
+
+      it('should call next() when the JWT-shaped bypass token has no banned claim at all', async () => {
+        mockedDecodeJwt.mockReturnValue({
+          sub: 'clean-user-id',
+          email: 'clean@wxyc.org',
+        });
+        const { req, res, next } = createMocks('Bearer some.jwt.token');
+        const middleware = requirePermissions({ bin: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+        expect(req.auth?.id).toBe('clean-user-id');
+      });
+
+      it('should still fall back to the raw token as user ID when the token is not a decodable JWT (banned check never runs)', async () => {
+        mockedDecodeJwt.mockImplementation(() => {
+          throw new Error('Invalid token');
+        });
+        const userId = 'raw-session-token';
+        const { req, res, next } = createMocks(`Bearer ${userId}`);
+        const middleware = requirePermissions({ bin: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+        expect(req.auth?.id).toBe(userId);
+      });
+    });
   });
 
   describe('token validation', () => {


### PR DESCRIPTION
## Summary

`requirePermissions`'s `AUTH_BYPASS` branch (`shared/authentication/src/auth.middleware.ts`, ~lines 88-128) never checked `payload.banned`, unlike the production JWT-verify branch (~lines 167-173/184). Under `AUTH_BYPASS=true` + `NODE_ENV=test` (the regime CI's `Integration-Tests` job runs under), a banned user's decodable JWT sailed straight through `requirePermissions`-gated routes with a 200 instead of a 403.

## Changes

1. **`shared/authentication/src/auth.middleware.ts`** — in the bypass branch, once `decodeJwt(token)` succeeds and `req.auth` is populated, check `req.auth.banned` and reject with the exact same status code and error shape (`403`, `{ message: 'Access denied', reason: ... }`) as the production branch. Strictly additive: only JWT-shaped tokens carrying a `banned` claim change behavior; the existing raw-token catch-all fallback is untouched.

2. **`tests/integration/requestLine.spec.js`** — un-skips `User Banning > with admin credentials > should return 403 when user is banned`, gated behind the same `TEST_ADMIN_BAN` flag as the sibling `check-request-ban.spec.js` admin case. The original test couldn't observe the 403 for two independent reasons: the bypass branch didn't check `banned` (fixed above), and the bearer token it supplied was a raw session token, not a decodable JWT. Beyond minting a JWT, this also had to work around a side effect of better-auth's `/admin/ban-user` endpoint: it unconditionally deletes the banned user's sessions, which would kill the very session needed to mint a post-ban JWT via `/token`. The test now flips `auth_user.banned` directly via SQL (the same direct-DB-setup convention `check-request-ban.spec.js` already uses for its fingerprint case) so the session stays alive, then mints a fresh JWT afterward — better-auth's `cookieCache` is off, so `/token` always reflects live DB state. Cleanup still goes through the real `unbanUser()` admin HTTP flow.

3. **`tests/unit/authentication/auth.middleware.test.ts`** — new unit coverage pinning the bypass branch's banned-claim handling: rejected when `banned: true` (with and without a `banReason`), passed through when `banned: false` or absent, and unaffected when the token isn't a decodable JWT at all.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 393 suites / 6095 tests passed, including the new/updated cases in `auth.middleware.test.ts`
- [ ] The two integration tests this change touches (`requestLine.spec.js`'s newly un-skipped ban test and its sibling in `check-request-ban.spec.js`) require the Docker Postgres + live auth/backend stack CI's `Integration-Tests` job runs — not runnable from this worktree. Verified via `gh run watch` once CI runs.

Closes #1941