### PR TITLE
fix(flowsheet): stop a go-live from guest-joining a just-ended tubafrenzy show

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -595,7 +595,21 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
     }
   }
 
-  if (current_show?.end_time !== null) {
+  // (b) Belt-and-braces (BS#1861): the tubafrenzy webhook's stub-show flow
+  // can leave `shows.end_time` NULL for a window after a legacy sign-off —
+  // option (a) now backfills it at write time, but this is a second,
+  // independent signal that doesn't depend on that write having landed.
+  // Treat the show as closed when its newest flowsheet entry is a
+  // `show_end` marker, regardless of what `end_time` currently holds, so a
+  // DJ going live in that window starts a NEW show instead of being
+  // guest-joined into the one that just ended. Only checked when `end_time`
+  // is still null — an already-closed show doesn't need the extra query.
+  const latestEntryIsShowEnd =
+    current_show !== undefined &&
+    current_show.end_time === null &&
+    (await flowsheet_service.isLatestEntryShowEnd(current_show.id));
+
+  if (current_show?.end_time !== null || latestEntryIsShowEnd) {
     const show_session: Show = await flowsheet_service.startShow(
       req.body.dj_id,
       req.body.show_name,
@@ -604,6 +618,13 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
     );
 
     res.status(200).json(show_session);
+  } else if (await flowsheet_service.isDjAlreadyActiveOnShow(current_show, req.body.dj_id)) {
+    // (c) No-op duplicate dj_join (BS#1861): the requesting DJ is already
+    // active on this show — either the primary DJ or an active co-host — so
+    // this is a retried "Go Live" toggle, not a genuine join. Hand back
+    // their existing (already-active) membership without writing another
+    // dj_join marker (the issue's 16:37:59 duplicate-marker trace).
+    res.status(200).json({ show_id: current_show.id, dj_id: req.body.dj_id, active: true } satisfies ShowDJ);
   } else {
     // Override is only consumed on the new-show path. Co-host join uses the
     // auth_user.dj_name resolution unchanged.

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -304,6 +304,12 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // Date. Computed once and shared by the INSERT and the ON-CONFLICT heal.
       const breakpointRadioHour = resolveRadioHour(entryType, entry.radioHour ?? null);
 
+      // Shared by the row's `add_time` and, for `show_end` markers, the
+      // `shows.end_time` fast-path below — one clock reading per delivery
+      // so the two never drift apart by the few ms between two `new Date()`
+      // calls when `entry.startTime` is absent.
+      const markerTimestamp = entry.startTime ? new Date(entry.startTime) : new Date();
+
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
       // INSERT / prior webhook delivery already claimed the
@@ -337,7 +343,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           request_flag: !!entry.requestFlag,
           segue: false,
           play_order: entry.sequenceWithinShow ?? 0,
-          add_time: entry.startTime ? new Date(entry.startTime) : new Date(),
+          add_time: markerTimestamp,
           radio_hour: breakpointRadioHour,
         })
         .onConflictDoNothing()
@@ -386,6 +392,39 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           refresh.radio_hour = breakpointRadioHour;
         }
         await db.update(flowsheet).set(refresh).where(eq(flowsheet.legacy_entry_id, entry.id));
