### PR TITLE
De-freeze linked-album Bandcamp: let a resolvable direct URL supersede the search fallback (ENRICHMENT_BANDCAMP_REASK)

### DIFF
--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -105,6 +105,30 @@ export { buildStreamingFieldConflictSet };
  */
 export const STREAMING_REASK_ATTEMPT_CAP = 3;
 
+/**
+ * Feature gate for the Bandcamp re-ask de-freeze (iOS Bandcamp
+ * search-fallback program). Default OFF, so merging this change is a no-op
+ * against the live worker: nothing in the write path or the sweep/precheck
+ * predicates changes until an operator sets `ENRICHMENT_BANDCAMP_REASK=true`.
+ *
+ * The gate exists for the cross-repo interlock, NOT because the behavior is
+ * risky in isolation: the LML-side workstreams are what teach LML to resolve
+ * a direct Bandcamp URL (and to return an explicit `streaming_status.bandcamp
+ * = 'unresolved'` on a cold miss). Flipping this on before LML can actually
+ * resolve Bandcamp would burn all three `streaming_reask_attempts` against an
+ * LML that still has no answer, wasting the bound. Flip it on once the LML
+ * side is live so a re-ask can actually produce a direct URL.
+ *
+ * Read at call time (not module load) so tests — and a live operator
+ * toggling the Railway variable + restarting the worker — see the current
+ * value. Strict `=== 'true'`: any other value (including `'1'`/`'yes'`) is
+ * off, matching the repo's other boolean env reads (the `DRY_RUN` flag in
+ * the rotation-artist-backfill job).
+ */
+export function isBandcampReaskEnabled(): boolean {
+  return process.env.ENRICHMENT_BANDCAMP_REASK === 'true';
+}
+
 /** One persisted streaming-service field's state: its resolution verdict (if any) and its url (if verified). */
 export interface StreamingFieldState {
   status: StreamingResolutionStatus | null;
@@ -207,7 +231,24 @@ export async function upsertMatchedAlbumMetadata(
     artwork.streaming_status?.apple_music,
     artwork.apple_music_url
   );
-  const bandcampIncomingStatus = inferIncomingStreamingStatus(artwork.streaming_status?.bandcamp, artwork.bandcamp_url);
+  // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK): when a matched
+  // album comes back with NO Bandcamp verdict at all (no direct url, no
+  // explicit `streaming_status.bandcamp`), the pre-existing behavior persists
+  // `bandcamp_status = NULL` — indistinguishable from "never consulted", so
+  // `precheck.ts` / the BS#1915 sweep never re-ask it and the row freezes on
+  // its `bandcamp.com/search?q=` fallback forever (the Bandcamp analog of the
+  // BS#1747 permanent-null freeze). Coerce that `undefined` to `'unresolved'`
+  // (retryable) so the status-driven sweep picks it back up and a later
+  // LML-resolved direct URL supersedes the fallback. The URL itself is left
+  // to the existing search-fallback logic below (display fallback preserved);
+  // only the STATUS becomes "retryable, not verified". Bandcamp-ONLY on
+  // purpose: an explicit LML verdict ('verified'/'absent') is untouched (it's
+  // returned non-undefined and wins here), and Apple/Spotify inference is
+  // deliberately not coerced — Apple Music's NULL is load-bearing "no
+  // verified iTunes match" (BS#1192) and must never become a re-ask magnet.
+  const bandcampInferred = inferIncomingStreamingStatus(artwork.streaming_status?.bandcamp, artwork.bandcamp_url);
+  const bandcampIncomingStatus =
+    isBandcampReaskEnabled() && bandcampInferred === undefined ? 'unresolved' : bandcampInferred;
   const spotifyIncomingUrl = artwork.spotify_url ?? null;
   const appleMusicIncomingUrl = artwork.apple_music_url ?? null;
   const bandcampIncomingUrl = artwork.bandcamp_url ?? null;

--- a/apps/enrichment-worker/precheck.ts
+++ b/apps/enrichment-worker/precheck.ts
@@ -47,7 +47,7 @@
 import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
 
-import { resolveComposer, STREAMING_REASK_ATTEMPT_CAP, type EnrichRow } from './enrich.js';
+import { isBandcampReaskEnabled, resolveComposer, STREAMING_REASK_ATTEMPT_CAP, type EnrichRow } from './enrich.js';
 
 /**
  * True when the album already has a persisted, load-bearing Discogs match in
@@ -69,12 +69,22 @@ export async function hasLoadBearingAlbumMetadata(albumId: number): Promise<bool
   // row, silently breaking the base BS#1747 skip for every plain
   // load-bearing row. COALESCE pins the "nothing to re-ask" default to an
   // explicit false before negating.
+  // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK): kept in lockstep
+  // with the positive form in `streaming-reask.ts#findUnresolvedStreamingCandidates`
+  // — see that function for the full rationale. A load-bearing row whose
+  // Bandcamp is a NULL-status search-fallback (the legacy frozen shape) is NOT
+  // "done": this negative gate returns false for it so a subsequent PLAY
+  // re-asks LML (the sweep covers albums that aren't played again). Gated, so
+  // flag-off is a byte-for-byte no-op.
+  const bandcampFrozenReask = isBandcampReaskEnabled()
+    ? sql` OR (${album_metadata.bandcamp_status} IS NULL AND ${album_metadata.bandcamp_url} LIKE ${'%bandcamp.com/search%'})`
+    : sql``;
   const needsStreamingReask = sql<boolean>`COALESCE(
     ${album_metadata.streaming_reask_attempts} < ${STREAMING_REASK_ATTEMPT_CAP}
     AND (
       ${album_metadata.spotify_status} = 'unresolved'
       OR ${album_metadata.apple_music_status} = 'unresolved'
-      OR ${album_metadata.bandcamp_status} = 'unresolved'
+      OR ${album_metadata.bandcamp_status} = 'unresolved'${bandcampFrozenReask}
     ),
     false
   )`;

--- a/apps/enrichment-worker/streaming-reask.ts
+++ b/apps/enrichment-worker/streaming-reask.ts
@@ -41,6 +41,7 @@ import { album_metadata, db, library } from '@wxyc/database';
 import {
   bumpStreamingReaskAttempts,
   extractArtwork,
+  isBandcampReaskEnabled,
   STREAMING_REASK_ATTEMPT_CAP,
   synthesizeSearchUrls,
   upsertMatchedAlbumMetadata,
@@ -69,12 +70,28 @@ export interface StreamingReaskCandidate {
  * kept for defense-in-depth and literal parity with precheck.ts.
  */
 export async function findUnresolvedStreamingCandidates(limit: number): Promise<StreamingReaskCandidate[]> {
+  // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK): the plain
+  // `bandcamp_status = 'unresolved'` disjunct below only catches rows written
+  // AFTER the write-side coercion in `enrich.ts` starts stamping 'unresolved'.
+  // Rows that were enriched BEFORE the gate went live carry
+  // `bandcamp_status = NULL` + a `bandcamp.com/search?q=` fallback URL — the
+  // frozen shape. This extra disjunct (gated, so flag-off is a byte-for-byte
+  // no-op) reaches that legacy backlog directly, WITHOUT a data migration:
+  // a NULL status paired with the synthesized search-fallback URL is exactly
+  // "matched, but Bandcamp never resolved to a direct URL". `absent` rows also
+  // carry a search-fallback URL but are excluded here by the `IS NULL` guard
+  // (they are terminal, never re-asked). Still bounded by the shared
+  // `streaming_reask_attempts < CAP` guard, and once re-asked the coercion
+  // moves them onto the clean `= 'unresolved'` disjunct.
+  const bandcampFrozenReask = isBandcampReaskEnabled()
+    ? sql` OR (${album_metadata.bandcamp_status} IS NULL AND ${album_metadata.bandcamp_url} LIKE ${'%bandcamp.com/search%'})`
+    : sql``;
   const needsStreamingReask = sql<boolean>`COALESCE(
     ${album_metadata.streaming_reask_attempts} < ${STREAMING_REASK_ATTEMPT_CAP}
     AND (
       ${album_metadata.spotify_status} = 'unresolved'
       OR ${album_metadata.apple_music_status} = 'unresolved'
-      OR ${album_metadata.bandcamp_status} = 'unresolved'
+      OR ${album_metadata.bandcamp_status} = 'unresolved'${bandcampFrozenReask}
     ),
     false
   )`;

--- a/tests/integration/enrichment-worker-cache-precheck.spec.js
+++ b/tests/integration/enrichment-worker-cache-precheck.spec.js
@@ -273,3 +273,83 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
   });
 });
