### PR TITLE
feat(library): compilation-track (CTA) write path (BS#1964)

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -1059,6 +1059,12 @@ const CTA_ARTIST_NAME_MAX = 255;
 const CTA_TRACK_TITLE_MAX = 255;
 const CTA_TRACK_POSITION_MAX = 20;
 
+// Upper bound on tracks per additive write. A real V/A tracklist is well under
+// this (Discogs box sets top out in the low hundreds); the cap keeps a single
+// request from building an unbounded multi-row INSERT. Reject as 400 rather
+// than truncating, so the client sees that its list was too large.
+const CTA_MAX_TRACKS = 500;
+
 /** Normalize an optional nullable free-text field: absent/blank/whitespace → null. */
 const normalizeOptionalCtaText = (v: unknown): string | null => {
   if (typeof v !== 'string') return null;
@@ -1074,11 +1080,15 @@ type CompilationTrackValidationResult =
  * unit-testable without a DB). `artist_name` is required and non-blank
  * (api.yaml `minLength: 1`); `track_title` / `track_position` are optional and
  * nullable, with blank/whitespace coerced to null so the `track_title IS NULL`
- * partial unique index behaves. All three are length-capped to their columns.
+ * partial unique index behaves. All three are length-capped to their columns,
+ * and the list itself is capped at `CTA_MAX_TRACKS` entries.
  */
 export function validateCompilationTracksBody(body: CompilationTracksWriteBody): CompilationTrackValidationResult {
   if (!body || !Array.isArray(body.tracks) || body.tracks.length === 0) {
     return { ok: false, message: 'tracks must be a non-empty array' };
+  }
+  if (body.tracks.length > CTA_MAX_TRACKS) {
+    return { ok: false, message: `tracks must not exceed ${CTA_MAX_TRACKS} entries` };
   }
   const tracks: libraryService.CompilationTrackInputRow[] = [];
   for (let i = 0; i < body.tracks.length; i++) {

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -1029,6 +1029,138 @@ export const manualDiscogsRecheck: RequestHandler<{ id: string }> = async (req, 
 };
 
 // ---------------------------------------------------------------------------
+// Compilation-track (CTA) write path — BS#1964 / Phase 3.5 `/wxycdb` cutover.
+//
+// Backs api.yaml v1.28.0 (WXYC/wxyc-shared#291): GET lists a release's stored
+// V/A per-track artists, POST additively writes an explicit client-confirmed
+// list, and GET .../discogs-suggestions returns a release's tracklist as
+// write-ready rows without writing. The `{id}` path param is the serial
+// `library.id` (like the sibling `/library/:id` PATCH/missing/found routes),
+// resolved to a Discogs release via `library_identity` for the suggestions
+// read. BS keeps LOCAL wire types here (mirroring `NewAlbumRequest` /
+// `UpdateAlbumRequest`) rather than importing `@wxyc/shared`, so this surface
+// ships without a shared publish. Service logic: `library.service.ts`.
+// ---------------------------------------------------------------------------
+
+type CompilationTrackInputWire = {
+  artist_name?: unknown;
+  track_title?: unknown;
+  track_position?: unknown;
+};
+
+type CompilationTracksWriteBody = {
+  tracks?: CompilationTrackInputWire[];
+};
+
+// Column caps from `compilation_track_artist` (schema.ts): reject over-length
+// input as a 400 rather than letting it reach the INSERT and trip PG 22001
+// ("value too long") → 500. Mirrors `updateAlbum`'s `MAX_ALBUM_TEXT_LENGTH`.
+const CTA_ARTIST_NAME_MAX = 255;
+const CTA_TRACK_TITLE_MAX = 255;
+const CTA_TRACK_POSITION_MAX = 20;
+
+/** Normalize an optional nullable free-text field: absent/blank/whitespace → null. */
+const normalizeOptionalCtaText = (v: unknown): string | null => {
+  if (typeof v !== 'string') return null;
+  const trimmed = v.trim();
+  return trimmed === '' ? null : trimmed;
+};
+
+type CompilationTrackValidationResult =
+  { ok: true; tracks: libraryService.CompilationTrackInputRow[] } | { ok: false; message: string };
+
+/**
+ * Validate + normalize a `CompilationTracksWriteRequest` body (pure, so it's
+ * unit-testable without a DB). `artist_name` is required and non-blank
+ * (api.yaml `minLength: 1`); `track_title` / `track_position` are optional and
+ * nullable, with blank/whitespace coerced to null so the `track_title IS NULL`
+ * partial unique index behaves. All three are length-capped to their columns.
+ */
+export function validateCompilationTracksBody(body: CompilationTracksWriteBody): CompilationTrackValidationResult {
+  if (!body || !Array.isArray(body.tracks) || body.tracks.length === 0) {
+    return { ok: false, message: 'tracks must be a non-empty array' };
+  }
+  const tracks: libraryService.CompilationTrackInputRow[] = [];
+  for (let i = 0; i < body.tracks.length; i++) {
+    const t = body.tracks[i];
+    if (t === null || typeof t !== 'object') {
+      return { ok: false, message: `tracks[${i}] must be an object` };
+    }
+    const artistRaw = t.artist_name;
+    if (typeof artistRaw !== 'string' || artistRaw.trim() === '') {
+      return { ok: false, message: `tracks[${i}].artist_name is required and must be a non-empty string` };
+    }
+    const artist_name = artistRaw.trim();
+    if (artist_name.length > CTA_ARTIST_NAME_MAX) {
+      return { ok: false, message: `tracks[${i}].artist_name exceeds ${CTA_ARTIST_NAME_MAX} characters` };
+    }
+    const track_title = normalizeOptionalCtaText(t.track_title);
+    if (track_title !== null && track_title.length > CTA_TRACK_TITLE_MAX) {
+      return { ok: false, message: `tracks[${i}].track_title exceeds ${CTA_TRACK_TITLE_MAX} characters` };
+    }
+    const track_position = normalizeOptionalCtaText(t.track_position);
+    if (track_position !== null && track_position.length > CTA_TRACK_POSITION_MAX) {
+      return { ok: false, message: `tracks[${i}].track_position exceeds ${CTA_TRACK_POSITION_MAX} characters` };
+    }
+    tracks.push({ artist_name, track_title, track_position });
+  }
+  return { ok: true, tracks };
+}
+
+/** GET /library/:id/compilation-tracks — list a release's stored CTA rows. */
+export const getCompilationTracks: RequestHandler<{ id: string }> = async (req, res) => {
+  const libraryId = parseAlbumId(req.params.id);
+  if (!(await libraryService.libraryRowExists(libraryId))) {
+    throw new WxycError('Library release not found', 404);
+  }
+  const tracks = await libraryService.getCompilationTracks(libraryId);
+  res.status(200).json({ library_id: libraryId, tracks });
+};
+
+/**
+ * POST /library/:id/compilation-tracks — additive write of an explicit,
+ * client-confirmed CTA list. Body is validated (400) before the library-row
+ * existence gate (404). Existing rows matched on the CTA uniqueness keys are
+ * skipped, never mutated (D6). Reports `inserted` vs `skipped` and returns the
+ * release's full stored set after the write.
+ */
+export const writeCompilationTracks: RequestHandler<{ id: string }, unknown, CompilationTracksWriteBody> = async (
+  req,
+  res
+) => {
+  const libraryId = parseAlbumId(req.params.id);
+  const validation = validateCompilationTracksBody(req.body);
+  if (!validation.ok) {
+    throw new WxycError(validation.message, 400);
+  }
+  if (!(await libraryService.libraryRowExists(libraryId))) {
+    throw new WxycError('Library release not found', 404);
+  }
+  const result = await libraryService.writeCompilationTracks(libraryId, validation.tracks);
+  res.status(200).json({
+    library_id: libraryId,
+    inserted: result.inserted,
+    skipped: result.skipped,
+    tracks: result.tracks,
+  });
+};
+
+/**
+ * GET /library/:id/compilation-tracks/discogs-suggestions — autopopulate
+ * source: the linked Discogs release's tracklist as write-ready
+ * `CompilationTrackInput` rows, without writing. `discogs_release_id: null` +
+ * empty `tracks` means "no upstream release resolved → manual entry".
+ */
+export const getCompilationTrackDiscogsSuggestions: RequestHandler<{ id: string }> = async (req, res) => {
+  const libraryId = parseAlbumId(req.params.id);
+  if (!(await libraryService.libraryRowExists(libraryId))) {
+    throw new WxycError('Library release not found', 404);
+  }
+  const { discogs_release_id, tracks } = await libraryService.getCompilationTrackSuggestions(libraryId);
+  res.status(200).json({ library_id: libraryId, discogs_release_id, tracks });
+};
+
+// ---------------------------------------------------------------------------
 // GET /library/query — query-builder search over the catalog
 // ---------------------------------------------------------------------------
 

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -126,3 +126,30 @@ library_route.post(
   requirePermissions({ catalog: ['write'] }),
   libraryController.manualDiscogsRecheck
 );
+
+// Compilation-track (CTA) write path — BS#1964 / Phase 3.5 `/wxycdb` cutover
+// (contract: wxyc-shared api.yaml v1.28.0, WXYC/wxyc-shared#291). Makes V/A
+// per-track artists writable so compilation track search survives the
+// tubafrenzy turndown. `{id}` is the serial `library.id` (like the sibling
+// `/:id` PATCH/missing/found routes). GET list is `catalog:read` (any DJ);
+// the additive POST and the Discogs-suggestions read are `catalog:write` (the
+// MD/SM librarian bar, matching addAlbum/updateAlbum). The two-segment
+// suggestions GET is registered before the one-segment list GET so it can't be
+// shadowed.
+library_route.get(
+  '/:id/compilation-tracks/discogs-suggestions',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.getCompilationTrackDiscogsSuggestions
+);
+
+library_route.get(
+  '/:id/compilation-tracks',
+  requirePermissions({ catalog: ['read'] }),
+  libraryController.getCompilationTracks
+);
+
+library_route.post(
+  '/:id/compilation-tracks',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.writeCompilationTracks
+);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1019,6 +1019,168 @@ export async function getRotationTracksFromRelease(releaseId: number): Promise<R
   return pending;
 }
 
+// ============================================================================
+// Compilation-track (CTA) write path — BS#1964 / Phase 3.5 `/wxycdb` cutover.
+//
+// `compilation_track_artist` (CTA) makes V/A per-track artists searchable, but
+// today rows arrive only via the insert-only `jobs/library-etl` MySQL mirror.
+// When `/wxycdb` goes dark that mirror stops; these functions back the api.yaml
+// v1.28.0 CTA write path (WXYC/wxyc-shared#291) so compilations added afterward
+// keep per-track artist search. The write is additive-only (the D6 decision —
+// the insert-only residue is never reconciled here) and Discogs-agnostic (it
+// carries only the durable free-text triple, so it survives the future
+// `library_track` rename, BS#801). HTTP surface: `library.controller.ts`.
+// ============================================================================
+
+/** A stored CTA row, projected onto the api.yaml `CompilationTrack` shape. */
+export interface CompilationTrackRow {
+  id: number;
+  artist_name: string;
+  track_title: string | null;
+  track_position: string | null;
+}
+
+/** A validated, write-ready CTA row (api.yaml `CompilationTrackInput`). */
+export interface CompilationTrackInputRow {
+  artist_name: string;
+  track_title: string | null;
+  track_position: string | null;
+}
+
+/** Outcome of an additive CTA write (api.yaml `CompilationTracksWriteResponse`). */
+export interface CompilationTracksWriteResult {
+  inserted: number;
+  skipped: number;
+  tracks: CompilationTrackRow[];
+}
+
+/**
+ * Does a `library` row exist for this serial id? Cheap existence probe for the
+ * CTA handlers' 404 gate. The CTA `{id}` path param is the serial `library.id`
+ * (like `/library/:id` PATCH/missing/found), not the legacy id.
+ */
+export async function libraryRowExists(libraryId: number): Promise<boolean> {
+  const rows = await db.select({ id: library.id }).from(library).where(eq(library.id, libraryId)).limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Serial-`library.id` twin of `getDiscogsReleaseIdByLegacyId` (BS#836). The CTA
+ * suggestions read keys on the serial id the dj-site edit surface holds (what
+ * `addAlbum` returns), so it reads `library_identity` directly by `library_id`
+ * rather than bridging through `library.legacy_release_id`. Returns null when
+ * the row has no `library_identity` entry or no resolved `discogs_release_id`.
+ */
+export async function getDiscogsReleaseIdByLibraryId(libraryId: number): Promise<number | null> {
+  const rows = await db
+    .select({ discogs_release_id: library_identity.discogs_release_id })
+    .from(library_identity)
+    .where(eq(library_identity.library_id, libraryId))
+    .limit(1);
+  return rows[0]?.discogs_release_id ?? null;
+}
+
+/** List a release's stored CTA rows, oldest first (stable insertion order). */
+export async function getCompilationTracks(libraryId: number): Promise<CompilationTrackRow[]> {
+  return db
+    .select({
+      id: compilation_track_artist.id,
+      artist_name: compilation_track_artist.artist_name,
+      track_title: compilation_track_artist.track_title,
+      track_position: compilation_track_artist.track_position,
+    })
+    .from(compilation_track_artist)
+    .where(eq(compilation_track_artist.library_id, libraryId))
+    .orderBy(asc(compilation_track_artist.id));
+}
+
+/**
+ * Additive CTA write. Every input row is inserted with an untargeted
+ * `ON CONFLICT DO NOTHING`, which arbiters on *both* CTA unique indexes
+ * (`cta_unique_idx` on `(library_id, artist_name, track_title)` and the
+ * `cta_unique_null_track_idx` partial covering `track_title IS NULL`). A row
+ * that duplicates one already stored — or one earlier in the same batch — is
+ * absorbed by the conflict clause and never lands, so `RETURNING` yields
+ * exactly the newly-inserted rows. `skipped` is therefore `input − inserted`,
+ * and the identity `inserted + skipped == input.length` holds even when the
+ * batch carries intra-request duplicates (api.yaml v1.28.0
+ * `CompilationTracksWriteResponse` semantics). Existing rows are never mutated
+ * — this path cannot replace or delete (the D6 boundary).
+ */
+export async function writeCompilationTracks(
+  libraryId: number,
+  inputs: CompilationTrackInputRow[]
+): Promise<CompilationTracksWriteResult> {
+  const values = inputs.map((t) => ({
+    library_id: libraryId,
+    artist_name: t.artist_name,
+    track_title: t.track_title,
+    track_position: t.track_position,
+  }));
+  const insertedRows = await db
+    .insert(compilation_track_artist)
+    .values(values)
+    .onConflictDoNothing()
+    .returning({ id: compilation_track_artist.id });
+  const tracks = await getCompilationTracks(libraryId);
+  return {
+    inserted: insertedRows.length,
+    skipped: inputs.length - insertedRows.length,
+    tracks,
+  };
+}
+
+/**
+ * Autopopulate source for the CTA edit surface: resolve the Discogs release
+ * linked to this library row and return its tracklist as write-ready
+ * `CompilationTrackInput` rows — *without writing*. This is the only
+ * Discogs-touching call in the CTA surface (a single `getRelease`, not the
+ * per-track N-validation fan-out that timed out in BS#1117); the client
+ * confirms/edits the rows and POSTs them back.
+ *
+ * Each track's per-track artist credit is flattened onto CTA's single
+ * `artist_name` free-text field via the same `projectInlineTracklist` used by
+ * the rotation-tracks picker (empty per-track `artists[]` falls back to the
+ * release-level artist — "Various" on a V/A comp — and multi-artist credits
+ * join on `', '`), so the two surfaces can't drift.
+ *
+ * `discogs_release_id: null` + empty `tracks` encodes "no upstream release
+ * resolved → manual entry". An LML 404 / `not_found` tombstone on an
+ * otherwise-resolved id degrades the same way (id echoed, empty tracks) rather
+ * than erroring, matching `getRotationTracksFromRelease`.
+ */
+export async function getCompilationTrackSuggestions(
+  libraryId: number
+): Promise<{ discogs_release_id: number | null; tracks: CompilationTrackInputRow[] }> {
+  const releaseId = await getDiscogsReleaseIdByLibraryId(libraryId);
+  if (releaseId === null) {
+    return { discogs_release_id: null, tracks: [] };
+  }
+
+  let release: DiscogsReleaseMetadata;
+  try {
+    release = await getRelease(releaseId);
+  } catch (err) {
+    if (err instanceof LmlClientError && err.statusCode === 404) {
+      return { discogs_release_id: releaseId, tracks: [] };
+    }
+    throw err;
+  }
+  if (release.not_found) {
+    return { discogs_release_id: releaseId, tracks: [] };
+  }
+
+  const projected = projectInlineTracklist(release.tracklist, release.artist) ?? [];
+  const tracks: CompilationTrackInputRow[] = projected.map((t) => ({
+    // `projectInlineTracklist` guarantees a non-empty `artists[]` (it seeds the
+    // release-artist fallback), so the join is always a real credit.
+    artist_name: t.artists.join(', '),
+    track_title: t.title,
+    track_position: t.position,
+  }));
+  return { discogs_release_id: releaseId, tracks };
+}
+
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {
   const response = await db.update(library).set({ on_streaming }).where(eq(library.id, id)).returning();
   return response[0];

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1138,16 +1138,19 @@ export async function writeCompilationTracks(
  * per-track N-validation fan-out that timed out in BS#1117); the client
  * confirms/edits the rows and POSTs them back.
  *
- * Each track's per-track artist credit is flattened onto CTA's single
- * `artist_name` free-text field via the same `projectInlineTracklist` used by
- * the rotation-tracks picker (empty per-track `artists[]` falls back to the
- * release-level artist — "Various" on a V/A comp — and multi-artist credits
- * join on `', '`), so the two surfaces can't drift.
+ * Delegates the release fetch to `getRotationTracksFromRelease`, so the CTA
+ * suggestions and rotation-tracks picker share one cached resolver: the
+ * per-release LRU + in-flight coalescing means a repeated suggestions read (or
+ * one racing a rotation-picker open on the same release) doesn't re-pay LML's
+ * 2-9 s cold release fetch, and the single `projectInlineTracklist` projection
+ * keeps the two surfaces from drifting. Each per-track artist credit flattens
+ * onto CTA's single `artist_name` free-text field (empty per-track `artists[]`
+ * falls back to the release-level artist — "Various" on a V/A comp — and
+ * multi-artist credits join on `', '`).
  *
  * `discogs_release_id: null` + empty `tracks` encodes "no upstream release
- * resolved → manual entry". An LML 404 / `not_found` tombstone on an
- * otherwise-resolved id degrades the same way (id echoed, empty tracks) rather
- * than erroring, matching `getRotationTracksFromRelease`.
+ * resolved → manual entry". A `null` from `getRotationTracksFromRelease` (LML
+ * 404 / absent tracklist) degrades the same way with the id echoed.
  */
 export async function getCompilationTrackSuggestions(
   libraryId: number
@@ -1157,20 +1160,7 @@ export async function getCompilationTrackSuggestions(
     return { discogs_release_id: null, tracks: [] };
   }
 
-  let release: DiscogsReleaseMetadata;
-  try {
-    release = await getRelease(releaseId);
-  } catch (err) {
-    if (err instanceof LmlClientError && err.statusCode === 404) {
-      return { discogs_release_id: releaseId, tracks: [] };
-    }
-    throw err;
-  }
-  if (release.not_found) {
-    return { discogs_release_id: releaseId, tracks: [] };
-  }
-
-  const projected = projectInlineTracklist(release.tracklist, release.artist) ?? [];
+  const projected = (await getRotationTracksFromRelease(releaseId)) ?? [];
   const tracks: CompilationTrackInputRow[] = projected.map((t) => ({
     // `projectInlineTracklist` guarantees a non-empty `artists[]` (it seeds the
     // release-artist fallback), so the join is always a real credit.

--- a/dev_env/mock-api-server/src/fixtures/lml.json
+++ b/dev_env/mock-api-server/src/fixtures/lml.json
@@ -112,6 +112,27 @@
     }
   },
   "releases": {
+    "5559001": {
+      "release_id": 5559001,
+      "title": "Freeform Frequencies Vol. 3",
+      "artist": "Various",
+      "year": 1998,
+      "label": "Duophonic Super 45s",
+      "artist_id": null,
+      "genres": ["Electronic"],
+      "styles": ["Compilation", "Leftfield"],
+      "tracklist": [
+        { "position": "1", "title": "La Paradoja", "duration": "3:40", "artists": ["Juana Molina"] },
+        { "position": "2", "title": "Back, Baby", "duration": "4:10", "artists": ["Jessica Pratt"] },
+        { "position": "3", "title": "Call Your Name", "duration": "5:02", "artists": ["Chuquimamani-Condori", "DJ E"] },
+        { "position": "4", "title": "Untitled Interlude", "duration": "1:12", "artists": [] }
+      ],
+      "artwork_url": "https://img.discogs.com/va-freeform-frequencies-vol3.jpg",
+      "release_url": "https://www.discogs.com/release/5559001",
+      "cached": false,
+      "artists": [{ "artist_id": null, "name": "Various", "join": "", "role": null }],
+      "released": "1998-06-01"
+    },
     "4080": {
       "release_id": 4080,
       "title": "Confield",

--- a/tests/integration/compilation-tracks.spec.js
+++ b/tests/integration/compilation-tracks.spec.js
@@ -1,0 +1,214 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+const { getTestDb } = require('../utils/db');
+const { isMockApiAvailable } = require('../utils/mock_api');
+
+/**
+ * Integration tests for the compilation-track (CTA) write path — BS#1964,
+ * Phase 3.5 `/wxycdb` cutover (contract: wxyc-shared api.yaml v1.28.0).
+ *
+ *   GET  /library/:id/compilation-tracks                     — list stored rows
+ *   POST /library/:id/compilation-tracks                     — additive write
+ *   GET  /library/:id/compilation-tracks/discogs-suggestions — autopopulate read
+ *
+ * `{id}` is the serial `library.id`. Fixture library rows come from
+ * tests/fixtures/shape.sql: 7000 carries 3 seeded CTA rows; 7009/7001/7003 are
+ * valid library rows with no seeded CTA. The discogs-suggestions read composes
+ * `library_identity` (BS PG) + LML's /api/v1/discogs/release/{id} (mock LML);
+ * the V/A release fixture 5559001 (with populated per-track `artists`) lives at
+ * dev_env/mock-api-server/src/fixtures/lml.json. This spec bridges the missing
+ * `library_identity` row, exercises the endpoints, and cleans up.
+ */
+
+const CTA_SEEDED_LIBRARY_ID = 7000; // shape.sql seeds 3 CTA rows here
+const WRITE_LIBRARY_ID = 7009; // valid library row, no seeded CTA (write target)
+const SUGGEST_LIBRARY_ID = 7001; // valid library row, bridged to the mock V/A release here
+const NO_IDENTITY_LIBRARY_ID = 7003; // valid library row, no library_identity
+const ABSENT_LIBRARY_ID = 99999999; // no library row
+const MOCK_VA_RELEASE_ID = 5559001; // V/A comp fixture w/ per-track artists (mock lml.json)
+
+// See library-tracks.spec.js: `describe.skip` (not an in-test early return) on
+// the mock-requiring block so an unconfigured environment doesn't silently pass.
+const mockApiConfigured = !!process.env.MOCK_API_URL;
+const describeWhenMockConfigured = mockApiConfigured ? describe : describe.skip;
+
+describe('Compilation-track (CTA) write path (BS#1964)', () => {
+  let auth;
+  let sql;
+  const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+  });
+
+  const cleanupCta = async (libraryId) =>
+    sql.unsafe(`DELETE FROM ${wxycSchema}.compilation_track_artist WHERE library_id = $1`, [libraryId]);
+
+  describe('GET /library/:id/compilation-tracks', () => {
+    test('lists the stored CTA rows for a shape-seeded library row (7000)', async () => {
+      const res = await auth.get(`/library/${CTA_SEEDED_LIBRARY_ID}/compilation-tracks`).expect(200);
+      expect(res.body.library_id).toBe(CTA_SEEDED_LIBRARY_ID);
+      expect(Array.isArray(res.body.tracks)).toBe(true);
+      expect(res.body.tracks.length).toBeGreaterThanOrEqual(3);
+      const names = res.body.tracks.map((t) => t.artist_name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'Shape Fixture Comp Guest Alpha',
+          'Shape Fixture Comp Guest Beta',
+          'Shape Fixture Comp Guest Gamma',
+        ])
+      );
+      res.body.tracks.forEach((t) => {
+        expect(typeof t.id).toBe('number');
+        expect(typeof t.artist_name).toBe('string');
+        expect(t.track_title === null || typeof t.track_title === 'string').toBe(true);
+        expect(t.track_position === null || typeof t.track_position === 'string').toBe(true);
+      });
+    });
+
+    test('returns 404 for a library id with no row', async () => {
+      const res = await auth.get(`/library/${ABSENT_LIBRARY_ID}/compilation-tracks`).expect(404);
+      expect(res.body.message ?? res.body.error ?? '').toMatch(/not found/i);
+    });
+
+    test('returns 400 for a non-numeric id', async () => {
+      await auth.get('/library/not-a-number/compilation-tracks').expect(400);
+    });
+  });
+
+  describe('POST /library/:id/compilation-tracks (additive write)', () => {
+    afterEach(async () => {
+      await cleanupCta(WRITE_LIBRARY_ID);
+    });
+
+    test('inserts new rows, reports inserted/skipped, and re-POST is idempotent', async () => {
+      const body = {
+        tracks: [
+          { artist_name: 'CTA Write Guest One', track_title: 'Aurora Ostinato', track_position: 'A1' },
+          { artist_name: 'CTA Write Guest Two', track_title: 'Petrichor Drift', track_position: 'A2' },
+        ],
+      };
+      const first = await auth.post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`).send(body).expect(200);
+      expect(first.body.library_id).toBe(WRITE_LIBRARY_ID);
+      expect(first.body.inserted).toBe(2);
+      expect(first.body.skipped).toBe(0);
+      expect(first.body.tracks.length).toBe(2);
+
+      // Additive + idempotent: re-POSTing the same list skips all, mutates none.
+      const second = await auth.post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`).send(body).expect(200);
+      expect(second.body.inserted).toBe(0);
+      expect(second.body.skipped).toBe(2);
+      expect(second.body.tracks.length).toBe(2);
+    });
+
+    test('counts intra-batch duplicates as skipped (inserted + skipped == input rows)', async () => {
+      const dup = { artist_name: 'CTA Dup Guest', track_title: 'Echo Twice', track_position: 'B1' };
+      const res = await auth
+        .post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`)
+        .send({ tracks: [dup, dup] })
+        .expect(200);
+      expect(res.body.inserted).toBe(1);
+      expect(res.body.skipped).toBe(1);
+      expect(res.body.inserted + res.body.skipped).toBe(2);
+      expect(res.body.tracks.filter((t) => t.artist_name === 'CTA Dup Guest').length).toBe(1);
+    });
+
+    test('dedupes intra-batch NULL-track duplicates via the partial unique index', async () => {
+      const dup = { artist_name: 'CTA Null-Track Guest' };
+      const res = await auth
+        .post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`)
+        .send({ tracks: [dup, dup] })
+        .expect(200);
+      expect(res.body.inserted).toBe(1);
+      expect(res.body.skipped).toBe(1);
+      const stored = res.body.tracks.filter((t) => t.artist_name === 'CTA Null-Track Guest');
+      expect(stored.length).toBe(1);
+      expect(stored[0].track_title).toBeNull();
+    });
+
+    test('returns 400 for an empty track list', async () => {
+      await auth.post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`).send({ tracks: [] }).expect(400);
+    });
+
+    test('returns 400 for a blank artist_name', async () => {
+      await auth
+        .post(`/library/${WRITE_LIBRARY_ID}/compilation-tracks`)
+        .send({ tracks: [{ artist_name: '   ', track_title: 'x' }] })
+        .expect(400);
+    });
+
+    test('returns 404 for a library id with no row', async () => {
+      await auth
+        .post(`/library/${ABSENT_LIBRARY_ID}/compilation-tracks`)
+        .send({ tracks: [{ artist_name: 'Nobody' }] })
+        .expect(404);
+    });
+  });
+
+  describe('GET /library/:id/compilation-tracks/discogs-suggestions', () => {
+    test('returns 200 + null release + empty tracks when the row has no library_identity', async () => {
+      const res = await auth
+        .get(`/library/${NO_IDENTITY_LIBRARY_ID}/compilation-tracks/discogs-suggestions`)
+        .expect(200);
+      expect(res.body).toEqual({
+        library_id: NO_IDENTITY_LIBRARY_ID,
+        discogs_release_id: null,
+        tracks: [],
+      });
+    });
+
+    test('returns 404 for a library id with no row', async () => {
+      await auth.get(`/library/${ABSENT_LIBRARY_ID}/compilation-tracks/discogs-suggestions`).expect(404);
+    });
+
+    describeWhenMockConfigured('with mock LML available (resolves a V/A release tracklist)', () => {
+      beforeAll(async () => {
+        if (!(await isMockApiAvailable())) {
+          throw new Error(
+            'MOCK_API_URL is set but mock-api-server is unreachable; cannot run mock-LML-dependent tests'
+          );
+        }
+        await sql.unsafe(
+          `INSERT INTO ${wxycSchema}.library_identity
+             (library_id, discogs_release_id, last_verified_at, method, confidence)
+           VALUES ($1, $2, NOW(), 'integration-test', 0.95)
+           ON CONFLICT (library_id) DO UPDATE
+             SET discogs_release_id = EXCLUDED.discogs_release_id`,
+          [SUGGEST_LIBRARY_ID, MOCK_VA_RELEASE_ID]
+        );
+      });
+
+      afterAll(async () => {
+        await sql.unsafe(`DELETE FROM ${wxycSchema}.library_identity WHERE library_id = $1`, [SUGGEST_LIBRARY_ID]);
+      });
+
+      test('flattens per-track artists onto write-ready CompilationTrackInput rows', async () => {
+        const res = await auth.get(`/library/${SUGGEST_LIBRARY_ID}/compilation-tracks/discogs-suggestions`).expect(200);
+        expect(res.body.library_id).toBe(SUGGEST_LIBRARY_ID);
+        expect(res.body.discogs_release_id).toBe(MOCK_VA_RELEASE_ID);
+        expect(res.body.tracks.length).toBe(4);
+        // per-track single artist, position + title passed through
+        expect(res.body.tracks[0]).toEqual({
+          artist_name: 'Juana Molina',
+          track_title: 'La Paradoja',
+          track_position: '1',
+        });
+        // multi-artist track joins on ', '
+        expect(res.body.tracks[2].artist_name).toBe('Chuquimamani-Condori, DJ E');
+        // empty per-track artists -> release-level fallback ("Various")
+        expect(res.body.tracks[3].artist_name).toBe('Various');
+        res.body.tracks.forEach((t) => {
+          expect(typeof t.artist_name).toBe('string');
+          expect(t.artist_name.length).toBeGreaterThan(0);
+        });
+      });
+
+      test('suggestions are read-only (do not write CTA rows)', async () => {
+        await auth.get(`/library/${SUGGEST_LIBRARY_ID}/compilation-tracks/discogs-suggestions`).expect(200);
+        const listed = await auth.get(`/library/${SUGGEST_LIBRARY_ID}/compilation-tracks`).expect(200);
+        expect(listed.body.tracks.length).toBe(0);
+      });
+    });
+  });
+});

--- a/tests/unit/controllers/library.compilationTracks.test.ts
+++ b/tests/unit/controllers/library.compilationTracks.test.ts
@@ -1,0 +1,167 @@
+import { Request, Response, NextFunction } from 'express';
+
+jest.mock('../../../apps/backend/services/library.service');
+
+import * as libraryService from '../../../apps/backend/services/library.service';
+import {
+  validateCompilationTracksBody,
+  getCompilationTracks,
+  writeCompilationTracks,
+  getCompilationTrackDiscogsSuggestions,
+} from '../../../apps/backend/controllers/library.controller';
+
+function mockReqResNext(overrides: Partial<Request> = {}) {
+  const req = { params: {}, body: {}, auth: { id: 'test-user-id' }, ...overrides } as unknown as Request;
+  const statusMock = jest.fn().mockReturnThis();
+  const jsonMock = jest.fn().mockReturnThis();
+  const sendMock = jest.fn().mockReturnThis();
+  const res = { status: statusMock, json: jsonMock, send: sendMock } as unknown as Response;
+  const next = jest.fn() as unknown as NextFunction;
+  return { req, res, next, statusMock, jsonMock, sendMock };
+}
+
+describe('validateCompilationTracksBody (BS#1964 CTA write validation)', () => {
+  it('rejects a missing/empty tracks array', () => {
+    expect(validateCompilationTracksBody({}).ok).toBe(false);
+    expect(validateCompilationTracksBody({ tracks: [] }).ok).toBe(false);
+    expect(validateCompilationTracksBody({ tracks: undefined }).ok).toBe(false);
+  });
+
+  it('rejects a track whose artist_name is missing or blank', () => {
+    expect(validateCompilationTracksBody({ tracks: [{ track_title: 'x' }] }).ok).toBe(false);
+    expect(validateCompilationTracksBody({ tracks: [{ artist_name: '' }] }).ok).toBe(false);
+    expect(validateCompilationTracksBody({ tracks: [{ artist_name: '   ' }] }).ok).toBe(false);
+  });
+
+  it('trims artist_name and coerces blank optional fields to null', () => {
+    const result = validateCompilationTracksBody({
+      tracks: [{ artist_name: '  Juana Molina  ', track_title: '  ', track_position: '' }],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.tracks[0]).toEqual({
+        artist_name: 'Juana Molina',
+        track_title: null,
+        track_position: null,
+      });
+    }
+  });
+
+  it('preserves populated optional fields (trimmed)', () => {
+    const result = validateCompilationTracksBody({
+      tracks: [{ artist_name: 'Jessica Pratt', track_title: '  Back, Baby ', track_position: 'A2' }],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.tracks[0]).toEqual({
+        artist_name: 'Jessica Pratt',
+        track_title: 'Back, Baby',
+        track_position: 'A2',
+      });
+    }
+  });
+
+  it('rejects over-length fields (255 / 255 / 20)', () => {
+    expect(validateCompilationTracksBody({ tracks: [{ artist_name: 'a'.repeat(256) }] }).ok).toBe(false);
+    expect(validateCompilationTracksBody({ tracks: [{ artist_name: 'ok', track_title: 'a'.repeat(256) }] }).ok).toBe(
+      false
+    );
+    expect(validateCompilationTracksBody({ tracks: [{ artist_name: 'ok', track_position: 'a'.repeat(21) }] }).ok).toBe(
+      false
+    );
+  });
+});
+
+describe('getCompilationTracks controller (BS#1964)', () => {
+  it('returns 404 when the library row is absent', async () => {
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(false);
+    const { req, res, next } = mockReqResNext({ params: { id: '7000' } } as Partial<Request>);
+    await expect(getCompilationTracks(req, res, next)).rejects.toThrow('not found');
+  });
+
+  it('returns 400 on a non-numeric id', async () => {
+    const { req, res, next } = mockReqResNext({ params: { id: 'nope' } } as Partial<Request>);
+    await expect(getCompilationTracks(req, res, next)).rejects.toThrow('Invalid album ID');
+  });
+
+  it('returns 200 with the library_id + stored tracks', async () => {
+    const rows = [{ id: 1, artist_name: 'Juana Molina', track_title: 'la paradoja', track_position: 'A1' }];
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(true);
+    (libraryService.getCompilationTracks as jest.Mock).mockResolvedValue(rows);
+    const { req, res, next, statusMock, jsonMock } = mockReqResNext({ params: { id: '7000' } } as Partial<Request>);
+    await getCompilationTracks(req, res, next);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({ library_id: 7000, tracks: rows });
+  });
+});
+
+describe('writeCompilationTracks controller (BS#1964)', () => {
+  it('returns 400 before touching the DB when the body is invalid', async () => {
+    const { req, res, next } = mockReqResNext({ params: { id: '7000' }, body: { tracks: [] } } as Partial<Request>);
+    await expect(writeCompilationTracks(req, res, next)).rejects.toThrow(/tracks/i);
+    expect(libraryService.writeCompilationTracks).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the library row is absent', async () => {
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(false);
+    const { req, res, next } = mockReqResNext({
+      params: { id: '7000' },
+      body: { tracks: [{ artist_name: 'Juana Molina' }] },
+    } as Partial<Request>);
+    await expect(writeCompilationTracks(req, res, next)).rejects.toThrow('not found');
+    expect(libraryService.writeCompilationTracks).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with inserted/skipped and the full stored set', async () => {
+    const tracks = [{ id: 1, artist_name: 'Juana Molina', track_title: 'la paradoja', track_position: 'A1' }];
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(true);
+    (libraryService.writeCompilationTracks as jest.Mock).mockResolvedValue({ inserted: 1, skipped: 0, tracks });
+    const { req, res, next, statusMock, jsonMock } = mockReqResNext({
+      params: { id: '7000' },
+      body: { tracks: [{ artist_name: '  Juana Molina  ', track_title: 'la paradoja', track_position: 'A1' }] },
+    } as Partial<Request>);
+    await writeCompilationTracks(req, res, next);
+    // service is handed the normalized (trimmed) rows
+    expect(libraryService.writeCompilationTracks).toHaveBeenCalledWith(7000, [
+      { artist_name: 'Juana Molina', track_title: 'la paradoja', track_position: 'A1' },
+    ]);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({ library_id: 7000, inserted: 1, skipped: 0, tracks });
+  });
+});
+
+describe('getCompilationTrackDiscogsSuggestions controller (BS#1964)', () => {
+  it('returns 404 when the library row is absent', async () => {
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(false);
+    const { req, res, next } = mockReqResNext({ params: { id: '7000' } } as Partial<Request>);
+    await expect(getCompilationTrackDiscogsSuggestions(req, res, next)).rejects.toThrow('not found');
+  });
+
+  it('returns 200 with discogs_release_id + write-ready suggestion rows', async () => {
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(true);
+    (libraryService.getCompilationTrackSuggestions as jest.Mock).mockResolvedValue({
+      discogs_release_id: 5559001,
+      tracks: [{ artist_name: 'Juana Molina', track_title: 'la paradoja', track_position: '1' }],
+    });
+    const { req, res, next, statusMock, jsonMock } = mockReqResNext({ params: { id: '7000' } } as Partial<Request>);
+    await getCompilationTrackDiscogsSuggestions(req, res, next);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({
+      library_id: 7000,
+      discogs_release_id: 5559001,
+      tracks: [{ artist_name: 'Juana Molina', track_title: 'la paradoja', track_position: '1' }],
+    });
+  });
+
+  it('returns 200 with a null release + empty tracks when nothing is resolvable', async () => {
+    (libraryService.libraryRowExists as jest.Mock).mockResolvedValue(true);
+    (libraryService.getCompilationTrackSuggestions as jest.Mock).mockResolvedValue({
+      discogs_release_id: null,
+      tracks: [],
+    });
+    const { req, res, next, statusMock, jsonMock } = mockReqResNext({ params: { id: '7009' } } as Partial<Request>);
+    await getCompilationTrackDiscogsSuggestions(req, res, next);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({ library_id: 7009, discogs_release_id: null, tracks: [] });
+  });
+});

--- a/tests/unit/controllers/library.compilationTracks.test.ts
+++ b/tests/unit/controllers/library.compilationTracks.test.ts
@@ -70,6 +70,16 @@ describe('validateCompilationTracksBody (BS#1964 CTA write validation)', () => {
       false
     );
   });
+
+  it('accepts a list at the 500-entry cap but rejects one over it', () => {
+    const track = { artist_name: 'Guest' };
+    expect(validateCompilationTracksBody({ tracks: Array(500).fill(track) }).ok).toBe(true);
+    const over = validateCompilationTracksBody({ tracks: Array(501).fill(track) });
+    expect(over.ok).toBe(false);
+    if (!over.ok) {
+      expect(over.message).toMatch(/exceed/i);
+    }
+  });
 });
 
 describe('getCompilationTracks controller (BS#1964)', () => {


### PR DESCRIPTION
Closes #1964. Backend arm of the CTA write path; Phase 3.5 `/wxycdb` cutover (WXYC/wiki#89). Contract prerequisite WXYC/wxyc-shared#291 (api.yaml v1.28.0) merged; codegen fan-out to LML (#1089) and request-o-matic (#203) merged.

## What / why

`compilation_track_artist` (CTA) makes V/A per-track artists searchable in Backend library search / suggest / request-line and in the daily `library.db` export, but CTA rows have only ever arrived via the insert-only `jobs/library-etl` MySQL mirror. When `/wxycdb` goes dark at the Phase 3.5 cutover that mirror stops, and without a write path every compilation added afterward permanently loses per-track artist search. This adds that write path.

## Shape A — Discogs-read, explicit-write

Implements the contract shape approved during design (WXYC/wxyc-shared#291), keyed on the serial `library.id` (like the sibling `/library/:id` PATCH/missing/found routes):

- `GET /library/:id/compilation-tracks` — list a release's stored CTA rows (`catalog:read`). 404 if the library row is absent.
- `POST /library/:id/compilation-tracks` — **additive** write of an explicit, client-confirmed list (`catalog:write`). An untargeted `ON CONFLICT DO NOTHING` arbiters *both* CTA unique indexes (`cta_unique_idx` + the `cta_unique_null_track_idx` partial), so `skipped = input − inserted` and the identity `inserted + skipped == input` holds even for intra-batch duplicates. Existing rows are matched on the uniqueness keys and skipped, **never mutated**. 400 on empty list / blank `artist_name` / over-length; 404 if the library row is absent.
- `GET /library/:id/compilation-tracks/discogs-suggestions` — the linked Discogs release's tracklist as write-ready `CompilationTrackInput` rows, **without writing** (`catalog:write`). `discogs_release_id: null` + empty `tracks` ⇒ no upstream release ⇒ manual entry.

## Reframing the "autopopulate" acceptance criterion

The issue's original sketch floated *seeding CTA as a side effect of `addAlbum`*. Design settled on Shape A instead: **autopopulate is the `discogs-suggestions` read**, which the dj-site add-release panel presents for confirm/edit and then writes back via the explicit `POST`. This is deliberate — it keeps the only Discogs-touching call to a single `getRelease` (not the per-track N-validation fan-out that timed out in #1117), does zero external I/O on the write, and never blocks the `addAlbum` request. So the acceptance bullets map as:

- Contract merged + fan-out — WXYC/wxyc-shared#291 / LML#1089 / r-o-m#203. ✅
- Autopopulate a V/A add's tracklist — the `discogs-suggestions` read (integration-tested against a V/A mock-LML release: per-track single artist, multi-artist `', '` join, empty-artists → release-level "Various" fallback). ✅
- Manual fallback write — the additive `POST`. ✅
- Existing CTA rows untouched — additive-only; the contract can't express replace/delete, and the re-POST-is-idempotent test proves stored rows aren't mutated. The 4,161-row D6 residue is unaffected. ✅
- New rows appear in search/suggest + next `library.db` build — writes land in the same `compilation_track_artist` table `searchLibraryByCTA` and the catalog export already read, so this is satisfied by construction (no new plumbing).

## Design-forward

The wire carries only the durable free-text triple (`artist_name`/`track_title`/`track_position`) — no `artist_id`/confidence/method — so the path is Discogs-agnostic and survives the future `compilation_track_artist` → `library_track` generalization (#801) without a contract rewrite. Per-track artists flatten onto CTA's single `artist_name` via the shared `projectInlineTracklist`, so the CTA-suggestions and rotation-tracks-picker projections can't drift. BS keeps local wire types here (mirroring `NewAlbumRequest`/`UpdateAlbumRequest`) rather than importing `@wxyc/shared`, so the surface ships without a shared publish.

## Tests

- **Unit** (`tests/unit/controllers/library.compilationTracks.test.ts`, 14 cases): `validateCompilationTracksBody` (empty list, blank/over-length `artist_name`, blank-optional→null coercion, trimming) + the three handlers with the service mocked (400/404/200 + response shapes + normalized service args).
- **Integration** (`tests/integration/compilation-tracks.spec.js`): list (shape-seeded 7000), 404/400, additive-write + re-POST idempotency, intra-batch dedup for both the non-null and NULL-track partial index, empty/blank/absent 400/404, and a V/A `discogs-suggestions` read against a new mock-LML release fixture (`5559001`, populated per-track `artists` + an empty-artists track for the fallback) with a `library_identity` bridge; also a read-only assertion that suggestions write nothing.

## Local verification

`typecheck` (all workspaces), `eslint`, `prettier --check`, and the unit suite (1677 existing + 14 new) all green. The intra-batch `ON CONFLICT DO NOTHING` + `RETURNING` semantics the contract's `inserted + skipped == input` invariant relies on were verified directly against PostgreSQL 18 (the `ci-db` version) using the exact CTA DDL (both unique indexes). The Dockerized integration stack (`ci:testmock`) could not be run locally — the image build 401s pulling `@wxyc/shared` from GitHub Packages (a local `NPM_TOKEN` build-arg propagation quirk, not a code issue; a bare `npm install` authenticates fine) — so the integration suite's first run is in CI, which has proper package auth.