+      }
+
+      // show_end → shows.end_time fast-path (BS#1861, option (a)).
+      //
+      // The stub-show flow above ("Create a stub show" in resolveShow)
+      // deliberately leaves a webhook-created show's metadata — including
+      // `end_time` — to the next flowsheet-etl incremental tick. That's fine
+      // for a show that's still being DJed, but a `show_end` marker means
+      // tubafrenzy just signed the show off — until the ETL's next tick
+      // (today, up to half-hourly) runs, `shows.end_time` stays NULL and the
+      // show reads as still open. `POST /flowsheet/join`'s start-vs-join
+      // decision keys on exactly that column (see BS#1861 (b) for the second,
+      // independent guard), so a DJ going live in that window would be
+      // silently guest-joined into the just-ended show instead of starting a
+      // new one.
+      //
+      // Fix: set `shows.end_time` here too, from the same timestamp the
+      // marker row itself gets. This is a fast-path, not a takeover — the
+      // ETL's shows UPSERT (jobs/flowsheet-etl/job.ts) remains authoritative
+      // for refinement and unconditionally overwrites `end_time` from
+      // tubafrenzy's own value on its next tick (value-aware `setWhere`, BS
+      // #1059/#1956), so a discrepancy between this webhook guess and
+      // tubafrenzy's real sign-off timestamp self-heals within one ETL cycle.
+      //
+      // `WHERE end_time IS NULL` is the data-safety guard (mirrors #1371's
+      // dj_name-at-write-time precedent on these same marker rows): never
+      // rewrite a value the ETL — or an earlier delivery of this same
+      // `show_end` — already repaired.
+      if (entryType === 'show_end' && showId !== null) {
+        await db
+          .update(shows)
+          .set({ end_time: markerTimestamp })
+          .where(and(eq(shows.id, showId), isNull(shows.end_time)));
       }
 
       // Sibling-marker heal (BS#1444 — residual of BS#1371).

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -894,6 +894,60 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
 };
 
 /**
+ * True when the newest flowsheet entry belonging to `showId` is a
+ * `show_end` marker.
+ *
+ * Belt-and-braces guard for `joinShow` (BS#1861 option (b)). The tubafrenzy
+ * webhook's stub-show flow can leave `shows.end_time` NULL for a window
+ * after a legacy sign-off (`resolveShow`'s "Create a stub show" comment in
+ * apps/backend/routes/internal.route.ts) — the webhook now also sets
+ * `end_time` at write time as a fast-path (BS#1861 option (a)), but this is
+ * a second, independent signal: a show whose last entry is `show_end` is
+ * closed regardless of what `end_time` currently holds, so `joinShow` can
+ * still route a go-live in that window to a new show even if the fast-path
+ * write above raced or was somehow missed.
+ *
+ * Ordered by `id DESC` (insertion order), not `play_order DESC` —
+ * `changeOrder` can renumber `play_order` for track reordering within a
+ * show, but marker rows are never reordered and the serial PK is an
+ * unambiguous "newest".
+ */
+export const isLatestEntryShowEnd = async (showId: number): Promise<boolean> => {
+  const [latest] = await db
+    .select({ entry_type: flowsheet.entry_type })
+    .from(flowsheet)
+    .where(eq(flowsheet.show_id, showId))
+    .orderBy(desc(flowsheet.id))
+    .limit(1);
+  return latest?.entry_type === 'show_end';
+};
+
+/**
+ * True when `dj_id` is already an active participant in `show` — either the
+ * primary DJ or a co-host whose `show_djs.active` is true.
+ *
+ * Belt-and-braces guard for `joinShow` (BS#1861 option (c)): a retried
+ * "Go Live" toggle that lands on an already-open show for a DJ already live
+ * on it is not a genuine join, and should not write another `dj_join`
+ * marker (the issue's 16:37:59 duplicate-marker trace). `addDJToShow`
+ * itself already no-ops the marker write when a co-host's `show_djs` row is
+ * found active (it only inserts/notifies on first join or reactivates from
+ * inactive) — this check makes that guarantee explicit at the call site and
+ * additionally covers the primary DJ, whose `show_djs` row this check does
+ * not assume is present.
+ */
+export const isDjAlreadyActiveOnShow = async (show: Show, dj_id: string): Promise<boolean> => {
+  if (show.primary_dj_id === dj_id) return true;
+
+  const [row] = await db
+    .select({ active: show_djs.active })
+    .from(show_djs)
+    .where(and(eq(show_djs.show_id, show.id), eq(show_djs.dj_id, dj_id)))
+    .limit(1);
+  return row?.active === true;
+};
+
+/**
  * Display name shown on air for a live show whose DJ we cannot name — an
  * anonymous human at the controls. The most common cause is a tubafrenzy
  * sign-on with a blank `djHandle`, which leaves `shows.legacy_dj_name` null:

--- a/tests/integration/flowsheet-join-after-tubafrenzy-signoff.spec.js
+++ b/tests/integration/flowsheet-join-after-tubafrenzy-signoff.spec.js
@@ -1,0 +1,223 @@
+/**
+ * Integration tests for BS#1861: a legacy tubafrenzy sign-off (webhook
+ * `show_end`) followed immediately by a dj-site go-live (`POST /flowsheet/join`)
+ * must start a NEW show — not silently guest-join the show that just ended.
+ *
+ * Exercises the full stack across all three fixes from the issue:
+ *   (a) the webhook's `shows.end_time` fast-path on a `show_end` delivery
+ *   (b) `joinShow`'s belt-and-braces "newest entry is show_end" check,
+ *       pinned in isolation by forcing `end_time` back to NULL so the test
+ *       can't pass on (a) alone
+ *   (c) no duplicate `dj_join` marker for a DJ already active on the show
+ *
+ * Companion unit coverage: tests/unit/routes/internal.route.test.ts (the
+ * end_time fast-path in isolation), tests/unit/controllers/flowsheet.controller.test.ts
+ * and tests/unit/services/flowsheet.joinShowGuards.test.ts (the two joinShow
+ * guards in isolation).
+ */
+
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const INTERNAL_KEY = process.env.ETL_NOTIFY_KEY || 'test-secret-key';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('POST /flowsheet/join after a tubafrenzy sign-off (BS#1861)', () => {
+  let sql;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  const buildEntry = (overrides = {}) => ({
+    radioShowId: 0,
+    flowsheetEntryType: 6,
+    artistName: 'Jessica Pratt',
+    songTitle: 'Back, Baby',
+    releaseTitle: 'On Your Own Love Again',
+    labelName: 'Drag City',
+    startTime: Date.now(),
+    requestFlag: false,
+    sequenceWithinShow: 1,
+    libraryReleaseId: 0,
+    rotationReleaseId: 0,
+    ...overrides,
+  });
+
+  const postWebhook = (entry) =>
+    request.post('/internal/flowsheet-webhook').set('X-Internal-Key', INTERNAL_KEY).send({ action: 'create', entry });
+
+  const cleanupLegacyShow = async (legacyShowId, entryIds) => {
+    if (entryIds.length > 0) {
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = ANY($1)`, [entryIds]);
+    }
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [legacyShowId]);
+  };
+
+  const endCurrentShow = () =>
+    request.post('/flowsheet/end').set('Authorization', global.access_token).send({ dj_id: global.primary_dj_id });
+
+  test('acceptance criterion 1: go-live right after a sign-off starts a NEW show, not a guest dj_join into the ended one', async () => {
+    const LEGACY_SHOW_ID = 7_777_001;
+    const START_ID = 7_777_101;
+    const END_ID = 7_777_102;
+
+    try {
+      await postWebhook(
+        buildEntry({ id: START_ID, radioShowId: LEGACY_SHOW_ID, flowsheetEntryType: 9, djHandle: 'DJ MONSTER' })
+      );
+      const endRes = await postWebhook(buildEntry({ id: END_ID, radioShowId: LEGACY_SHOW_ID, flowsheetEntryType: 10 }));
+      expect(endRes.status).toBe(200);
+
+      // Fast-path (option (a)): the webhook should have closed the legacy
+      // show at write time, not left it for the next ETL tick.
+      const [legacyShow] = await sql.unsafe(`SELECT id, end_time FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+        LEGACY_SHOW_ID,
+      ]);
+      expect(legacyShow.end_time).not.toBeNull();
+
+      // Go live immediately, as the real dj-site flow would.
+      const joinRes = await request
+        .post('/flowsheet/join')
+        .set('Authorization', global.access_token)
+        .send({ dj_id: global.primary_dj_id, show_name: 'BS#1861 regression 1' });
+      expect(joinRes.status).toBe(200);
+      // A startShow response is a Show (start_time/show_name); an
+      // addDJToShow response is a ShowDJ (show_id/dj_id/active) with neither
+      // field. Their presence proves the startShow branch ran.
+      expect(joinRes.body.start_time).toBeDefined();
+      expect(joinRes.body.show_name).toEqual('BS#1861 regression 1');
+      expect(joinRes.body.id).not.toEqual(legacyShow.id);
+
+      const newShowId = joinRes.body.id;
+
+      const [newShowFirstEntry] = await sql.unsafe(
+        `SELECT entry_type FROM ${SCHEMA}.flowsheet WHERE show_id = $1 ORDER BY id ASC LIMIT 1`,
+        [newShowId]
+      );
+      expect(newShowFirstEntry.entry_type).toBe('show_start');
+
+      const legacyDjJoinRows = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_join'`,
+        [legacyShow.id]
+      );
+      expect(legacyDjJoinRows.length).toBe(0);
+
+      await endCurrentShow();
+    } finally {
+      await cleanupLegacyShow(LEGACY_SHOW_ID, [START_ID, END_ID]);
+    }
+  });
+
+  test('option (b): joinShow still starts a new show when end_time is NULL but the newest entry is show_end', async () => {
+    const LEGACY_SHOW_ID = 7_777_002;
+    const START_ID = 7_777_201;
+    const END_ID = 7_777_202;
+
+    try {
+      await postWebhook(
+        buildEntry({ id: START_ID, radioShowId: LEGACY_SHOW_ID, flowsheetEntryType: 9, djHandle: 'DJ GHOST' })
+      );
+      await postWebhook(buildEntry({ id: END_ID, radioShowId: LEGACY_SHOW_ID, flowsheetEntryType: 10 }));
+
+      const [legacyShow] = await sql.unsafe(`SELECT id FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [
+        LEGACY_SHOW_ID,
+      ]);
+
+      // Simulate the fast-path (a) having been skipped or lost a race — the
+      // pre-#1861 window. The show's newest flowsheet entry is still
+      // show_end, so (b) is the only thing standing between this and a
+      // mis-join.
+      await sql.unsafe(`UPDATE ${SCHEMA}.shows SET end_time = NULL WHERE id = $1`, [legacyShow.id]);
+
+      const joinRes = await request
+        .post('/flowsheet/join')
+        .set('Authorization', global.access_token)
+        .send({ dj_id: global.primary_dj_id, show_name: 'BS#1861 regression 2' });
+      expect(joinRes.status).toBe(200);
+      expect(joinRes.body.start_time).toBeDefined();
+      expect(joinRes.body.id).not.toEqual(legacyShow.id);
+
+      const legacyDjJoinRows = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_join'`,
+        [legacyShow.id]
+      );
+      expect(legacyDjJoinRows.length).toBe(0);
+
+      await endCurrentShow();
+    } finally {
+      await cleanupLegacyShow(LEGACY_SHOW_ID, [START_ID, END_ID]);
+    }
+  });
+
+  test('option (c): an already-active DJ re-join does not write a duplicate dj_join marker', async () => {
+    const startRes = await request
+      .post('/flowsheet/join')
+      .set('Authorization', global.access_token)
+      .send({ dj_id: global.primary_dj_id, show_name: 'BS#1861 regression 3' });
+    expect(startRes.status).toBe(200);
+    const showId = startRes.body.id;
+
+    try {
+      // Secondary DJ joins as a co-host — first join, genuine dj_join marker.
+      const firstJoin = await request
+        .post('/flowsheet/join')
+        .set('Authorization', global.secondary_access_token)
+        .send({ dj_id: global.secondary_dj_id });
+      expect(firstJoin.status).toBe(200);
+
+      const afterFirstJoin = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_join'`,
+        [showId]
+      );
+      expect(afterFirstJoin.length).toBe(1);
+
+      // Secondary DJ retries the same join (the dj-site "Go Live" retry flap
+      // from the issue's 16:32-16:35 trace).
+      const secondJoin = await request
+        .post('/flowsheet/join')
+        .set('Authorization', global.secondary_access_token)
+        .send({ dj_id: global.secondary_dj_id });
+      expect(secondJoin.status).toBe(200);
+
+      const afterSecondJoin = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_join'`,
+        [showId]
+      );
+      // Still exactly one — the retry did not write a second marker.
+      expect(afterSecondJoin.length).toBe(1);
+
+      // The primary DJ re-joining their own already-active show (the
+      // issue's 16:37:59 duplicate) must not write a dj_join either.
+      const primaryRejoin = await request
+        .post('/flowsheet/join')
+        .set('Authorization', global.access_token)
+        .send({ dj_id: global.primary_dj_id });
+      expect(primaryRejoin.status).toBe(200);
+
+      const afterPrimaryRejoin = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_join'`,
+        [showId]
+      );
+      expect(afterPrimaryRejoin.length).toBe(1);
+    } finally {
+      await endCurrentShow();
+    }
+  });
+});

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -38,6 +38,11 @@ const mockStartShow = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockAddDJToShow = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockEndShow = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockServiceLeaveShow = jest.fn<() => Promise<Record<string, unknown>>>();
+// BS#1861 (b)/(c): joinShow's belt-and-braces checks. Default to the
+// pre-existing behavior (show open per end_time, DJ not already active) so
+// every joinShow test not specifically about these guards is unaffected.
+const mockIsLatestEntryShowEnd = jest.fn<() => Promise<boolean>>().mockResolvedValue(false);
+const mockIsDjAlreadyActiveOnShow = jest.fn<() => Promise<boolean>>().mockResolvedValue(false);
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntriesByPage: mockGetEntriesByPage,
@@ -62,6 +67,8 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   addDJToShow: mockAddDJToShow,
   endShow: mockEndShow,
   leaveShow: mockServiceLeaveShow,
