### PR TITLE
feat(flowsheet): emit discogsUnavailable on realtime + mutation-echo payloads (BS#1962)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -8,7 +8,8 @@ type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
 import type { ConcertDTO } from '../services/concerts.service.js';
 import type { CriticReviewItem } from '@wxyc/shared/dtos';
-import { projectFlowsheetEntry } from '../utils/flowsheet-projection.js';
+import { projectFlowsheetEntry, toDiscogsUnavailableWireFields } from '../utils/flowsheet-projection.js';
+import { getDiscogsUnavailableFlagsById } from '../services/library.service.js';
 import { stashMirrorData } from '../middleware/legacy/mirror.middleware.js';
 import WxycError from '../utils/error.js';
 
@@ -341,10 +342,33 @@ export type FSEntryRequestBody = {
  * mutation site can't pick up the projection without the stash. The stash is
  * inert on routes with no mirror middleware attached (changeOrder today) and
  * becomes load-bearing automatically if one is wired up.
+ *
+ * BS#1962: when the entry has a non-null `album_id`, additionally merges
+ * `discogsUnavailable` / `discogsUnavailableNote` onto the projected body —
+ * parity with the paginated read path's `transformToV2` (#1908) and the SSE
+ * feeder (`metadata-broadcast.ts`). The lookup is a single, uncached,
+ * freshest-wins direct read: mutations are DJ-paced and single-row, so there's
+ * no N+1 concern here (contrast the SSE hot path's LRU + coalescing, needed
+ * because a backfill burst can replay many terminal broadcasts for the same
+ * album_id in a short window). Additive-failure (mirrors the proxy path,
+ * `proxy.controller.ts`'s `getDiscogsUnavailableFlagsById` call site): a DB
+ * blip on this read degrades to omitting the fields, never 500s the mutation.
  */
-const sendProjectedEntry = (res: Response, statusCode: number, entry: FSEntry): void => {
+const sendProjectedEntry = async (res: Response, statusCode: number, entry: FSEntry): Promise<void> => {
   stashMirrorData(res, entry);
-  res.status(statusCode).json(projectFlowsheetEntry(entry));
+  const projected = projectFlowsheetEntry(entry);
+  if (entry.album_id != null) {
+    try {
+      const flags = await getDiscogsUnavailableFlagsById(entry.album_id);
+      Object.assign(projected, toDiscogsUnavailableWireFields(flags));
+    } catch (err) {
+      console.warn(
+        `[flowsheet.controller] discogs-unavailable lookup failed for album_id=${entry.album_id}; omitting field:`,
+        err
+      );
+    }
+  }
+  res.status(statusCode).json(projected);
 };
 
 /**
@@ -406,7 +430,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
       dj_name,
     };
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-    sendProjectedEntry(res, 201, completedEntry);
+    await sendProjectedEntry(res, 201, completedEntry);
     return;
   }
 
@@ -452,7 +476,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
         extra: { album_id: body.album_id, show_id: latestShow.id },
       });
       const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-      sendProjectedEntry(res, 201, completedEntry);
+      await sendProjectedEntry(res, 201, completedEntry);
       return;
     }
 
@@ -473,7 +497,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     };
 
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-    sendProjectedEntry(res, 201, completedEntry);
+    await sendProjectedEntry(res, 201, completedEntry);
   } else {
     // No album_id (explicit null from the dj-site rotation snapshot, BS#933,
     // or simply omitted): insert the request's own snapshot fields with
@@ -481,7 +505,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     // fallback above (BS#1680) so both routes into this shape stay identical.
     const fsEntry = buildSnapshotFieldsEntry(body, latestShow.id, dj_name);
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-    sendProjectedEntry(res, 201, completedEntry);
+    await sendProjectedEntry(res, 201, completedEntry);
   }
 };
 
@@ -499,7 +523,7 @@ export const deleteEntry: RequestHandler<object, unknown, { entry_id: number }> 
   if (!removedEntry) {
     throw new WxycError(`Flowsheet entry ${entry_id} not found`, 404);
   }
-  sendProjectedEntry(res, 200, removedEntry);
+  await sendProjectedEntry(res, 200, removedEntry);
 };
 
 export type UpdateRequestBody = {
@@ -569,7 +593,7 @@ export const updateEntry: RequestHandler<object, unknown, { entry_id: number; da
   if (!updatedEntry) {
     throw new WxycError(`Flowsheet entry ${entry_id} not found`, 404);
   }
-  sendProjectedEntry(res, 200, updatedEntry);
+  await sendProjectedEntry(res, 200, updatedEntry);
 };
 
 export type JoinRequestBody = {
@@ -721,18 +745,24 @@ export const changeOrder: RequestHandler<object, unknown, { entry_id: number; ne
   }
 
   const release = await orderMutex.acquire();
+  let updatedEntry;
   try {
-    const updatedEntry = await flowsheet_service.changeOrder(entry_id, new_position);
-    // The service 404s when the entry is missing at transaction start, but its
-    // confirmation read runs post-commit — a concurrent delete landing in that
-    // window returns undefined. See the 404 rationale on deleteEntry above.
-    if (!updatedEntry) {
-      throw new WxycError(`Flowsheet entry ${entry_id} not found`, 404);
-    }
-    sendProjectedEntry(res, 200, updatedEntry);
+    updatedEntry = await flowsheet_service.changeOrder(entry_id, new_position);
   } finally {
     release();
   }
+  // The projection's discogs-unavailable read (BS#1962) and the response write
+  // don't need the reorder lock — only the play_order mutation does — so they
+  // run after `release()` to keep the extra DB round-trip out of the critical
+  // section other reorders serialize behind.
+  //
+  // The service 404s when the entry is missing at transaction start, but its
+  // confirmation read runs post-commit — a concurrent delete landing in that
+  // window returns undefined. See the 404 rationale on deleteEntry above.
+  if (!updatedEntry) {
+    throw new WxycError(`Flowsheet entry ${entry_id} not found`, 404);
+  }
+  await sendProjectedEntry(res, 200, updatedEntry);
 };
 
 export interface ShowMetadata extends Show {

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -904,6 +904,11 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
     throw new WxycError('Album not found', 404);
   }
 
+  // BS#1962: the SSE feeder's discogs-unavailable cache is invalidated off the
+  // `cdc_library` CDC stream (see `metadata-broadcast.ts`), not from here — this
+  // UPDATE's own NOTIFY drops the flipped album from every BS instance's cache,
+  // so no write-path poke is needed.
+
   if (identityChanged && isLmlConfigured()) {
     const canonicalArtistName =
       updates.artist_name ?? existing.artist_name ?? (await libraryService.getArtistNameById(existing.artist_id));

--- a/apps/backend/services/metadata-broadcast/discogs-unavailable-cache.ts
+++ b/apps/backend/services/metadata-broadcast/discogs-unavailable-cache.ts
@@ -1,0 +1,167 @@
+/**
+ * Bounded lookup for the BS#1962 SSE-feeder (`metadata-broadcast.ts`'s
+ * realtime `liveFs:update` / `liveFs:insert` broadcast): an LRU +
+ * in-flight-promise-coalescing wrapper over
+ * `library.service.getDiscogsUnavailableFlagsById`.
+ *
+ * The SSE hot path can see a burst of terminal `liveFs:update`s writing
+ * repeated `album_id`s (e.g. the `flowsheet-metadata-backfill` gap-recovery
+ * sweep) — an uncached direct read per broadcast would be an unbounded
+ * per-broadcast query (the AC this module exists to satisfy). This caps
+ * reads to one per distinct `album_id` per TTL window:
+ *
+ *   - `max` ~2000 / `ttl` 60_000 ms, mirroring the sibling LRUs in
+ *     `proxy.controller.ts`.
+ *   - Value is `{ flags }`-wrapped (not a bare `DiscogsUnavailableFlags |
+ *     undefined`) because `LRUCache`'s value type must extend `{}`, so an
+ *     `undefined` (no library row) result needs a wrapper to be cacheable —
+ *     same convention as `proxy.controller.ts`'s `artistMetadataCache` /
+ *     `entityResolveCache`. Caching `undefined` is deliberate: a track with
+ *     no library row stays a negative cache hit for the rest of the TTL
+ *     rather than re-querying every broadcast.
+ *   - In-flight-promise coalescing (`Map<number, InflightEntry>`) collapses
+ *     concurrent lookups for the same `album_id` (e.g. a cold `insert`
+ *     immediately followed by its terminal `update`) into one underlying
+ *     read; both callers await the identical promise, so a same-row
+ *     insert→update pair preserves broadcast ordering (FIFO by
+ *     await-registration on the shared promise) — see `metadata-broadcast.ts`'s
+ *     `setupMetadataBroadcast` docstring for the full ordering argument.
+ *   - A rejected underlying read is NEVER cached (positive or negative) —
+ *     only a *resolved* read (including a resolved `undefined`) is written
+ *     to the LRU. A transient DB blip is retried on the next broadcast
+ *     rather than pinned as a false "no library row" for the rest of the TTL.
+ *
+ * Staleness + invalidation (BS#1962): because a resolved `false`/`undefined`
+ * is cached, a writer that flips `library.discogs_unavailable` — an MD's
+ * interactive `PATCH /library/{id}`, or the `library-discogs-unavailable-
+ * recheck` cron — could otherwise sit behind the TTL for up to 60 s, the
+ * newly-flagged-album backfill-rebroadcast window this feature exists to
+ * cover. Invalidation is driven off the SAME CDC stream the broadcasts
+ * already consume rather than from the write path: `library` is CDC-tracked
+ * (`cdc_library`, migration 0046), so `setupMetadataBroadcast` registers an
+ * `onCdcEvent` handler that calls {@link invalidateDiscogsUnavailableFlags}
+ * on every `library` UPDATE/DELETE. Because that NOTIFY reaches *every* BS
+ * instance's LISTEN connection, the flipped album is dropped from *every*
+ * instance's cache within one CDC round-trip — so the fresh flag appears on
+ * the very next broadcast regardless of which instance serves it (a
+ * write-path poke would only reach the one instance that served the PATCH).
+ * The TTL remains the backstop if the CDC stream is unavailable.
+ *
+ * Invalidate-vs-in-flight-read TOCTOU: a bare `cache.delete` on invalidate
+ * would not close the flip window if a read for the same `album_id` is already
+ * in flight when the write lands — that read observed the *pre-flip* snapshot,
+ * and its `.then` would re-pin the stale value into the cache *after* the
+ * delete, resurrecting it for the rest of the TTL. Each in-flight read carries
+ * a mutable `poisoned` flag on its {@link InflightEntry}; `invalidate` sets it,
+ * and the read's `.then` skips the cache write when poisoned. The flag is
+ * per-`album_id` (a shared counter would make an invalidation of one album
+ * spuriously suppress the caching of unrelated in-flight reads) and lives only
+ * as long as its entry, so nothing accumulates even though invalidation now
+ * fires on every `library` write. The racing read still returns its pre-flip
+ * value to its own caller (that broadcast reflects pre-flip state, which is
+ * inherent and acceptable), but it never poisons the cache, so the *next* read
+ * re-queries and observes the fresh flag.
+ */
+
+import { LRUCache } from 'lru-cache';
+import { getDiscogsUnavailableFlagsById, type DiscogsUnavailableFlags } from '../library.service.js';
+
+const CACHE_MAX = 2000;
+const CACHE_TTL_MS = 60_000;
+
+type CachedFlags = { flags: DiscogsUnavailableFlags | undefined };
+
+const cache = new LRUCache<number, CachedFlags>({
+  max: CACHE_MAX,
+  ttl: CACHE_TTL_MS,
+});
+
+/**
+ * One in-flight read: the shared promise concurrent callers await, plus a
+ * mutable `poisoned` flag an invalidation sets so this read's now-stale result
+ * is kept out of the cache. See the module docstring's "Invalidate-vs-in-flight-
+ * read TOCTOU" note.
+ */
+type InflightEntry = { promise: Promise<CachedFlags>; poisoned: boolean };
+
+/**
+ * In-flight reads keyed by `album_id`. A second lookup for an `album_id`
+ * already being read awaits the same promise rather than issuing a second
+ * DB query. Cleared (success or failure) once the read settles, guarded by an
+ * identity check so a settling read never evicts a newer read that replaced it.
+ */
+const inflight = new Map<number, InflightEntry>();
+
+/**
+ * Cache-through read of the BS#1281 discogs-unavailable flag trio for a
+ * `library.id`, bounded by the LRU + in-flight coalescing described above.
+ * Returns `undefined` when the album_id has no `library` row (mirrors
+ * {@link getDiscogsUnavailableFlagsById}'s own contract) — callers merge the
+ * result through `toDiscogsUnavailableWireFields` (`flowsheet-projection.ts`).
+ *
+ * Propagates a genuine DB error to the caller (never cached); the SSE feeder
+ * wraps this call in its own additive-failure `try/catch` so a rejection
+ * degrades to omitting the fields rather than failing the broadcast.
+ */
+export async function getCachedDiscogsUnavailableFlags(albumId: number): Promise<DiscogsUnavailableFlags | undefined> {
+  const cached = cache.get(albumId);
+  if (cached !== undefined) return cached.flags;
+
+  const existing = inflight.get(albumId);
+  if (existing) return (await existing.promise).flags;
+
+  // Build the entry first (with a throwaway resolved promise) so the
+  // `.then`/`.finally` closures below can capture it by reference — they run
+  // only after the DB read settles, long after `entry.promise` is reassigned
+  // synchronously below.
+  const entry: InflightEntry = { poisoned: false, promise: Promise.resolve({ flags: undefined }) };
+  entry.promise = (async (): Promise<CachedFlags> => {
+    const flags = await getDiscogsUnavailableFlagsById(albumId);
+    return { flags };
+  })()
+    .then((result) => {
+      // Only a settled (resolved) read is cached — a rejection skips this
+      // `.then` entirely, so nothing is written for a transient failure — and
+      // only when no invalidation poisoned this read while it was in flight.
+      if (!entry.poisoned) {
+        cache.set(albumId, result);
+      }
+      return result;
+    })
+    .finally(() => {
+      // Identity guard: only clear the slot if it still holds THIS entry. An
+      // invalidation may have already deleted it and a newer read may now own
+      // the slot — a bare `inflight.delete` would evict that newer read and
+      // break its coalescing.
+      if (inflight.get(albumId) === entry) {
+        inflight.delete(albumId);
+      }
+    });
+
+  inflight.set(albumId, entry);
+  return (await entry.promise).flags;
+}
+
+/**
+ * Drop any cached entry for `albumId` so the next
+ * {@link getCachedDiscogsUnavailableFlags} call re-reads `library` instead of
+ * serving a stale TTL-cached value. Registered against the CDC stream by
+ * `metadata-broadcast.ts`'s `setupMetadataBroadcast` and fired on every
+ * `library` UPDATE/DELETE (BS#1962), so a `discogs_unavailable` flip is dropped
+ * from every BS instance's cache. Poisons any in-flight read for this id
+ * (issued before the flip) so it cannot re-pin its now-stale value, and drops
+ * the in-flight entry so the next caller starts a fresh read rather than
+ * joining the doomed one. A no-op when the id is neither cached nor in flight.
+ */
+export function invalidateDiscogsUnavailableFlags(albumId: number): void {
+  const existing = inflight.get(albumId);
+  if (existing) existing.poisoned = true;
+  cache.delete(albumId);
+  inflight.delete(albumId);
+}
+
+/** Test-only: drop cached entries + in-flight promises between cases. */
+export function __resetDiscogsUnavailableCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -48,7 +48,8 @@ import type { CdcEvent } from '@wxyc/database';
 import { onCdcEvent } from '@wxyc/database';
 import type { LiveFsInsertEvent } from '@wxyc/shared/dtos';
 import { serverEventsMgr, Topics, FsEvents } from '../../utils/serverEvents.js';
-import { pickClientFacingColumns } from '../../utils/flowsheet-projection.js';
+import { pickClientFacingColumns, toDiscogsUnavailableWireFields } from '../../utils/flowsheet-projection.js';
+import { getCachedDiscogsUnavailableFlags, invalidateDiscogsUnavailableFlags } from './discogs-unavailable-cache.js';
 
 const TERMINAL_STATUSES = new Set(['enriched_match', 'enriched_no_match', 'failed_no_retry']);
 
@@ -141,11 +142,46 @@ export function filterMetadataInsert(event: CdcEvent): LiveFsInsertEvent['payloa
  * `apps/backend/services/cdc/dispatcher.ts`). The dispatcher runs whether
  * or not the websocket is configured (BS#1187), so this handler fires in
  * environments without `CDC_SECRET`.
+ *
+ * BS#1962: both handlers additionally enrich a library-linked payload with
+ * `discogsUnavailable` / `discogsUnavailableNote` before broadcasting, for
+ * parity with the paginated read path's `transformToV2` (#1908). The filters
+ * (`filterMetadataUpdate` / `filterMetadataInsert`) stay pure and synchronous
+ * — their "no DB" testability seam is load-bearing for the existing filter
+ * unit tests — so the enrichment lives here, gated behind a non-null
+ * `album_id`: a non-library row (`album_id === null`) takes the ORIGINAL
+ * fully-synchronous path unchanged (the `await` on an already-resolved
+ * value would still defer the broadcast to a later microtask and break the
+ * "broadcast fired synchronously" assertions those fixtures pin). Only a
+ * library-linked row pays the extra (cached, coalesced) read.
+ *
+ * The cache read is fire-and-forget from the CDC dispatcher's perspective:
+ * `startCdcDispatcher` invokes every registered callback synchronously and
+ * does not await them (`cdc-listener.ts`'s `cb(event)` inside a try that only
+ * catches *synchronous* throws), so the `void (async () => {...})()` IIFE
+ * below — whose own inner `try/catch` swallows every rejection — never
+ * leaves a dangling unhandled rejection for the dispatcher to see.
+ *
+ * Ordering: `getCachedDiscogsUnavailableFlags` coalesces concurrent lookups
+ * for the same `album_id` onto one in-flight promise (see
+ * `discogs-unavailable-cache.ts`). A same-row `insert` (cold, slow read)
+ * followed seconds later by its terminal `update` share that promise; both
+ * `await` the identical object, and promise continuations resolve FIFO by
+ * await-registration order, so `insert` still broadcasts before `update`.
+ * Only cross-album_id ordering (a cold read for album A racing a warm hit
+ * for album B) can reorder — benign, since SSE patches are per-`id` and
+ * convergent on both dj-site and iOS.
+ *
+ * A third handler invalidates the discogs-unavailable cache on every `library`
+ * UPDATE/DELETE. `library` is CDC-tracked (`cdc_library`, migration 0046), so a
+ * `discogs_unavailable` flip NOTIFYs every BS instance's LISTEN connection —
+ * driving invalidation from here (rather than the write path, which only runs
+ * on the one instance that served the PATCH) drops the flipped album from every
+ * instance's cache, so the fresh flag appears on the very next broadcast
+ * regardless of which instance serves it. See `discogs-unavailable-cache.ts`.
  */
 export function setupMetadataBroadcast(): void {
-  onCdcEvent((event) => {
-    const payload = filterMetadataUpdate(event);
-    if (!payload) return;
+  const broadcastUpdate = (payload: LiveFsUpdatePayload): void => {
     try {
       serverEventsMgr.broadcast(Topics.liveFs, {
         type: FsEvents.update,
@@ -162,16 +198,33 @@ export function setupMetadataBroadcast(): void {
         extra: { id: payload.id, metadata_status: payload.metadata_status },
       });
     }
+  };
+
+  onCdcEvent((event) => {
+    const payload = filterMetadataUpdate(event);
+    if (!payload) return;
+    const albumId = typeof payload.album_id === 'number' ? payload.album_id : null;
+    if (albumId === null) {
+      broadcastUpdate(payload);
+      return;
+    }
+    void (async () => {
+      try {
+        const flags = await getCachedDiscogsUnavailableFlags(albumId);
+        Object.assign(payload, toDiscogsUnavailableWireFields(flags));
+      } catch {
+        // Additive-failure (BS#1962): a DB blip on the enrichment read must
+        // never suppress the broadcast — omit the fields and send the
+        // pre-#1962 payload shape. Deliberately swallowed here (not
+        // rethrown) so it can never trip the broadcast-level Sentry capture
+        // in broadcastUpdate, which stays scoped to genuine broadcast
+        // failures.
+      }
+      broadcastUpdate(payload);
+    })();
   });
 
-  // BS#1888: broadcast `liveFs:insert` the instant a track row is created,
-  // before enrichment. A separate `onCdcEvent` registration (INSERT vs the
-  // update handler's UPDATE) so the two never double-emit for one row — a track
-  // fires `insert` on creation, then `update` when its metadata_status reaches a
-  // terminal state. Same per-process LISTEN + own-clients-only fan-out.
-  onCdcEvent((event) => {
-    const payload = filterMetadataInsert(event);
-    if (!payload) return;
+  const broadcastInsert = (payload: LiveFsInsertEvent['payload']): void => {
     try {
       serverEventsMgr.broadcast(Topics.liveFs, {
         type: FsEvents.insert,
@@ -183,5 +236,47 @@ export function setupMetadataBroadcast(): void {
         extra: { id: payload.id },
       });
     }
+  };
+
+  // BS#1888: broadcast `liveFs:insert` the instant a track row is created,
+  // before enrichment. A separate `onCdcEvent` registration (INSERT vs the
+  // update handler's UPDATE) so the two never double-emit for one row — a track
+  // fires `insert` on creation, then `update` when its metadata_status reaches a
+  // terminal state. Same per-process LISTEN + own-clients-only fan-out.
+  onCdcEvent((event) => {
+    const payload = filterMetadataInsert(event);
+    if (!payload) return;
+    const albumId = typeof payload.album_id === 'number' ? payload.album_id : null;
+    if (albumId === null) {
+      broadcastInsert(payload);
+      return;
+    }
+    void (async () => {
+      try {
+        const flags = await getCachedDiscogsUnavailableFlags(albumId);
+        Object.assign(payload, toDiscogsUnavailableWireFields(flags));
+      } catch {
+        // Additive-failure — see the update handler's comment above.
+      }
+      broadcastInsert(payload);
+    })();
+  });
+
+  // BS#1962: invalidate the discogs-unavailable cache off the same CDC stream.
+  // `library` is CDC-tracked (`cdc_library`, migration 0046), so a
+  // `discogs_unavailable` flip — an MD's PATCH /library/{id}, or the recheck
+  // cron — NOTIFYs every BS instance's LISTEN connection; dropping the cached
+  // flag on every instance here (not just the one that served the write) means
+  // the fresh flag rides the very next broadcast on whichever instance serves
+  // it. Purely synchronous — no broadcast, so no ordering interaction with the
+  // two enrich handlers above. Scoped to UPDATE/DELETE: a fresh INSERT gets a
+  // new serial id no flowsheet row can FK yet, so it can't already be cached.
+  onCdcEvent((event) => {
+    if (event.table !== 'library') return;
+    if (event.action !== 'UPDATE' && event.action !== 'DELETE') return;
+    if (!event.data) return;
+    const id = (event.data as Record<string, unknown>).id;
+    if (typeof id !== 'number') return;
+    invalidateDiscogsUnavailableFlags(id);
   });
 }

--- a/apps/backend/utils/flowsheet-projection.ts
+++ b/apps/backend/utils/flowsheet-projection.ts
@@ -1,5 +1,6 @@
 import type { FSEntry } from '@wxyc/database';
 import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
+import type { DiscogsUnavailableFlags } from '../services/library.service.js';
 
 /**
  * Client-facing flowsheet-row projection (BS#1513).
@@ -165,4 +166,40 @@ export function pickClientFacingColumns(row: Record<string, unknown>): Record<st
     projected.apple_music_url = null;
   }
   return projected;
+}
+
+/**
+ * Wire shape merged onto both the realtime (SSE) and mutation-echo flowsheet
+ * payloads (BS#1962). Deliberately just the two fields the published
+ * `FlowsheetEntryResponse` contract (v3.2.0) carries for this pair —
+ * `lastDiscogsRecheckAt` rides the proxy album-detail surface only, not the
+ * flowsheet track shape (see #1908's `transformToV2`).
+ */
+export type DiscogsUnavailableWireFields = {
+  discogsUnavailable?: boolean;
+  discogsUnavailableNote?: string;
+};
+
+/**
+ * Project a {@link DiscogsUnavailableFlags} read (or its absence) onto the
+ * present-or-absent camelCase wire shape both feeders merge onto their
+ * payload — the single point where this semantic lives, so the SSE feeder
+ * (`metadata-broadcast.ts`) and the mutation-echo feeder
+ * (`flowsheet.controller.ts`'s `sendProjectedEntry`) can't drift from each
+ * other or from the V2 read path's `transformToV2` (BS#1908).
+ *
+ * - `undefined` (no `album_id`, or `album_id` misses in `library`) -> `{}`
+ *   (both fields absent).
+ * - a resolved row -> `discogsUnavailable` is ALWAYS emitted (true or false —
+ *   a linked-but-unflagged row emits `false`, matching #1908's `!== null`
+ *   gate on the read path), and `discogsUnavailableNote` only when non-null.
+ */
+export function toDiscogsUnavailableWireFields(
+  flags: DiscogsUnavailableFlags | undefined
+): DiscogsUnavailableWireFields {
+  if (!flags) return {};
+  return {
+    discogsUnavailable: flags.discogsUnavailable,
+    ...(flags.discogsUnavailableNote !== null ? { discogsUnavailableNote: flags.discogsUnavailableNote } : {}),
+  };
 }

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -1609,3 +1609,87 @@ describe('V1 API - entry_type field', () => {
     expect(getRes.body.entries[0].entry_type).toBeDefined();
   });
 });
+
+/*
+ * BS#1962: discogsUnavailable / discogsUnavailableNote on the single-row
+ * mutation echo (POST /flowsheet) — parity with the paginated read path's
+ * transformToV2 (#1908). Seeds a dedicated library row (reusing artist_id 1 /
+ * genre_id 11 / format_id 1's existing genre_artist_crossreference so
+ * getAlbumFromDB's inner joins resolve) rather than mutating the widely-shared
+ * seed album_id 1, to avoid any cross-test interference.
+ */
+describe('discogsUnavailable on the flowsheet mutation echo (BS#1962)', () => {
+  let sql;
+  let flaggedAlbumId;
+
+  beforeAll(async () => {
+    sql = makeSql();
+    const rows = await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (artist_id, genre_id, format_id, album_title, code_number, discogs_unavailable, discogs_unavailable_note)
+      VALUES
+        (1, 11, 1, 'BS1962 Test Embargoed Pressing', 9001, true, 'Embargoed promo pressing')
+      RETURNING id
+    `;
+    flaggedAlbumId = rows[0].id;
+  });
+
+  afterAll(async () => {
+    if (flaggedAlbumId) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ${flaggedAlbumId}`;
+    }
+    if (sql) await sql.end({ timeout: 5 });
+  });
+
+  beforeEach(async () => {
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('flagged library-linked track: echo carries discogsUnavailable: true + the note', async () => {
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: flaggedAlbumId,
+        track_title: 'Test Track',
+      })
+      .expect(201);
+
+    expect(res.body.discogsUnavailable).toBe(true);
+    expect(res.body.discogsUnavailableNote).toBe('Embargoed promo pressing');
+  });
+
+  test('unlinked free-text track: echo omits discogsUnavailable / discogsUnavailableNote', async () => {
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        artist_name: 'Csillagrablók',
+        album_title: 'BS1962 Free-Text Album',
+        track_title: 'BS1962 Free-Text Track',
+        record_label: 'self-released',
+      })
+      .expect(201);
+
+    expect(res.body).not.toHaveProperty('discogsUnavailable');
+    expect(res.body).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  test('library-linked but unflagged track (seed album_id 1): echo carries discogsUnavailable: false (present)', async () => {
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1, // Built to Spill - Keep it Like a Secret (seeded, unflagged)
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('discogsUnavailable', false);
+    expect(res.body).not.toHaveProperty('discogsUnavailableNote');
+  });
+});

--- a/tests/unit/apps/backend/services/metadata-broadcast.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast.test.ts
@@ -28,6 +28,18 @@ jest.mock('@wxyc/database', () => ({
   onCdcEvent: jest.fn(),
 }));
 
+// BS#1962: the SSE feeder's discogs-unavailable enrichment is a thin guard
+// around this cache module (LRU + in-flight coalescing tested on its own in
+// discogs-unavailable-cache.test.ts). Mocking it here isolates these tests to
+// the broadcast-handler plumbing: the album_id guard, the additive-failure
+// try/catch, and same-row insert/update ordering over a shared promise.
+const mockGetCachedDiscogsUnavailableFlags = jest.fn<() => Promise<unknown>>();
+const mockInvalidateDiscogsUnavailableFlags = jest.fn();
+jest.mock('../../../../../apps/backend/services/metadata-broadcast/discogs-unavailable-cache.js', () => ({
+  getCachedDiscogsUnavailableFlags: mockGetCachedDiscogsUnavailableFlags,
+  invalidateDiscogsUnavailableFlags: mockInvalidateDiscogsUnavailableFlags,
+}));
+
 import * as Sentry from '@sentry/node';
 import {
   filterMetadataUpdate,
@@ -36,6 +48,9 @@ import {
 } from '../../../../../apps/backend/services/metadata-broadcast/metadata-broadcast';
 import { onCdcEvent } from '@wxyc/database';
 import { serverEventsMgr } from '../../../../../apps/backend/utils/serverEvents.js';
+
+/** Flushes pending microtasks (the cache-await + Object.assign + broadcast chain). */
+const flushAsync = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 const flowsheetUpdate = (overrides: Partial<Record<string, unknown>> = {}): CdcEvent => ({
   table: 'flowsheet',
@@ -297,8 +312,9 @@ describe('setupMetadataBroadcast liveFs:insert registration (BS#1888)', () => {
 
     setupMetadataBroadcast();
 
-    // Two registrations: [0] = update (asserted above), [1] = insert.
-    expect((onCdcEvent as jest.Mock).mock.calls.length).toBe(2);
+    // Three registrations: [0] = update, [1] = insert, [2] = library-CDC cache
+    // invalidation (BS#1962). The insert handler stays at index [1].
+    expect((onCdcEvent as jest.Mock).mock.calls.length).toBe(3);
     const insertCb = (onCdcEvent as jest.Mock).mock.calls[1][0] as (event: CdcEvent) => void;
     insertCb(flowsheetInsert({ artist_name: 'Stereolab', album_title: 'Aluminum Tunes' }));
 
@@ -339,5 +355,201 @@ describe('setupMetadataBroadcast liveFs:insert registration (BS#1888)', () => {
       tags: expect.objectContaining({ module: 'metadata-broadcast' }),
       extra: expect.objectContaining({ id: 77 }),
     });
+  });
+});
+
+describe('setupMetadataBroadcast discogs-unavailable enrichment (BS#1962)', () => {
+  // AC #3 (non-library rows omit the field) is covered by every existing
+  // test above — none of their fixtures set album_id, so they stay on the
+  // fully-synchronous no-cache-call path unchanged. These tests cover the
+  // album_id-bearing branch: the guarded async enrich, additive-failure
+  // degrade, and same-row insert/update ordering over a shared (coalesced)
+  // promise.
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => undefined);
+  });
+
+  it('enriches an update broadcast for a flagged library-linked album (id + note)', async () => {
+    mockGetCachedDiscogsUnavailableFlags.mockResolvedValueOnce({
+      discogsUnavailable: true,
+      discogsUnavailableNote: 'Embargoed promo pressing',
+      lastDiscogsRecheckAt: null,
+    });
+
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    updateCb(flowsheetUpdate({ album_id: 501 }));
+
+    await flushAsync();
+
+    expect(mockGetCachedDiscogsUnavailableFlags).toHaveBeenCalledWith(501);
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
+    const [, frame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    expect(frame.payload).toMatchObject({
+      id: 42,
+      discogsUnavailable: true,
+      discogsUnavailableNote: 'Embargoed promo pressing',
+    });
+  });
+
+  it('emits discogsUnavailable: false (present, not omitted) for a linked-unflagged album', async () => {
+    mockGetCachedDiscogsUnavailableFlags.mockResolvedValueOnce({
+      discogsUnavailable: false,
+      discogsUnavailableNote: null,
+      lastDiscogsRecheckAt: null,
+    });
+
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    updateCb(flowsheetUpdate({ album_id: 501 }));
+
+    await flushAsync();
+
+    const [, frame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    expect(frame.payload).toHaveProperty('discogsUnavailable', false);
+    expect(frame.payload).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('a null album_id never calls the cache and stays on the synchronous path (AC #3)', () => {
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    updateCb(flowsheetUpdate()); // default fixture carries no album_id
+
+    // No await/flush at all: if this were routed onto the async enrich path,
+    // the broadcast would not yet have fired synchronously here.
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
+    expect(mockGetCachedDiscogsUnavailableFlags).not.toHaveBeenCalled();
+    const [, frame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    expect(frame.payload).not.toHaveProperty('discogsUnavailable');
+    expect(frame.payload).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('a rejected cache lookup degrades to omitting the fields — broadcast still fires, no Sentry trip', async () => {
+    mockGetCachedDiscogsUnavailableFlags.mockRejectedValueOnce(new Error('db blip'));
+
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    updateCb(flowsheetUpdate({ album_id: 501 }));
+
+    await flushAsync();
+
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
+    const [, frame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    expect(frame.payload).not.toHaveProperty('discogsUnavailable');
+    expect(frame.payload).not.toHaveProperty('discogsUnavailableNote');
+    // The additive-failure catch is INNER and swallowing — it must not trip
+    // the broadcast-level Sentry capture, which stays scoped to genuine
+    // serverEventsMgr.broadcast failures.
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('the same per-path Sentry extra shape (id + metadata_status) still fires on a broadcast failure with album_id present', async () => {
+    mockGetCachedDiscogsUnavailableFlags.mockResolvedValueOnce({
+      discogsUnavailable: true,
+      discogsUnavailableNote: null,
+      lastDiscogsRecheckAt: null,
+    });
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    updateCb(flowsheetUpdate({ album_id: 501 }));
+
+    await flushAsync();
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    const [, context] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(context).toMatchObject({
+      tags: expect.objectContaining({ module: 'metadata-broadcast' }),
+      extra: expect.objectContaining({ id: 42, metadata_status: 'enriched_match' }),
+    });
+  });
+
+  it('insert then update for the same cold album_id broadcast in insert-before-update order (coalesced shared promise)', async () => {
+    // Every call to the (mocked) cache returns the SAME pending promise —
+    // the faithful stand-in for the real cache module's in-flight
+    // coalescing (both the insert and update handler await the identical
+    // promise). Both handlers register their `await` in call order, so
+    // resolving the shared promise resumes them FIFO: insert broadcasts
+    // before update.
+    let resolveShared!: (value: unknown) => void;
+    const sharedPromise = new Promise((resolve) => {
+      resolveShared = resolve;
+    });
+    mockGetCachedDiscogsUnavailableFlags.mockReturnValue(sharedPromise);
+
+    setupMetadataBroadcast();
+    const updateCb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    const insertCb = (onCdcEvent as jest.Mock).mock.calls[1][0] as (event: CdcEvent) => void;
+
+    insertCb(flowsheetInsert({ id: 501, album_id: 501 }));
+    updateCb(flowsheetUpdate({ id: 501, album_id: 501 }));
+
+    resolveShared({ discogsUnavailable: true, discogsUnavailableNote: null, lastDiscogsRecheckAt: null });
+    await flushAsync();
+
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(2);
+    const [, firstFrame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[0];
+    const [, secondFrame] = (serverEventsMgr.broadcast as jest.Mock).mock.calls[1];
+    expect(firstFrame.type).toBe('insert');
+    expect(secondFrame.type).toBe('update');
+  });
+});
+
+describe('setupMetadataBroadcast library-CDC cache invalidation (BS#1962)', () => {
+  // The third onCdcEvent registration invalidates the discogs-unavailable cache
+  // off the same CDC stream, so a `library` flag flip is dropped from every BS
+  // instance's cache (not just the one that served the PATCH). Registered LAST,
+  // so `mock.calls[2]` is this handler and the update/insert indices above are
+  // unchanged.
+  const libraryCb = (): ((event: CdcEvent) => void) => {
+    setupMetadataBroadcast();
+    return (onCdcEvent as jest.Mock).mock.calls[2][0] as (event: CdcEvent) => void;
+  };
+
+  const libraryEvent = (overrides: Partial<CdcEvent> = {}): CdcEvent => ({
+    table: 'library',
+    schema: 'wxyc_schema',
+    action: 'UPDATE',
+    data: { id: 42, discogs_unavailable: true },
+    timestamp: 1779856000000,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('invalidates the cache for the library row id on a library UPDATE', () => {
+    libraryCb()(libraryEvent({ action: 'UPDATE' }));
+    expect(mockInvalidateDiscogsUnavailableFlags).toHaveBeenCalledWith(42);
+    expect(mockInvalidateDiscogsUnavailableFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the cache for the library row id on a library DELETE', () => {
+    libraryCb()(libraryEvent({ action: 'DELETE', data: { id: 7 } }));
+    expect(mockInvalidateDiscogsUnavailableFlags).toHaveBeenCalledWith(7);
+  });
+
+  it('does NOT invalidate on a library INSERT (a fresh serial id can not be cached yet)', () => {
+    libraryCb()(libraryEvent({ action: 'INSERT' }));
+    expect(mockInvalidateDiscogsUnavailableFlags).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-library tables', () => {
+    libraryCb()(libraryEvent({ table: 'flowsheet' }));
+    expect(mockInvalidateDiscogsUnavailableFlags).not.toHaveBeenCalled();
+  });
+
+  it('skips an event whose data is missing or carries a non-numeric id', () => {
+    const cb = libraryCb();
+    cb(libraryEvent({ data: null }));
+    cb(libraryEvent({ data: { id: 'forty-two' } }));
+    cb(libraryEvent({ data: {} }));
+    expect(mockInvalidateDiscogsUnavailableFlags).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/apps/backend/services/metadata-broadcast/discogs-unavailable-cache.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast/discogs-unavailable-cache.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for the BS#1962 discogs-unavailable SSE-feeder cache
+ * (`discogs-unavailable-cache.ts`): an LRU + in-flight-promise-coalescing
+ * wrapper over `library.service.getDiscogsUnavailableFlagsById`, plus a
+ * targeted `invalidateDiscogsUnavailableFlags` for the interactive
+ * `PATCH /library/{id}` flip.
+ *
+ * Pins the "no unbounded per-broadcast query" acceptance criterion: two
+ * concurrent lookups for the same album_id must collapse to one underlying
+ * DB read (in-flight coalescing), and a resolved value is served from cache
+ * on a subsequent call without re-hitting the DB. A rejected underlying read
+ * must never be cached (so a transient DB blip is retried on the next call,
+ * not pinned as a false negative for the rest of the TTL).
+ */
+
+import { jest } from '@jest/globals';
+
+const mockGetDiscogsUnavailableFlagsById = jest.fn<() => Promise<unknown>>();
+
+jest.mock('../../../../../../apps/backend/services/library.service', () => ({
+  getDiscogsUnavailableFlagsById: mockGetDiscogsUnavailableFlagsById,
+}));
+
+import {
+  getCachedDiscogsUnavailableFlags,
+  invalidateDiscogsUnavailableFlags,
+  __resetDiscogsUnavailableCacheForTests,
+} from '../../../../../../apps/backend/services/metadata-broadcast/discogs-unavailable-cache';
+
+const FLAGS_SET = {
+  discogsUnavailable: true,
+  discogsUnavailableNote: 'Embargoed promo pressing',
+  lastDiscogsRecheckAt: null,
+};
+const FLAGS_UNSET = { discogsUnavailable: false, discogsUnavailableNote: null, lastDiscogsRecheckAt: null };
+
+describe('getCachedDiscogsUnavailableFlags (BS#1962)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetDiscogsUnavailableCacheForTests();
+  });
+
+  it('returns the underlying result on a cache miss', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET);
+
+    const result = await getCachedDiscogsUnavailableFlags(501);
+
+    expect(result).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledWith(501);
+  });
+
+  it('serves a warm cache hit without re-reading the DB', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET);
+
+    await getCachedDiscogsUnavailableFlags(501);
+    const second = await getCachedDiscogsUnavailableFlags(501);
+
+    expect(second).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+  });
+
+  it('negative-caches an undefined result (no library row) — one read, cached', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(undefined);
+
+    const first = await getCachedDiscogsUnavailableFlags(999);
+    const second = await getCachedDiscogsUnavailableFlags(999);
+
+    expect(first).toBeUndefined();
+    expect(second).toBeUndefined();
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces two concurrent lookups for the same album_id into one DB read', async () => {
+    let resolveRead!: (value: unknown) => void;
+    mockGetDiscogsUnavailableFlagsById.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        })
+    );
+
+    const p1 = getCachedDiscogsUnavailableFlags(501);
+    const p2 = getCachedDiscogsUnavailableFlags(501);
+
+    // Both calls in flight; only one underlying read should have started.
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+
+    resolveRead(FLAGS_UNSET);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toEqual(FLAGS_UNSET);
+    expect(r2).toEqual(FLAGS_UNSET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a rejected underlying read — a later call retries', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockRejectedValueOnce(new Error('db blip'));
+
+    await expect(getCachedDiscogsUnavailableFlags(501)).rejects.toThrow('db blip');
+
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET);
+    const result = await getCachedDiscogsUnavailableFlags(501);
+
+    expect(result).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps independent album_ids on independent cache entries', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET).mockResolvedValueOnce(FLAGS_UNSET);
+
+    const a = await getCachedDiscogsUnavailableFlags(501);
+    const b = await getCachedDiscogsUnavailableFlags(502);
+
+    expect(a).toEqual(FLAGS_SET);
+    expect(b).toEqual(FLAGS_UNSET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('invalidateDiscogsUnavailableFlags (BS#1962)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetDiscogsUnavailableCacheForTests();
+  });
+
+  it('forces a fresh read on the next call after invalidation (interactive-flip flip-lag closure)', async () => {
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_UNSET);
+    const before = await getCachedDiscogsUnavailableFlags(501);
+    expect(before).toEqual(FLAGS_UNSET);
+
+    invalidateDiscogsUnavailableFlags(501);
+
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET);
+    const after = await getCachedDiscogsUnavailableFlags(501);
+
+    expect(after).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a safe no-op on an album_id that was never cached', () => {
+    expect(() => invalidateDiscogsUnavailableFlags(123456)).not.toThrow();
+  });
+
+  it('does not re-pin a stale value when invalidated mid-flight (F1 TOCTOU)', async () => {
+    // A cold read is in flight, observing the pre-flip UNSET snapshot.
+    let resolveRead!: (value: unknown) => void;
+    mockGetDiscogsUnavailableFlagsById.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        })
+    );
+    const p1 = getCachedDiscogsUnavailableFlags(501);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+
+    // An MD's PATCH /library flips the flag and invalidates *before* the
+    // in-flight read resolves.
+    invalidateDiscogsUnavailableFlags(501);
+
+    // The in-flight read now settles with the stale (pre-flip) value.
+    resolveRead(FLAGS_UNSET);
+    await p1;
+
+    // That stale value must NOT have been pinned into the cache: the next
+    // call re-queries and observes the fresh flagged value, rather than
+    // serving the stale `false` for the rest of the TTL window.
+    mockGetDiscogsUnavailableFlagsById.mockResolvedValueOnce(FLAGS_SET);
+    const after = await getCachedDiscogsUnavailableFlags(501);
+
+    expect(after).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+  });
+
+  it('an invalidation of one album_id does not suppress caching of an unrelated in-flight read', async () => {
+    // Poisoning is per-album_id (not a shared counter): invalidating album 501
+    // must not stop album 502's concurrently-in-flight read from caching its
+    // fresh result — otherwise every interactive flip would bust caching for
+    // whatever unrelated reads happened to be in flight, defeating the LRU
+    // during exactly the backfill burst it exists to protect.
+    let resolveB!: (value: unknown) => void;
+    mockGetDiscogsUnavailableFlagsById.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveB = resolve;
+        })
+    );
+    const pB = getCachedDiscogsUnavailableFlags(502); // album 502 read in flight
+
+    // An interactive flip invalidates a DIFFERENT album.
+    invalidateDiscogsUnavailableFlags(501);
+
+    // 502 resolves fresh — it must still be cached despite the 501 invalidation.
+    resolveB(FLAGS_SET);
+    await pB;
+
+    const second = await getCachedDiscogsUnavailableFlags(502);
+    expect(second).toEqual(FLAGS_SET);
+    // Cached → no second read for 502.
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(1);
+  });
+
+  it('a settling read does not evict a newer in-flight read for the same album_id', async () => {
+    // Regression for the in-flight-map clobber: after an invalidate drops R1's
+    // slot and R2 registers a fresh read under the same id, R1's `.finally`
+    // must NOT delete R2's slot — otherwise a later caller misses the in-flight
+    // entry and issues a THIRD redundant DB read, defeating coalescing.
+    let resolveR1!: (value: unknown) => void;
+    let resolveR2!: (value: unknown) => void;
+    mockGetDiscogsUnavailableFlagsById
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveR1 = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveR2 = resolve;
+          })
+      );
+
+    const p1 = getCachedDiscogsUnavailableFlags(501); // R1 in flight
+    invalidateDiscogsUnavailableFlags(501); // drop + poison R1
+    const p2 = getCachedDiscogsUnavailableFlags(501); // R2 starts (2nd read)
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+
+    // R1 settles; its `.finally` must leave R2's slot in place (identity guard).
+    resolveR1(FLAGS_UNSET);
+    await p1;
+
+    // A third caller must coalesce onto R2, NOT start a third read.
+    const p3 = getCachedDiscogsUnavailableFlags(501);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+
+    resolveR2(FLAGS_SET);
+    const [r2, r3] = await Promise.all([p2, p3]);
+    expect(r2).toEqual(FLAGS_SET);
+    expect(r3).toEqual(FLAGS_SET);
+    expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/controllers/flowsheet.sendProjectedEntry.test.ts
+++ b/tests/unit/controllers/flowsheet.sendProjectedEntry.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for BS#1962: the single-row mutation-echo feeder
+ * (`sendProjectedEntry` in `flowsheet.controller.ts`) enriching the
+ * client-facing projection with `discogsUnavailable` /
+ * `discogsUnavailableNote`, for parity with the SSE feeder
+ * (`metadata-broadcast.ts`, tested separately) and the paginated read
+ * path's `transformToV2` (#1908).
+ *
+ * A dedicated file (rather than extending the large existing
+ * `flowsheet.controller.test.ts`) per the BS#1962 plan's stated option —
+ * keeps the `library.service` mock scoped to exactly the tests that need it.
+ *
+ * Exercises `addEntry` (the library-hit branch, which is the sole `addEntry`
+ * branch that ever carries a non-null `album_id` into `sendProjectedEntry`),
+ * `deleteEntry`, and `updateEntry` directly against the real controller
+ * exports — `flowsheet.service` and `library.service` are mocked, and
+ * `flowsheet-projection`'s allow-list projector runs for real so the
+ * assertions observe the actual wire payload (matching the sibling
+ * `flowsheet.controller.test.ts` convention).
+ */
+
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+
+const mockCaptureException = jest.fn();
+const mockCaptureMessage = jest.fn();
+jest.mock('@sentry/node', () => ({ captureException: mockCaptureException, captureMessage: mockCaptureMessage }));
+
+const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
+const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
+const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockRemoveTrack = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockUpdateEntry = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: mockGetLatestShow,
+  resolveDjNameForShow: mockResolveDjNameForShow,
+  getAlbumFromDB: mockGetAlbumFromDB,
+  addTrack: mockAddTrack,
+  removeTrack: mockRemoveTrack,
+  updateEntry: mockUpdateEntry,
+}));
+
+const mockGetDiscogsUnavailableFlagsById = jest.fn<() => Promise<unknown>>();
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  getDiscogsUnavailableFlagsById: mockGetDiscogsUnavailableFlagsById,
+}));
+
+// flowsheet-projection is intentionally NOT mocked — these tests observe the
+// real client-facing allow-list projection (BS#1513), same convention as
+// flowsheet.controller.test.ts.
+
+import { addEntry, deleteEntry, updateEntry } from '../../../apps/backend/controllers/flowsheet.controller';
+
+const createMockRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.locals = {} as Response['locals'];
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res as Response;
+};
+
+const FLAGS_SET = {
+  discogsUnavailable: true,
+  discogsUnavailableNote: 'Embargoed promo pressing',
+  lastDiscogsRecheckAt: null,
+};
+const FLAGS_UNSET = { discogsUnavailable: false, discogsUnavailableNote: null, lastDiscogsRecheckAt: null };
+
+const makeFsEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  show_id: 100,
+  album_id: null,
+  rotation_id: null,
+  entry_type: 'track',
+  artist_name: 'Chuquimamani-Condori',
+  album_title: 'Edits',
+  track_title: 'Call Your Name',
+  track_position: null,
+  record_label: 'self-released',
+  label_id: null,
+  play_order: 1,
+  request_flag: false,
+  segue: false,
+  message: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  radio_hour: null,
+  dj_name: null,
+  metadata_status: 'enriched_match',
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  ...overrides,
+});
+
+describe('sendProjectedEntry discogs-unavailable enrichment (BS#1962)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLatestShow.mockResolvedValue({ id: 100, end_time: null });
+    mockResolveDjNameForShow.mockResolvedValue(null);
+  });
+
+  describe('addEntry (library-hit branch)', () => {
+    it('flagged library-linked track: response carries discogsUnavailable + note', async () => {
+      mockGetAlbumFromDB.mockResolvedValue({
+        artist_name: 'Duke Ellington',
+        album_title: 'Duke Ellington & John Coltrane',
+        record_label: 'Impulse Records',
+      });
+      mockAddTrack.mockResolvedValue(makeFsEntry({ album_id: 501 }));
+      mockGetDiscogsUnavailableFlagsById.mockResolvedValue(FLAGS_SET);
+
+      const req = { body: { album_id: 501, track_title: 'In a Sentimental Mood' } } as unknown as Request;
+      const res = createMockRes();
+
+      await addEntry(req, res, jest.fn());
+
+      expect(mockGetDiscogsUnavailableFlagsById).toHaveBeenCalledWith(501);
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body.discogsUnavailable).toBe(true);
+      expect(body.discogsUnavailableNote).toBe('Embargoed promo pressing');
+    });
+
+    it('linked-unflagged track: response carries discogsUnavailable: false (present, not omitted)', async () => {
+      mockGetAlbumFromDB.mockResolvedValue({
+        artist_name: 'Duke Ellington',
+        album_title: 'Duke Ellington & John Coltrane',
+        record_label: 'Impulse Records',
+      });
+      mockAddTrack.mockResolvedValue(makeFsEntry({ album_id: 501 }));
+      mockGetDiscogsUnavailableFlagsById.mockResolvedValue(FLAGS_UNSET);
+
+      const req = { body: { album_id: 501, track_title: 'In a Sentimental Mood' } } as unknown as Request;
+      const res = createMockRes();
+
+      await addEntry(req, res, jest.fn());
+
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body).toHaveProperty('discogsUnavailable', false);
+      expect(body).not.toHaveProperty('discogsUnavailableNote');
+    });
+
+    it('album_id null (free-text entry): response omits the field, no lookup performed', async () => {
+      mockAddTrack.mockResolvedValue(makeFsEntry({ album_id: null }));
+
+      const req = {
+        body: {
+          artist_name: 'Jessica Pratt',
+          album_title: 'On Your Own Love Again',
+          track_title: 'Back, Baby',
+          record_label: 'Drag City',
+        },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await addEntry(req, res, jest.fn());
+
+      expect(mockGetDiscogsUnavailableFlagsById).not.toHaveBeenCalled();
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('discogsUnavailable');
+      expect(body).not.toHaveProperty('discogsUnavailableNote');
+    });
+
+    it('a lookup failure degrades to omitting the field — response still 201 with the projected row', async () => {
+      mockGetAlbumFromDB.mockResolvedValue({
+        artist_name: 'Duke Ellington',
+        album_title: 'Duke Ellington & John Coltrane',
+        record_label: 'Impulse Records',
+      });
+      mockAddTrack.mockResolvedValue(makeFsEntry({ album_id: 501 }));
+      mockGetDiscogsUnavailableFlagsById.mockRejectedValue(new Error('db blip'));
+
+      const req = { body: { album_id: 501, track_title: 'In a Sentimental Mood' } } as unknown as Request;
+      const res = createMockRes();
+
+      await addEntry(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('discogsUnavailable');
+      expect(body).not.toHaveProperty('discogsUnavailableNote');
+      expect(body.id).toBe(1);
+    });
+  });
+
+  describe('deleteEntry', () => {
+    it('flagged library-linked track: echo carries the flag', async () => {
+      mockRemoveTrack.mockResolvedValue(makeFsEntry({ album_id: 501 }));
+      mockGetDiscogsUnavailableFlagsById.mockResolvedValue(FLAGS_SET);
+
+      const req = { body: { entry_id: 1 } } as unknown as Request;
+      const res = createMockRes();
+
+      await deleteEntry(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body.discogsUnavailable).toBe(true);
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('flagged library-linked track: echo carries the flag', async () => {
+      mockUpdateEntry.mockResolvedValue(makeFsEntry({ album_id: 501 }));
+      mockGetDiscogsUnavailableFlagsById.mockResolvedValue(FLAGS_SET);
+
+      const req = { body: { entry_id: 1, data: { track_title: 'Renamed' } } } as unknown as Request;
+      const res = createMockRes();
+
+      await updateEntry(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body.discogsUnavailable).toBe(true);
+      expect(body.discogsUnavailableNote).toBe('Embargoed promo pressing');
+    });
+
+    it('unlinked entry: echo omits the field, no lookup performed', async () => {
+      mockUpdateEntry.mockResolvedValue(makeFsEntry({ album_id: null }));
+
+      const req = { body: { entry_id: 1, data: { track_title: 'Renamed' } } } as unknown as Request;
+      const res = createMockRes();
+
+      await updateEntry(req, res, jest.fn());
+
+      expect(mockGetDiscogsUnavailableFlagsById).not.toHaveBeenCalled();
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('discogsUnavailable');
+    });
+  });
+});

