### PR TITLE
fix(flowsheet): defer joins in getEntriesByPage so deep page reads stop hitting the statement timeout (BS#1960)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -112,6 +112,17 @@ const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual 
 // fine as a JS integer (passing Number.isInteger) but blows up downstream as
 // an unhandled "value out of range for type integer" Postgres error (BS#1800).
 const INT4_MAX = 2147483647;
+// BS#1960 cost/DoS guard on `page * limit` (the OFFSET passed to
+// getEntriesByPage). The BS#1960 deferred-join rewrite of getEntriesByPage
+// made deep offsets cheap (a bare flowsheet.id PK index scan, no joins on
+// the discarded rows), so this is not a correctness bound — it's a ceiling
+// on how much index-scanning a single request can ask for. Set well above
+// any realistic UI paging depth: the acceptance floor is page=50 at
+// limit=100 (offset 5,000), and this allows offset up to page 500 at
+// limit=100 — 10x that. A genuine deep-history pull (further back than a UI
+// paginator would ever click) should use the start_id/end_id range path
+// above, which is a true index range scan regardless of depth.
+const MAX_OFFSET = 50_000;
 
 /**
  * Project a page of flowsheet entries to their V2 wire shape, tolerating — but
@@ -217,6 +228,12 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   if (isNaN(page) || page < 0) throw new WxycError('page must be a non-negative number', 400);
 
   const offset = page * limit;
+  // BS#1960: reject an out-of-envelope page depth before it reaches the
+  // query, rather than letting a client walk arbitrarily deep pages. See
+  // MAX_OFFSET above for the cap rationale.
+  if (offset > MAX_OFFSET) {
+    throw new WxycError('Requested page depth too large', 400);
+  }
   const [entries, total, onAirDjName] = await Promise.all([
     flowsheet_service.getEntriesByPage(offset, limit),
     flowsheet_service.getEntryCount(),
@@ -236,6 +253,13 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   // the whole page. Independent attaches, so run concurrently.
   await Promise.all([flowsheet_service.attachUpcomingShows(entries), flowsheet_service.attachCriticReviews(entries)]);
 
+  // BS#1960 note: totalPages is derived from the full row estimate, so it can
+  // advertise more pages than MAX_OFFSET actually permits (e.g. ~26k pages at
+  // limit=100 against a ~2.6M-row table, while offset is capped at 50k / page
+  // 500). A client that lets a user jump past the cap gets an explicit 400
+  // rather than the old timeout-500; genuine deep-history reads belong on the
+  // start_id/end_id range path. Left unclamped deliberately — totalPages stays
+  // an honest "how many pages of data exist" for the "Page X of N" display.
   const totalPages = Math.ceil(total / limit);
 
   // `on_air` lets clients render the on-air banner without scanning the fetched

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -493,17 +493,46 @@ export const getEntryCount = async (): Promise<number> => {
   return Number(row?.count ?? 0);
 };
 
-/** Gets flowsheet entries by page with metadata joins */
+/**
+ * Gets flowsheet entries by page with metadata joins.
+ *
+ * BS#1960: deferred-join / late-row-lookup rewrite. The naive form —
+ * OFFSET/LIMIT applied to the fully-joined query — makes Postgres compute
+ * the joined row (3 LEFT JOINs against rotation/library/album_metadata) for
+ * every one of the `offset` discarded rows before it can discard them.
+ * Latency grew ~11ms per discarded row and the endpoint 500'd once `offset`
+ * passed ~450-500, hitting this RDS instance's 5s statement_timeout — plain
+ * OFFSET-with-joins pagination pathology.
+ *
+ * The fix: resolve the page of `flowsheet.id`s FIRST, against the bare PK
+ * index (no joins touched), then join only that already-bounded `limit`-row
+ * set. `page` is a subquery-in-FROM (`.as('page')`) so it plans as an index
+ * range scan over `flowsheet.id DESC` — the same cheap shape
+ * `getEntriesByRange` already gets from its `WHERE id BETWEEN` predicate.
+ * The inner `ORDER BY ... OFFSET ... LIMIT` picks the page; the outer
+ * `ORDER BY flowsheet.id DESC` re-establishes descending order after the
+ * join (a join doesn't guarantee it preserves the subquery's row order).
+ * flowsheet.id is a unique, monotonic PK, so no tie-break column is needed
+ * here (contrast `getEntriesByShow`, which ties on `play_order`).
+ */
 export const getEntriesByPage = async (offset: number, limit: number): Promise<IFSEntry[]> => {
+  const page = db
+    .select({ id: flowsheet.id })
+    .from(flowsheet)
+    .orderBy(desc(flowsheet.id))
+    .offset(offset)
+    .limit(limit)
+    .as('page');
+
   const raw = await db
     .select(FSEntryFieldsRaw)
-    .from(flowsheet)
+    .from(page)
+    .innerJoin(flowsheet, eq(flowsheet.id, page.id))
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-    .orderBy(desc(flowsheet.id))
-    .offset(offset)
-    .limit(limit);
+    .orderBy(desc(flowsheet.id));
+
   return raw.map(transformToIFSEntry);
 };
 

--- a/tests/integration/flowsheet-deep-pagination.spec.js
+++ b/tests/integration/flowsheet-deep-pagination.spec.js
@@ -1,0 +1,107 @@
+/**
+ * BS#1960 — deep OFFSET pagination on GET /flowsheet.
+ *
+ * Pre-fix, `getEntriesByPage`'s OFFSET/LIMIT sat on the fully-joined query
+ * (3 LEFT JOINs against rotation/library/album_metadata), so Postgres had to
+ * compute the joined row for every one of the `offset` discarded rows before
+ * it could discard them. Latency grew ~11ms per discarded row and the
+ * endpoint 500'd once `offset` passed roughly 450-500, hitting this RDS
+ * instance's 5s statement_timeout. The fix (deferred-join / late-row-lookup)
+ * resolves the page of `flowsheet.id`s first, against the bare PK index, and
+ * joins only the already-bounded page.
+ *
+ * This spec bulk-inserts a large, uniquely-tagged batch of track rows so a
+ * deep page (page=50, limit=100 — offset 5,000, the acceptance floor from
+ * the issue) has real, predictable content to assert on regardless of
+ * whatever else is in the shared dev/CI schema. It is a correctness/
+ * regression check (200 not 500, right shape, right rows) — it does not by
+ * itself prove the latency fix; that needs an EXPLAIN ANALYZE against
+ * prod-shaped data (reviewer/deploy-time step).
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const MARKER = 'BS1960 Deep Page Probe';
+// Comfortably clears the page=50 * limit=100 = 5,000 offset acceptance
+// floor, with headroom so the assertions below land entirely inside this
+// spec's own batch rather than spilling into whatever else is seeded.
+const BATCH_SIZE = 5200;
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('GET /flowsheet deep OFFSET pagination (BS#1960)', () => {
+  let sql;
+  let insertedIds = [];
+
+  beforeAll(async () => {
+    sql = makeSql();
+
+    // Single bulk INSERT ... SELECT so the batch lands as one contiguous,
+    // monotonically increasing id block at the tail of the table — no other
+    // writer touches `flowsheet` while this statement runs (--runInBand).
+    // n=1 is the OLDEST row in the batch (lowest id), n=BATCH_SIZE the
+    // NEWEST (highest id) — the batch is therefore the most-recent
+    // BATCH_SIZE rows in the whole table once this insert commits.
+    const rows = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet (entry_type, artist_name, track_title, play_order)
+       SELECT 'track', $1, $1 || ' #' || n, n
+       FROM generate_series(1, $2) AS n
+       RETURNING id`,
+      [MARKER, BATCH_SIZE]
+    );
+    insertedIds = rows.map((r) => r.id);
+  });
+
+  afterAll(async () => {
+    if (insertedIds.length > 0) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE id = ANY($1::int[])`, [insertedIds]);
+    }
+    if (sql) await sql.end();
+  });
+
+  test('page=50&limit=100 (offset 5,000) returns 200 with correctly-shaped, correctly-ordered V2 entries', async () => {
+    const res = await request.get('/flowsheet').query({ page: 50, limit: 100 }).send().expect(200);
+
+    expect(Array.isArray(res.body.entries)).toBe(true);
+    expect(res.body.entries).toHaveLength(100);
+    expect(res.body.page).toBe(50);
+    expect(res.body.limit).toBe(100);
+
+    // Deterministic content check. Ordered by flowsheet.id DESC (most recent
+    // first), skipping the top 5,000 rows (offset) and taking the next 100
+    // (limit) lands entirely inside this batch: the first row on the page is
+    // n = BATCH_SIZE - 5000 = 200 (counting from the top: rank 5001 overall
+    // == the 5001st-most-recent row == n=200), descending to n=101.
+    const firstN = BATCH_SIZE - 5000;
+    expect(res.body.entries[0].track_title).toBe(`${MARKER} #${firstN}`);
+    expect(res.body.entries[99].track_title).toBe(`${MARKER} #${firstN - 99}`);
+
+    // V2 wire shape sanity: flat discriminated-union track entry, not a raw
+    // DB row (matches the existing V2 shape assertions in flowsheet.spec.js).
+    for (const entry of res.body.entries) {
+      expect(entry.entry_type).toBe('track');
+      expect(entry.artist_name).toBe(MARKER);
+      expect(entry).not.toHaveProperty('search_doc');
+      expect(entry).not.toHaveProperty('metadata_attempt_at');
+    }
+  }, 30000);
+
+  test('a page depth beyond MAX_OFFSET is rejected with 400, not a 500 or a hang', async () => {
+    // page 501 * limit 100 = offset 50,100 > MAX_OFFSET (50,000).
+    const res = await request.get('/flowsheet').query({ page: 501, limit: 100 }).send();
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/flowsheet-deep-pagination.spec.js
+++ b/tests/integration/flowsheet-deep-pagination.spec.js
@@ -54,10 +54,17 @@ describe('GET /flowsheet deep OFFSET pagination (BS#1960)', () => {
     // n=1 is the OLDEST row in the batch (lowest id), n=BATCH_SIZE the
     // NEWEST (highest id) — the batch is therefore the most-recent
     // BATCH_SIZE rows in the whole table once this insert commits.
+    //
+    // The explicit `$1::text` / `$2::int` casts are load-bearing: postgres-js
+    // prepares this statement and `$1` is used both bare (feeding the `text`
+    // artist_name column) and inside a `||` concat, which makes the server
+    // deduce two conflicting types for the same parameter — a
+    // `PostgresError: inconsistent types deduced for parameter $1` (42P08).
+    // Pinning each parameter's type removes the ambiguity. Don't drop them.
     const rows = await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet (entry_type, artist_name, track_title, play_order)
-       SELECT 'track', $1, $1 || ' #' || n, n
-       FROM generate_series(1, $2) AS n
+       SELECT 'track', $1::text, $1::text || ' #' || n, n
+       FROM generate_series(1, $2::int) AS n
        RETURNING id`,
       [MARKER, BATCH_SIZE]
     );

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -585,6 +585,66 @@ describe('flowsheet.controller', () => {
       });
     });
 
+    // BS#1960: `getEntriesByPage`'s deferred-join rewrite fixed the deep-OFFSET
+    // 500 (Postgres was paying the 3-LEFT-JOIN cost for every discarded row,
+    // ~11ms/row, hitting the 5s statement_timeout past an offset of ~450-500).
+    // This guard is a separate cost/DoS ceiling on top of that fix — see
+    // MAX_OFFSET in flowsheet.controller.ts — so an absurd page*limit fails
+    // fast with a 400 instead of ever reaching the query.
+    describe('deep-offset guard (BS#1960)', () => {
+      it('rejects an offset (page * limit) exceeding MAX_OFFSET with 400', async () => {
+        // page 501 * limit 100 = offset 50,100 > MAX_OFFSET (50,000).
+        const req = createMockReq({ page: '501', limit: '100' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'Requested page depth too large'
+        );
+        expect(mockGetEntriesByPage).not.toHaveBeenCalled();
+      });
+
+      it('rejects with a WxycError (400), not an unhandled error', async () => {
+        const req = createMockReq({ page: '501', limit: '100' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      });
+
+      it('accepts an offset exactly at MAX_OFFSET (page 500 * limit 100 = 50,000)', async () => {
+        mockGetEntriesByPage.mockResolvedValue([]);
+        mockGetEntryCount.mockResolvedValue(0);
+        mockGetOnAirDJName.mockResolvedValue(null);
+
+        const req = createMockReq({ page: '500', limit: '100' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(mockGetEntriesByPage).toHaveBeenCalledWith(50000, 100);
+      });
+
+      // The acceptance floor this cap must clear: a UI paginator walking to
+      // page 50 at the default-ish limit=100 (offset 5,000) must stay green.
+      it('accepts page=50&limit=100 (offset 5,000) — the deep-paging acceptance case', async () => {
+        const entries = [createMockEntry(1)];
+        mockGetEntriesByPage.mockResolvedValue(entries);
+        mockGetEntryCount.mockResolvedValue(10000);
+        mockGetOnAirDJName.mockResolvedValue(null);
+
+        const req = createMockReq({ page: '50', limit: '100' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(mockGetEntriesByPage).toHaveBeenCalledWith(5000, 100);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({ entries: entries.map((e) => ({ ...e, v2: true })), page: 50, limit: 100 })
+        );
+      });
+    });
+
     it('rejects with error on service failure', async () => {
       const error = new Error('DB connection failed');
       mockGetEntriesByPage.mockRejectedValue(error);

--- a/tests/unit/services/flowsheet.albumMetadataProjection.test.ts
+++ b/tests/unit/services/flowsheet.albumMetadataProjection.test.ts
@@ -43,10 +43,20 @@ function installRecursiveSelectMock(): MockCapture {
       capture.leftJoinCalls.push({ table, on });
       return c;
     });
+    // BS#1960: getEntriesByPage's deferred-join rewrite adds an innerJoin
+    // (bounded id-page -> flowsheet) ahead of the pre-existing leftJoins.
+    // Not tracked in capture.leftJoinCalls — the leftJoin-count assertions
+    // below are specifically about the 3 LEFT JOINs, unaffected by it.
+    c.innerJoin = jest.fn().mockReturnValue(c);
     c.where = jest.fn().mockReturnValue(c);
     c.orderBy = jest.fn().mockReturnValue(c);
     c.offset = jest.fn().mockReturnValue(c);
-    c.limit = jest.fn().mockResolvedValue([] as never);
+    // Chain-returning, not terminal: getEntriesByPage's inner id-subquery
+    // chains .limit(m).as('page') — .as needs a chain to call onto.
+    c.limit = jest.fn().mockReturnValue(c);
+    // Terminal for the id-subquery: returns a stand-in Subquery whose `.id`
+    // is what the outer query's innerJoin predicate references.
+    c.as = jest.fn().mockReturnValue({ id: 'mock-page-id' });
     // Drizzle terminal methods that may be awaited directly
     c.then = jest.fn().mockImplementation((onFulfilled: (v: unknown) => unknown) => {
       return Promise.resolve([]).then(onFulfilled);

--- a/tests/unit/services/flowsheet.discogsUnavailable.test.ts
+++ b/tests/unit/services/flowsheet.discogsUnavailable.test.ts
@@ -61,10 +61,20 @@ function installRecursiveSelectMock(): MockCapture {
       capture.leftJoinCalls.push({ table, on });
       return c;
     });
+    // BS#1960: getEntriesByPage's deferred-join rewrite adds an innerJoin
+    // (bounded id-page -> flowsheet) ahead of the pre-existing leftJoins.
+    // Not tracked in capture.leftJoinCalls — the "still exactly 3 leftJoins"
+    // assertion below is specifically about rotation/library/album_metadata.
+    c.innerJoin = jest.fn().mockReturnValue(c);
     c.where = jest.fn().mockReturnValue(c);
     c.orderBy = jest.fn().mockReturnValue(c);
     c.offset = jest.fn().mockReturnValue(c);
-    c.limit = jest.fn().mockResolvedValue([] as never);
+    // Chain-returning, not terminal: getEntriesByPage's inner id-subquery
+    // chains .limit(m).as('page') — .as needs a chain to call onto.
+    c.limit = jest.fn().mockReturnValue(c);
+    // Terminal for the id-subquery: returns a stand-in Subquery whose `.id`
+    // is what the outer query's innerJoin predicate references.
+    c.as = jest.fn().mockReturnValue({ id: 'mock-page-id' });
     c.then = jest.fn().mockImplementation((onFulfilled: (v: unknown) => unknown) => {
       return Promise.resolve([]).then(onFulfilled);
     });
@@ -90,10 +100,13 @@ describe('flowsheet.service — discogs-unavailable SQL projection (BS#1908)', (
   });
 
   describe.each([
-    ['getEntriesByPage', () => getEntriesByPage(0, 10)],
-    ['getEntriesByRange', () => getEntriesByRange(1, 10)],
-    ['getEntriesByShow', () => getEntriesByShow(1)],
-  ] as const)('%s', (_name, run) => {
+    // BS#1960: getEntriesByPage's deferred-join rewrite issues a constant TWO
+    // db.select calls (the bare id-page subquery, then the joined lookup) —
+    // still page-size-independent (no N+1), just no longer exactly one.
+    ['getEntriesByPage', () => getEntriesByPage(0, 10), 2],
+    ['getEntriesByRange', () => getEntriesByRange(1, 10), 1],
+    ['getEntriesByShow', () => getEntriesByShow(1), 1],
+  ] as const)('%s', (_name, run, expectedSelectCalls) => {
     it('projects discogs_unavailable/discogs_unavailable_note as raw library column refs', async () => {
       await run();
 
@@ -112,10 +125,10 @@ describe('flowsheet.service — discogs-unavailable SQL projection (BS#1908)', (
       expect(capture.leftJoinCalls).toHaveLength(3);
     });
 
-    it('issues exactly one db.select call regardless of page size (no N+1)', async () => {
+    it('issues a constant number of db.select calls regardless of page size (no N+1)', async () => {
       await run();
 
-      expect(capture.selectCallCount).toBe(1);
+      expect(capture.selectCallCount).toBe(expectedSelectCalls);
     });
   });
 });

--- a/tests/unit/services/flowsheet.getEntriesByPage.deferredJoin.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByPage.deferredJoin.test.ts
@@ -1,0 +1,163 @@
+// Regression guard for BS#1960: deep OFFSET pagination on the joined query
+// made Postgres compute the 3-LEFT-JOIN row for every discarded offset row,
+// 500ing past ~450-500 rows deep (5s statement_timeout). The fix resolves
+// the page of flowsheet.id's FIRST (a bare PK-index OFFSET/LIMIT, no joins),
+// then joins only that already-bounded page. This test pins the query SHAPE
+// so a future edit can't quietly reintroduce OFFSET/LIMIT on the joined
+// query — it does not exercise a real planner, so it can't catch a cost
+// regression by itself; that needs an EXPLAIN against prod-shaped data.
+
+import { jest } from '@jest/globals';
+import { db, flowsheet, rotation, library, album_metadata } from '@wxyc/database';
+import { desc, eq } from 'drizzle-orm';
+import { getEntriesByPage } from '../../../apps/backend/services/flowsheet.service';
+
+describe('flowsheet.service', () => {
+  describe('getEntriesByPage deferred-join shape (BS#1960)', () => {
+    // Sentinel standing in for whatever `.as('page')` returns from the real
+    // query builder. Its `id` property is what the outer query's innerJoin
+    // predicate must reference (`eq(flowsheet.id, page.id)`) — using a
+    // distinct sentinel value (not the same string as `flowsheet.id`) makes
+    // a bug that joins against the wrong column visible as a failed toEqual
+    // rather than an accidental pass.
+    const pageSubquery = { id: 'page.id-sentinel' };
+
+    // Inner (subquery) chain: select({id}) -> from(flowsheet) ->
+    // orderBy(desc(id)) -> offset(n) -> limit(m) -> as('page').
+    const asMock = jest.fn().mockReturnValue(pageSubquery);
+    const subLimitMock = jest.fn().mockReturnValue({ as: asMock });
+    const subOffsetMock = jest.fn().mockReturnValue({ limit: subLimitMock });
+    const subOrderByMock = jest.fn().mockReturnValue({ offset: subOffsetMock });
+    const subFromMock = jest.fn().mockReturnValue({ orderBy: subOrderByMock });
+
+    // Outer chain: select(FSEntryFieldsRaw) -> from(page) ->
+    // innerJoin(flowsheet) -> leftJoin(rotation) -> leftJoin(library) ->
+    // leftJoin(album_metadata) -> orderBy(desc(id)).
+    const outerOrderByMock = jest.fn().mockResolvedValue([]);
+    const leftJoin3Mock = jest.fn().mockReturnValue({ orderBy: outerOrderByMock });
+    const leftJoin2Mock = jest.fn().mockReturnValue({ leftJoin: leftJoin3Mock });
+    const leftJoin1Mock = jest.fn().mockReturnValue({ leftJoin: leftJoin2Mock });
+    const innerJoinMock = jest.fn().mockReturnValue({ leftJoin: leftJoin1Mock });
+    const outerFromMock = jest.fn().mockReturnValue({ innerJoin: innerJoinMock });
+
+    const selectMock = jest
+      .fn()
+      .mockReturnValueOnce({ from: subFromMock })
+      .mockReturnValueOnce({ from: outerFromMock });
+
+    beforeEach(() => {
+      asMock.mockClear();
+      subLimitMock.mockClear();
+      subOffsetMock.mockClear();
+      subOrderByMock.mockClear();
+      subFromMock.mockClear();
+      outerOrderByMock.mockClear();
+      outerOrderByMock.mockResolvedValue([]);
+      leftJoin3Mock.mockClear();
+      leftJoin2Mock.mockClear();
+      leftJoin1Mock.mockClear();
+      innerJoinMock.mockClear();
+      outerFromMock.mockClear();
+
+      asMock.mockReturnValue(pageSubquery);
+      subLimitMock.mockReturnValue({ as: asMock });
+      subOffsetMock.mockReturnValue({ limit: subLimitMock });
+      subOrderByMock.mockReturnValue({ offset: subOffsetMock });
+      subFromMock.mockReturnValue({ orderBy: subOrderByMock });
+      leftJoin3Mock.mockReturnValue({ orderBy: outerOrderByMock });
+      leftJoin2Mock.mockReturnValue({ leftJoin: leftJoin3Mock });
+      leftJoin1Mock.mockReturnValue({ leftJoin: leftJoin2Mock });
+      innerJoinMock.mockReturnValue({ leftJoin: leftJoin1Mock });
+      outerFromMock.mockReturnValue({ innerJoin: innerJoinMock });
+
+      selectMock.mockReset();
+      selectMock.mockReturnValueOnce({ from: subFromMock }).mockReturnValueOnce({ from: outerFromMock });
+      (db as unknown as { select: jest.Mock }).select = selectMock;
+    });
+
+    it('applies offset/limit to the bare id subquery, not the joined query', async () => {
+      await getEntriesByPage(5000, 100);
+
+      // The subquery is built from the bare flowsheet table (no joins) and
+      // carries the offset/limit — this is the load-bearing fix: pre-#1960
+      // these landed on the fully-joined query instead.
+      expect(subFromMock).toHaveBeenCalledWith(flowsheet);
+      expect(subOrderByMock).toHaveBeenCalledWith(desc(flowsheet.id));
+      expect(subOffsetMock).toHaveBeenCalledWith(5000);
+      expect(subLimitMock).toHaveBeenCalledWith(100);
+      expect(asMock).toHaveBeenCalledWith('page');
+    });
+
+    it('joins the bounded id-page against flowsheet, then rotation/library/album_metadata', async () => {
+      await getEntriesByPage(5000, 100);
+
+      expect(outerFromMock).toHaveBeenCalledWith(pageSubquery);
+      expect(innerJoinMock).toHaveBeenCalledWith(flowsheet, eq(flowsheet.id, pageSubquery.id));
+      expect(leftJoin1Mock).toHaveBeenCalledWith(rotation, eq(rotation.id, flowsheet.rotation_id));
+      expect(leftJoin2Mock).toHaveBeenCalledWith(library, eq(library.id, flowsheet.album_id));
+      expect(leftJoin3Mock).toHaveBeenCalledWith(album_metadata, eq(album_metadata.album_id, flowsheet.album_id));
+    });
+
+    it('re-establishes descending order on the outer query after the join', async () => {
+      await getEntriesByPage(5000, 100);
+
+      expect(outerOrderByMock).toHaveBeenCalledWith(desc(flowsheet.id));
+      // Never desc(play_order) — flowsheet.id is globally monotonic and
+      // unique, unlike play_order (see getEntriesByShow's tie-break).
+      expect(outerOrderByMock).not.toHaveBeenCalledWith(desc(flowsheet.play_order));
+    });
+
+    it('applies the transform to each raw row returned by the outer query', async () => {
+      const rawRow = {
+        id: 42,
+        show_id: 1,
+        album_id: null,
+        entry_type: 'track',
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        track_title: 'Call Your Name',
+        track_position: 'A1',
+        record_label: 'self-released',
+        label_id: null,
+        rotation_id: null,
+        rotation_bin: null,
+        artist_id: null,
+        request_flag: false,
+        segue: false,
+        message: null,
+        play_order: 1,
+        legacy_entry_id: null,
+        legacy_release_id: null,
+        add_time: new Date('2026-01-01T00:00:00Z'),
+        dj_name: 'DJ Test',
+        linkage_source: null,
+        linkage_confidence: null,
+        linked_at: null,
+        artwork_url: null,
+        discogs_url: null,
+        release_year: null,
+        spotify_url: null,
+        apple_music_url: null,
+        youtube_music_url: null,
+        bandcamp_url: null,
+        soundcloud_url: null,
+        artist_bio: null,
+        artist_wikipedia_url: null,
+        genres: null,
+        styles: null,
+        on_streaming: null,
+        discogs_unavailable: null,
+        discogs_unavailable_note: null,
+        metadata_status: 'enriched_no_match',
+        enriching_since: null,
+        radio_hour: null,
+      };
+      outerOrderByMock.mockResolvedValue([rawRow]);
+
+      const result = await getEntriesByPage(5000, 100);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ id: 42, artist_name: 'Chuquimamani-Condori', track_title: 'Call Your Name' });
+    });
+  });
+});


### PR DESCRIPTION
Closes #1960

## Problem

The public `GET /flowsheet?page=N&limit=M` read (`security: []`) returns **500** once the requested offset passes ~450–500 rows. `getEntriesByPage` runs three `LEFT JOIN`s (rotation, library, album_metadata) for every scanned-and-discarded offset row, so latency grows **linearly at ~11 ms/row** and fails at a hard **~5.23 s** wall — the Postgres `statement_timeout`, not a data bug. The `start_id`/`end_id` range path (`getEntriesByRange`) over the identical rows, joins, and projection returns in milliseconds, which ruled out a poison-row/projection cause and pinned the OFFSET scan.

## Fix

**1. Deferred join (`apps/backend/services/flowsheet.service.ts`).** `getEntriesByPage` now resolves the page of bare `flowsheet.id` values first — a subquery whose `OFFSET`/`LIMIT` hit the `flowsheet.id` PK index with **no joins on the discarded rows** — then `innerJoin`s that bounded id set back onto `flowsheet` and the three `LEFT JOIN`s, re-establishing `ORDER BY flowsheet.id DESC` on the outer query:

```sql
SELECT <FSEntryFieldsRaw> FROM (
    SELECT id FROM flowsheet ORDER BY id DESC OFFSET n LIMIT m
) page
JOIN flowsheet ON flowsheet.id = page.id
LEFT JOIN rotation … LEFT JOIN library … LEFT JOIN album_metadata …
ORDER BY flowsheet.id DESC
```

The V2 wire contract, `FSEntryFieldsRaw` projection, and `transformToIFSEntry` are unchanged. All three join keys are primary keys (`album_metadata.album_id`, `library.id`, `rotation.id`) and the reconnect is on the unique `flowsheet.id`, so there is **no row fan-out** — the result set and `id DESC` order are identical to the original for every input.

**2. `MAX_OFFSET` cost guard (`apps/backend/controllers/flowsheet.controller.ts`).** The default `getEntries` branch now rejects `page * limit > 50_000` (page 500 at limit 100 — 10× the page-50 acceptance floor) with an explicit `400` **before** the query runs, mirroring the range path's `MAX_ITEMS`/`INT4_MAX` guard style (BS#1800). This is a DoS/cost ceiling on index-scanning depth, not a correctness bound — genuine deep-history pulls belong on the `start_id`/`end_id` range path, which is a true index range scan at any depth.

`getEntryCount`, `totalPages`, and the conditional-GET (`Last-Modified`) middleware are untouched. No schema migration.

## Tests

- **`flowsheet.getEntriesByPage.deferredJoin.test.ts`** (new) — pins the deferred-join shape: offset/limit land on the bare-id subquery, the outer query joins the bounded page against `flowsheet` then the three tables, outer order is `desc(flowsheet.id)`, transform is applied. Uses a distinct sentinel for `page.id` so a wrong join predicate fails loudly.
- **`flowsheet.controller.test.ts`** — new cap block: rejects offset > `MAX_OFFSET` with 400/`WxycError`, accepts exactly at the cap, and pins `page=50&limit=100` → 200.
- **`flowsheet-deep-pagination.spec.js`** (new, integration) — bulk-inserts 5,200 rows and asserts `page=50&limit=100` returns the correct 100 rows in `id DESC` order, plus a 400-not-500 over-cap check.
- Adapts two pre-existing mock tests (`albumMetadataProjection`, `discogsUnavailable`) to the new two-`db.select` shape; the "exactly 3 leftJoins" and no-N+1 invariants are preserved (the `innerJoin` is deliberately not counted).

## Verification

- `npm run typecheck` — pass. `npm run lint` — 0 errors (821 pre-existing warnings). `npm run format:check` — pass.
- `npm run test:unit` — **396 suites / 6155 tests pass**.
- Integration suite not run locally (the only local Postgres was shared with another active worktree — the documented parallel-worktree hazard); the new spec runs in CI.
- **Deploy-time step:** `EXPLAIN ANALYZE` before/after on prod-shaped 2.6M-row data to confirm the plan is the cheap bare-index scan (only observable against production-scale data, which the test suite can't exercise).

## Acceptance criteria

- [x] `GET /flowsheet?page=N&limit=100` returns 200 well past the old failure boundary (integration test at page 50).
- [x] Requests beyond `MAX_OFFSET` return an explicit 4xx, not a 500-by-timeout.
- [x] V2 wire shape and conditional-GET behavior unchanged (existing tests + new pagination-depth tests).
- [x] The firing timeout is identified (pg `statement_timeout`, 5 s) and the cap sits below it.
- [ ] Latency flat-ish in offset verified with `EXPLAIN ANALYZE` before/after on prod-shaped data — deploy-time step.