+  isLatestEntryShowEnd: mockIsLatestEntryShowEnd,
+  isDjAlreadyActiveOnShow: mockIsDjAlreadyActiveOnShow,
 }));
 
 // flowsheet-projection is intentionally NOT mocked — the controller boundary
@@ -1536,6 +1543,52 @@ describe('flowsheet.controller', () => {
 
       await expect(joinShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
       expect(mockStartShow).not.toHaveBeenCalled();
+    });
+
+    it('does not query isLatestEntryShowEnd when end_time already marks the show closed', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+
+      const req = { auth: { id: 'caller-dj' }, body: { dj_id: 'caller-dj' } } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      // The extra check is only needed when end_time is still null — an
+      // already-closed show doesn't need the belt-and-braces query.
+      expect(mockIsLatestEntryShowEnd).not.toHaveBeenCalled();
+      expect(mockStartShow).toHaveBeenCalled();
+    });
+
+    it('(b) starts a new show when the latest entry on an end_time-null show is show_end (BS#1861)', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 5, end_time: null });
+      mockIsLatestEntryShowEnd.mockResolvedValueOnce(true);
+      mockStartShow.mockResolvedValue({ id: 6, primary_dj_id: 'caller-dj' });
+
+      const req = { auth: { id: 'caller-dj' }, body: { dj_id: 'caller-dj' } } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockIsLatestEntryShowEnd).toHaveBeenCalledWith(5);
+      expect(mockStartShow).toHaveBeenCalled();
+      expect(mockAddDJToShow).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('(c) no-ops when the DJ is already active on the current show, instead of writing a duplicate dj_join (BS#1861)', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 7, end_time: null, primary_dj_id: 'someone-else' });
+      mockIsDjAlreadyActiveOnShow.mockResolvedValueOnce(true);
+
+      const req = { auth: { id: 'caller-dj' }, body: { dj_id: 'caller-dj' } } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockIsDjAlreadyActiveOnShow).toHaveBeenCalledWith(expect.objectContaining({ id: 7 }), 'caller-dj');
+      expect(mockAddDJToShow).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ show_id: 7, dj_id: 'caller-dj', active: true });
     });
   });
 

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -25,7 +25,8 @@ jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
 }));
 
