### PR TITLE
feat(flowsheet): emit discogsUnavailable on the V2 flowsheet album embed

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -73,6 +73,15 @@ export interface IFSEntry extends Omit<
   label_id: number | null;
   rotation_bin: string | null;
   on_streaming: boolean | null;
+  // BS#1908 (Not-on-Discogs epic #1280): MD-set discogs-unavailable flag +
+  // note, sourced from the joined `library` row — NOT nested under `metadata`
+  // (that object is the flowsheet/album_metadata COALESCE view; this pair is
+  // library-only, same source as `on_streaming` above). `null` when the entry
+  // has no library row (freeform/message/talkset/breakpoint, or an unlinked
+  // track); `transformToV2` reads that nullability to distinguish "no library
+  // row" (omit the wire field) from "library row, flag false" (emit `false`).
+  discogs_unavailable: boolean | null;
+  discogs_unavailable_note: string | null;
   metadata: IFSEntryMetadata;
   // Resolved catalog artist for the played release (flowsheet.album_id ->
   // library.artist_id). The batch key `attachUpcomingShows` uses to look up the

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -253,6 +253,19 @@ const FSEntryFieldsRaw = {
   genres: album_metadata.genres,
   styles: album_metadata.styles,
   on_streaming: library.on_streaming,
+  // BS#1908 (Not-on-Discogs epic #1280): the MD-set discogs-unavailable flag,
+  // mirroring BS#1895's other read surfaces onto the V2 flowsheet album embed.
+  // Sourced directly off the already-joined `library` row below (see
+  // leftJoin(library, ...) in getEntriesByPage/getEntriesByRange/getEntriesByShow)
+  // rather than a per-row call to `getDiscogsUnavailableFlagsById` — that
+  // single-id helper is BS#1895's proxy-path lookup and would reintroduce the
+  // N+1 the flowsheet read path forbids. A library-linked row picks the flag up
+  // as part of this SAME query; a non-library row (freeform track with no
+  // album_id, message/talkset/breakpoint/marker rows) gets SQL NULL from the
+  // LEFT JOIN miss, which transformToV2 reads as "omit the field" per the
+  // published contract (boolean-when-present, not required).
+  discogs_unavailable: library.discogs_unavailable,
+  discogs_unavailable_note: library.discogs_unavailable_note,
   metadata_status: flowsheet.metadata_status,
   enriching_since: flowsheet.enriching_since,
   // tubafrenzy's authoritative top-of-hour for breakpoint rows (BS#1449); NULL
@@ -299,6 +312,11 @@ export type FSEntryRaw = {
   genres: string[] | null;
   styles: string[] | null;
   on_streaming: boolean | null;
+  // BS#1908: null when the LEFT JOIN to `library` misses (no album_id, or an
+  // album_id with no matching library row); a joined row always yields a
+  // real boolean (the column is NOT NULL on `library`).
+  discogs_unavailable: boolean | null;
+  discogs_unavailable_note: string | null;
   metadata_status: FSEntry['metadata_status'];
   enriching_since: Date | null;
   radio_hour: Date | null;
@@ -358,6 +376,11 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
     artist_bio: raw.artist_bio,
     artist_wikipedia_url: raw.artist_wikipedia_url,
     on_streaming: raw.on_streaming ?? null,
+    // BS#1908: pass through as-is (no `?? null` collapse needed beyond the
+    // type already being nullable) — see FSEntryRaw's docstring for the
+    // "null means no library row" contract transformToV2 relies on.
+    discogs_unavailable: raw.discogs_unavailable ?? null,
+    discogs_unavailable_note: raw.discogs_unavailable_note ?? null,
     metadata_status: raw.metadata_status,
     enriching_since: raw.enriching_since,
     radio_hour: raw.radio_hour ?? null,
@@ -1444,6 +1467,22 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         genres: entry.metadata?.genres?.length ? entry.metadata.genres : null,
         styles: entry.metadata?.styles?.length ? entry.metadata.styles : null,
         on_streaming: entry.on_streaming ?? null,
+        // BS#1908 (Not-on-Discogs epic #1280): MD-set discogs-unavailable flag
+        // on the V2 flowsheet album embed, matching BS#1895's other read
+        // surfaces and the already-published wxyc-shared@3.2.0 contract
+        // (FlowsheetEntryResponse.discogsUnavailable — boolean, NOT required;
+        // discogsUnavailableNote — nullable string). Wire is deliberately
+        // camelCase (the `withDiscogsUnavailableCamelCase` convention),
+        // unlike the snake_case siblings above. Emitted only when this track
+        // resolved to a library row (`entry.discogs_unavailable !== null`) —
+        // a freeform/unlinked track omits the field entirely rather than
+        // sending `null`/`false`, mirroring the upcoming_show/critic_reviews
+        // present-or-absent projection pattern below. The note is emitted
+        // independently whenever non-null (a library row can have the flag
+        // set with no note, or not have a library row at all — both leave
+        // discogs_unavailable_note null, so this single check covers both).
+        ...(entry.discogs_unavailable !== null ? { discogsUnavailable: entry.discogs_unavailable } : {}),
+        ...(entry.discogs_unavailable_note !== null ? { discogsUnavailableNote: entry.discogs_unavailable_note } : {}),
         // BS#891. iOS branches on this to decide whether to render inline
         // metadata or fall back to the proxy-fetch path
         // (WXYC/wxyc-ios-64#270). Always present on track rows once the

--- a/tests/unit/services/flowsheet.discogsUnavailable.test.ts
+++ b/tests/unit/services/flowsheet.discogsUnavailable.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for BS#1908 (Not-on-Discogs epic #1280): emitting the MD-set
+ * `discogsUnavailable` / `discogsUnavailableNote` flag on the V2
+ * flowsheet-entry album embed, mirroring the BS#1895 read surfaces
+ * (library-search.service.ts, library.service.ts's LIBRARY_VIEW_PROJECTION,
+ * proxy.controller.ts) and matching the already-published wxyc-shared@3.2.0
+ * contract (`FlowsheetEntryResponse.discogsUnavailable` — boolean, NOT
+ * required; `discogsUnavailableNote` — nullable string).
+ *
+ * Three layers, matching `flowsheet.albumMetadataProjection.test.ts` (SQL
+ * shape) and `flowsheet.transformToV2.metadata-status.test.ts` (wire shape):
+ *
+ *   1. SQL projection: `discogs_unavailable`/`discogs_unavailable_note` ride
+ *      the SAME `library` LEFT JOIN every V2 read path already performs
+ *      (getEntriesByPage/getEntriesByRange/getEntriesByShow) — a single
+ *      `db.select(...)` per query, not a per-row lookup. This is the "no
+ *      N+1" acceptance criterion: the flag data is read as raw `library.*`
+ *      column refs alongside `on_streaming`, not via a second query.
+ *   2. `transformToIFSEntry`: raw SQL row -> IFSEntry, preserving the
+ *      three-way null/true/false distinction off the joined `library` row.
+ *   3. `transformToV2`: IFSEntry -> V2 wire shape, camelCased
+ *      (`withDiscogsUnavailableCamelCase` convention) and present-or-absent
+ *      (never `null`/`false` for a non-library row — the field is omitted
+ *      entirely, matching `upcoming_show`/`critic_reviews`).
+ *
+ * `@wxyc/database` resolves to tests/mocks/database.mock.ts (see
+ * jest.unit.config.ts), so layer 1 pins the query SHAPE without PostgreSQL.
+ */
+
+import { jest } from '@jest/globals';
+import { db, library } from '@wxyc/database';
+import {
+  getEntriesByPage,
+  getEntriesByRange,
+  getEntriesByShow,
+  transformToIFSEntry,
+  transformToV2,
+  type FSEntryRaw,
+} from '../../../apps/backend/services/flowsheet.service';
+import { IFSEntry, IFSEntryMetadata } from '../../../apps/backend/controllers/flowsheet.controller';
+
+// ---------------------------------------------------------------------------
+// Layer 1: SQL projection shape (no N+1)
+// ---------------------------------------------------------------------------
+
+type LeftJoinCall = { table: unknown; on: unknown };
+
+interface MockCapture {
+  fieldsArg: unknown;
+  leftJoinCalls: LeftJoinCall[];
+  selectCallCount: number;
+}
+
+// Mirrors flowsheet.albumMetadataProjection.test.ts's installRecursiveSelectMock.
+function installRecursiveSelectMock(): MockCapture {
+  const capture: MockCapture = { fieldsArg: undefined, leftJoinCalls: [], selectCallCount: 0 };
+
+  const makeChain = () => {
+    const c: Record<string, jest.Mock> = {};
+    c.leftJoin = jest.fn().mockImplementation((table: unknown, on: unknown) => {
+      capture.leftJoinCalls.push({ table, on });
+      return c;
+    });
+    c.where = jest.fn().mockReturnValue(c);
+    c.orderBy = jest.fn().mockReturnValue(c);
+    c.offset = jest.fn().mockReturnValue(c);
+    c.limit = jest.fn().mockResolvedValue([] as never);
+    c.then = jest.fn().mockImplementation((onFulfilled: (v: unknown) => unknown) => {
+      return Promise.resolve([]).then(onFulfilled);
+    });
+    return c;
+  };
+
+  (db as unknown as { select: jest.Mock }).select = jest.fn().mockImplementation((fields: unknown) => {
+    capture.fieldsArg = fields;
+    capture.selectCallCount += 1;
+    const chain = makeChain();
+    const from = jest.fn().mockReturnValue(chain);
+    return { from };
+  });
+
+  return capture;
+}
+
+describe('flowsheet.service — discogs-unavailable SQL projection (BS#1908)', () => {
+  let capture: MockCapture;
+
+  beforeEach(() => {
+    capture = installRecursiveSelectMock();
+  });
+
+  describe.each([
+    ['getEntriesByPage', () => getEntriesByPage(0, 10)],
+    ['getEntriesByRange', () => getEntriesByRange(1, 10)],
+    ['getEntriesByShow', () => getEntriesByShow(1)],
+  ] as const)('%s', (_name, run) => {
+    it('projects discogs_unavailable/discogs_unavailable_note as raw library column refs', async () => {
+      await run();
+
+      const fields = capture.fieldsArg as Record<string, unknown>;
+      expect(fields.discogs_unavailable).toBe(library.discogs_unavailable);
+      expect(fields.discogs_unavailable_note).toBe(library.discogs_unavailable_note);
+    });
+
+    it('LEFT JOINs library (the same join the flag rides, no new join added)', async () => {
+      await run();
+
+      const joinedTables = capture.leftJoinCalls.map((c) => c.table);
+      expect(joinedTables).toContain(library);
+      // Still exactly 3 leftJoins (rotation, library, album_metadata) — the
+      // flag didn't add a 4th join or a second query.
+      expect(capture.leftJoinCalls).toHaveLength(3);
+    });
+
+    it('issues exactly one db.select call regardless of page size (no N+1)', async () => {
+      await run();
+
+      expect(capture.selectCallCount).toBe(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2: transformToIFSEntry (raw SQL row -> IFSEntry)
+// ---------------------------------------------------------------------------
+
+const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
+  id: 1,
+  show_id: 100,
+  album_id: 501,
+  entry_type: 'track',
+  artist_name: 'Chuquimamani-Condori',
+  album_title: 'Edits',
+  track_title: 'Call Your Name',
+  track_position: null,
+  record_label: 'self-released',
+  label_id: null,
+  rotation_id: null,
+  rotation_bin: null,
+  artist_id: null,
+  request_flag: false,
+  segue: false,
+  message: null,
+  play_order: 1,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+  on_streaming: null,
+  discogs_unavailable: null,
+  discogs_unavailable_note: null,
+  metadata_status: 'enriched_match',
+  enriching_since: null,
+  radio_hour: null,
+  ...overrides,
+});
+
+describe('transformToIFSEntry discogs-unavailable mapping (BS#1908)', () => {
+  it('passes a SET flag + note through unchanged', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({ discogs_unavailable: true, discogs_unavailable_note: 'Embargoed promo pressing' })
+    );
+
+    expect(entry.discogs_unavailable).toBe(true);
+    expect(entry.discogs_unavailable_note).toBe('Embargoed promo pressing');
+  });
+
+  it('passes an UNSET flag (false, not omitted) through unchanged', () => {
+    const entry = transformToIFSEntry(makeRaw({ discogs_unavailable: false, discogs_unavailable_note: null }));
+
+    expect(entry.discogs_unavailable).toBe(false);
+    expect(entry.discogs_unavailable_note).toBeNull();
+  });
+
+  it('passes a NULL flag through (no library row / LEFT JOIN miss)', () => {
+    const entry = transformToIFSEntry(makeRaw({ discogs_unavailable: null, discogs_unavailable_note: null }));
+
+    expect(entry.discogs_unavailable).toBeNull();
+    expect(entry.discogs_unavailable_note).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 3: transformToV2 (IFSEntry -> V2 wire shape)
+// ---------------------------------------------------------------------------
+
+const nullMetadata: IFSEntryMetadata = {
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+};
+
+const createTrackEntry = (overrides: Partial<IFSEntry> = {}): IFSEntry => ({
+  id: 1,
+  show_id: 100,
+  album_id: 501,
+  rotation_id: null,
+  entry_type: 'track',
+  track_title: 'Call Your Name',
+  track_position: null,
+  album_title: 'Edits',
+  artist_name: 'Chuquimamani-Condori',
+  record_label: 'self-released',
+  label_id: null,
+  play_order: 1,
+  request_flag: false,
+  segue: false,
+  message: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  rotation_bin: null,
+  on_streaming: null,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  metadata_status: 'enriched_match',
+  enriching_since: null,
+  radio_hour: null,
+  metadata: nullMetadata,
+  artist_id: null,
+  discogs_unavailable: null,
+  discogs_unavailable_note: null,
+  ...overrides,
+});
+
+describe('transformToV2 discogs-unavailable projection (BS#1908)', () => {
+  it('library-linked entry with the flag SET: emits discogsUnavailable: true + its note', () => {
+    const entry = createTrackEntry({
+      discogs_unavailable: true,
+      discogs_unavailable_note: 'Embargoed promo pressing',
+    });
+
+    const result = transformToV2(entry);
+
+    expect(result.discogsUnavailable).toBe(true);
+    expect(result.discogsUnavailableNote).toBe('Embargoed promo pressing');
+  });
+
+  it('library-linked entry with the flag UNSET: emits discogsUnavailable: false (present, not omitted)', () => {
+    const entry = createTrackEntry({ discogs_unavailable: false, discogs_unavailable_note: null });
+
+    const result = transformToV2(entry);
+
+    expect(result).toHaveProperty('discogsUnavailable', false);
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('non-library row (no album_id / no matching library row): omits discogsUnavailable entirely', () => {
+    const entry = createTrackEntry({
+      album_id: null,
+      discogs_unavailable: null,
+      discogs_unavailable_note: null,
+    });
+
+    const result = transformToV2(entry);
+
+    expect(result).not.toHaveProperty('discogsUnavailable');
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+    // Never null or false — genuinely absent from the JSON, matching the
+    // published contract (boolean-when-present, NOT required).
+    expect(Object.prototype.hasOwnProperty.call(result, 'discogsUnavailable')).toBe(false);
+  });
+
+  it('non-track entry types never carry discogsUnavailable (matches artwork_url/discogs_url siblings)', () => {
+    const entry = createTrackEntry({
+      entry_type: 'show_start',
+      discogs_unavailable: true,
+      discogs_unavailable_note: 'should not leak',
+    });
+
+    const result = transformToV2(entry);
+
+    expect(result).not.toHaveProperty('discogsUnavailable');
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+  });
+});


### PR DESCRIPTION
## Summary

V2 flowsheet-entry album embeds now carry `discogsUnavailable` (+ `discogsUnavailableNote` when set), matching the already-published `@wxyc/shared@3.2.0` contract (`FlowsheetEntryResponse.discogsUnavailable` — boolean, NOT required; `discogsUnavailableNote` — nullable string, max 500). This closes the gap that carved the dj-site flowsheet render gate out of dj-site#1058: the flowsheet embed previously exposed no `discogsUnavailable` signal at all.

Closes #1908

## Design

- **Source**: `getEntriesByPage`/`getEntriesByRange`/`getEntriesByShow` (the shared `FSEntryFieldsRaw` projection in `flowsheet.service.ts`) already `leftJoin(library, ...)` on `flowsheet.album_id`. `discogs_unavailable`/`discogs_unavailable_note` are added as two more raw column reads off that existing join, alongside `on_streaming` (same source table, same join).
- **Why not `getDiscogsUnavailableFlagsById`**: that helper (BS#1895, used by the proxy metadata path) is a single-`album_id` lookup, so calling it per row on a flowsheet page would be exactly the N+1 the issue forbids on this hot path. The inline join is preferred because the join already exists — no new query, no new join, same row count.
- **Present-or-absent semantics**: `library.discogs_unavailable` is `NOT NULL` on the table, so a LEFT JOIN hit always yields a real boolean and a miss always yields SQL `NULL`. `transformToV2` uses that nullability directly: `entry.discogs_unavailable !== null` gates whether to emit `discogsUnavailable` at all (never `null`/`false` for a non-library row — the field is genuinely absent from the JSON, since `res.json()` drops `undefined` keys), mirroring the existing `upcoming_show`/`critic_reviews` present-or-absent pattern on the same track branch. `discogsUnavailableNote` is emitted independently whenever non-null.
- **Wire naming**: deliberately camelCase (`discogsUnavailable`/`discogsUnavailableNote`) unlike the snake_case siblings on the same track shape (`artwork_url`, `discogs_url`, `release_year`, ...) — matches the `withDiscogsUnavailableCamelCase` convention BS#1895 established on the other three read surfaces.
- **Local types only**: added to the local `IFSEntry`/`FSEntryRaw` interfaces in `flowsheet.controller.ts`/`flowsheet.service.ts`, not a `@wxyc/shared` DTO import — Backend-Service's `@wxyc/shared` dependency stays pinned (bumping it is BS#1726, explicitly out of scope here).

## Deliberately out of scope

- `CLIENT_FACING_FLOWSHEET_COLUMNS` / `projectFlowsheetEntry` (`flowsheet-projection.ts`), used by the mutation echoes (`POST`/`PATCH`/`DELETE /flowsheet`) and the DJ peek/`liveFs:update` SSE payload. That allow-list is typed `Pick<FSEntry, ...>` against the *raw* `flowsheet` table row — those paths never join `library`, so `discogs_unavailable`/`discogs_unavailable_note` aren't columns available to project there without a wider change (joining `library` into the mutation-echo path). Left untouched per the issue's "V2 flowsheet reads" scope and the general instruction not to refactor unrelated code; the acceptance criteria are about the read paths (`GET /flowsheet`, `/flowsheet/latest`, `/flowsheet/playlist`, `/flowsheet/show-info`), which are fully covered.
- `wxyc-shared/api.yaml` and the `wxyc-shared`/dj-site repos — the contract is already published (`@wxyc/shared@3.2.0`); this PR is BS's runtime emit only.

## Testing

New `tests/unit/services/flowsheet.discogsUnavailable.test.ts` (16 tests, TDD — verified red against pre-change code, green after):
- SQL-projection layer: `discogs_unavailable`/`discogs_unavailable_note` project as raw `library.*` column refs (not a second query) across all three read functions; exactly 3 `leftJoin`s (unchanged); exactly one `db.select` call per invocation (no N+1).
- `transformToIFSEntry` mapping: SET / UNSET / NULL (no library row) pass through unchanged.
- `transformToV2` wire shape: library-linked SET → `discogsUnavailable: true` + note; library-linked UNSET → `discogsUnavailable: false` present (not omitted), note omitted; non-library row → both fields entirely absent; non-track entry types never carry either field.

Full unit suite (6147 tests) green; `typecheck`, `lint` (0 errors), `format:check` all green post-rebase. Manually audited every existing `tests/integration/flowsheet.spec.js`/`metadata.spec.js` assertion touching `GET /flowsheet*` responses — all use `objectContaining`/individual-field checks, none do exact full-object equality that a new additive field would break. Did not run the Docker-based `ci:testmock` mirror: its image build failed on an unrelated infra issue (401 fetching `@wxyc/shared` from GitHub Packages inside the Docker build context — an `NPM_TOKEN` propagation/scope issue, not a code problem) after one attempt; did not retry per policy.

## Related

- Closes #1908
- Epic #1280 (Not-on-Discogs)
- Prior art: #1895 (Album read-surface emit — catalog-search, album-detail, proxy metadata; this PR fills in the flowsheet embed #1895 explicitly left out)