### PR TITLE
fix(flowsheet-sync): make tubafrenzy sync respect BS write authority

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -352,6 +352,15 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
         // anchored to the first INSERT's values, mutable metadata-ish
         // fields move with the latest webhook payload.
         //
+        // `request_flag` (BS#1857 / BS#1623) is deliberately EXCLUDED here
+        // too, joining `segue`: for a live show, BS's DJ-facing
+        // PATCH /flowsheet is the authoritative writer for both flags.
+        // Refreshing `request_flag` from tubafrenzy's copy on every
+        // conflict-refresh could revert a DJ's toggle if tubafrenzy's
+        // mirror ever lags or diverges from BS's live state. The fresh-
+        // INSERT branch above still writes it from the payload — this only
+        // scopes the never-overwrite rule to the re-sync UPDATE path.
+        //
         // `dj_name` is conditionally refreshed only when the resolver
         // produced a non-null value (defense-in-depth for the stub-then-
         // fill race: webhook may have inserted with dj_name=NULL when the
@@ -366,7 +375,6 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           track_title: trackTitle,
           record_label: truncate(entry.labelName, 128),
           message: isMsgType ? truncate(entry.artistName, 250) : null,
-          request_flag: !!entry.requestFlag,
           entry_type: entryType,
         };
         if (markerDjName !== null) {

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -370,6 +370,14 @@ export const runIncremental = async (): Promise<SyncResult> => {
       .onConflictDoUpdate({
         target: shows.legacy_show_id,
         set: {
+          // start_time (BS#1084): the webhook's resolveShow stub-inserts a
+          // show with start_time = NOW() when a legacy_show_id it doesn't
+          // yet know arrives (apps/backend/routes/internal.route.ts). That
+          // NOW() is a BS-invented placeholder with no authority — tubafrenzy
+          // is the source of truth for show metadata via this UPSERT, so the
+          // next incremental tick must overwrite the stub value with the
+          // authoritative one rather than leaving it to drift forever.
+          start_time: sql`excluded.start_time`,
           end_time: sql`excluded.end_time`,
           show_name: sql`excluded.show_name`,
           legacy_dj_name: sql`excluded.legacy_dj_name`,
@@ -378,6 +386,7 @@ export const runIncremental = async (): Promise<SyncResult> => {
         // Same dead-tuple amplification mechanic as the flowsheet upsert
         // below, lower volume. See BS#1059.
         setWhere: sql`
+          ${shows.start_time} IS DISTINCT FROM excluded.start_time OR
           ${shows.end_time} IS DISTINCT FROM excluded.end_time OR
           ${shows.show_name} IS DISTINCT FROM excluded.show_name OR
           ${shows.legacy_dj_name} IS DISTINCT FROM excluded.legacy_dj_name OR
@@ -459,14 +468,20 @@ export const runIncremental = async (): Promise<SyncResult> => {
       })
       .onConflictDoUpdate({
         target: flowsheet.legacy_entry_id,
+        // request_flag / segue (BS#1857 / BS#1623): deliberately OMITTED
+        // from this SET list (and still written on INSERT above via
+        // `.values`). For a live show, BS's DJ-facing PATCH /flowsheet is
+        // the authoritative writer for these two flags — blindly refreshing
+        // them from tubafrenzy's copy on every re-sync could revert a DJ's
+        // toggle if tubafrenzy's mirror ever lags or diverges. A brand-new
+        // tubafrenzy entry still gets its flags from `.values` on first
+        // INSERT; only the re-sync UPDATE path leaves them alone.
         set: {
           artist_name: sql`excluded.artist_name`,
           album_title: sql`excluded.album_title`,
           track_title: sql`excluded.track_title`,
           record_label: sql`excluded.record_label`,
           message: sql`excluded.message`,
-          request_flag: sql`excluded.request_flag`,
-          segue: sql`excluded.segue`,
           entry_type: sql`excluded.entry_type`,
           add_time: sql`excluded.add_time`,
           show_id: sql`excluded.show_id`,
@@ -486,8 +501,6 @@ export const runIncremental = async (): Promise<SyncResult> => {
           ${flowsheet.track_title} IS DISTINCT FROM excluded.track_title OR
           ${flowsheet.record_label} IS DISTINCT FROM excluded.record_label OR
           ${flowsheet.message} IS DISTINCT FROM excluded.message OR
-          ${flowsheet.request_flag} IS DISTINCT FROM excluded.request_flag OR
-          ${flowsheet.segue} IS DISTINCT FROM excluded.segue OR
           ${flowsheet.entry_type} IS DISTINCT FROM excluded.entry_type OR
           ${flowsheet.add_time} IS DISTINCT FROM excluded.add_time OR
           ${flowsheet.show_id} IS DISTINCT FROM excluded.show_id OR

--- a/tests/integration/flowsheet-etl-setwhere.spec.js
+++ b/tests/integration/flowsheet-etl-setwhere.spec.js
@@ -7,6 +7,14 @@
  *
  * Uses xmin rather than `pg_stat_user_tables.n_tup_upd` because xmin is
  * row-local and immediate; n_tup_upd lags via the stats collector.
+ *
+ * `request_flag` / `segue` are intentionally OMITTED from this shape's SET
+ * list and `setWhere` guard (BS#1857 / BS#1623): a live show's flags are
+ * authoritatively owned by BS's DJ-facing PATCH /flowsheet, and a blind
+ * re-sync refresh from tubafrenzy's copy could revert a DJ's toggle. They
+ * stay in the INSERT column list / VALUES below so a brand-new tubafrenzy
+ * entry still gets its flags on first sync — see the dedicated re-sync
+ * survival test at the bottom of this file.
  */
 
 const { getTestDb } = require('../utils/db');
@@ -29,8 +37,6 @@ async function upsertEtlShape(sql, row) {
       track_title = excluded.track_title,
       record_label = excluded.record_label,
       message = excluded.message,
-      request_flag = excluded.request_flag,
-      segue = excluded.segue,
       entry_type = excluded.entry_type,
       add_time = excluded.add_time,
       play_order = excluded.play_order
@@ -40,8 +46,6 @@ async function upsertEtlShape(sql, row) {
       ${sql(SCHEMA)}.flowsheet.track_title IS DISTINCT FROM excluded.track_title OR
       ${sql(SCHEMA)}.flowsheet.record_label IS DISTINCT FROM excluded.record_label OR
       ${sql(SCHEMA)}.flowsheet.message IS DISTINCT FROM excluded.message OR
-      ${sql(SCHEMA)}.flowsheet.request_flag IS DISTINCT FROM excluded.request_flag OR
-      ${sql(SCHEMA)}.flowsheet.segue IS DISTINCT FROM excluded.segue OR
       ${sql(SCHEMA)}.flowsheet.entry_type IS DISTINCT FROM excluded.entry_type OR
       ${sql(SCHEMA)}.flowsheet.add_time IS DISTINCT FROM excluded.add_time OR
       ${sql(SCHEMA)}.flowsheet.play_order IS DISTINCT FROM excluded.play_order
@@ -165,5 +169,78 @@ describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
     `;
     expect(after[0].xmin).not.toBe(before[0].xmin);
     expect(after[0].artist_name).toBe('Chuquimamani-Condori');
+  });
+
+  // BS#1857 / BS#1623: request_flag / segue must NOT be reverted by a
+  // tubafrenzy re-sync once a DJ has toggled them in BS. A brand-new entry
+  // must still receive its flags on first sync (INSERT path unaffected).
+  test('a re-sync with a differing request_flag/segue in the incoming payload does not revert the stored value', async () => {
+    const legacyId = 2000001623;
+    insertedLegacyIds.push(legacyId);
+    const row = {
+      legacy_entry_id: legacyId,
+      entry_type: 'track',
+      artist_name: 'Duke Ellington & John Coltrane',
+      album_title: 'Duke Ellington & John Coltrane',
+      track_title: 'In a Sentimental Mood',
+      record_label: 'Impulse Records',
+      message: null,
+      request_flag: false,
+      segue: false,
+      play_order: 99004,
+      add_time: new Date('2026-05-24T14:00:00Z'),
+    };
+    // First sync: brand-new tubafrenzy entry, flags false on INSERT.
+    await upsertEtlShape(sql, row);
+
+    // A DJ toggles both flags on in BS (out of band — mirrors PATCH /flowsheet's
+    // direct UPDATE, not the ETL upsert shape under test).
+    await sql`
+      UPDATE ${sql(SCHEMA)}.flowsheet
+      SET request_flag = true, segue = true
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+
+    // tubafrenzy's copy still carries the stale pre-toggle flags (false).
+    // Re-syncing with a differing album_title (so the setWhere guard fires
+    // an UPDATE at all) must NOT drag request_flag/segue back to false.
+    await upsertEtlShape(sql, { ...row, album_title: 'Duke Ellington & John Coltrane (Remastered)' });
+
+    const after = await sql`
+      SELECT album_title, request_flag, segue
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(after[0].album_title).toBe('Duke Ellington & John Coltrane (Remastered)');
+    expect(after[0].request_flag).toBe(true);
+    expect(after[0].segue).toBe(true);
+  });
+
+  test('a brand-new entry still receives request_flag/segue from tubafrenzy on first sync', async () => {
+    const legacyId = 2000001624;
+    insertedLegacyIds.push(legacyId);
+    const row = {
+      legacy_entry_id: legacyId,
+      entry_type: 'track',
+      artist_name: 'Chuquimamani-Condori',
+      album_title: 'Edits',
+      track_title: 'Call Your Name',
+      record_label: 'self-released',
+      message: null,
+      request_flag: true,
+      segue: true,
+      play_order: 99005,
+      add_time: new Date('2026-05-24T14:30:00Z'),
+    };
+    await upsertEtlShape(sql, row);
+
+    const rows = await sql`
+      SELECT request_flag, segue
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].request_flag).toBe(true);
+    expect(rows[0].segue).toBe(true);
   });
 });

--- a/tests/integration/flowsheet-etl-shows-start-time-repair.spec.js
+++ b/tests/integration/flowsheet-etl-shows-start-time-repair.spec.js
@@ -1,0 +1,159 @@
+/**
+ * Integration test: stub-show start_time repair (BS#1084).
+ *
+ * When a tubafrenzy webhook arrives referencing a `legacy_show_id` Backend
+ * doesn't yet know, `resolveShow` (apps/backend/routes/internal.route.ts)
+ * inserts a stub `shows` row with `start_time: new Date()` — a BS-invented
+ * placeholder with no authority ("the ETL will fill in details later"). The
+ * flowsheet-etl incremental sync's `runIncremental` (jobs/flowsheet-etl/job.ts)
+ * re-syncs the same `legacy_show_id` from tubafrenzy on its next tick and must
+ * now overwrite the stub's start_time with the authoritative value, instead of
+ * leaving the wrong-but-NOW() timestamp to persist indefinitely.
+ *
+ * The integration runner is babel-jest and cannot import the ETL's
+ * drizzle-orm TS source (see flowsheet-etl-setwhere.spec.js's header for the
+ * same constraint), so the "next ETL tick" half of this test hand-mirrors
+ * `runIncremental`'s shows `onConflictDoUpdate` SQL shape verbatim. If that
+ * shape drifts from jobs/flowsheet-etl/job.ts, the unit-test pin at
+ * tests/unit/jobs/flowsheet-etl/job.test.ts is the source of truth — fix it
+ * there and update here in lockstep.
+ */
+
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const INTERNAL_KEY = process.env.ETL_NOTIFY_KEY || 'test-secret-key';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 4,
+  });
+}
+
+/**
+ * Mirrors `runIncremental`'s shows `onConflictDoUpdate` at
+ * jobs/flowsheet-etl/job.ts (BS#1084 / BS#1059) — including `start_time` in
+ * both the SET list and the value-aware `setWhere` churn-guard.
+ */
+async function upsertEtlShowShape(sql, row) {
+  return sql`
+    INSERT INTO ${sql(SCHEMA)}.shows
+      (legacy_show_id, legacy_dj_name, legacy_dj_id, start_time, end_time, show_name)
+    VALUES
+      (${row.legacy_show_id}, ${row.legacy_dj_name}, ${row.legacy_dj_id}, ${row.start_time}, ${row.end_time}, ${row.show_name})
+    ON CONFLICT (legacy_show_id) DO UPDATE SET
+      start_time = excluded.start_time,
+      end_time = excluded.end_time,
+      show_name = excluded.show_name,
+      legacy_dj_name = excluded.legacy_dj_name,
+      legacy_dj_id = excluded.legacy_dj_id
+    WHERE
+      ${sql(SCHEMA)}.shows.start_time IS DISTINCT FROM excluded.start_time OR
+      ${sql(SCHEMA)}.shows.end_time IS DISTINCT FROM excluded.end_time OR
+      ${sql(SCHEMA)}.shows.show_name IS DISTINCT FROM excluded.show_name OR
+      ${sql(SCHEMA)}.shows.legacy_dj_name IS DISTINCT FROM excluded.legacy_dj_name OR
+      ${sql(SCHEMA)}.shows.legacy_dj_id IS DISTINCT FROM excluded.legacy_dj_id
+  `;
+}
+
+describe('flowsheet-etl start_time repair for webhook stub shows (BS#1084)', () => {
+  let sql;
+  const LEGACY_SHOW_ID = 9_999_970;
+  const LEGACY_ENTRY_ID = 8_888_870;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  afterEach(async () => {
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+  });
+
+  test('a webhook-created stub start_time is overwritten by the next ETL tick', async () => {
+    const beforeRequestMs = Date.now();
+
+    // 1) Tubafrenzy webhook delivery for a legacy_show_id Backend doesn't yet
+    // know: resolveShow stub-inserts `shows` with start_time = NOW().
+    const entry = {
+      id: LEGACY_ENTRY_ID,
+      radioShowId: LEGACY_SHOW_ID,
+      flowsheetEntryType: 6, // track
+      artistName: 'Jessica Pratt',
+      songTitle: 'Back, Baby',
+      releaseTitle: 'On Your Own Love Again',
+      labelName: 'Drag City',
+      startTime: 1706799600000,
+      requestFlag: false,
+      sequenceWithinShow: 1,
+      libraryReleaseId: 0,
+      rotationReleaseId: 0,
+    };
+    const webhookRes = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'create', entry });
+    expect(webhookRes.status).toBe(200);
+
+    const [stub] = await sql.unsafe(`SELECT start_time FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+      LEGACY_SHOW_ID,
+    ]);
+    expect(stub).toBeDefined();
+    const stubStartTimeMs = new Date(stub.start_time).getTime();
+    // The stub's start_time is "now" at insert time. Assert it's recent —
+    // NOT the much-earlier authoritative value the ETL is about to sync in —
+    // so the later assertion is a genuine before/after, not a coincidence.
+    expect(stubStartTimeMs).toBeGreaterThanOrEqual(beforeRequestMs - 5000);
+
+    // 2) The flowsheet-etl incremental tick re-syncs the show from
+    // tubafrenzy's authoritative FLOWSHEET_RADIO_SHOW_PROD row, which carries
+    // the real start_time — long before the stub's NOW().
+    const authoritativeStartTime = new Date('2024-02-01T13:00:00Z');
+    await upsertEtlShowShape(sql, {
+      legacy_show_id: LEGACY_SHOW_ID,
+      legacy_dj_name: 'DJ Bluejay',
+      legacy_dj_id: 42,
+      start_time: authoritativeStartTime,
+      end_time: new Date('2024-02-01T14:00:00Z'),
+      show_name: 'The Nest',
+    });
+
+    const [healed] = await sql.unsafe(`SELECT start_time, show_name FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+      LEGACY_SHOW_ID,
+    ]);
+    expect(new Date(healed.start_time).getTime()).toBe(authoritativeStartTime.getTime());
+    expect(healed.show_name).toBe('The Nest');
+  });
+
+  test('re-running the same ETL upsert is a no-op once start_time already matches (xmin unchanged)', async () => {
+    const row = {
+      legacy_show_id: LEGACY_SHOW_ID,
+      legacy_dj_name: 'DJ Bluejay',
+      legacy_dj_id: 42,
+      start_time: new Date('2024-02-01T13:00:00Z'),
+      end_time: new Date('2024-02-01T14:00:00Z'),
+      show_name: 'The Nest',
+    };
+    await upsertEtlShowShape(sql, row);
+    const [before] = await sql.unsafe(`SELECT xmin::text AS xmin FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+      LEGACY_SHOW_ID,
+    ]);
+
+    await upsertEtlShowShape(sql, row);
+    const [after] = await sql.unsafe(`SELECT xmin::text AS xmin FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+      LEGACY_SHOW_ID,
+    ]);
+    expect(after.xmin).toBe(before.xmin);
+  });
+});

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -239,6 +239,65 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     expect(rows[0].album_title).toBe('DOGA (remastered)');
   });
 
+  // BS#1857 / BS#1623: a live show's request_flag/segue are authoritatively
+  // owned by BS's DJ-facing PATCH /flowsheet. A tubafrenzy re-sync (webhook
+  // conflict-refresh) must not revert a DJ's toggle back to tubafrenzy's
+  // stale copy, while a brand-new entry must still receive its flags from
+  // the first delivery.
+  test('a DJ-toggled request_flag survives a webhook entry-refresh; a new entry still gets flags on first sync', async () => {
+    // First delivery: fresh INSERT with requestFlag=false from tubafrenzy.
+    const initial = buildEntry({ requestFlag: false });
+    const firstRes = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'create', entry: initial });
+    expect(firstRes.status).toBe(200);
+
+    const [afterInsert] = await sql.unsafe(`SELECT request_flag FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+      LEGACY_ENTRY_ID,
+    ]);
+    expect(afterInsert.request_flag).toBe(false);
+
+    // A DJ toggles the flag on via PATCH /flowsheet (simulated directly —
+    // this spec exercises the webhook, not the DJ-facing route).
+    await sql.unsafe(`UPDATE ${SCHEMA}.flowsheet SET request_flag = true WHERE legacy_entry_id = $1`, [
+      LEGACY_ENTRY_ID,
+    ]);
+
+    // tubafrenzy redelivers the entry — its copy still carries requestFlag=false
+    // (it never saw the DJ's BS-side toggle) and a different album_title so the
+    // conflict-refresh path actually fires an UPDATE.
+    const stale = buildEntry({ requestFlag: false, releaseTitle: 'DOGA (remastered)' });
+    const secondRes = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'update', entry: stale });
+    expect(secondRes.status).toBe(200);
+
+    const [afterRefresh] = await sql.unsafe(
+      `SELECT album_title, request_flag FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`,
+      [LEGACY_ENTRY_ID]
+    );
+    // The refresh moved the unrelated mutable field...
+    expect(afterRefresh.album_title).toBe('DOGA (remastered)');
+    // ...but did NOT revert the DJ's toggle back to tubafrenzy's stale false.
+    expect(afterRefresh.request_flag).toBe(true);
+  });
+
+  test('a brand-new entry still receives requestFlag from tubafrenzy on first delivery', async () => {
+    const entry = buildEntry({ requestFlag: true });
+    const res = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'create', entry });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(`SELECT request_flag FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+      LEGACY_ENTRY_ID,
+    ]);
+    expect(row.request_flag).toBe(true);
+  });
+
   // BS#1444 (residual of #1371): the show_start is the FIRST entry of a show,
   // so it loses a structural race — when it arrives the stub `shows` row has no
   // `legacy_dj_name` yet, and the marker lands NULL. The ETL fills the name

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -254,6 +254,64 @@ describe('runIncremental', () => {
       expect(arg.setWhere).toBeTruthy();
     }
   });
+
+  // BS#1084: the stub `shows` row the webhook inserts with start_time = NOW()
+  // (apps/backend/routes/internal.route.ts's resolveShow) must be repaired by
+  // the next incremental tick — the shows UPSERT's conflict set must include
+  // start_time, or the wrong-but-NOW() value persists forever. PG semantics
+  // (the setWhere churn-guard actually firing an UPDATE) are pinned in
+  // tests/integration/flowsheet-etl-shows-start-time-repair.spec.js; this is
+  // the shape check that the Drizzle call site carries the column at all.
+  it('includes start_time in the shows onConflictDoUpdate set (BS#1084)', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([]);
+
+    await runIncremental();
+
+    const showsUpsertCall = chain.onConflictDoUpdate.mock.calls.find(
+      ([arg]: [{ target: unknown }]) => arg.target === shows.legacy_show_id
+    );
+    expect(showsUpsertCall).toBeDefined();
+    const [arg] = showsUpsertCall as [{ set: Record<string, unknown> }];
+    expect(arg.set).toHaveProperty('start_time');
+  });
+
+  // BS#1857 / BS#1623: request_flag/segue are authoritatively owned by BS's
+  // DJ-facing PATCH /flowsheet on a live show. The entries onConflictDoUpdate
+  // must NOT refresh either column from tubafrenzy's copy (they stay in
+  // .values() for the INSERT branch only — asserted separately below). PG
+  // semantics (a differing incoming value not reverting the stored one) are
+  // pinned in tests/integration/flowsheet-etl-setwhere.spec.js.
+  it('omits request_flag and segue from the entries onConflictDoUpdate set (BS#1857 / BS#1623)', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry()]);
+
+    await runIncremental();
+
+    const entriesUpsertCall = chain.onConflictDoUpdate.mock.calls.find(
+      ([arg]: [{ target: unknown }]) => arg.target === flowsheet.legacy_entry_id
+    );
+    expect(entriesUpsertCall).toBeDefined();
+    const [arg] = entriesUpsertCall as [{ set: Record<string, unknown> }];
+    expect(arg.set).not.toHaveProperty('request_flag');
+    expect(arg.set).not.toHaveProperty('segue');
+  });
+
+  it('still writes request_flag/segue on the INSERT values for a brand-new entry (BS#1857 / BS#1623)', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry({ requestFlag: 1, segueFlag: 1 })]);
+
+    await runIncremental();
+
+    const insertCalls = chain.values.mock.calls;
+    const flowsheetInsert = insertCalls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).legacy_entry_id === 2001
+    );
+    expect(flowsheetInsert).toBeDefined();
+    const values = flowsheetInsert![0] as Record<string, unknown>;
+    expect(values.request_flag).toBe(true);
+    expect(values.segue).toBe(true);
+  });
 });
 
 /**

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -250,6 +250,21 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(lastInsertValues()).toEqual(expect.objectContaining({ album_id: 7777 }));
   });
 
+  // BS#1857 / BS#1623: a fresh INSERT still writes request_flag straight from
+  // the tubafrenzy payload — the never-refresh rule scopes only to the
+  // conflict-UPDATE branch (pinned separately below).
+  it('writes request_flag from the payload on a fresh INSERT', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, requestFlag: true } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ request_flag: true }));
+  });
+
   it('writes album_id: null when libraryReleaseId is 0 (no library link)', async () => {
     // libraryReleaseId=0 short-circuits resolveAlbumId — no album SELECT issued.
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
@@ -645,6 +660,28 @@ describe('POST /internal/flowsheet-webhook', () => {
     const setClause = lastUpdateSet();
     expect(setClause).not.toHaveProperty('dj_name');
     expect(setClause).toEqual(expect.objectContaining({ entry_type: 'track' }));
+  });
+
+  // -- ON CONFLICT UPDATE never refreshes request_flag (BS#1857 / BS#1623) --
+  //
+  // BS's DJ-facing PATCH /flowsheet is the authoritative writer for
+  // request_flag on a live show. The conflict-refresh branch here must never
+  // overwrite it from tubafrenzy's payload — that would silently revert a
+  // DJ's toggle on the next redelivery. The fresh-INSERT branch (asserted
+  // elsewhere in this file, e.g. "returns 200 for valid create") still writes
+  // it from the payload; only the re-sync UPDATE path omits it.
+
+  it('UPDATE on conflict OMITS request_flag regardless of the incoming payload value (BS#1857 / BS#1623)', async () => {
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', entry: { ...validEntry, requestFlag: true } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(lastUpdateSet()).not.toHaveProperty('request_flag');
   });
 
   // -- Sibling-marker heal probe-before-write (BS#1444) --


### PR DESCRIPTION
## Summary

Two tubafrenzy<->BS sync paths were fighting over which side owns which field on `flowsheet`/`shows`, in opposite directions.

- **`shows.start_time` was never repaired (#1084).** When a tubafrenzy webhook arrives referencing a `legacy_show_id` Backend doesn't yet know, `resolveShow` (`apps/backend/routes/internal.route.ts`) inserts a stub `shows` row with `start_time: new Date()` — a BS-invented placeholder with no authority. The flowsheet-etl's `runIncremental` shows UPSERT (`jobs/flowsheet-etl/job.ts`) re-syncs that show from tubafrenzy on every subsequent tick, but its conflict set omitted `start_time`, so the wrong-but-NOW() value persisted indefinitely instead of being overwritten by tubafrenzy's authoritative value.
- **`request_flag`/`segue` were being clobbered on re-sync (#1857, #1623).** For a live show, BS's DJ-facing `PATCH /flowsheet` is the authoritative writer for these two flags. Both the flowsheet-etl entries UPSERT and the webhook's conflict-refresh branch blindly overwrote them from tubafrenzy's copy on every re-sync/redelivery, silently reverting a DJ's toggle whenever tubafrenzy's mirrored copy lagged or diverged from BS's live state — including the un-set (`true` -> `false`) case #1623 reported, since a stale `false` from tubafrenzy would win back over a DJ's explicit un-check.

## Changes

1. `jobs/flowsheet-etl/job.ts` — shows `onConflictDoUpdate`: added `start_time: sql`excluded.start_time`` to the `set` and the matching `IS DISTINCT FROM` clause to the `setWhere` churn-guard. Tubafrenzy is already authoritative for show metadata via this UPSERT, so this direction is correct — it just closes the one column the original list missed.
2. `jobs/flowsheet-etl/job.ts` — entries `onConflictDoUpdate`: removed `request_flag`/`segue` from the `set` and `setWhere`. Both stay in the INSERT `.values()` above, so a brand-new tubafrenzy entry still gets its flags on first sync; only the re-sync UPDATE path now leaves them alone.
3. `apps/backend/routes/internal.route.ts` — the webhook's conflict-refresh branch: removed `request_flag` from the `refresh` set object (the fresh-INSERT branch is untouched and still writes it from the payload). `segue` was already absent from this branch (hardcoded `false` at INSERT only), so no change was needed there.

## Tests

- New integration spec `tests/integration/flowsheet-etl-shows-start-time-repair.spec.js`: drives the real webhook to create a stub show, then applies the ETL's shows-upsert SQL shape (hand-mirrored, per this test tier's existing convention — the babel-jest integration runner can't import the ETL's drizzle-orm TS source) with an authoritative `start_time`, and asserts the stub value is overwritten. Also pins the setWhere's no-op-skip behavior via `xmin`.
- Extended `tests/integration/flowsheet-etl-setwhere.spec.js` (the existing ETL-upsert PG-semantics pin) to match the new shape, plus two new cases: a re-sync with a differing `request_flag`/`segue` in the incoming payload does not revert a BS-side toggle, and a brand-new entry still receives both flags on first sync.
- Extended `tests/integration/internal-flowsheet-webhook.spec.js` with the webhook-side mirror of the same two cases (DJ-toggled flag survives a redelivery; a brand-new entry still gets its flag).
- Extended the mocked-DB unit suites (`tests/unit/jobs/flowsheet-etl/job.test.ts`, `tests/unit/routes/internal.route.test.ts`) with shape-level pins: `start_time` present in the shows conflict set, `request_flag`/`segue` absent from the entries conflict set, and `request_flag` absent from the webhook's conflict-refresh set — all while confirming the INSERT-path values are untouched.

## Out of scope

The historical `start_time` drift already sitting in prod is **deliberately not touched here** — no backfill/repair UPDATE is included in this PR. That repair is owned by #1543's final-dump sweep; this PR is forward-only (new conflict-set/handler behavior for future syncs).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (6095 tests, full suite)
- [x] `npx tsc --noEmit -p jobs/flowsheet-etl/tsconfig.json`
- [ ] CI's Integration-Tests job (requires Docker Postgres, not run locally) — this is what actually exercises the new/modified integration specs above; watching after push.

Closes #1084
Closes #1857
Closes #1623