-import { db } from '@wxyc/database';
+import { db, shows } from '@wxyc/database';
+import { and, eq, isNull } from 'drizzle-orm';
 import express from 'express';
 import request from 'supertest';
 
@@ -559,6 +560,74 @@ describe('POST /internal/flowsheet-webhook', () => {
     const setMock = (mockChain as unknown as { set: jest.Mock }).set;
     return setMock.mock.calls[0]![0] as Record<string, unknown>;
   };
+
+  // -- show_end → shows.end_time fast-path (BS#1861 option (a)) --
+  //
+  // The webhook's stub-show flow defers `shows.end_time` to the next
+  // flowsheet-etl tick; a show_end delivery now also backfills it here, from
+  // the same timestamp the marker row itself gets, guarded WHERE end_time IS
+  // NULL so a redelivery (or a value the ETL already repaired) is never
+  // clobbered. Each test drains the heal probe empty and forces a fresh
+  // INSERT so this new update is the ONLY update call in the request,
+  // keeping the shared mock chain's `.set`/`.where` call history unambiguous.
+
+  it('sets shows.end_time from the marker timestamp on a show_end delivery', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Iman Amadou' }]) // resolveShow
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([]) // heal probe → nothing to heal
+      .mockResolvedValue([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh INSERT
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 10 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(shows);
+    expect(lastUpdateSet()).toEqual({ end_time: new Date(validEntry.startTime) });
+
+    const whereMock = (mockChain as unknown as { where: jest.Mock }).where;
+    expect(whereMock).toHaveBeenCalledWith(and(eq(shows.id, 9999), isNull(shows.end_time)));
+  });
+
+  it('does not touch shows.end_time on a non-show_end delivery', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Iman Amadou' }]) // resolveShow
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([]) // heal probe → nothing to heal
+      .mockResolvedValue([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh INSERT
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry }); // track (flowsheetEntryType: 6)
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not touch shows.end_time on a show_end delivery with no resolvable show (radioShowId=0)', async () => {
+    mockLimit.mockReset();
+    mockReturning.mockReset();
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh INSERT
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({
+        action: 'create',
+        entry: { ...validEntry, flowsheetEntryType: 10, radioShowId: 0, libraryReleaseId: 0, rotationReleaseId: 0 },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
 
   it('UPDATE on conflict refreshes dj_name for a marker entry when the show resolves to a non-null name', async () => {
     // resolveShow → {id:9999, dj_name:'Aubrey'}; INSERT conflict (empty

--- a/tests/unit/services/flowsheet.joinShowGuards.test.ts
+++ b/tests/unit/services/flowsheet.joinShowGuards.test.ts
@@ -1,0 +1,82 @@
+import { eq, desc, and } from 'drizzle-orm';
+import { db, createMockQueryChain, flowsheet, show_djs } from '../../mocks/database.mock';
+import { isLatestEntryShowEnd, isDjAlreadyActiveOnShow } from '../../../apps/backend/services/flowsheet.service';
+
+/**
+ * Unit shape-pins for the two belt-and-braces reads `joinShow` uses (BS#1861
+ * options (b) and (c)). The end-to-end start-vs-join decision is covered by
+ * the controller unit tests (tests/unit/controllers/flowsheet.controller.test.ts)
+ * and by the integration spec exercising the real webhook → join sequence
+ * against Postgres; these tests pin each read in isolation.
+ */
+describe('flowsheet.service: joinShow belt-and-braces guards (BS#1861)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isLatestEntryShowEnd', () => {
+    it('returns true when the newest flowsheet entry for the show is show_end', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([{ entry_type: 'show_end' }]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isLatestEntryShowEnd(42)).resolves.toBe(true);
+
+      // Filters by show_id, orders by id DESC (insertion order — immune to
+      // play_order renumbering from changeOrder), takes only the newest row.
+      expect(chain.where).toHaveBeenCalledWith(eq(flowsheet.show_id, 42));
+      expect(chain.orderBy).toHaveBeenCalledWith(desc(flowsheet.id));
+      expect(chain.limit).toHaveBeenCalledWith(1);
+    });
+
+    it('returns false when the newest entry is not show_end', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([{ entry_type: 'dj_join' }]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isLatestEntryShowEnd(42)).resolves.toBe(false);
+    });
+
+    it('returns false when the show has no flowsheet entries at all', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isLatestEntryShowEnd(42)).resolves.toBe(false);
+    });
+  });
+
+  describe('isDjAlreadyActiveOnShow', () => {
+    const show = { id: 1, primary_dj_id: 'dj-A' } as unknown as Parameters<typeof isDjAlreadyActiveOnShow>[0];
+
+    it('returns true for the primary DJ without a show_djs round trip', async () => {
+      await expect(isDjAlreadyActiveOnShow(show, 'dj-A')).resolves.toBe(true);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('returns true when a co-host show_djs row is active', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([{ active: true }]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isDjAlreadyActiveOnShow(show, 'dj-B')).resolves.toBe(true);
+      expect(chain.where).toHaveBeenCalledWith(and(eq(show_djs.show_id, 1), eq(show_djs.dj_id, 'dj-B')));
+    });
+
+    it('returns false when the co-host show_djs row is inactive', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([{ active: false }]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isDjAlreadyActiveOnShow(show, 'dj-B')).resolves.toBe(false);
+    });
+
+    it('returns false when no show_djs row exists for the DJ', async () => {
+      const chain = createMockQueryChain();
+      chain.limit.mockResolvedValue([]);
+      db.select.mockReturnValueOnce(chain);
+
+      await expect(isDjAlreadyActiveOnShow(show, 'dj-B')).resolves.toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a legacy DJ signs off on tubafrenzy, the `/internal` flowsheet webhook writes the `show_end` flowsheet marker row but leaves `shows.end_time` NULL — by design, the stub-show flow defers it to the next flowsheet-etl tick. Until that tick runs, the show reads as still open. `POST /flowsheet/join` decides start-vs-join on `current_show?.end_time !== null`, so a dj-site DJ going live in that gap is silently attached to the *ended* show as a guest (`dj_join`) instead of starting a new one, with their playcuts appended to the dead show's play_order sequence.

Closes #1861

## Fix

Implements all three (non-mutually-exclusive) options from the issue:

**(a) Webhook `show_end` sets `shows.end_time` at write time** (`apps/backend/routes/internal.route.ts`). When the delivered entry is a `show_end` marker, the webhook now `UPDATE`s `shows.end_time` for the resolved show, using the same timestamp the marker row itself gets (`entry.startTime`, falling back to `new Date()`). Guarded `WHERE end_time IS NULL` — this never rewrites a value the ETL (or an earlier delivery of the same `show_end`) already repaired. The ETL's shows UPSERT remains authoritative for refinement and unconditionally overwrites `end_time` from tubafrenzy's own value on its next tick, so a discrepancy self-heals within one cycle. Symmetric with #1371's dj_name-at-write-time precedent on these same marker rows.

**(b) Belt-and-braces in the join controller** (`apps/backend/controllers/flowsheet.controller.ts`, `apps/backend/services/flowsheet.service.ts`). `joinShow` now also treats a show as closed when its *newest* flowsheet entry is a `show_end` marker, regardless of what `end_time` currently holds. New service helper `isLatestEntryShowEnd(showId)` orders by `id DESC` (insertion order, immune to `changeOrder`'s `play_order` renumbering) and is only queried when `end_time` is still null, so an already-closed show skips the extra read. This is a second, independent signal that still protects a go-live if (a)'s write raced or was somehow missed.

**(c) No-op duplicate `dj_join`** (same two files). `joinShow` no longer writes a duplicate `dj_join` marker for a DJ who is already active on the current show — either the primary DJ or an active co-host. New service helper `isDjAlreadyActiveOnShow(show, dj_id)` checks `primary_dj_id` directly (no round trip) and falls back to a `show_djs.active` lookup for co-hosts. A retried "Go Live" toggle (the issue's 16:37:59 duplicate) now gets back the DJ's existing membership instead of a fresh marker.

## Tests

- `tests/unit/routes/internal.route.test.ts` — the webhook's `end_time` fast-path: sets it from the marker timestamp on `show_end`, leaves it alone on non-`show_end` deliveries and when no show resolves.
- `tests/unit/services/flowsheet.joinShowGuards.test.ts` — `isLatestEntryShowEnd` and `isDjAlreadyActiveOnShow` in isolation.
- `tests/unit/controllers/flowsheet.controller.test.ts` — `joinShow`'s updated decision: starts a new show when the latest entry is `show_end` even with `end_time` still null, short-circuits the extra query when `end_time` already marks the show closed, and no-ops (no `addDJToShow` call) when the DJ is already active.
- `tests/integration/flowsheet-join-after-tubafrenzy-signoff.spec.js` (new, Docker Postgres tier) — three scenarios against a real database:
  1. **Acceptance criterion 1**: a webhook `show_start` + `show_end` sequence immediately followed by `POST /flowsheet/join` creates a NEW show (`show_start`), with no `dj_join` landing on the ended show.
  2. **Option (b) in isolation**: same sequence, but `end_time` is forced back to NULL afterward (simulating (a) having raced or been skipped) — `joinShow` still starts a new show because the newest entry is `show_end`.
  3. **Acceptance criterion 2 / option (c)**: a secondary DJ's retried join and the primary DJ's re-join both land on an already-active show without writing a second `dj_join` marker.

Existing webhook/mirror/ETL tests stay green (full unit suite: 394 suites / 6113 tests passing).

**CI-only assertions**: all three integration-spec scenarios above require the Docker Postgres tier and could not be run locally in this environment (a local `ci:testmock` attempt hit an unrelated GitHub Packages 401 pulling `@wxyc/shared` during the Docker image build — a registry-credential limitation of this sandbox, not a code issue). CI's Integration-Tests job is authoritative for these three tests.

## Local checks run

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors; pre-existing warnings only)
- `npm run format:check` — pass
- `npm run test:unit` — pass (394 suites / 6113 tests)

## Assumptions

- No migration needed — no schema change, just a new write time + new read-path logic.
- The webhook's `end_time` write only ever narrows a NULL to a real timestamp (`WHERE end_time IS NULL`); it never contests the ETL's authority for refinement.
- Left the `attachUpcomingShows`/`GET /flowsheet/latest` null-safety issue (BS#1864, surfaced during this issue's triage) out of scope, per the issue's own scoping.