+
+/**
+ * Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK) — the precheck gate.
+ * A load-bearing row whose Bandcamp is the legacy frozen shape
+ * (`bandcamp_status = NULL` + a `bandcamp.com/search` fallback URL) is
+ * "done" today (skip LML), which is the freeze. With the gate on, it is NOT
+ * done: the predicate returns false so a subsequent PLAY re-asks LML. Flag
+ * off is a byte-for-byte no-op (asserted alongside each on case). Mirrors the
+ * positive form validated in `enrichment-worker-streaming-reask.spec.js`.
+ *
+ * @see WXYC/Backend-Service#1747 (the freeze), #1915 (the self-heal sweep)
+ */
+describe('enrichment-worker cache-first pre-check predicate — Bandcamp de-freeze gate (real PG)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+  const priorFlag = process.env.ENRICHMENT_BANDCAMP_REASK;
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (priorFlag === undefined) delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    else process.env.ENRICHMENT_BANDCAMP_REASK = priorFlag;
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  async function insertFrozenBandcampRow(sql, suffix) {
+    const albumId = await insertLibraryAlbum(sql, 'bandcamp-freeze-' + suffix);
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_url, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://bandcamp.com/search?q=Stereolab%20Aluminum%20Tunes', NOW())
+    `;
+    return albumId;
+  }
+
+  test('FLAG OFF: a NULL-status search-fallback bandcamp row is still "done" → true (skip, current behavior)', async () => {
+    delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    const albumId = await insertFrozenBandcampRow(sql, 'precheck-off');
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('FLAG ON: the same frozen bandcamp row is NOT done → false (worker re-asks LML on the next play)', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertFrozenBandcampRow(sql, 'precheck-on');
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('FLAG ON: an absent bandcamp with a search-fallback url stays "done" → true (terminal, never re-asked)', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertLibraryAlbum(sql, 'bandcamp-absent-precheck');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_status, bandcamp_url, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'absent', 'https://bandcamp.com/search?q=x', NOW())
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('FLAG ON: a verified bandcamp (direct url, not a search fallback) stays "done" → true', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertLibraryAlbum(sql, 'bandcamp-verified-precheck');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_status, bandcamp_url, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'verified', 'https://stereolab.bandcamp.com/album/aluminum-tunes', NOW())
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+});

--- a/tests/integration/enrichment-worker-streaming-reask.spec.js
+++ b/tests/integration/enrichment-worker-streaming-reask.spec.js
@@ -58,6 +58,14 @@ function mergeStreamingField(current, incoming) {
  * same reason here).
  */
 async function findCandidateAlbumIds(sql, albumIds) {
+  // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK) mirror — see
+  // `streaming-reask.ts#findUnresolvedStreamingCandidates`. Read at call time
+  // so a test can toggle the env var per case; empty fragment (flag off) is a
+  // byte-for-byte no-op against every pre-existing assertion in this spec.
+  const bandcampFrozenReask =
+    process.env.ENRICHMENT_BANDCAMP_REASK === 'true'
+      ? sql`OR (bandcamp_status IS NULL AND bandcamp_url LIKE ${'%bandcamp.com/search%'})`
+      : sql``;
   const rows = await sql`
     SELECT album_id
       FROM ${sql(SCHEMA)}.album_metadata
@@ -69,6 +77,7 @@ async function findCandidateAlbumIds(sql, albumIds) {
            spotify_status = 'unresolved'
            OR apple_music_status = 'unresolved'
            OR bandcamp_status = 'unresolved'
+           ${bandcampFrozenReask}
          ),
          false
        )
@@ -292,6 +301,114 @@ describe('enrichment-worker streaming self-heal — BS#1915 candidate query + wr
 
     // Row is fully resolved now (apple verified, spotify terminal-absent) —
     // it drops out of candidacy rather than re-asking the resurrected spotify.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+});
+
+/**
+ * Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK) — the candidate query
+ * reaches the LEGACY frozen backlog: rows enriched before the write-side
+ * coercion went live carry `bandcamp_status = NULL` + a `bandcamp.com/search`
+ * fallback URL, which the plain `bandcamp_status = 'unresolved'` disjunct can
+ * never match. Real-PG coverage of the gated NULL+search-fallback disjunct
+ * added to `findUnresolvedStreamingCandidates` (mirrored above), and of the
+ * end-to-end heal to a direct Bandcamp URL on re-ask.
+ *
+ * @see WXYC/Backend-Service#1747 (the freeze), #1915 (the self-heal sweep)
+ */
+describe('enrichment-worker streaming self-heal — Bandcamp de-freeze candidate query (real PG)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+  const priorFlag = process.env.ENRICHMENT_BANDCAMP_REASK;
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (priorFlag === undefined) delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    else process.env.ENRICHMENT_BANDCAMP_REASK = priorFlag;
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  async function insertFrozenBandcampRow(sql, suffix) {
+    const albumId = await insertLibraryAlbum(sql, 'bandcamp-freeze-' + suffix);
+    insertedAlbumIds.push(albumId);
+    // The exact frozen shape: load-bearing artwork present, bandcamp_status
+    // NULL, bandcamp_url the synthesized search fallback.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_url, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'https://bandcamp.com/search?q=Chuquimamani-Condori%20Edits', 0, NOW())
+    `;
+    return albumId;
+  }
+
+  test('FLAG OFF: a NULL-status search-fallback bandcamp row is NOT a candidate (current behavior preserved)', async () => {
+    delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    const albumId = await insertFrozenBandcampRow(sql, 'flag-off');
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+
+  test('FLAG ON: the same frozen bandcamp row becomes a candidate', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertFrozenBandcampRow(sql, 'flag-on');
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([albumId]);
+  });
+
+  test('FLAG ON: an absent bandcamp (also carries a search-fallback url) is NEVER a candidate — terminal', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertLibraryAlbum(sql, 'bandcamp-absent-terminal');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, bandcamp_status, bandcamp_url, streaming_reask_attempts, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/x.jpg', 'absent', 'https://bandcamp.com/search?q=x', 0, NOW())
+    `;
+    // The `IS NULL` guard in the gated disjunct excludes an absent row even
+    // though its url matches the search-fallback LIKE.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+
+  test('FLAG ON: HEAL — a re-ask that resolves a direct bandcamp url flips the row to verified and out of candidacy', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertFrozenBandcampRow(sql, 'heal');
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([albumId]);
+
+    // LML (now Bandcamp-capable) returns a direct album URL on the re-ask.
+    await applyReaskVerdict(sql, albumId, {
+      bandcamp: { status: 'verified', url: 'https://chuquimamani.bandcamp.com/album/edits' },
+    });
+
+    const row = await readStreamingState(sql, albumId);
+    expect(row.bandcamp_status).toBe('verified');
+    expect(row.bandcamp_url).toBe('https://chuquimamani.bandcamp.com/album/edits');
+    // Resolved — no longer frozen, no longer a candidate.
+    expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
+  });
+
+  test('FLAG ON: BOUNDED — a frozen bandcamp that LML still cannot resolve stops at the attempt cap', async () => {
+    process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    const albumId = await insertFrozenBandcampRow(sql, 'bounded');
+
+    let reaskCount = 0;
+    for (let i = 0; i < STREAMING_REASK_ATTEMPT_CAP + 3; i++) {
+      const candidates = await findCandidateAlbumIds(sql, [albumId]);
+      if (candidates.length === 0) break;
+      // Mirror the write-side coercion: a match with no bandcamp verdict
+      // persists 'unresolved' (retryable) rather than leaving it NULL.
+      await applyReaskVerdict(sql, albumId, { bandcamp: { status: 'unresolved', url: null } });
+      reaskCount++;
+    }
+
+    expect(reaskCount).toBe(STREAMING_REASK_ATTEMPT_CAP);
+    const row = await readStreamingState(sql, albumId);
+    expect(row.streaming_reask_attempts).toBe(STREAMING_REASK_ATTEMPT_CAP);
     expect(await findCandidateAlbumIds(sql, [albumId])).toEqual([]);
   });
 });

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -22,6 +22,7 @@ import {
   extractArtwork,
   finalizeRow,
   inferIncomingStreamingStatus,
+  isBandcampReaskEnabled,
   mergeStreamingField,
   synthesizeSearchUrls,
   type StreamingFieldState,
@@ -1253,6 +1254,184 @@ describe('extractArtwork', () => {
 
     it('rejects an absent search_type (fail-closed)', () => {
       expect(extractArtwork(withSearchType(undefined))).toBeNull();
+    });
+  });
+});
+
+/**
+ * Bandcamp re-ask de-freeze (iOS Bandcamp search-fallback program).
+ *
+ * The freeze this un-sticks: a MATCHED album (load-bearing artwork/discogs
+ * present) for which LML returns no direct `bandcamp_url` and no explicit
+ * `streaming_status.bandcamp` currently persists `bandcamp_status = NULL` +
+ * the synthesized `bandcamp.com/search?q=` fallback URL. NULL is
+ * indistinguishable from "never consulted" — neither `precheck.ts` nor the
+ * BS#1915 streaming-reask sweep ever re-ask a NULL-status field — so once
+ * the LML-side workstreams teach LML to resolve a direct Bandcamp URL, that
+ * fresh URL can never reach the already-written row: it stays frozen on the
+ * search fallback forever (the same class of permanent-null freeze BS#1747
+ * documents for the Apple/Spotify precheck skip).
+ *
+ * The interlock, Bandcamp-only, behind `ENRICHMENT_BANDCAMP_REASK` (default
+ * off, so merging is a no-op until the LML side is live): when LML returns a
+ * match with no Bandcamp verdict at all, infer `'unresolved'` (retryable)
+ * instead of leaving the status NULL. The displayed URL still falls back to
+ * the search URL (no UX regression — same as pre-#1915 Bandcamp), but the
+ * STATUS now says "retryable, not verified", so the existing status-driven
+ * sweep re-asks it and a later direct URL supersedes the fallback. The
+ * coercion is Bandcamp-scoped on purpose: Apple Music's NULL is load-bearing
+ * "no verified iTunes match" (BS#1192) and must NOT become a re-ask magnet.
+ */
+describe('Bandcamp re-ask de-freeze — ENRICHMENT_BANDCAMP_REASK gate', () => {
+  const priorFlag = process.env.ENRICHMENT_BANDCAMP_REASK;
+
+  afterEach(() => {
+    if (priorFlag === undefined) delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    else process.env.ENRICHMENT_BANDCAMP_REASK = priorFlag;
+  });
+
+  describe('isBandcampReaskEnabled', () => {
+    it("is true only for the exact string 'true'", () => {
+      process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+      expect(isBandcampReaskEnabled()).toBe(true);
+    });
+
+    it('is false when unset', () => {
+      delete process.env.ENRICHMENT_BANDCAMP_REASK;
+      expect(isBandcampReaskEnabled()).toBe(false);
+    });
+
+    it.each(['false', '1', 'yes', 'TRUE', ''])("is false for a non-'true' value (%p)", (raw) => {
+      process.env.ENRICHMENT_BANDCAMP_REASK = raw;
+      expect(isBandcampReaskEnabled()).toBe(false);
+    });
+  });
+
+  // Linked match whose artwork carries NO bandcamp signal at all: no direct
+  // url, no streaming_status object. This is exactly the shape that freezes
+  // bandcamp_status at NULL today.
+  const bandcampMissingResponse = {
+    search_type: 'direct',
+    results: [
+      {
+        artwork: {
+          artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+          release_url: 'https://discogs.com/release/123',
+          spotify_url: 'https://open.spotify.com/album/x',
+          apple_music_url: null,
+          bandcamp_url: null,
+        },
+      },
+    ],
+  } as unknown as LookupResponse;
+
+  describe('flag OFF (default) — behavior is exactly as before', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      delete process.env.ENRICHMENT_BANDCAMP_REASK;
+    });
+
+    it('a match with no bandcamp url/status leaves bandcamp_status NULL on the fresh INSERT', async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+      await finalizeRow(LINKED_ROW, bandcampMissingResponse);
+
+      const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(insertPayload.bandcamp_status).toBeNull();
+      // The display URL still falls back to the synthesized search URL.
+      expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    });
+
+    it('the conflict branch leaves bandcamp_status a bare, unchanged column reference (never consulted)', async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+      await finalizeRow(LINKED_ROW, bandcampMissingResponse);
+
+      const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+      expect(renderSql(conflictCfg.set.bandcamp_status)).toBe('<col>');
+      expect(sqlValues(conflictCfg.set.bandcamp_status)).toEqual([album_metadata.bandcamp_status]);
+    });
+  });
+
+  describe('flag ON — a bandcamp-less match becomes retryable (unresolved), not frozen', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      process.env.ENRICHMENT_BANDCAMP_REASK = 'true';
+    });
+
+    it("persists bandcamp_status='unresolved' + the search-fallback url on the fresh INSERT", async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+      await finalizeRow(LINKED_ROW, bandcampMissingResponse);
+
+      const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(insertPayload.bandcamp_status).toBe('unresolved');
+      // Display fallback preserved — status carries the "retryable" signal,
+      // the URL stays clickable.
+      expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    });
+
+    it('the conflict branch flips bandcamp_status to the retryable CASE (unless already verified/absent)', async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+      await finalizeRow(LINKED_ROW, bandcampMissingResponse);
+
+      const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+      // Same shape buildStreamingFieldConflictSet emits for an incoming
+      // 'unresolved' verdict: terminal verified/absent are preserved, anything
+      // else (NULL included) becomes 'unresolved'.
+      expect(renderSql(conflictCfg.set.bandcamp_status)).toBe(
+        "CASE WHEN <col> = 'verified' OR <col> = 'absent' THEN <col> ELSE 'unresolved' END"
+      );
+      // URL recomputes the search fallback in the non-verified branch.
+      expect(renderSql(conflictCfg.set.bandcamp_url)).toBe("CASE WHEN <col> = 'verified' THEN <col> ELSE <col> END");
+      const bandcampUrlValues = sqlValues(conflictCfg.set.bandcamp_url);
+      expect(bandcampUrlValues[2]).toContain('bandcamp.com/search');
+    });
+
+    it('does NOT touch a genuinely verified bandcamp — a real direct url still infers verified', async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+      // matchResponse carries a real bandcamp_url → inferred 'verified',
+      // coercion never fires.
+      await finalizeRow(LINKED_ROW, matchResponse);
+
+      const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(insertPayload.bandcamp_status).toBe('verified');
+      expect(insertPayload.bandcamp_url).toBe('https://artist.bandcamp.com/album/w');
+    });
+
+    it("does NOT override an explicit LML 'absent' bandcamp verdict (absent stays terminal)", async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+      const absentResponse = {
+        search_type: 'direct',
+        results: [
+          {
+            artwork: {
+              artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+              release_url: 'https://discogs.com/release/123',
+              bandcamp_url: null,
+              streaming_status: { bandcamp: 'absent' },
+            },
+          },
+        ],
+      } as unknown as LookupResponse;
+
+      await finalizeRow(LINKED_ROW, absentResponse);
+
+      const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(insertPayload.bandcamp_status).toBe('absent');
+    });
+
+    it('leaves Apple Music and Spotify inference untouched — coercion is Bandcamp-only', async () => {
+      mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+      // bandcampMissingResponse has apple_music_url null and no apple status —
+      // Apple must stay NULL (never a re-ask magnet), only bandcamp is coerced.
+      await finalizeRow(LINKED_ROW, bandcampMissingResponse);
+
+      const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(insertPayload.apple_music_status).toBeNull();
+      // Spotify DID carry a url → verified, unrelated to the bandcamp coercion.
+      expect(insertPayload.spotify_status).toBe('verified');
     });
   });
 });

--- a/tests/utils/enrichment-precheck.js
+++ b/tests/utils/enrichment-precheck.js
@@ -46,6 +46,15 @@ const STREAMING_REASK_ATTEMPT_CAP = 3;
  *   LML (self-heal path).
  */
 async function hasLoadBearingMetadata(sql, albumId) {
+  // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK) mirror: when the
+  // gate is on, a load-bearing row whose Bandcamp is a NULL-status
+  // `bandcamp.com/search` fallback (the legacy frozen shape) is re-ask
+  // eligible too. Read at call time so a test can toggle the env var per
+  // case; empty fragment (flag off) is a byte-for-byte no-op.
+  const bandcampFrozenReask =
+    process.env.ENRICHMENT_BANDCAMP_REASK === 'true'
+      ? sql`OR (bandcamp_status IS NULL AND bandcamp_url LIKE ${'%bandcamp.com/search%'})`
+      : sql``;
   const rows = await sql`
     SELECT 1
       FROM ${sql(SCHEMA)}.album_metadata
@@ -65,6 +74,7 @@ async function hasLoadBearingMetadata(sql, albumId) {
            spotify_status = 'unresolved'
            OR apple_music_status = 'unresolved'
            OR bandcamp_status = 'unresolved'
+           ${bandcampFrozenReask}
          ),
          false
        )


### PR DESCRIPTION
## The freeze

The iOS flowsheet metadata is enriched by the CDC enrichment worker (`apps/enrichment-worker/`) calling LML. For a **linked** album (`flowsheet.album_id` set → `album_metadata`), when LML returns a match (load-bearing `artwork_url`/`discogs_url` present) but **no direct `bandcamp_url` and no explicit `streaming_status.bandcamp`**, `upsertMatchedAlbumMetadata` (`enrich.ts`) persists `bandcamp_status = NULL` plus the synthesized `bandcamp.com/search?q=` fallback URL.

`NULL` is indistinguishable from "never consulted", so the row freezes:

- `precheck.ts#hasLoadBearingAlbumMetadata` treats the album as "done" (load-bearing artwork present, no `unresolved` status) → the next play **skips** LML.
- The BS#1915 streaming-reask sweep (`streaming-reask.ts`) only selects `*_status = 'unresolved'` → a NULL bandcamp status is **never** re-asked.

So the search-fallback URL is terminal. This is the Bandcamp analog of the BS#1747 permanent-null freeze. Once the LML-side workstreams teach LML to resolve a **direct** Bandcamp album URL, that fresh URL can never reach the already-written row — iOS keeps showing `bandcamp.com/search?q=`.

## The fix (this PR — linked albums)

Behind a new env flag **`ENRICHMENT_BANDCAMP_REASK` (default off)**, so merging is a byte-for-byte no-op against the live worker until an operator flips it on:

1. **Write-side coercion (`enrich.ts#upsertMatchedAlbumMetadata`, Bandcamp-only).** When the fresh LML verdict for Bandcamp is `undefined` (no url, no explicit status), infer `'unresolved'` (retryable) instead of leaving the status NULL. The displayed URL still falls back to the search URL — **no UX regression** — but the STATUS now says "retryable, not verified", so the existing status-driven sweep re-asks it and a later direct URL supersedes the fallback. This flows through the unchanged BS#1923 `buildStreamingFieldConflictSet('unresolved', …)` machinery, which keeps terminal `verified`/`absent` untouched and bumps `streaming_reask_attempts` on re-ask.

2. **Read-side de-freeze (`streaming-reask.ts` + `precheck.ts`, gated disjunct).** The plain `bandcamp_status = 'unresolved'` disjunct only catches rows written **after** the coercion goes live. Rows enriched **before** the gate carry `bandcamp_status = NULL` + the search-fallback URL. A gated disjunct — `bandcamp_status IS NULL AND bandcamp_url LIKE '%bandcamp.com/search%'` — reaches that legacy backlog directly, **without a data migration**. The `IS NULL` guard excludes terminal `absent` rows (which also carry a search-fallback URL). Everything stays bounded by the shared `streaming_reask_attempts < CAP` guard; once re-asked, the coercion moves a row onto the clean `= 'unresolved'` disjunct.

Net: a Bandcamp URL that LML can newly provide now reaches both already-written and future linked rows. Terminal `verified`/`absent` rows are never touched, and flag-off is exactly today's behavior.

### Why Bandcamp-only

The coercion is scoped to Bandcamp deliberately. Apple Music's NULL is the load-bearing "no verified iTunes match" signal (BS#1192) — coercing it to `'unresolved'` would make nearly every album a re-ask magnet. Spotify is out of scope. Only Bandcamp is coerced.

### Interlock with the LML-side Bandcamp-resolution work

The gate exists for the cross-repo interlock, not because the change is risky in isolation. The LML-side workstreams are what teach LML to resolve a direct Bandcamp URL (and to return an explicit `streaming_status.bandcamp = 'unresolved'` on a cold miss). Flipping this on **before** LML can resolve Bandcamp would burn all three `streaming_reask_attempts` against an LML that still has no answer, wasting the bound. **Roll-out: land the LML side, then set `ENRICHMENT_BANDCAMP_REASK=true` on the enrichment-worker (Railway) and restart.** Kill-switch: unset it (in-flight `'unresolved'` rows still drain to the cap, which bounds them).

## Deliberately out of scope — free-form rows (→ #1967)

Free-form / rotation rows (`album_id IS NULL`, ~43% of music plays) are the other freeze half: enriched inline once, with **no** re-ask path (they have no `album_metadata` row, so neither the precheck nor the sweep touch them). Bounding a free-form re-ask at the attempt cap requires **new persistent per-row state** — `flowsheet` has `bandcamp_url` but no `bandcamp_status` and no `streaming_reask_attempts` column — i.e. a schema change on the hot `flowsheet` table. Per the org's "isolate schema changes" rule, and since the linked fix ships cleanly without one, this is split into **#1967** (blocked, flagged for the schema-approach decision).

## Product judgment calls flagged for human sign-off

- **Free-form deferral** (above) — needs a call on the counter substrate (widen `flowsheet` vs. a side table). Filed as #1967.
- **Bounded re-ask cost.** With the flag on, every matched linked album lacking a direct Bandcamp URL becomes re-ask-eligible for up to `STREAMING_REASK_ATTEMPT_CAP` (=3) low-priority class-5 lookups. That is the inherent cost of de-freezing; it settles once LML returns explicit `verified`/`absent` verdicts. Confirm the appetite before flipping the flag on in prod.
- **`LIKE '%bandcamp.com/search%'` as the frozen-row signal.** Robust in practice (BS controls the synthesizer format; direct album URLs are `<artist>.bandcamp.com/album/<slug>`), but it is a URL-shape match rather than a status column, used only for the one-time legacy backlog.

## Tests

- **Unit** (`tests/unit/apps/enrichment-worker/enrich.test.ts`): `isBandcampReaskEnabled` env parsing; flag-off leaves `bandcamp_status` NULL / a bare column ref (current behavior); flag-on persists `'unresolved'` + the search-fallback URL on INSERT and the retryable CASE on conflict; a real direct URL still infers `verified`; an explicit `absent` is never overridden; Apple/Spotify inference untouched.
- **Integration** (`enrichment-worker-streaming-reask.spec.js`, `enrichment-worker-cache-precheck.spec.js`, and the shared `tests/utils/enrichment-precheck.js` SQL mirror): the gated predicate against real PG — a NULL-status search-fallback row is a candidate / not-"done" only when the flag is on; `absent` and `verified` rows stay terminal; end-to-end heal to a direct URL; the attempt cap holds.

Local: unit `6161 passed`; enrichment-worker typecheck clean; eslint/prettier clean on the diff. Integration specs (real PG) run in CI; flag-off keeps every pre-existing assertion byte-identical, and the gated drizzle SQL was validated to serialize correctly for both flag states.

Refs BS#1747 (freeze), BS#1915 (self-heal sweep). Follow-up: #1967.