--- a/tests/unit/utils/flowsheet-projection.test.ts
+++ b/tests/unit/utils/flowsheet-projection.test.ts
@@ -1,9 +1,11 @@
 import {
   projectFlowsheetEntry,
   pickClientFacingColumns,
+  toDiscogsUnavailableWireFields,
   CLIENT_FACING_FLOWSHEET_COLUMNS,
 } from '../../../apps/backend/utils/flowsheet-projection';
 import { INTERNAL_FLOWSHEET_COLUMNS, makeFullFlowsheetRow } from '../../fixtures/flowsheet-row.fixture';
+import type { DiscogsUnavailableFlags } from '../../../apps/backend/services/library.service';
 
 /**
  * BS#1513. The mutation (`addEntry`/`deleteEntry`/`updateEntry`/`changeOrder`)
@@ -193,5 +195,64 @@ describe('pickClientFacingColumns (BS#1534)', () => {
       expect(picked).not.toHaveProperty('spotify_url');
       expect(picked).not.toHaveProperty('apple_music_url');
     });
+  });
+});
+
+describe('toDiscogsUnavailableWireFields (BS#1962)', () => {
+  // Mirrors #1908's flowsheet.discogsUnavailable.test.ts wire-shape cases —
+  // this is the single point where the SSE feeder and the mutation-echo
+  // feeder share the present-or-absent camelCase semantics with the V2 read
+  // path's transformToV2.
+
+  it('undefined (no album_id, or album_id misses in library) -> {} (both absent)', () => {
+    const result = toDiscogsUnavailableWireFields(undefined);
+    expect(result).toEqual({});
+    expect(result).not.toHaveProperty('discogsUnavailable');
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('resolved row with the flag UNSET -> discogsUnavailable: false present, note absent', () => {
+    const flags: DiscogsUnavailableFlags = {
+      discogsUnavailable: false,
+      discogsUnavailableNote: null,
+      lastDiscogsRecheckAt: null,
+    };
+    const result = toDiscogsUnavailableWireFields(flags);
+    expect(result).toEqual({ discogsUnavailable: false });
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('resolved row with the flag SET + a note -> both fields present', () => {
+    const flags: DiscogsUnavailableFlags = {
+      discogsUnavailable: true,
+      discogsUnavailableNote: 'Embargoed promo pressing',
+      lastDiscogsRecheckAt: null,
+    };
+    const result = toDiscogsUnavailableWireFields(flags);
+    expect(result).toEqual({
+      discogsUnavailable: true,
+      discogsUnavailableNote: 'Embargoed promo pressing',
+    });
+  });
+
+  it('resolved row with the flag SET but no note -> only discogsUnavailable present', () => {
+    const flags: DiscogsUnavailableFlags = {
+      discogsUnavailable: true,
+      discogsUnavailableNote: null,
+      lastDiscogsRecheckAt: null,
+    };
+    const result = toDiscogsUnavailableWireFields(flags);
+    expect(result).toEqual({ discogsUnavailable: true });
+    expect(result).not.toHaveProperty('discogsUnavailableNote');
+  });
+
+  it('never emits lastDiscogsRecheckAt — that rides the proxy album-detail surface only', () => {
+    const flags: DiscogsUnavailableFlags = {
+      discogsUnavailable: true,
+      discogsUnavailableNote: 'note',
+      lastDiscogsRecheckAt: new Date('2026-07-01T00:00:00Z'),
+    };
+    const result = toDiscogsUnavailableWireFields(flags);
+    expect(result).not.toHaveProperty('lastDiscogsRecheckAt');
   });
 });


### PR DESCRIPTION
## Summary

Extends the `discogsUnavailable` (+ `discogsUnavailableNote`) flag from the paginated read path (#1908 / #1961) to the two flowsheet surfaces that were missing it: the SSE realtime broadcasts (`liveFs:update` / `liveFs:insert`) and the single-row mutation echoes (add / update / delete / reorder). A client can now render the "Not on Discogs" gate from any payload source without waiting for the next 60 s poll.

Both surfaces project a raw `flowsheet` row through the default-closed `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list (#1513), which can't carry the `library`-sourced flag. Rather than widen the allow-list into a join (forbidden by #1513), a single shared pure mapper `toDiscogsUnavailableWireFields` merges the present-or-absent camelCase fields alongside the projected snake_case row — the one place the present-or-absent semantics live, so the two feeders can't drift from each other or from the read path.

## Design

- **Shared mapper** (`apps/backend/utils/flowsheet-projection.ts`): `undefined` (no `album_id`, or `album_id` misses `library`) → `{}` (both absent); a resolved row → `discogsUnavailable` always (true *or* false, mirroring #1908's `!== null` gate), plus `discogsUnavailableNote` only when non-null. The allow-list projectors are untouched.
- **Mutation echo** (`flowsheet.controller.ts`): `sendProjectedEntry` is now `async` and does one direct `getDiscogsUnavailableFlagsById(album_id)` read for library-linked rows (single-row, DJ-paced — freshest-wins, no cache). Additive-failure `try/catch` → `console.warn`: a DB blip omits the field, never 500s the mutation. `album_id IS NULL` rows skip the lookup. All 7 call sites are `await`ed. `changeOrder` performs that read **after** releasing `orderMutex`, so the extra round-trip stays out of the reorder critical section.
- **SSE feeder** (`metadata-broadcast.ts` + `metadata-broadcast/discogs-unavailable-cache.ts`): the filters stay pure/sync (that testability seam is load-bearing). Enrichment happens in the `onCdcEvent` handlers, guarded behind a non-null `album_id` so the null path stays fully synchronous. Non-null rows run a fire-and-forget `void (async () => {…})()` backed by a bounded `LRUCache` (max 2000, ttl 60 s) + in-flight-promise coalescing — one read per distinct `album_id` per TTL window, so a `flowsheet-metadata-backfill` burst can't issue an unbounded per-broadcast query.
- **CDC-driven cache invalidation**: a resolved `false`/`undefined` is cached, so a `discogs_unavailable` flip could otherwise sit behind the 60 s TTL. Invalidation is driven off the **`cdc_library`** CDC stream the broadcasts already consume — `setupMetadataBroadcast` registers a third `onCdcEvent` handler that invalidates on every `library` UPDATE/DELETE. Because that NOTIFY reaches **every** BS instance's LISTEN connection, the flipped album is dropped from *every* instance's cache within one CDC round-trip (a write-path poke would only reach the one instance that served the PATCH). An interactive `PATCH /library/{id}`'s own UPDATE therefore self-invalidates on all instances, so `library.controller.ts` needs no cross-module poke.
- **Invalidate-vs-in-flight TOCTOU**: each in-flight read carries a **per-`album_id` `poisoned` flag**; `invalidate` sets it and the read's `.then` skips the cache write when poisoned (a shared counter would let one album's flip suppress unrelated reads' caching). The in-flight map is cleared under an identity guard so a settling read never evicts a newer read that replaced it.

## Contract

No `api.yaml` change, no `@wxyc/shared` bump, no migration. `FlowsheetEntryResponse.discogsUnavailable` / `discogsUnavailableNote` are already published in the v3.2.0 SSOT (not `required`), and both `LiveFsUpdateEvent.payload` / `LiveFsInsertEvent.payload` `$ref` it — these emits are additive and within contract, exactly as #1908 was.

## Acceptance criteria

- [x] Flagged, library-linked track via SSE `liveFs:update` / `liveFs:insert` carries `discogsUnavailable: true` (+ note when set).
- [x] Single-row mutation echo (add / update / reorder / delete) for a flagged library-linked track carries the flag.
- [x] Non-library rows (`album_id IS NULL`) omit the field on all paths, as on the read path.
- [x] No unbounded per-broadcast query on the SSE hot path (LRU + in-flight coalescing → ≤1 read per `album_id` per TTL window).
- [x] An interactive flag flip is visible on the next broadcast **on every instance** (CDC-driven invalidation), not lagging the 60 s TTL.
- [x] Unit coverage over the projection for both paths (flagged / unflagged / non-library).

## Testing

- **Unit:** pure mapper; cache (miss/hit, negative-cache, coalescing, no-cache-on-rejection, per-id independence, invalidate-then-refetch, the invalidate-vs-in-flight poison guard, cross-album isolation, and the settling-read-doesn't-evict-a-newer-read regression); SSE feeder (flagged / unflagged / null-`album_id` / lookup-throws / coalescing / insert-before-update ordering, per-path Sentry `extra` intact, and the library-CDC invalidation handler: UPDATE/DELETE invalidate, INSERT/non-library/bad-id skip); mutation echo (flagged / unflagged / absent / additive-failure). Full unit suite green (400 suites / 6222 tests).
- **Integration:** `tests/integration/flowsheet.spec.js` mutation-echo cases (seeded flagged album carries the flag; unlinked/free-text omits; linked-unflagged emits `false`).

## Notes

- The SSE feeder is covered by unit tests (including the coalescing/ordering guarantees against a controlled shared promise); an end-to-end `events.spec.js` CDC→broadcast round-trip was scoped out — building a timing-sensitive greenfield harness for a `sev:low` additive field was judged not worth the flake risk.
- **Review revisions (this branch):** invalidation moved from a process-local `library.controller.ts` call to the CDC stream so it holds across instances; the monotonic generation counter was replaced with a per-`album_id` poison flag (no cross-album suppression, no unbounded bookkeeping) and an identity-guarded in-flight cleanup (no coalescing clobber); `changeOrder`'s enrichment read moved outside `orderMutex`.

Closes #1962
