### PR TITLE
feat(library): extend catalog export + add CTA export for the library.db producer (BS#1965)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.68.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^3.1.0",
+    "@wxyc/shared": "^3.3.0",
     "better-auth": "^1.6.23",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -250,11 +250,25 @@ components:
         One catalog row in the `GET /library/catalog` NDJSON export (BS#1468).
         `rotation_bin` / `rotation_kill_date` are raw (the most-recently-added
         rotation record per album); the client evaluates "in rotation" locally.
+        BS#1965 added the four library.db-producer fields (legacy_release_id,
+        alternate_artist_name, album_artist, cross_reference_names); the SSOT
+        (wxyc-shared api.yaml) carries the authoritative descriptions.
       properties:
         id:
           type: integer
+        legacy_release_id:
+          type: integer
         artist_name:
           type: string
+        alternate_artist_name:
+          type: string
+          nullable: true
+        album_artist:
+          type: string
+          nullable: true
+        cross_reference_names:
+          type: string
+          nullable: true
         album_title:
           type: string
         code_letters:
@@ -293,6 +307,26 @@ components:
         rotation_kill_date:
           type: string
           format: date
+          nullable: true
+
+    CatalogCompilationTrackRow:
+      type: object
+      description: >
+        One compilation_track_artist row in the `GET
+        /library/catalog/compilation-tracks` NDJSON export (BS#1965). Keyed on
+        `legacy_release_id` (the owning library row's surrogate key, which the
+        producer maps to library.db's compilation_track_artist.library_release_id).
+        The SSOT (wxyc-shared api.yaml) carries the authoritative description.
+      required:
+        - legacy_release_id
+        - artist_name
+      properties:
+        legacy_release_id:
+          type: integer
+        artist_name:
+          type: string
+        track_title:
+          type: string
           nullable: true
 
     BmiPerformanceRow:
@@ -1347,6 +1381,57 @@ paths:
             application/x-ndjson:
               schema:
                 $ref: '#/components/schemas/CatalogExportRow'
+        '304':
+          description: Catalog unchanged since `If-Modified-Since` / `since`.
+        '401':
+          description: Missing or invalid bearer token.
+
+  /library/catalog/compilation-tracks:
+    get:
+      summary: Bulk compilation-track (CTA) export (gzipped NDJSON, conditional-GET)
+      description: >
+        Sibling of `GET /library/catalog` for the Backend-sourced library.db
+        producer (BS#1965 / discogs-etl#351): every compilation_track_artist row
+        as one gzipped NDJSON body (one CatalogCompilationTrackRow per line), so
+        the producer can build library.db's `compilation_track_artist` table over
+        HTTP. Same `library_watermark` conditional-GET (`If-Modified-Since` /
+        `?since=` -> `304`) as the library export. Rows are keyed on
+        `legacy_release_id` (the owning library row's surrogate key) and ordered
+        by it.
+      security:
+        - BearerAuth: ['catalog-read']
+      parameters:
+        - name: If-Modified-Since
+          in: header
+          required: false
+          description: RFC 9110 HTTP date from a prior response's `Last-Modified`.
+          schema:
+            type: string
+        - name: since
+          in: query
+          required: false
+          description: Alternative to `If-Modified-Since` (any parseable date string).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: All CTA rows as gzipped NDJSON. One CatalogCompilationTrackRow per line.
+          headers:
+            Last-Modified:
+              description: Catalog watermark; echo back as `If-Modified-Since`.
+              schema:
+                type: string
+            Content-Encoding:
+              description: '`gzip` when the request accepts gzip.'
+              schema:
+                type: string
+            Vary:
+              schema:
+                type: string
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: '#/components/schemas/CatalogCompilationTrackRow'
         '304':
           description: Catalog unchanged since `If-Modified-Since` / `since`.
         '401':

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -258,6 +258,7 @@ components:
           type: integer
         legacy_release_id:
           type: integer
+          nullable: true
         artist_name:
           type: string
         alternate_artist_name:
@@ -267,8 +268,16 @@ components:
           type: string
           nullable: true
         cross_reference_names:
-          type: string
+          type: array
           nullable: true
+          items:
+            type: string
+          description: >
+            Cross-referenced artist names, in either FK direction, ordered by
+            Unicode code point. An ARRAY, not the pipe-joined string library.db
+            stores — the producer does the `" | "` join itself, because nothing
+            constrains an artist name from containing a pipe. Empty array when
+            the artist has no cross-references.
         album_title:
           type: string
         code_letters:
@@ -325,8 +334,11 @@ components:
           type: integer
         artist_name:
           type: string
+          minLength: 1
+          maxLength: 255
         track_title:
           type: string
+          maxLength: 255
           nullable: true
 
     BmiPerformanceRow:
@@ -1398,6 +1410,12 @@ paths:
         `?since=` -> `304`) as the library export. Rows are keyed on
         `legacy_release_id` (the owning library row's surrogate key) and ordered
         by it.
+
+        A CTA row is emitted only if its owning library row is itself eligible
+        for `GET /library/catalog` — same four INNER JOINs, notably
+        `genre_artist_crossreference` on the (artist_id, genre_id) pair. An
+        unfiltered export would ship `library_release_id` values that join to
+        nothing in the `library` table the sibling endpoint produces.
       security:
         - BearerAuth: ['catalog-read']
       parameters:

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -1366,6 +1366,39 @@ export const exportCatalog: RequestHandler = async (req, res) => {
 };
 
 // ---------------------------------------------------------------------------
+// GET /library/catalog/compilation-tracks — CTA bulk export (BS#1965)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sibling of {@link exportCatalog} for the Backend-sourced library.db producer
+ * (discogs-etl#351): stream every compilation_track_artist row as gzipped NDJSON
+ * (one CatalogCompilationTrackRow per line) so the producer can build library.db's
+ * `compilation_track_artist` table over HTTP. Same freshness (the
+ * `conditionalGet(getCatalogLastModifiedAt)` middleware short-circuits to 304 on
+ * an unchanged `library_watermark`), same pre-gzipped per-watermark cache, and
+ * the same Accept-Encoding negotiation as the library export — this handler is a
+ * memcpy on the hot path.
+ */
+export const exportCompilationTracks: RequestHandler = async (req, res) => {
+  const gzipped = await catalogExportService.getCompilationTracksExportGzip();
+  const acceptsGzip = req.acceptsEncodings('gzip') === 'gzip';
+
+  res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+  res.setHeader('Vary', 'Accept-Encoding');
+
+  if (acceptsGzip) {
+    res.setHeader('Content-Encoding', 'gzip');
+    res.setHeader('Content-Length', gzipped.length);
+    res.status(200).end(gzipped);
+    return;
+  }
+
+  const inflated = gunzipSync(gzipped);
+  res.setHeader('Content-Length', inflated.length);
+  res.status(200).end(inflated);
+};
+
+// ---------------------------------------------------------------------------
 // GET /library/bmi-performance-list — played-works export for BMI (BS#1500)
 // ---------------------------------------------------------------------------
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^3.1.0",
+    "@wxyc/shared": "^3.3.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -58,6 +58,17 @@ library_route.get(
   libraryController.exportCatalog
 );
 
+// CTA sibling of the catalog export (BS#1965): compilation_track_artist rows for
+// the Backend-sourced library.db producer (discogs-etl#351). Same `catalog:read`
+// auth, same `library_watermark` conditional-GET. A distinct literal path, so it
+// is not shadowed by `/catalog` regardless of registration order.
+library_route.get(
+  '/catalog/compilation-tracks',
+  requirePermissions({ catalog: ['read'] }),
+  conditionalGet(getCatalogLastModifiedAt),
+  libraryController.exportCompilationTracks
+);
+
 // BMI played-works export (BS#1500 — tubafrenzy `recentBMI` successor). Gated
 // to MD/SM via `catalog:['write']` (DJs/members lack it), which is exactly the
 // librarian/MD submission audience with no new permission minted. Keyed on a

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -60,8 +60,17 @@ library_route.get(
 
 // CTA sibling of the catalog export (BS#1965): compilation_track_artist rows for
 // the Backend-sourced library.db producer (discogs-etl#351). Same `catalog:read`
-// auth, same `library_watermark` conditional-GET. A distinct literal path, so it
-// is not shadowed by `/catalog` regardless of registration order.
+// auth, same `library_watermark` conditional-GET.
+//
+// REGISTRATION ORDER IS LOAD-BEARING — keep this next to the '/catalog' literal
+// above, ahead of the '/:id' routes. The competing route is not '/catalog' (two
+// distinct literals never shadow each other, in any order); it is the TEMPLATED
+// GET '/:id/compilation-tracks' further down, which matches this same URL with
+// id === 'catalog'. Registered after it, Express hands this request to that
+// handler, `Number('catalog')` is NaN, and the producer gets a 4xx/5xx — with no
+// auth-layer signal to distinguish it, since both routes carry the identical
+// catalog:['read'] permission. The integration spec's 200 from this path is what
+// proves the ordering holds.
 library_route.get(
   '/catalog/compilation-tracks',
   requirePermissions({ catalog: ['read'] }),

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -49,7 +49,7 @@ export type CatalogExportRow = {
   artist_name: string;
   alternate_artist_name: string | null;
   album_artist: string | null;
-  cross_reference_names: string | null;
+  cross_reference_names: string[];
   album_title: string;
   code_letters: string;
   code_number: number;
@@ -159,13 +159,16 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    not advance `library_watermark`).
  *  - the four BS#1965 library.db-producer fields: `legacy_release_id`,
  *    `alternate_artist_name`, and `album_artist` are raw `library` columns;
- *    `cross_reference_names` is the pipe-joined artist-alias string from the
- *    `artist_aliases` CTE (see its inline comment). These feed the Backend-sourced
- *    `library.db` producer (discogs-etl#351) — `legacy_release_id` becomes
- *    library.db's `library.id`. `cross_reference_names` rides `library_watermark`
- *    freshness like `plays`/`popularity`: an `artist_crossreference` edit surfaces
- *    only on the next watermark-advancing write — acceptable day-scale lag for the
- *    daily producer.
+ *    `cross_reference_names` is the artist-alias ARRAY from the `artist_aliases`
+ *    CTE (see its inline comment). These feed the Backend-sourced `library.db`
+ *    producer (discogs-etl#351) — `legacy_release_id` becomes library.db's
+ *    `library.id`, and the producer does the `" | "` join itself when it writes
+ *    the SQLite column. Unlike `plays`/`popularity`, `cross_reference_names` does
+ *    NOT ride a stale watermark: migration 0138 attaches
+ *    `touch_library_watermark()` to `artist_crossreference`, so a cross-reference
+ *    edit advances the watermark and rebuilds this cache on its own. Without that
+ *    trigger the failure is silent and unbounded, not a lag — the producer would
+ *    304 forever against a body that will never contain the new alias.
  *
  * One scan per watermark (cached below), so the full-table cost is paid ~daily.
  */
@@ -175,12 +178,28 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
       -- Per-artist alias aggregation for cross_reference_names (BS#1965,
       -- discogs-etl#334). UNION folds artist_crossreference in BOTH FK directions
       -- into (artist_id, other_id) pairs so a row filed under either endpoint
-      -- surfaces the other; string_agg DISTINCT ... ORDER BY yields a stable,
-      -- deduplicated, alphabetically-ordered pipe-joined string — the deterministic
-      -- analogue of the legacy MySQL GROUP_CONCAT(DISTINCT ... SEPARATOR ' | ').
+      -- surfaces the other. Aggregated as an ARRAY, not the pipe-joined string
+      -- library.db stores: nothing constrains artists.artist_name from containing
+      -- '|' or ' | ', so a joined wire value would silently split into phantom
+      -- aliases downstream (LML splits this field on the pipe) with no escaping
+      -- rule to recover from. The producer does the join when it writes SQLite.
+      --
+      -- ORDER BY ... COLLATE "C" (Unicode code point), NOT the database default.
+      -- en_US.UTF-8 ignores punctuation and case at the primary level, so it
+      -- orders exactly the diacritic- and punctuation-bearing names most likely
+      -- to carry aliases unstably across locales. The legacy MySQL
+      -- GROUP_CONCAT(DISTINCT ... SEPARATOR ' | ') this replaces has no ORDER BY
+      -- at all, so there is no legacy order to match — pick the deterministic
+      -- one. The COLLATE must repeat on the DISTINCT argument: Postgres requires
+      -- an aggregate's ORDER BY expression to appear in its argument list, and
+      -- a bare column is a different expression from that column COLLATE "C".
+      -- Collation is a comparison property, not a value transform, so the
+      -- emitted strings are byte-identical either way.
+      --
       -- O(crossref rows), joined once per artist, NOT a per-library correlated scan.
       SELECT cp.artist_id AS artist_id,
-             string_agg(DISTINCT ${artists.artist_name}, ' | ' ORDER BY ${artists.artist_name})
+             array_agg(DISTINCT ${artists.artist_name} COLLATE "C"
+                       ORDER BY ${artists.artist_name} COLLATE "C")
                AS cross_reference_names
       FROM (
         SELECT ${artist_crossreference.source_artist_id} AS artist_id,
@@ -201,7 +220,11 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
       COALESCE(${library.artist_name}, ${artists.artist_name}) AS artist_name,
       ${library.alternate_artist_name}         AS alternate_artist_name,
       ${library.album_artist}                  AS album_artist,
-      artist_aliases.cross_reference_names     AS cross_reference_names,
+      -- COALESCE, not a raw LEFT JOIN null: the contract says an artist with no
+      -- cross-references ships an empty array, so the producer never has to
+      -- distinguish "no aliases" from "field absent".
+      COALESCE(artist_aliases.cross_reference_names, ARRAY[]::varchar[])
+                                               AS cross_reference_names,
       ${library.album_title}                   AS album_title,
       ${artists.code_letters}                  AS code_letters,
       ${library.code_number}                   AS code_number,
@@ -293,18 +316,36 @@ export const serializeCompilationTracksNdjson = (rows: CompilationTrackExportRow
   rows.map((row) => JSON.stringify(projectCompilationTrackRow(row))).join('\n');
 
 /**
- * Read every compilation_track_artist row as flat export rows, keyed on the
- * owning library row's `legacy_release_id` (NOT the serial CTA `library_id`).
- * INNER JOIN to `library` because `compilation_track_artist.library_id` is a
- * NOT-NULL cascade FK, so every CTA row has exactly one library parent with a
- * (now total, BS#1963) `legacy_release_id`. Ordered by `legacy_release_id` (then
- * CTA `id` for a stable tiebreak), matching the legacy MySQL export's
- * `ORDER BY LIBRARY_RELEASE_ID`.
+ * Read every EXPORT-ELIGIBLE compilation_track_artist row as flat export rows,
+ * keyed on the owning library row's `legacy_release_id` (NOT the serial CTA
+ * `library_id`). Ordered by `legacy_release_id` (then CTA `id` for a stable
+ * tiebreak), matching the legacy MySQL export's `ORDER BY LIBRARY_RELEASE_ID`.
+ *
+ * ROW ELIGIBILITY — this repeats `getCatalogExportRows`' four INNER JOINs
+ * (artists, format, genres, and genre_artist_crossreference on the
+ * artist_id + genre_id PAIR), not just the join to `library`. That export is not
+ * "every library row": a row whose (artist, genre) pair has no
+ * `genre_artist_crossreference` entry is silently dropped from it — a shape the
+ * ETL preserves (see the schema comment on that table). Exporting CTA rows
+ * unfiltered would ship `library_release_id` values that join to nothing in
+ * library.db's `library` table, and LML's CTA UNION would surface a compilation
+ * track whose release row it cannot resolve. The two endpoints must apply the
+ * same predicate; the pg integration spec pins that they do.
+ *
+ * The joins are eligibility filters only — no column from them is projected, so
+ * this stays a semi-join in spirit. `genre_artist_crossreference` is the only
+ * one that can drop rows in practice (the other three are NOT NULL FKs), but
+ * all four are written out so the predicate reads as a copy of the sibling
+ * query rather than a subset a later edit could drift from.
  *
  * One scan per watermark (cached below). CTA freshness rides `library_watermark`
- * (see the endpoint docblock): a new compilation's rows surface as soon as its
- * library add advances the watermark; a standalone CTA edit lags to the next
- * library write — acceptable day-scale lag for the daily producer.
+ * and migration 0138 attaches `touch_library_watermark()` to
+ * `compilation_track_artist`, so a CTA write advances the watermark on its own.
+ * That trigger is load-bearing, not belt-and-suspenders: the CTA POST always
+ * FOLLOWS the library add it would otherwise ride, so without it the cached body
+ * for the library-add watermark never contains the tracks and this endpoint 304s
+ * until some unrelated write moves the watermark. Post-tubafrenzy-turndown there
+ * is no daily library sync to eventually supply that write.
  */
 export const getCompilationTrackExportRows = async (): Promise<CompilationTrackExportRow[]> => {
   const rows = await db.execute(sql`
@@ -314,6 +355,12 @@ export const getCompilationTrackExportRows = async (): Promise<CompilationTrackE
       ${compilation_track_artist.track_title}  AS track_title
     FROM ${compilation_track_artist}
       INNER JOIN ${library} ON ${library.id} = ${compilation_track_artist.library_id}
+      INNER JOIN ${artists} ON ${artists.id} = ${library.artist_id}
+      INNER JOIN ${format} ON ${format.id} = ${library.format_id}
+      INNER JOIN ${genres} ON ${genres.id} = ${library.genre_id}
+      INNER JOIN ${genre_artist_crossreference}
+        ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
+       AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
     ORDER BY ${library.legacy_release_id} ASC, ${compilation_track_artist.id} ASC
   `);
   return rows as unknown as CompilationTrackExportRow[];
@@ -328,8 +375,35 @@ const buildCompilationTracksExportGzip = async (): Promise<Buffer> => {
 };
 
 // One shared gzipped copy per pod, rebuilt only when the catalog watermark
-// advances (≈daily) — same watermark as the library export, so the two exports
-// the producer fetches together stay a consistent snapshot.
+// advances — same watermark as the library export, so the two exports the
+// producer fetches together stay a consistent snapshot.
+//
+// SIZING (the api.yaml "size it before shipping" note). This is a SECOND
+// long-lived resident buffer on a memory-constrained host, so it was measured
+// rather than assumed, against the 2026-07-19 prod library.db snapshot's real
+// artist/title strings at the prod CTA row count (144,778):
+//
+//                          rows      raw     gzipped   resident
+//   catalog export       64,815   28.5 MB    2.6 MB     2.6 MB
+//   CTA export          144,778   13.1 MB    3.2 MB     3.2 MB
+//
+// The CTA buffer is slightly LARGER than the catalog one despite carrying 3
+// fields instead of 19 — 2.2x the rows outweighs the narrower shape. Resident
+// cost of this endpoint is therefore ~3.2 MB, and ~5.8 MB for both.
+//
+// The steady state is not the interesting number; the build path is. It
+// materializes every row as a JS object, then the full NDJSON string, then a
+// Buffer, before gzip discards all three — a measured ~39 MB heap peak (plus the
+// ~13 MB off-heap Buffer), roughly 12x what stays resident. That transient is
+// still SMALLER than the one the catalog export already pays on the same
+// watermark (28.5 MB of string vs 13.1 MB), so this endpoint does not raise the
+// process's high-water mark; it just reaches it twice.
+//
+// Verdict: not material — keep the sibling endpoint rather than folding these
+// rows into /library/catalog behind `?include=compilation_tracks`. Revisit if
+// the CTA table grows past ~1M rows, or if a future consumer needs a payload
+// that can't be built streaming-free. The `?include=` fold is the documented
+// fallback and stays open (api.yaml leaves the shape open).
 const compilationTracksExportCache = createWatermarkCache<Buffer>(
   getCatalogLastModifiedAt,
   buildCompilationTracksExportGzip

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -325,8 +325,11 @@ export const serializeCompilationTracksNdjson = (rows: CompilationTrackExportRow
  * (artists, format, genres, and genre_artist_crossreference on the
  * artist_id + genre_id PAIR), not just the join to `library`. That export is not
  * "every library row": a row whose (artist, genre) pair has no
- * `genre_artist_crossreference` entry is silently dropped from it — a shape the
- * ETL preserves (see the schema comment on that table). Exporting CTA rows
+ * `genre_artist_crossreference` entry is silently dropped from it, and the
+ * upstream tubafrenzy library genuinely contains such rows (the ETL preserves
+ * the full upstream shape rather than synthesizing the missing pair — see the
+ * `library` table docblock in `schema.ts` on tolerating upstream gaps).
+ * Exporting CTA rows
  * unfiltered would ship `library_release_id` values that join to nothing in
  * library.db's `library` table, and LML's CTA UNION would surface a compilation
  * track whose release row it cannot resolve. The two endpoints must apply the
@@ -375,8 +378,13 @@ const buildCompilationTracksExportGzip = async (): Promise<Buffer> => {
 };
 
 // One shared gzipped copy per pod, rebuilt only when the catalog watermark
-// advances — same watermark as the library export, so the two exports the
-// producer fetches together stay a consistent snapshot.
+// advances — same watermark as the library export. The two exports the producer
+// fetches are separate HTTP requests sharing a watermark VALUE, not one
+// transaction: they are a consistent snapshot only while the watermark is stable
+// across both fetches. If it advances between them the producer can pair
+// catalog@T with CTA@T+1 — a CTA legacy_release_id with no row yet in the catalog
+// body — so the producer must treat a Last-Modified change across the two GETs as
+// "re-fetch both". The pairing self-heals on the next producer run regardless.
 //
 // SIZING (the api.yaml "size it before shipping" note). This is a SECOND
 // long-lived resident buffer on a memory-constrained host, so it was measured
@@ -397,7 +405,11 @@ const buildCompilationTracksExportGzip = async (): Promise<Buffer> => {
 // ~13 MB off-heap Buffer), roughly 12x what stays resident. That transient is
 // still SMALLER than the one the catalog export already pays on the same
 // watermark (28.5 MB of string vs 13.1 MB), so this endpoint does not raise the
-// process's high-water mark; it just reaches it twice.
+// per-build high-water mark. Both caches key on the SAME watermark, though, so a
+// single advance followed by concurrent first-hits to both endpoints runs the two
+// rebuilds at once and their transients STACK (sum, not max) rather than reaching
+// the peak twice serially — the thundering-herd guard in watermark-cache dedups
+// within an endpoint, not across the two. Still well within budget at these sizes.
 //
 // Verdict: not material — keep the sibling endpoint rather than folding these
 // rows into /library/catalog behind `?include=compilation_tracks`. Revisit if

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -21,6 +21,8 @@ import {
   format,
   genres,
   genre_artist_crossreference,
+  artist_crossreference,
+  compilation_track_artist,
   rotation,
   album_plays,
   album_popularity,
@@ -43,7 +45,11 @@ import { logicalAlbumKeySql } from './logical-album-key.service.js';
  */
 export type CatalogExportRow = {
   id: number;
+  legacy_release_id: number;
   artist_name: string;
+  alternate_artist_name: string | null;
+  album_artist: string | null;
+  cross_reference_names: string | null;
   album_title: string;
   code_letters: string;
   code_number: number;
@@ -67,7 +73,11 @@ export type CatalogExportRow = {
  */
 const projectRow = (row: CatalogExportRow): CatalogExportRow => ({
   id: row.id,
+  legacy_release_id: row.legacy_release_id,
   artist_name: row.artist_name,
+  alternate_artist_name: row.alternate_artist_name,
+  album_artist: row.album_artist,
+  cross_reference_names: row.cross_reference_names,
   album_title: row.album_title,
   code_letters: row.code_letters,
   code_number: row.code_number,
@@ -147,14 +157,51 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    means the logical album has no plays at all (linked or free-text), per the
  *    merged SSOT contract. Same watermark-lag caveat as `plays` (the refresh does
  *    not advance `library_watermark`).
+ *  - the four BS#1965 library.db-producer fields: `legacy_release_id`,
+ *    `alternate_artist_name`, and `album_artist` are raw `library` columns;
+ *    `cross_reference_names` is the pipe-joined artist-alias string from the
+ *    `artist_aliases` CTE (see its inline comment). These feed the Backend-sourced
+ *    `library.db` producer (discogs-etl#351) — `legacy_release_id` becomes
+ *    library.db's `library.id`. `cross_reference_names` rides `library_watermark`
+ *    freshness like `plays`/`popularity`: an `artist_crossreference` edit surfaces
+ *    only on the next watermark-advancing write — acceptable day-scale lag for the
+ *    daily producer.
  *
  * One scan per watermark (cached below), so the full-table cost is paid ~daily.
  */
 export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
   const rows = await db.execute(sql`
+    WITH artist_aliases AS (
+      -- Per-artist alias aggregation for cross_reference_names (BS#1965,
+      -- discogs-etl#334). UNION folds artist_crossreference in BOTH FK directions
+      -- into (artist_id, other_id) pairs so a row filed under either endpoint
+      -- surfaces the other; string_agg DISTINCT ... ORDER BY yields a stable,
+      -- deduplicated, alphabetically-ordered pipe-joined string — the deterministic
+      -- analogue of the legacy MySQL GROUP_CONCAT(DISTINCT ... SEPARATOR ' | ').
+      -- O(crossref rows), joined once per artist, NOT a per-library correlated scan.
+      SELECT cp.artist_id AS artist_id,
+             string_agg(DISTINCT ${artists.artist_name}, ' | ' ORDER BY ${artists.artist_name})
+               AS cross_reference_names
+      FROM (
+        SELECT ${artist_crossreference.source_artist_id} AS artist_id,
+               ${artist_crossreference.target_artist_id} AS other_id
+        FROM ${artist_crossreference}
+        UNION
+        SELECT ${artist_crossreference.target_artist_id} AS artist_id,
+               ${artist_crossreference.source_artist_id} AS other_id
+        FROM ${artist_crossreference}
+      ) cp
+        INNER JOIN ${artists} ON ${artists.id} = cp.other_id
+      WHERE cp.other_id <> cp.artist_id
+      GROUP BY cp.artist_id
+    )
     SELECT DISTINCT ON (${library.id})
       ${library.id}                            AS id,
+      ${library.legacy_release_id}             AS legacy_release_id,
       COALESCE(${library.artist_name}, ${artists.artist_name}) AS artist_name,
+      ${library.alternate_artist_name}         AS alternate_artist_name,
+      ${library.album_artist}                  AS album_artist,
+      artist_aliases.cross_reference_names     AS cross_reference_names,
       ${library.album_title}                   AS album_title,
       ${artists.code_letters}                  AS code_letters,
       ${library.code_number}                   AS code_number,
@@ -175,6 +222,7 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
       INNER JOIN ${genre_artist_crossreference}
         ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
+      LEFT JOIN artist_aliases ON artist_aliases.artist_id = ${library.artist_id}
       LEFT JOIN ${rotation} ON ${rotation.album_id} = ${library.id}
       LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library.id}
       LEFT JOIN ${album_popularity} ON ${album_popularity.logical_album_key} = ${logicalAlbumKeySql(
@@ -205,3 +253,91 @@ const catalogExportCache = createWatermarkCache<Buffer>(getCatalogLastModifiedAt
  * doesn't accept gzip.
  */
 export const getCatalogExportGzip = (): Promise<Buffer> => catalogExportCache.get();
+
+// ---------------------------------------------------------------------------
+// Compilation-track (CTA) export (BS#1965) — sibling of the catalog export
+// ---------------------------------------------------------------------------
+
+/**
+ * One compilation_track_artist row as exported to the library.db producer
+ * (BS#1965 / discogs-etl#351). Feeds library.db's `compilation_track_artist`
+ * table (3 columns), the sibling of the `library` table that `CatalogExportRow`
+ * feeds. Keyed on `legacy_release_id` — the owning library row's surrogate key,
+ * which `CatalogExportRow` also emits AS library.db's `library.id` — so the
+ * producer maps `legacy_release_id` -> `compilation_track_artist.library_release_id`.
+ * Deliberately drops the CTA row `id` + `track_position`: library.db's 3-column
+ * CTA table carries neither.
+ */
+export type CompilationTrackExportRow = {
+  legacy_release_id: number;
+  artist_name: string;
+  track_title: string | null;
+};
+
+/**
+ * Project to exactly the CTA export contract fields, in a fixed key order.
+ * Explicit projection (not a passthrough) so the CTA row `id`, the serial
+ * `library_id`, or `track_position` can never leak into the produced library.db.
+ */
+const projectCompilationTrackRow = (row: CompilationTrackExportRow): CompilationTrackExportRow => ({
+  legacy_release_id: row.legacy_release_id,
+  artist_name: row.artist_name,
+  track_title: row.track_title,
+});
+
+/**
+ * Serialize CTA export rows to NDJSON (one JSON object per line). Empty input
+ * yields an empty string (no trailing newline to mis-parse as a row).
+ */
+export const serializeCompilationTracksNdjson = (rows: CompilationTrackExportRow[]): string =>
+  rows.map((row) => JSON.stringify(projectCompilationTrackRow(row))).join('\n');
+
+/**
+ * Read every compilation_track_artist row as flat export rows, keyed on the
+ * owning library row's `legacy_release_id` (NOT the serial CTA `library_id`).
+ * INNER JOIN to `library` because `compilation_track_artist.library_id` is a
+ * NOT-NULL cascade FK, so every CTA row has exactly one library parent with a
+ * (now total, BS#1963) `legacy_release_id`. Ordered by `legacy_release_id` (then
+ * CTA `id` for a stable tiebreak), matching the legacy MySQL export's
+ * `ORDER BY LIBRARY_RELEASE_ID`.
+ *
+ * One scan per watermark (cached below). CTA freshness rides `library_watermark`
+ * (see the endpoint docblock): a new compilation's rows surface as soon as its
+ * library add advances the watermark; a standalone CTA edit lags to the next
+ * library write — acceptable day-scale lag for the daily producer.
+ */
+export const getCompilationTrackExportRows = async (): Promise<CompilationTrackExportRow[]> => {
+  const rows = await db.execute(sql`
+    SELECT
+      ${library.legacy_release_id}             AS legacy_release_id,
+      ${compilation_track_artist.artist_name}  AS artist_name,
+      ${compilation_track_artist.track_title}  AS track_title
+    FROM ${compilation_track_artist}
+      INNER JOIN ${library} ON ${library.id} = ${compilation_track_artist.library_id}
+    ORDER BY ${library.legacy_release_id} ASC, ${compilation_track_artist.id} ASC
+  `);
+  return rows as unknown as CompilationTrackExportRow[];
+};
+
+/**
+ * Build the gzipped NDJSON CTA payload from a fresh scan.
+ */
+const buildCompilationTracksExportGzip = async (): Promise<Buffer> => {
+  const rows = await getCompilationTrackExportRows();
+  return gzipSync(Buffer.from(serializeCompilationTracksNdjson(rows), 'utf8'));
+};
+
+// One shared gzipped copy per pod, rebuilt only when the catalog watermark
+// advances (≈daily) — same watermark as the library export, so the two exports
+// the producer fetches together stay a consistent snapshot.
+const compilationTracksExportCache = createWatermarkCache<Buffer>(
+  getCatalogLastModifiedAt,
+  buildCompilationTracksExportGzip
+);
+
+/**
+ * The gzipped NDJSON CTA export for the current watermark. Served as-is on the
+ * gzip-accepting path; gunzipped by the controller for the rare client that
+ * doesn't accept gzip.
+ */
+export const getCompilationTracksExportGzip = (): Promise<Buffer> => compilationTracksExportCache.get();

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@sentry/node": "^10.68.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^3.1.0",
+        "@wxyc/shared": "^3.3.0",
         "better-auth": "^1.6.23",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^3.1.0",
+        "@wxyc/shared": "^3.3.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -6828,9 +6828,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.1.0/e6b6c1794ef0e00d956c1c21bffd355d5c848118",
-      "integrity": "sha512-pHo39RYSFlIXp2h9IIiR6zftT6fWGQtK9VhqzpA+Vp82/FcqFBZsj+HtfAWl1/ErXKuxX/qq+MhfUo4WLaFJdw==",
+      "version": "3.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.3.0/59a732ace25762ee1162961d66c00dd7b8faf10e",
+      "integrity": "sha512-sWw3UI/y8utojUBUM6IJy7W26AEIillxftGFmq0vOCrH56lyXO2tTthrTDQz5aLWTZ/weNYhjCa8HN/RizEdEQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -15076,7 +15076,7 @@
         "@aws-sdk/client-ses": "^3.1096.0",
         "@sentry/node": "^10.68.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^3.1.0",
+        "@wxyc/shared": "^3.3.0",
         "better-auth": "^1.6.23",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15366,7 +15366,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.68.0",
-        "@wxyc/shared": "^3.1.0"
+        "@wxyc/shared": "^3.3.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1096.0",
     "@sentry/node": "^10.68.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^3.1.0",
+    "@wxyc/shared": "^3.3.0",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/database/src/migrations/0138_catalog-export-watermark-triggers.sql
+++ b/shared/database/src/migrations/0138_catalog-export-watermark-triggers.sql
@@ -1,0 +1,59 @@
+-- BS#1965 — extend the catalog freshness watermark to the two tables the
+-- library.db-producer export reads that migration 0105 does not cover.
+--
+-- 0104 (#1467) created `library_watermark` + `touch_library_watermark()` and
+-- attached the AFTER STATEMENT trigger to `library`. 0105 (#1468) fanned it out
+-- to the five join parents whose columns `GET /library/catalog` projects
+-- (artists, genres, format, genre_artist_crossreference, rotation). BS#1965 adds
+-- two more source tables to that export surface, and the same coverage invariant
+-- applies: every exported field's source table must advance the watermark.
+--
+--   artist_crossreference    -> CatalogExportRow.cross_reference_names
+--   compilation_track_artist -> the whole GET /library/catalog/compilation-tracks body
+--
+-- Neither is a "lag" without this migration — both are SILENT AND UNBOUNDED.
+-- The conditional-GET middleware short-circuits to 304 on an unchanged
+-- watermark, and the per-watermark gzip cache is only rebuilt when the watermark
+-- moves. So a write to either table lands in Postgres, changes nothing the
+-- client can observe, and stays invisible until some UNRELATED write to one of
+-- the seven already-covered tables happens to bump the watermark.
+--
+-- `compilation_track_artist` is the sharper of the two, because the intuitive
+-- "it'll ride the library add" reasoning is backwards. The real sequence is:
+--
+--   1. POST /library                          -> library trigger bumps watermark to T
+--   2. (first request after)                  -> gzip cache builds for T
+--   3. POST /library/{id}/compilation-tracks  -> CTA rows land at T+delta, no trigger
+--
+-- The CTA POST always FOLLOWS the library add it would supposedly ride, so the
+-- cached body for T never contains the tracks. Post-tubafrenzy-turndown the daily
+-- library sync goes away too, so "the next daily write will pick it up" stops
+-- holding and a CTA-only cataloging session can stay invisible indefinitely.
+--
+-- Reuses `touch_library_watermark()` verbatim (defined in 0104) — same one-row
+-- UPDATE, same monotonic `GREATEST(now(), last_modified_at)` advance, same
+-- per-statement O(1) cost regardless of how many rows the statement touched. No
+-- schema objects change, so `drizzle:generate` produces no diff and this is a
+-- `--custom` migration whose snapshot is byte-identical to 0137's apart from the
+-- id/prevId chain link. TRUNCATE is included for symmetry with 0104/0105.
+--
+-- Write-rate note: both tables are curated, not hot. `artist_crossreference` is
+-- librarian-edited at human cadence; `compilation_track_artist` is written by the
+-- BS#1964 CTA path on V/A catalog adds. Neither approaches `rotation`, which 0105
+-- already accepted as the continuously-curated case. The cost of a bumped
+-- watermark is one full-catalog rebuild on the next request — the same cost the
+-- `library` trigger already pays on every catalog add.
+--
+-- @no-analyze-needed: no UPDATE on a stats-bearing table — the only write is the
+-- one-row `library_watermark` UPDATE inside the reused trigger function.
+-- @no-precondition-needed: trigger DDL only; no constraint, no data invariant.
+
+CREATE TRIGGER touch_library_watermark_from_artist_crossreference
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.artist_crossreference
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();
+--> statement-breakpoint
+CREATE TRIGGER touch_library_watermark_from_compilation_track_artist
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.compilation_track_artist
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();

--- a/shared/database/src/migrations/meta/0138_snapshot.json
+++ b/shared/database/src/migrations/meta/0138_snapshot.json
@@ -1,0 +1,6252 @@
+{
+  "id": "17e880d1-b075-48ed-8ce4-a1e6a2af7316",
+  "prevId": "659366d4-303a-41c2-83b4-6ee1a7ea89a9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_status": {
+          "name": "spotify_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_status": {
+          "name": "apple_music_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_status": {
+          "name": "bandcamp_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_reask_attempts": {
+          "name": "streaming_reask_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concert_performers": {
+      "name": "concert_performers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "concert_id": {
+          "name": "concert_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "concert_performer_role_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id_source": {
+          "name": "discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concert_performers_concert_role_raw_name_idx": {
+          "name": "concert_performers_concert_role_raw_name_idx",
+          "columns": [
+            {
+              "expression": "concert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "concert_performers_concert_id_concerts_id_fk": {
+          "name": "concert_performers_concert_id_concerts_id_fk",
+          "tableFrom": "concert_performers",
+          "columnsFrom": [
+            "concert_id"
+          ],
+          "tableTo": "concerts",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "concert_performers_artist_id_artists_id_fk": {
+          "name": "concert_performers_artist_id_artists_id_fk",
+          "tableFrom": "concert_performers",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "has_resolved_support": {
+          "name": "has_resolved_support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"has_resolved_support\") AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false
+        },
+        "flowsheet_rotation_no_match_idx": {
+          "name": "flowsheet_rotation_no_match_idx",
+          "columns": [
+            {
+              "expression": "rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriched_no_match' AND \"wxyc_schema\".\"flowsheet\".\"rotation_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "columns": [
+            "flowsheet_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "columns": [
+            "label_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('\"wxyc_schema\".\"library_legacy_release_id_seq\"'::regclass)"
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unresolved_attempted_at": {
+          "name": "unresolved_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "auth_oauth_application",
+          "columnsTo": [
+            "client_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "columns": [
+            "access_token"
+          ],
+          "nullsNotDistinct": false
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "columns": [
+            "refresh_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "columns": [
+            "client_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "auth_oauth_application",
+          "columnsTo": [
+            "client_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "columns": [
+            "album_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "discogs_release_id_resolve_attempted_at": {
+          "name": "discogs_release_id_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_performer_role_enum": {
+      "name": "concert_performer_role_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "headliner",
+        "support"
+      ]
+    },
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\", \"wxyc_schema\".\"library\".\"discogs_unavailable\", \"wxyc_schema\".\"library\".\"discogs_unavailable_note\", \"wxyc_schema\".\"library\".\"last_discogs_recheck_at\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.album_plays": {
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "materialized": true,
+      "isExisting": true
+    }
+  },
+  "sequences": {
+    "wxyc_schema.library_legacy_release_id_seq": {
+      "name": "library_legacy_release_id_seq",
+      "increment": "1",
+      "minValue": "1000000",
+      "maxValue": "9223372036854775807",
+      "startWith": "1000000",
+      "cache": "1",
+      "cycle": false,
+      "schema": "wxyc_schema"
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -946,6 +946,13 @@
       "when": 1785643907962,
       "tag": "0137_mint-legacy-release-id",
       "breakpoints": true
+    },
+    {
+      "idx": 138,
+      "version": "7",
+      "when": 1785643907963,
+      "tag": "0138_catalog-export-watermark-triggers",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -133,5 +133,6 @@
   "0134_fold-artist-name": "fd865d83c820b9437ae31073f3d30eced23b874b076256c2db1c0dcac3829a5b",
   "0135_album-metadata-streaming-reask": "ee0309ccc3e4ded44d7dfd9f301f1f2b905c2fd2f36f31a99837356aee1327e5",
   "0136_flowsheet-album-link-lookup-stats": "cb520c875456af28a5e54fe080f8b3364b211b7c560f4e8f9bf6e92e28d2899c",
-  "0137_mint-legacy-release-id": "f3718406cf1e32ffe2ccba30d286434eac8c139abbeb5a0e2a7e109d6345d85f"
+  "0137_mint-legacy-release-id": "f3718406cf1e32ffe2ccba30d286434eac8c139abbeb5a0e2a7e109d6345d85f",
+  "0138_catalog-export-watermark-triggers": "eac1674c4b42d7473a147a9c02a0caa7d2d7946a069c79aa5f7f2e71323a6090"
 }

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.68.0",
-    "@wxyc/shared": "^3.1.0"
+    "@wxyc/shared": "^3.3.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -49,18 +49,23 @@ const PROBE_POP_LIBFALLBACK = 7061; // NULL canonical -> ELSE branch key 'librar
 const POP_LIBFALLBACK_KEY = `library:${PROBE_POP_LIBFALLBACK}`;
 const POP_LIBFALLBACK_TOTAL = 7; // seeded album_popularity.plays for the library: key
 
-// Exactly the export contract field set (#1468 AC + #1493 popularity), sorted.
+// Exactly the export contract field set (#1468 AC + #1493 popularity + the four
+// BS#1965 library.db-producer fields), sorted.
 const CONTRACT_KEYS = [
+  'album_artist',
   'album_title',
+  'alternate_artist_name',
   'artist_name',
   'artwork_url',
   'code_artist_number',
   'code_letters',
   'code_number',
+  'cross_reference_names',
   'format_name',
   'genre_name',
   'id',
   'label',
+  'legacy_release_id',
   'on_streaming',
   'plays',
   'popularity',

--- a/tests/integration/library-catalog-producer-export.spec.js
+++ b/tests/integration/library-catalog-producer-export.spec.js
@@ -7,6 +7,15 @@
  * and adds the sibling CTA export GET /library/catalog/compilation-tracks that
  * feeds library.db's compilation_track_artist table.
  *
+ * Also covers the three things the merged SSOT (WXYC/wxyc-shared#293) makes
+ * load-bearing and that no unit test can reach:
+ *   - cross_reference_names is an ARRAY ordered by Unicode code point
+ *     (COLLATE "C"), not the pipe-joined string and not the locale default;
+ *   - the CTA export applies the SAME 4-INNER-JOIN row-eligibility predicate as
+ *     /library/catalog, so no CTA key joins to nothing in the produced library.db;
+ *   - migration 0138's watermark triggers, without which a cross-reference or
+ *     CTA write is invisible to the conditional GET silently and unboundedly.
+ *
  * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL seeds
  * isolated fixtures, supertest drives the HTTP surface. All seeded rows live in a
  * dedicated 7170-range this spec owns end-to-end (created + reaped here), so it
@@ -23,18 +32,36 @@ const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 const GEN = 11; // 'Rock'
 const FMT = 1; // 'cd'
 
-// Isolated artists: a "main" filing artist + two cross-reference partners.
+// Isolated artists: a "main" filing artist + three cross-reference partners.
 const ART_MAIN = 7170;
 const ART_XREF_A = 7171; // 'BS1965 Xref Beta'
 const ART_XREF_B = 7172; // 'BS1965 Xref Gamma'
+const ART_XREF_C = 7175; // 'bs1965 Xref Delta' — lowercase initial, the collation probe
 const XREF_A_NAME = 'BS1965 Xref Beta';
 const XREF_B_NAME = 'BS1965 Xref Gamma';
-// Alphabetical, deduplicated, pipe-joined — the deterministic analogue of the
-// legacy MySQL GROUP_CONCAT(DISTINCT ... SEPARATOR ' | ').
-const EXPECTED_XREF = `${XREF_A_NAME} | ${XREF_B_NAME}`;
+const XREF_C_NAME = 'bs1965 Xref Delta';
+
+// Deduplicated, bidirectional, ordered by UNICODE CODE POINT (Postgres
+// COLLATE "C") — an ARRAY on the wire, never the pipe-joined string library.db
+// stores (the producer does that join itself).
+//
+// The lowercase-initial third name is the load-bearing part of this fixture.
+// Under COLLATE "C", 'b' (U+0062) sorts after 'B' (U+0042), so Delta lands LAST:
+//   ['BS1965 Xref Beta', 'BS1965 Xref Gamma', 'bs1965 Xref Delta']
+// Under the database's default en_US.UTF-8 collation, case is ignored at the
+// primary level and Delta would sort BETWEEN Beta and Gamma. The two orderings
+// disagree, so this array pins that the query really is collation-explicit
+// rather than accidentally passing on the local database's default.
+const EXPECTED_XREF = [XREF_A_NAME, XREF_B_NAME, XREF_C_NAME];
 
 const LIB_PRODUCER = 7173; // library row under ART_MAIN, with album_artist + alternate
 const LIB_CTA = 7174; // library row under ART_MAIN that owns the seeded CTA rows
+
+// Row-eligibility probe: an artist deliberately given NO genre_artist_crossreference
+// entry for GEN, so its library row fails the catalog export's 4-INNER-JOIN
+// predicate. Its CTA rows must be dropped from the CTA export too.
+const ART_NO_GAC = 7176;
+const LIB_NO_GAC = 7177;
 
 function makeSql() {
   return postgres({
@@ -73,36 +100,44 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
   let sql;
   let mainLegacyId; // minted legacy_release_id of LIB_PRODUCER (queried at runtime)
   let ctaLegacyId; // minted legacy_release_id of LIB_CTA
+  let noGacLegacyId; // minted legacy_release_id of the export-ineligible LIB_NO_GAC
 
   beforeAll(async () => {
     auth = createAuthRequest(request, global.access_token);
     sql = makeSql();
 
     // Isolated artists + genre crossref so the export's INNER JOINs resolve.
+    // ART_NO_GAC deliberately gets NO genre_artist_crossreference row (below).
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".artists (id, artist_name, alphabetical_name, code_letters)
        VALUES ($1, 'BS1965 Main Filing Artist', 'BS1965 Main Filing Artist', 'ZA'),
-              ($2, $4, $4, 'ZB'),
-              ($3, $5, $5, 'ZC')
+              ($2, $5, $5, 'ZB'),
+              ($3, $6, $6, 'ZC'),
+              ($4, $7, $7, 'ZD'),
+              ($8, 'BS1965 Ineligible Artist', 'BS1965 Ineligible Artist', 'ZE')
        ON CONFLICT (id) DO NOTHING`,
-      [ART_MAIN, ART_XREF_A, ART_XREF_B, XREF_A_NAME, XREF_B_NAME]
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, XREF_A_NAME, XREF_B_NAME, XREF_C_NAME, ART_NO_GAC]
     );
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-       VALUES ($1, $4, 970), ($2, $4, 971), ($3, $4, 972)
+       VALUES ($1, $5, 970), ($2, $5, 971), ($3, $5, 972), ($4, $5, 973)
        ON CONFLICT (artist_id, genre_id) DO NOTHING`,
-      [ART_MAIN, ART_XREF_A, ART_XREF_B, GEN]
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, GEN]
     );
 
-    // Cross-references in BOTH FK directions, plus a redundant reverse row, to
-    // prove the export folds both directions and dedups: ART_MAIN -> A (forward),
-    // A -> ART_MAIN (redundant reverse; must NOT double 'Beta'), and B -> ART_MAIN
-    // (reverse only). Expected result for ART_MAIN: {Beta, Gamma}.
+    // Cross-references in BOTH FK directions, plus a redundant reverse row and a
+    // self-reference, to prove the export folds both directions, dedups, and
+    // excludes the row's own artist: ART_MAIN -> A (forward), A -> ART_MAIN
+    // (redundant reverse; must NOT double 'Beta'), B -> ART_MAIN (reverse only),
+    // ART_MAIN -> C (the collation probe), and ART_MAIN -> ART_MAIN (self; must
+    // NOT appear — LML would otherwise match the artist against itself).
+    // Expected result for ART_MAIN: {Beta, Gamma, delta}, C-ordered.
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".artist_crossreference (source_artist_id, target_artist_id, comment)
-       VALUES ($1, $2, 'forward'), ($2, $1, 'reverse-dup'), ($3, $1, 'reverse-only')
+       VALUES ($1, $2, 'forward'), ($2, $1, 'reverse-dup'), ($3, $1, 'reverse-only'),
+              ($1, $4, 'collation-probe'), ($1, $1, 'self-reference')
        ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING`,
-      [ART_MAIN, ART_XREF_A, ART_XREF_B]
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C]
     );
 
     // Producer-fields probe: album_artist + alternate_artist_name populated.
@@ -131,12 +166,30 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       [LIB_CTA]
     );
 
+    // Row-eligibility probe: a library row whose (artist_id, genre_id) pair has
+    // NO genre_artist_crossreference entry, so the catalog export's INNER JOIN
+    // drops it. It owns a CTA row, which must be dropped from the CTA export too.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, 'BS1965 Ineligible Compilation', 73, 'BS1965 Ineligible Artist')
+       ON CONFLICT (id) DO NOTHING`,
+      [LIB_NO_GAC, ART_NO_GAC, GEN, FMT]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".compilation_track_artist (library_id, artist_name, track_title, track_position)
+       VALUES ($1, 'BS1965 Orphan Track Artist', 'Should Not Be Exported', 'B1')`,
+      [LIB_NO_GAC]
+    );
+
     // Capture the minted legacy_release_ids (BS#1963 nextval default; not
     // hardcodable) so assertions bind to the real surrogate keys.
     const mainRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_PRODUCER]);
     const ctaRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_CTA]);
+    const noGacRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_NO_GAC]);
     mainLegacyId = mainRow[0].legacy_release_id;
     ctaLegacyId = ctaRow[0].legacy_release_id;
+    noGacLegacyId = noGacRow[0].legacy_release_id;
   });
 
   afterAll(async () => {
@@ -144,23 +197,22 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       // compilation_track_artist.library_id is ON DELETE CASCADE, so the library
       // delete reaps the seeded CTA rows. artist_crossreference has no FK to
       // library; reap it explicitly. Delete library rows before artists (FK).
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2)`, [LIB_PRODUCER, LIB_CTA]);
+      const artistIds = [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, ART_NO_GAC];
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3)`, [LIB_PRODUCER, LIB_CTA, LIB_NO_GAC]);
       await sql.unsafe(
         `DELETE FROM "${SCHEMA}".artist_crossreference
-         WHERE source_artist_id IN ($1, $2, $3) OR target_artist_id IN ($1, $2, $3)`,
-        [ART_MAIN, ART_XREF_A, ART_XREF_B]
+         WHERE source_artist_id = ANY($1::int[]) OR target_artist_id = ANY($1::int[])`,
+        [artistIds]
       );
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".genre_artist_crossreference WHERE artist_id IN ($1, $2, $3)`, [
-        ART_MAIN,
-        ART_XREF_A,
-        ART_XREF_B,
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".genre_artist_crossreference WHERE artist_id = ANY($1::int[])`, [
+        artistIds,
       ]);
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE id IN ($1, $2, $3)`, [ART_MAIN, ART_XREF_A, ART_XREF_B]);
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE id = ANY($1::int[])`, [artistIds]);
       await sql.end();
     }
   });
 
-  test('catalog export carries legacy_release_id + album_artist + alternate_artist_name + pipe-joined cross_reference_names', async () => {
+  test('catalog export carries legacy_release_id + album_artist + alternate_artist_name + cross_reference_names', async () => {
     // Seeding crossref/library does bump library_watermark (library INSERT), but a
     // subsequent bump makes the per-watermark cache rebuild deterministic here.
     await sql.unsafe(`UPDATE "${SCHEMA}".library SET album_title = album_title WHERE id = $1`, [LIB_PRODUCER]);
@@ -179,17 +231,46 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
     expect(row.album_artist).toBe('Various Artists');
     expect(row.alternate_artist_name).toBe('V/A');
 
-    // Bidirectional + deduped + alphabetically ordered pipe-join.
-    expect(row.cross_reference_names).toBe(EXPECTED_XREF);
+    // An ARRAY on the wire — never the pipe-joined string library.db stores.
+    expect(Array.isArray(row.cross_reference_names)).toBe(true);
+    expect(row.cross_reference_names.join('')).not.toContain('|');
+
+    // Bidirectional + deduped + self-excluded + ordered by Unicode code point.
+    expect(row.cross_reference_names).toEqual(EXPECTED_XREF);
   });
 
-  test('cross_reference_names is null for an artist with no cross-references', async () => {
-    // The CTA-owning row shares ART_MAIN — which HAS cross-references — so use a
-    // shape-fixture row whose artist (7001 'Beta') has none seeded.
+  test('orders cross_reference_names by Unicode code point, not the default collation', async () => {
+    // The 'bs1965 Xref Delta' fixture has a lowercase initial. COLLATE "C" sorts
+    // it LAST ('b' U+0062 > 'B' U+0042); the database's default en_US.UTF-8
+    // collation ignores case at the primary level and would sort it BETWEEN Beta
+    // and Gamma. Asserting the C order pins that the query is collation-explicit
+    // — without the COLLATE the local default would produce the other order.
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    const names = byId.get(LIB_PRODUCER).cross_reference_names;
+
+    expect(names).toEqual(['BS1965 Xref Beta', 'BS1965 Xref Gamma', 'bs1965 Xref Delta']);
+    // Explicitly NOT the locale-collated order, so a regression to the default
+    // fails here with a readable diff rather than passing by coincidence.
+    expect(names).not.toEqual(['BS1965 Xref Beta', 'bs1965 Xref Delta', 'BS1965 Xref Gamma']);
+  });
+
+  test('excludes the row own artist from cross_reference_names (self-reference guard)', async () => {
+    // A self-referencing artist_crossreference row must not produce a self-alias
+    // — LML would match the artist against itself.
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    expect(byId.get(LIB_PRODUCER).cross_reference_names).not.toContain('BS1965 Main Filing Artist');
+  });
+
+  test('cross_reference_names is an EMPTY ARRAY for an artist with no cross-references', async () => {
+    // Contract: empty array, not null and not absent, so the producer never has
+    // to distinguish "no aliases" from "field missing". The CTA-owning row shares
+    // ART_MAIN — which HAS cross-references — so use a shape-fixture row whose
+    // artist (7001 'Beta') has none seeded.
     const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
     const noXref = byId.get(7002); // 'Shape Fixture Album Beta 1', artist 7001
     expect(noXref).toBeDefined();
-    expect(noXref.cross_reference_names).toBeNull();
+    expect(noXref.cross_reference_names).toEqual([]);
+    expect(noXref.cross_reference_names).not.toBeNull();
   });
 
   test('GET /library/catalog/compilation-tracks returns gzipped NDJSON with freshness + content headers', async () => {
@@ -275,6 +356,113 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
     expect(res.status).toBe(401);
   });
 
+  // ---- Row eligibility: the two exports must apply the SAME predicate --------
+
+  test('drops CTA rows whose owning library row is ineligible for /library/catalog', async () => {
+    // LIB_NO_GAC's (artist_id, genre_id) pair has no genre_artist_crossreference
+    // entry, so the catalog export's INNER JOIN drops it. An unfiltered CTA export
+    // would still ship its track — a library_release_id joining to nothing in the
+    // library.db `library` table the sibling endpoint produces, which LML's CTA
+    // UNION would surface as a compilation track whose release it cannot resolve.
+    const catalogIds = new Set(parseRows(await getCatalog(auth)).map((r) => r.legacy_release_id));
+    expect(catalogIds.has(noGacLegacyId)).toBe(false); // precondition: really ineligible
+    expect(catalogIds.has(ctaLegacyId)).toBe(true); // control: the eligible sibling IS present
+
+    const ctaRows = parseRows(await getCta(auth));
+    expect(ctaRows.map((r) => r.legacy_release_id)).not.toContain(noGacLegacyId);
+    expect(ctaRows.map((r) => r.artist_name)).not.toContain('BS1965 Orphan Track Artist');
+  });
+
+  test('every CTA legacy_release_id resolves to a row in the catalog export', async () => {
+    // The invariant the eligibility predicate exists to hold, asserted over the
+    // WHOLE body rather than just the seeded fixture: the producer builds
+    // library.db's compilation_track_artist FK against library.db's library table,
+    // so a CTA key with no library row is a broken join in the artifact.
+    const catalogIds = new Set(parseRows(await getCatalog(auth)).map((r) => r.legacy_release_id));
+    const orphans = [...new Set(parseRows(await getCta(auth)).map((r) => r.legacy_release_id))].filter(
+      (id) => !catalogIds.has(id)
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  // ---- Watermark coverage (migration 0138) ----------------------------------
+
+  test('an artist_crossreference write advances the watermark and republishes the catalog', async () => {
+    // Without the 0138 trigger this failure is silent and unbounded, not a lag:
+    // artist_crossreference is not one of the seven tables 0104/0105 cover, so a
+    // new alias would never advance the watermark, the per-watermark gzip cache
+    // would never rebuild, and the producer would 304 forever against a body that
+    // will never contain it.
+    const before = await getCatalog(auth);
+    const lastModified = before.headers['last-modified'];
+    expect(parseRows(before).find((r) => r.id === LIB_PRODUCER).cross_reference_names).toEqual(EXPECTED_XREF);
+
+    await sleep(1100); // Last-Modified has 1-second resolution
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".artist_crossreference
+       WHERE source_artist_id = $1 AND target_artist_id = $2`,
+      [ART_MAIN, ART_XREF_C]
+    );
+
+    const after = await auth
+      .get('/library/catalog')
+      .set('If-Modified-Since', lastModified)
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(after.status).toBe(200); // NOT 304 — the crossref write moved the watermark
+    expect(parseRows(after).find((r) => r.id === LIB_PRODUCER).cross_reference_names).toEqual([
+      XREF_A_NAME,
+      XREF_B_NAME,
+    ]);
+
+    // Restore for the fixture-parity test, and confirm the re-add republishes too.
+    await sleep(1100);
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_crossreference (source_artist_id, target_artist_id, comment)
+       VALUES ($1, $2, 'collation-probe')
+       ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING`,
+      [ART_MAIN, ART_XREF_C]
+    );
+    expect(parseRows(await getCatalog(auth)).find((r) => r.id === LIB_PRODUCER).cross_reference_names).toEqual(
+      EXPECTED_XREF
+    );
+  });
+
+  test('a compilation_track_artist write advances the watermark and republishes the CTA export', async () => {
+    // The sharp case. The intuitive "the CTA rows ride the library add" reasoning
+    // is backwards: the CTA POST always FOLLOWS the library add, so the cached
+    // body for the library-add watermark never contains the tracks. Without the
+    // 0138 trigger this endpoint 304s until some unrelated write moves the
+    // watermark — and post-tubafrenzy-turndown there is no daily library sync left
+    // to eventually supply one.
+    const before = await getCta(auth);
+    const lastModified = before.headers['last-modified'];
+    const countBefore = parseRows(before).filter((r) => r.legacy_release_id === ctaLegacyId).length;
+
+    await sleep(1100);
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".compilation_track_artist (library_id, artist_name, track_title, track_position)
+       VALUES ($1, 'BS1965 Late Added Track Artist', 'Added After The Library Row', 'C1')`,
+      [LIB_CTA]
+    );
+
+    const after = await auth
+      .get('/library/catalog/compilation-tracks')
+      .set('If-Modified-Since', lastModified)
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(after.status).toBe(200); // NOT 304 — the CTA write moved the watermark
+    const mine = parseRows(after).filter((r) => r.legacy_release_id === ctaLegacyId);
+    expect(mine).toHaveLength(countBefore + 1);
+    expect(mine.map((r) => r.artist_name)).toContain('BS1965 Late Added Track Artist');
+
+    // Reap so the fixture-parity test still sees exactly its three seeded rows.
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".compilation_track_artist WHERE library_id = $1 AND artist_name = $2`, [
+      LIB_CTA,
+      'BS1965 Late Added Track Artist',
+    ]);
+  });
+
   // The acceptance-criterion parity check: for one known release, the exported
   // library row + CTA rows match the library.db shape the legacy MySQL TSV
   // produces (modulo the documented `label` omission), so the producer can build
@@ -298,7 +486,10 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       alternate_artist_name: lib.alternate_artist_name,
       album_artist: lib.album_artist,
       label: null, // library.db always-NULL by design
-      cross_reference_names: lib.cross_reference_names,
+      // The producer owns the ' | ' join — the wire ships an array, SQLite stores
+      // the joined string. This line IS that join, so the parity check exercises
+      // the same transformation discogs-etl#351 performs.
+      cross_reference_names: lib.cross_reference_names.join(' | '),
     };
     expect(libraryDbRow).toEqual({
       id: mainLegacyId,
@@ -312,7 +503,7 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       alternate_artist_name: 'V/A',
       album_artist: 'Various Artists',
       label: null,
-      cross_reference_names: EXPECTED_XREF,
+      cross_reference_names: EXPECTED_XREF.join(' | '),
     });
 
     // The 3-column library.db `compilation_track_artist` rows for a known release,

--- a/tests/integration/library-catalog-producer-export.spec.js
+++ b/tests/integration/library-catalog-producer-export.spec.js
@@ -18,9 +18,10 @@
  *
  * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL seeds
  * isolated fixtures, supertest drives the HTTP surface. All seeded rows live in a
- * dedicated 7170-range this spec owns end-to-end (created + reaped here), so it
- * can't collide with the shared shape fixture or the 7050-range the sibling
- * catalog-export spec uses.
+ * dedicated 900170+ range this spec owns end-to-end (created + reaped here) and
+ * every assertion binds to a row this file seeded — no dependency on the shared
+ * shape fixture, and above the prod-clone fixture's id space (see the id block
+ * below for why that matters).
  */
 
 const zlib = require('zlib');
@@ -32,11 +33,19 @@ const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 const GEN = 11; // 'Rock'
 const FMT = 1; // 'cd'
 
-// Isolated artists: a "main" filing artist + three cross-reference partners.
-const ART_MAIN = 7170;
-const ART_XREF_A = 7171; // 'BS1965 Xref Beta'
-const ART_XREF_B = 7172; // 'BS1965 Xref Gamma'
-const ART_XREF_C = 7175; // 'bs1965 Xref Delta' — lowercase initial, the collation probe
+// Fixture id range. 900000+ deliberately: the dev prod-clone fixture
+// (`dev_env/seed-clone.sql`, loaded when LOAD_CLONE_FIXTURE=true) occupies
+// artists 1-27050 and library 1-70351, so the 7xxx range this spec originally
+// used collided with real clone rows (artists 7169-7178 are Helmet, Helms, Hem,
+// Karl Hendricks, Jimi Hendrix, ...). Under the clone, the ON CONFLICT DO
+// NOTHING seeds below silently no-op onto those rows and the afterAll DELETEs
+// reap catalog data the spec never created. CI never loads the clone, so this
+// was dev-only — but "dev-only data loss" is still data loss.
+const ART_MAIN = 900170;
+const ART_XREF_A = 900171; // 'BS1965 Xref Beta'
+const ART_XREF_B = 900172; // 'BS1965 Xref Gamma'
+const ART_XREF_C = 900175; // 'bs1965 Xref Delta' — lowercase initial, the collation probe
+const ART_NO_XREF = 900179; // has no artist_crossreference rows at all
 const XREF_A_NAME = 'BS1965 Xref Beta';
 const XREF_B_NAME = 'BS1965 Xref Gamma';
 const XREF_C_NAME = 'bs1965 Xref Delta';
@@ -45,23 +54,31 @@ const XREF_C_NAME = 'bs1965 Xref Delta';
 // COLLATE "C") — an ARRAY on the wire, never the pipe-joined string library.db
 // stores (the producer does that join itself).
 //
-// The lowercase-initial third name is the load-bearing part of this fixture.
-// Under COLLATE "C", 'b' (U+0062) sorts after 'B' (U+0042), so Delta lands LAST:
-//   ['BS1965 Xref Beta', 'BS1965 Xref Gamma', 'bs1965 Xref Delta']
-// Under the database's default en_US.UTF-8 collation, case is ignored at the
-// primary level and Delta would sort BETWEEN Beta and Gamma. The two orderings
-// disagree, so this array pins that the query really is collation-explicit
-// rather than accidentally passing on the local database's default.
+// Under COLLATE "C", 'b' (U+0062) sorts after 'B' (U+0042), so Delta lands LAST.
+// On prod (RDS PostgreSQL 14.22, glibc) the database default en_US.utf8 ignores
+// case at the primary level and would instead sort Delta BETWEEN Beta and Gamma,
+// so there the collation is doing real, observable work.
+//
+// It does NOT do observable work here, and this assertion cannot prove it is
+// present. CI and dev run postgres:18.0-alpine; musl does not implement glibc
+// locales, so the database reports datcollate=en_US.utf8 but collates by byte
+// order — identical to COLLATE "C". Deleting the COLLATE from the query leaves
+// this expectation green. The guard that actually fails on its removal is the
+// source-level one in tests/unit/services/catalog-export.sql-invariants.test.ts;
+// see that file's docblock for the measured before/after on both platforms.
+// Keep this assertion anyway: it pins the array contents and dedup/self-exclusion,
+// and it is the assertion that would catch a real ordering bug on a glibc host.
 const EXPECTED_XREF = [XREF_A_NAME, XREF_B_NAME, XREF_C_NAME];
 
-const LIB_PRODUCER = 7173; // library row under ART_MAIN, with album_artist + alternate
-const LIB_CTA = 7174; // library row under ART_MAIN that owns the seeded CTA rows
+const LIB_PRODUCER = 900173; // library row under ART_MAIN, with album_artist + alternate
+const LIB_CTA = 900174; // library row under ART_MAIN that owns the seeded CTA rows
+const LIB_NO_XREF = 900180; // library row under ART_NO_XREF (empty-array probe)
 
 // Row-eligibility probe: an artist deliberately given NO genre_artist_crossreference
 // entry for GEN, so its library row fails the catalog export's 4-INNER-JOIN
 // predicate. Its CTA rows must be dropped from the CTA export too.
-const ART_NO_GAC = 7176;
-const LIB_NO_GAC = 7177;
+const ART_NO_GAC = 900176;
+const LIB_NO_GAC = 900177;
 
 function makeSql() {
   return postgres({
@@ -114,15 +131,16 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
               ($2, $5, $5, 'ZB'),
               ($3, $6, $6, 'ZC'),
               ($4, $7, $7, 'ZD'),
-              ($8, 'BS1965 Ineligible Artist', 'BS1965 Ineligible Artist', 'ZE')
+              ($8, 'BS1965 Ineligible Artist', 'BS1965 Ineligible Artist', 'ZE'),
+              ($9, 'BS1965 No Xref Artist', 'BS1965 No Xref Artist', 'ZF')
        ON CONFLICT (id) DO NOTHING`,
-      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, XREF_A_NAME, XREF_B_NAME, XREF_C_NAME, ART_NO_GAC]
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, XREF_A_NAME, XREF_B_NAME, XREF_C_NAME, ART_NO_GAC, ART_NO_XREF]
     );
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-       VALUES ($1, $5, 970), ($2, $5, 971), ($3, $5, 972), ($4, $5, 973)
+       VALUES ($1, $6, 970), ($2, $6, 971), ($3, $6, 972), ($4, $6, 973), ($5, $6, 974)
        ON CONFLICT (artist_id, genre_id) DO NOTHING`,
-      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, GEN]
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, ART_NO_XREF, GEN]
     );
 
     // Cross-references in BOTH FK directions, plus a redundant reverse row and a
@@ -182,6 +200,19 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       [LIB_NO_GAC]
     );
 
+    // Empty-array probe: an eligible library row whose artist has no
+    // artist_crossreference rows in either direction. Seeded here rather than
+    // borrowing a shared-fixture row so the assertion can't be invalidated by an
+    // unrelated fixture edit (or by the prod clone supplying a same-id row that
+    // DOES have cross-references).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, 'BS1965 No Xref Probe', 74, 'BS1965 No Xref Artist')
+       ON CONFLICT (id) DO NOTHING`,
+      [LIB_NO_XREF, ART_NO_XREF, GEN, FMT]
+    );
+
     // Capture the minted legacy_release_ids (BS#1963 nextval default; not
     // hardcodable) so assertions bind to the real surrogate keys.
     const mainRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_PRODUCER]);
@@ -197,8 +228,10 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
       // compilation_track_artist.library_id is ON DELETE CASCADE, so the library
       // delete reaps the seeded CTA rows. artist_crossreference has no FK to
       // library; reap it explicitly. Delete library rows before artists (FK).
-      const artistIds = [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, ART_NO_GAC];
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3)`, [LIB_PRODUCER, LIB_CTA, LIB_NO_GAC]);
+      const artistIds = [ART_MAIN, ART_XREF_A, ART_XREF_B, ART_XREF_C, ART_NO_GAC, ART_NO_XREF];
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id = ANY($1::int[])`, [
+        [LIB_PRODUCER, LIB_CTA, LIB_NO_GAC, LIB_NO_XREF],
+      ]);
       await sql.unsafe(
         `DELETE FROM "${SCHEMA}".artist_crossreference
          WHERE source_artist_id = ANY($1::int[]) OR target_artist_id = ANY($1::int[])`,
@@ -263,11 +296,11 @@ describe('GET /library/catalog + /compilation-tracks — library.db producer pat
 
   test('cross_reference_names is an EMPTY ARRAY for an artist with no cross-references', async () => {
     // Contract: empty array, not null and not absent, so the producer never has
-    // to distinguish "no aliases" from "field missing". The CTA-owning row shares
-    // ART_MAIN — which HAS cross-references — so use a shape-fixture row whose
-    // artist (7001 'Beta') has none seeded.
+    // to distinguish "no aliases" from "field missing". Binds to this spec's own
+    // ART_NO_XREF row (seeded with a genre crossref so it IS export-eligible, but
+    // with no artist_crossreference rows in either direction).
     const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
-    const noXref = byId.get(7002); // 'Shape Fixture Album Beta 1', artist 7001
+    const noXref = byId.get(LIB_NO_XREF);
     expect(noXref).toBeDefined();
     expect(noXref.cross_reference_names).toEqual([]);
     expect(noXref.cross_reference_names).not.toBeNull();

--- a/tests/integration/library-catalog-producer-export.spec.js
+++ b/tests/integration/library-catalog-producer-export.spec.js
@@ -1,0 +1,336 @@
+/**
+ * BS#1965 — the Backend-sourced library.db producer path.
+ *
+ * Extends the BS#1468 catalog export with the four fields the Option-B producer
+ * (discogs-etl#351) needs to build a byte-parity library.db over HTTP
+ * (legacy_release_id, album_artist, alternate_artist_name, cross_reference_names),
+ * and adds the sibling CTA export GET /library/catalog/compilation-tracks that
+ * feeds library.db's compilation_track_artist table.
+ *
+ * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL seeds
+ * isolated fixtures, supertest drives the HTTP surface. All seeded rows live in a
+ * dedicated 7170-range this spec owns end-to-end (created + reaped here), so it
+ * can't collide with the shared shape fixture or the 7050-range the sibling
+ * catalog-export spec uses.
+ */
+
+const zlib = require('zlib');
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const GEN = 11; // 'Rock'
+const FMT = 1; // 'cd'
+
+// Isolated artists: a "main" filing artist + two cross-reference partners.
+const ART_MAIN = 7170;
+const ART_XREF_A = 7171; // 'BS1965 Xref Beta'
+const ART_XREF_B = 7172; // 'BS1965 Xref Gamma'
+const XREF_A_NAME = 'BS1965 Xref Beta';
+const XREF_B_NAME = 'BS1965 Xref Gamma';
+// Alphabetical, deduplicated, pipe-joined — the deterministic analogue of the
+// legacy MySQL GROUP_CONCAT(DISTINCT ... SEPARATOR ' | ').
+const EXPECTED_XREF = `${XREF_A_NAME} | ${XREF_B_NAME}`;
+
+const LIB_PRODUCER = 7173; // library row under ART_MAIN, with album_artist + alternate
+const LIB_CTA = 7174; // library row under ART_MAIN that owns the seeded CTA rows
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+function collectBuffer(res, cb) {
+  const chunks = [];
+  res.on('data', (d) => chunks.push(Buffer.from(d)));
+  res.on('end', () => cb(null, Buffer.concat(chunks)));
+}
+function decodeBody(res) {
+  let buf = Buffer.isBuffer(res.body) && res.body.length ? res.body : Buffer.from(res.text || '', 'utf8');
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) buf = zlib.gunzipSync(buf);
+  return buf.toString('utf8');
+}
+function parseRows(res) {
+  return decodeBody(res)
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+const getCatalog = (auth) => auth.get('/library/catalog').buffer(true).parse(collectBuffer);
+const getCta = (auth) => auth.get('/library/catalog/compilation-tracks').buffer(true).parse(collectBuffer);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe('GET /library/catalog + /compilation-tracks — library.db producer path (BS#1965)', () => {
+  let auth;
+  let sql;
+  let mainLegacyId; // minted legacy_release_id of LIB_PRODUCER (queried at runtime)
+  let ctaLegacyId; // minted legacy_release_id of LIB_CTA
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+
+    // Isolated artists + genre crossref so the export's INNER JOINs resolve.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (id, artist_name, alphabetical_name, code_letters)
+       VALUES ($1, 'BS1965 Main Filing Artist', 'BS1965 Main Filing Artist', 'ZA'),
+              ($2, $4, $4, 'ZB'),
+              ($3, $5, $5, 'ZC')
+       ON CONFLICT (id) DO NOTHING`,
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, XREF_A_NAME, XREF_B_NAME]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+       VALUES ($1, $4, 970), ($2, $4, 971), ($3, $4, 972)
+       ON CONFLICT (artist_id, genre_id) DO NOTHING`,
+      [ART_MAIN, ART_XREF_A, ART_XREF_B, GEN]
+    );
+
+    // Cross-references in BOTH FK directions, plus a redundant reverse row, to
+    // prove the export folds both directions and dedups: ART_MAIN -> A (forward),
+    // A -> ART_MAIN (redundant reverse; must NOT double 'Beta'), and B -> ART_MAIN
+    // (reverse only). Expected result for ART_MAIN: {Beta, Gamma}.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_crossreference (source_artist_id, target_artist_id, comment)
+       VALUES ($1, $2, 'forward'), ($2, $1, 'reverse-dup'), ($3, $1, 'reverse-only')
+       ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING`,
+      [ART_MAIN, ART_XREF_A, ART_XREF_B]
+    );
+
+    // Producer-fields probe: album_artist + alternate_artist_name populated.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, album_artist, alternate_artist_name)
+       VALUES ($1, $2, $3, $4, 'BS1965 Producer Probe', 71, 'BS1965 Main Filing Artist', 'Various Artists', 'V/A')
+       ON CONFLICT (id) DO NOTHING`,
+      [LIB_PRODUCER, ART_MAIN, GEN, FMT]
+    );
+
+    // CTA-owning library row + its compilation tracks (one with a NULL track_title
+    // to exercise the nullable column end-to-end).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, 'BS1965 CTA Compilation', 72, 'BS1965 Main Filing Artist')
+       ON CONFLICT (id) DO NOTHING`,
+      [LIB_CTA, ART_MAIN, GEN, FMT]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".compilation_track_artist (library_id, artist_name, track_title, track_position)
+       VALUES ($1, 'Chuquimamani-Condori', 'Call Your Name', 'A1'),
+              ($1, 'DJ E, Chuquimamani-Condori', 'Wayño', 'A2'),
+              ($1, 'Juana Molina', NULL, NULL)`,
+      [LIB_CTA]
+    );
+
+    // Capture the minted legacy_release_ids (BS#1963 nextval default; not
+    // hardcodable) so assertions bind to the real surrogate keys.
+    const mainRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_PRODUCER]);
+    const ctaRow = await sql.unsafe(`SELECT legacy_release_id FROM "${SCHEMA}".library WHERE id = $1`, [LIB_CTA]);
+    mainLegacyId = mainRow[0].legacy_release_id;
+    ctaLegacyId = ctaRow[0].legacy_release_id;
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      // compilation_track_artist.library_id is ON DELETE CASCADE, so the library
+      // delete reaps the seeded CTA rows. artist_crossreference has no FK to
+      // library; reap it explicitly. Delete library rows before artists (FK).
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2)`, [LIB_PRODUCER, LIB_CTA]);
+      await sql.unsafe(
+        `DELETE FROM "${SCHEMA}".artist_crossreference
+         WHERE source_artist_id IN ($1, $2, $3) OR target_artist_id IN ($1, $2, $3)`,
+        [ART_MAIN, ART_XREF_A, ART_XREF_B]
+      );
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".genre_artist_crossreference WHERE artist_id IN ($1, $2, $3)`, [
+        ART_MAIN,
+        ART_XREF_A,
+        ART_XREF_B,
+      ]);
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE id IN ($1, $2, $3)`, [ART_MAIN, ART_XREF_A, ART_XREF_B]);
+      await sql.end();
+    }
+  });
+
+  test('catalog export carries legacy_release_id + album_artist + alternate_artist_name + pipe-joined cross_reference_names', async () => {
+    // Seeding crossref/library does bump library_watermark (library INSERT), but a
+    // subsequent bump makes the per-watermark cache rebuild deterministic here.
+    await sql.unsafe(`UPDATE "${SCHEMA}".library SET album_title = album_title WHERE id = $1`, [LIB_PRODUCER]);
+
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    const row = byId.get(LIB_PRODUCER);
+    expect(row).toBeDefined();
+
+    // legacy_release_id: total (BS#1963), a positive integer, matching the DB.
+    expect(row.legacy_release_id).toBe(mainLegacyId);
+    expect(Number.isInteger(row.legacy_release_id)).toBe(true);
+    // id (BS serial) and legacy_release_id are distinct keyspaces.
+    expect(row.id).toBe(LIB_PRODUCER);
+    expect(row.legacy_release_id).not.toBe(row.id);
+
+    expect(row.album_artist).toBe('Various Artists');
+    expect(row.alternate_artist_name).toBe('V/A');
+
+    // Bidirectional + deduped + alphabetically ordered pipe-join.
+    expect(row.cross_reference_names).toBe(EXPECTED_XREF);
+  });
+
+  test('cross_reference_names is null for an artist with no cross-references', async () => {
+    // The CTA-owning row shares ART_MAIN — which HAS cross-references — so use a
+    // shape-fixture row whose artist (7001 'Beta') has none seeded.
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    const noXref = byId.get(7002); // 'Shape Fixture Album Beta 1', artist 7001
+    expect(noXref).toBeDefined();
+    expect(noXref.cross_reference_names).toBeNull();
+  });
+
+  test('GET /library/catalog/compilation-tracks returns gzipped NDJSON with freshness + content headers', async () => {
+    const res = await auth
+      .get('/library/catalog/compilation-tracks')
+      .set('Accept-Encoding', 'gzip')
+      .buffer(true)
+      .parse(collectBuffer);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect((res.headers['vary'] || '').toLowerCase()).toContain('accept-encoding');
+    expect(res.headers['last-modified']).toBeTruthy();
+    expect((res.headers['content-type'] || '').toLowerCase()).toContain('ndjson');
+
+    const rows = parseRows(res);
+    expect(rows.length).toBeGreaterThan(0);
+    // Every line carries exactly the 3-column CTA export contract — no id /
+    // track_position / library_id leak.
+    for (const row of rows) {
+      expect(Object.keys(row).sort()).toEqual(['artist_name', 'legacy_release_id', 'track_title'].sort());
+    }
+  });
+
+  test('CTA export rows are keyed on legacy_release_id and carry a nullable track_title', async () => {
+    const rows = parseRows(await getCta(auth));
+    const mine = rows.filter((r) => r.legacy_release_id === ctaLegacyId);
+
+    // The three seeded CTA rows for LIB_CTA, keyed on ITS legacy_release_id.
+    expect(mine).toHaveLength(3);
+    const byArtist = new Map(mine.map((r) => [r.artist_name, r]));
+    expect(byArtist.get('Chuquimamani-Condori').track_title).toBe('Call Your Name');
+    expect(byArtist.get('DJ E, Chuquimamani-Condori').track_title).toBe('Wayño');
+    // The NULL-track row round-trips as JSON null, not dropped or coerced.
+    expect(byArtist.has('Juana Molina')).toBe(true);
+    expect(byArtist.get('Juana Molina').track_title).toBeNull();
+  });
+
+  test('CTA export is ordered by legacy_release_id', async () => {
+    const rows = parseRows(await getCta(auth));
+    const ids = rows.map((r) => r.legacy_release_id);
+    const sorted = [...ids].sort((a, b) => a - b);
+    expect(ids).toEqual(sorted);
+  });
+
+  test('honors Accept-Encoding: gzip;q=0 by serving identity NDJSON', async () => {
+    const res = await auth
+      .get('/library/catalog/compilation-tracks')
+      .set('Accept-Encoding', 'gzip;q=0')
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    const rows = parseRows(res);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  test('CTA export returns 304 when If-Modified-Since matches the current watermark', async () => {
+    const first = await getCta(auth);
+    expect(first.status).toBe(200);
+    const second = await auth
+      .get('/library/catalog/compilation-tracks')
+      .set('If-Modified-Since', first.headers['last-modified']);
+    expect(second.status).toBe(304);
+    expect(second.text === '' || second.text === undefined).toBe(true);
+  });
+
+  test('CTA export returns 200 after a library row changes (watermark advanced)', async () => {
+    const first = await getCta(auth);
+    const lastModified = first.headers['last-modified'];
+    await sleep(1100);
+    await sql.unsafe(`UPDATE "${SCHEMA}".library SET plays = COALESCE(plays, 0) WHERE id = $1`, [LIB_CTA]);
+    const after = await auth
+      .get('/library/catalog/compilation-tracks')
+      .set('If-Modified-Since', lastModified)
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(after.status).toBe(200);
+  });
+
+  test('CTA export requires catalog:read auth (401 without a token)', async () => {
+    const res = await request.get('/library/catalog/compilation-tracks');
+    expect(res.status).toBe(401);
+  });
+
+  // The acceptance-criterion parity check: for one known release, the exported
+  // library row + CTA rows match the library.db shape the legacy MySQL TSV
+  // produces (modulo the documented `label` omission), so the producer can build
+  // byte-parity library.db.
+  test('fixture-level parity: a known release maps to the library.db row + CTA shape', async () => {
+    const libById = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    const lib = libById.get(LIB_PRODUCER);
+    expect(lib).toBeDefined();
+
+    // The 12-column library.db `library` row the producer builds via
+    // `legacy_release_id AS id` (label omitted -> always NULL in library.db).
+    const libraryDbRow = {
+      id: lib.legacy_release_id,
+      title: lib.album_title,
+      artist: lib.artist_name,
+      call_letters: lib.code_letters,
+      artist_call_number: lib.code_artist_number,
+      release_call_number: lib.code_number,
+      genre: lib.genre_name,
+      format: lib.format_name,
+      alternate_artist_name: lib.alternate_artist_name,
+      album_artist: lib.album_artist,
+      label: null, // library.db always-NULL by design
+      cross_reference_names: lib.cross_reference_names,
+    };
+    expect(libraryDbRow).toEqual({
+      id: mainLegacyId,
+      title: 'BS1965 Producer Probe',
+      artist: 'BS1965 Main Filing Artist',
+      call_letters: 'ZA',
+      artist_call_number: 970,
+      release_call_number: 71,
+      genre: 'Rock',
+      format: 'cd',
+      alternate_artist_name: 'V/A',
+      album_artist: 'Various Artists',
+      label: null,
+      cross_reference_names: EXPECTED_XREF,
+    });
+
+    // The 3-column library.db `compilation_track_artist` rows for a known release,
+    // keyed by the SAME legacy_release_id the library row exports as its id.
+    const cta = parseRows(await getCta(auth)).filter((r) => r.legacy_release_id === ctaLegacyId);
+    const ctaDbRows = cta
+      .map((r) => ({
+        library_release_id: r.legacy_release_id,
+        artist_name: r.artist_name,
+        track_title: r.track_title,
+      }))
+      .sort((a, b) => a.artist_name.localeCompare(b.artist_name));
+    expect(ctaDbRows).toEqual(
+      [
+        { library_release_id: ctaLegacyId, artist_name: 'Chuquimamani-Condori', track_title: 'Call Your Name' },
+        { library_release_id: ctaLegacyId, artist_name: 'DJ E, Chuquimamani-Condori', track_title: 'Wayño' },
+        { library_release_id: ctaLegacyId, artist_name: 'Juana Molina', track_title: null },
+      ].sort((a, b) => a.artist_name.localeCompare(b.artist_name))
+    );
+  });
+});

--- a/tests/integration/slack-webhook.spec.js
+++ b/tests/integration/slack-webhook.spec.js
@@ -34,6 +34,22 @@ describe('Slack Webhook (Mock API)', () => {
     await resetMockApi();
   });
 
+  // The mock server's error rules are PROCESS-GLOBAL and survive the suite that
+  // armed them. The last test below arms a slack 500 with no `count`, so it is
+  // unbounded — without this teardown it leaks into every suite that runs after
+  // this file, and any later `POST /request` comes back 200 with
+  // `result.success: false`. The `beforeEach` reset above only protects the
+  // tests INSIDE this file; nothing was cleaning up on the way out.
+  //
+  // That made suite ORDER load-bearing, which is why it stayed hidden: jest
+  // ordered requestLine.spec.js ahead of this file, so the leaked rule was never
+  // observed. BS#1965 added tests elsewhere, the ordering shifted, and
+  // requestLine.spec.js started failing on a rule this file left armed.
+  afterAll(async () => {
+    if (!mockApiAvailable) return;
+    await resetMockApi();
+  });
+
   test('song request posts message to mock Slack webhook', async () => {
     if (!mockApiAvailable || !testToken) return;
 

--- a/tests/unit/services/catalog-export.parity.test.ts
+++ b/tests/unit/services/catalog-export.parity.test.ts
@@ -56,8 +56,11 @@ import { describe, it, expect } from '@jest/globals';
 import { readFileSync, readdirSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { createRequire } from 'module';
-import type { CatalogExportRow as PrivateRow } from '../../../apps/backend/services/catalog-export.service';
-import type { CatalogExportRow as SharedRow } from '@wxyc/shared/dtos';
+import type {
+  CatalogExportRow as PrivateRow,
+  CompilationTrackExportRow as PrivateCtaRow,
+} from '../../../apps/backend/services/catalog-export.service';
+import type { CatalogExportRow as SharedRow, CatalogCompilationTrackRow as SharedCtaRow } from '@wxyc/shared/dtos';
 
 // ---------------------------------------------------------------------------
 // Compile-time contract (belt-and-suspenders; enforced by a real `tsc`, e.g.
@@ -80,6 +83,10 @@ const _sharedBinAcceptsRawString: SharedRow['rotation_bin'] = 'N';
 void _privateBinAcceptsRawString;
 void _sharedBinAcceptsRawString;
 
+// Same mutual key-set equality for the BS#1965 CTA export pair.
+const _ctaKeysAgree: KeysEqual<PrivateCtaRow, SharedCtaRow> = true;
+void _ctaKeysAgree;
+
 // ---------------------------------------------------------------------------
 // Runtime contract (the assertion that actually fails CI on drift).
 // ---------------------------------------------------------------------------
@@ -88,12 +95,12 @@ void _sharedBinAcceptsRawString;
  * Field names declared in the private `export type CatalogExportRow = { ... }`
  * block of `apps/backend/services/catalog-export.service.ts`.
  */
-function extractPrivateRowKeys(): string[] {
+function extractPrivateRowKeys(typeName: string): string[] {
   const servicePath = resolve(__dirname, '../../../apps/backend/services/catalog-export.service.ts');
   const source = readFileSync(servicePath, 'utf-8');
-  const block = source.match(/export type CatalogExportRow = \{([\s\S]*?)\};/)?.[1];
+  const block = source.match(new RegExp(`export type ${typeName} = \\{([\\s\\S]*?)\\};`))?.[1];
   if (!block) {
-    throw new Error('private `export type CatalogExportRow = { ... }` block not found in catalog-export.service.ts');
+    throw new Error(`private \`export type ${typeName} = { ... }\` block not found in catalog-export.service.ts`);
   }
   return extractObjectTypeKeys(block);
 }
@@ -107,8 +114,8 @@ function extractPrivateRowKeys(): string[] {
  * (not a checked-in copy) makes the `@wxyc/shared` dependency bump load-bearing:
  * a version without `CatalogExportRow` makes this throw.
  */
-function extractSsotRowKeys(): string[] {
-  const block = readSsotCatalogExportRowBlock();
+function extractSsotRowKeys(schemaName: string): string[] {
+  const block = readSsotRowBlock(schemaName);
   return extractObjectTypeKeys(block);
 }
 
@@ -116,7 +123,7 @@ function extractSsotRowKeys(): string[] {
  * Locate and return the raw text of the SSOT `CatalogExportRow: { ... }` schema
  * block from the installed `@wxyc/shared` bundled declaration file.
  */
-function readSsotCatalogExportRowBlock(): string {
+function readSsotRowBlock(schemaName: string): string {
   const require = createRequire(__filename);
   // dist/dtos/index.js -> dist/
   const distDir = dirname(dirname(require.resolve('@wxyc/shared/dtos')));
@@ -127,12 +134,11 @@ function readSsotCatalogExportRowBlock(): string {
   const decl = readFileSync(join(distDir, bundle), 'utf-8');
   // The schema block: `CatalogExportRow: { ... };` under components['schemas'].
   // Balance braces from the opening `{` so nested members don't end it early.
-  const startToken = 'CatalogExportRow: {';
+  const startToken = `${schemaName}: {`;
   const startIdx = decl.indexOf(startToken);
   if (startIdx === -1) {
     throw new Error(
-      `SSOT CatalogExportRow schema not found in ${bundle}. ` +
-        'Is the installed @wxyc/shared new enough to carry it (>= 1.13.0)?'
+      `SSOT ${schemaName} schema not found in ${bundle}. ` + 'Is the installed @wxyc/shared new enough to carry it?'
     );
   }
   const braceOpen = startIdx + startToken.length - 1;
@@ -201,8 +207,8 @@ function extractObjectTypeKeys(body: string): string[] {
 }
 
 describe('CatalogExportRow parity: private TS type vs @wxyc/shared SSOT schema (BS#1477)', () => {
-  const privateKeys = extractPrivateRowKeys();
-  const ssotKeys = extractSsotRowKeys();
+  const privateKeys = extractPrivateRowKeys('CatalogExportRow');
+  const ssotKeys = extractSsotRowKeys('CatalogExportRow');
 
   it('extracts a non-trivial key set from each side (sanity)', () => {
     // Guards against an extractor that silently matches nothing and lets a real
@@ -223,7 +229,7 @@ describe('CatalogExportRow parity: private TS type vs @wxyc/shared SSOT schema (
     // ships the RAW rotation bin so an off-cohort value can't break a strict
     // enum decoder. If api.yaml ever re-narrows rotation_bin to RotationBin, the
     // generated type references the enum and this fails.
-    const ssotBlock = readSsotCatalogExportRowBlock();
+    const ssotBlock = readSsotRowBlock('CatalogExportRow');
     const binLine = ssotBlock.split('\n').find((l) => /\brotation_bin\b\s*\??\s*:/.test(l));
     expect(binLine).toBeDefined();
     expect(binLine).toMatch(/:\s*string\b/);
@@ -238,5 +244,50 @@ describe('CatalogExportRow parity: private TS type vs @wxyc/shared SSOT schema (
     expect(binLine).toBeDefined();
     expect(binLine).toMatch(/rotation_bin\s*:\s*string\s*\|\s*null\s*;/);
     expect(binLine).not.toMatch(/RotationBin/);
+  });
+});
+
+describe('CompilationTrackExportRow parity: private TS type vs @wxyc/shared SSOT schema (BS#1965)', () => {
+  // Same guard, same reasons, for the CTA export's hand-defined wire shape. The
+  // docblock above nominates itself as the template for "the next bulk endpoint
+  // that hand-defines its wire shape instead of consuming the SSOT type" — this
+  // is that endpoint (GET /library/catalog/compilation-tracks), so the extractors
+  // are parameterized and reused rather than copied.
+  //
+  // The drift this catches is worse here than for CatalogExportRow, because the
+  // consumer is a byte-parity gate: the library.db producer (discogs-etl#351)
+  // writes these three columns into SQLite and discogs-etl#346 diffs the result
+  // against the legacy MySQL artifact. A field added on one side only shifts the
+  // produced table's shape with nothing else in the chain to notice.
+  // Same "what this does NOT guard" caveat as above applies: the SSOT marks
+  // `track_title` optional (no `required:` entry) where the private type marks it
+  // required. That `?`-vs-required difference is expected and tolerated — the
+  // key-set comparison strips the `?`. The third hand-maintained copy in
+  // `app.yaml` is still unguarded (BS#1479).
+  const privateKeys = extractPrivateRowKeys('CompilationTrackExportRow');
+  const ssotKeys = extractSsotRowKeys('CatalogCompilationTrackRow');
+
+  it('extracts a non-trivial key set from each side (sanity)', () => {
+    // The CTA row is deliberately narrow (3 columns), so the floor is 3 rather
+    // than the 10 the wide catalog row uses. Still guards an extractor that
+    // silently matches nothing and lets drift pass as two empty, "equal" sets.
+    expect(privateKeys.length).toBeGreaterThanOrEqual(3);
+    expect(ssotKeys.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the private CompilationTrackExportRow key set equals the SSOT CatalogCompilationTrackRow key set', () => {
+    expect(privateKeys).toEqual(ssotKeys);
+  });
+
+  it('carries exactly the three library.db CTA columns — no id / track_position / library_id leak', () => {
+    // library.db's compilation_track_artist table has 3 columns. The BS serial
+    // CTA `id`, the serial `library_id` (the export is keyed on
+    // legacy_release_id instead), and `track_position` are all deliberately
+    // dropped; shipping any of them breaks parity with the legacy artifact.
+    expect(privateKeys).toEqual(['artist_name', 'legacy_release_id', 'track_title']);
+    for (const leaked of ['id', 'library_id', 'track_position']) {
+      expect(privateKeys).not.toContain(leaked);
+      expect(ssotKeys).not.toContain(leaked);
+    }
   });
 });

--- a/tests/unit/services/catalog-export.serialize.test.ts
+++ b/tests/unit/services/catalog-export.serialize.test.ts
@@ -1,13 +1,24 @@
 import { describe, it, expect } from '@jest/globals';
-import { serializeCatalogNdjson, type CatalogExportRow } from '../../../apps/backend/services/catalog-export.service';
+import {
+  serializeCatalogNdjson,
+  serializeCompilationTracksNdjson,
+  type CatalogExportRow,
+  type CompilationTrackExportRow,
+} from '../../../apps/backend/services/catalog-export.service';
 
 // BS#1468 — the bulk catalog export ships NDJSON (one JSON object per line) so a
 // client can build/parse it incrementally. These tests pin the wire shape: the
 // exact field set the iOS Spotlight clone consumes, and the NDJSON framing.
+// BS#1965 extended CatalogExportRow with the four library.db-producer fields and
+// added the sibling compilation-track (CTA) export.
 
 const sampleRow = (overrides: Partial<CatalogExportRow> = {}): CatalogExportRow => ({
   id: 7000,
+  legacy_release_id: 1_000_042,
   artist_name: 'Juana Molina',
+  alternate_artist_name: null,
+  album_artist: null,
+  cross_reference_names: null,
   album_title: 'DOGA',
   code_letters: 'MO',
   code_number: 42,
@@ -36,9 +47,10 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
     expect(JSON.parse(lines[1])).toEqual(rows[1]);
   });
 
-  it('emits exactly the 15 contract fields per line and excludes search_doc', () => {
-    // The field set is the acceptance criterion for #1468. A row carrying an
-    // extra server-only field (e.g. search_doc) must not leak into the export.
+  it('emits exactly the 19 contract fields per line and excludes search_doc', () => {
+    // The field set is the acceptance criterion for #1468 + the four BS#1965
+    // library.db-producer fields. A row carrying an extra server-only field (e.g.
+    // search_doc) must not leak into the export.
     const rowWithExtra = {
       ...sampleRow(),
       search_doc: 'juana molina doga sonamos',
@@ -50,16 +62,20 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
 
     expect(Object.keys(parsed).sort()).toEqual(
       [
+        'album_artist',
         'album_title',
+        'alternate_artist_name',
         'artist_name',
         'artwork_url',
         'code_artist_number',
         'code_letters',
         'code_number',
+        'cross_reference_names',
         'format_name',
         'genre_name',
         'id',
         'label',
+        'legacy_release_id',
         'on_streaming',
         'plays',
         'popularity',
@@ -93,5 +109,71 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
     expect(parsed.on_streaming).toBeNull();
     expect(parsed.plays).toBeNull();
     expect(parsed).toHaveProperty('popularity', null);
+  });
+
+  it('round-trips the BS#1965 producer fields, keeping the nullable trio as JSON null when unset', () => {
+    // legacy_release_id is required (non-null); the three curated free-text fields
+    // are genuine library gaps and must ship as JSON null, not be dropped.
+    const populated = sampleRow({
+      legacy_release_id: 1_234_567,
+      album_artist: 'Various',
+      alternate_artist_name: 'V/A',
+      cross_reference_names: 'Grouper | Liz Harris',
+    });
+    const parsedPopulated = JSON.parse(serializeCatalogNdjson([populated]));
+    expect(parsedPopulated.legacy_release_id).toBe(1_234_567);
+    expect(parsedPopulated.album_artist).toBe('Various');
+    expect(parsedPopulated.alternate_artist_name).toBe('V/A');
+    expect(parsedPopulated.cross_reference_names).toBe('Grouper | Liz Harris');
+
+    const unset = sampleRow({ album_artist: null, alternate_artist_name: null, cross_reference_names: null });
+    const parsedUnset = JSON.parse(serializeCatalogNdjson([unset]));
+    expect(parsedUnset).toHaveProperty('album_artist', null);
+    expect(parsedUnset).toHaveProperty('alternate_artist_name', null);
+    expect(parsedUnset).toHaveProperty('cross_reference_names', null);
+  });
+});
+
+describe('catalog-export.service: serializeCompilationTracksNdjson (BS#1965)', () => {
+  const ctaRow = (overrides: Partial<CompilationTrackExportRow> = {}): CompilationTrackExportRow => ({
+    legacy_release_id: 1_000_100,
+    artist_name: 'Chuquimamani-Condori',
+    track_title: 'Call Your Name',
+    ...overrides,
+  });
+
+  it('emits one JSON object per line, each parsing back to the input row', () => {
+    const rows = [ctaRow(), ctaRow({ artist_name: 'DJ E', track_title: 'Wayño' })];
+    const lines = serializeCompilationTracksNdjson(rows)
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual(rows[0]);
+    expect(JSON.parse(lines[1])).toEqual(rows[1]);
+  });
+
+  it('emits exactly {legacy_release_id, artist_name, track_title} — no CTA id / track_position / library_id leak', () => {
+    // library.db's CTA table is 3 columns; the row id, serial library_id, and
+    // track_position must not ride along (parity + no internal-id leak).
+    const rowWithExtra = {
+      ...ctaRow(),
+      id: 999,
+      library_id: 7001,
+      track_position: 'B2',
+    } as unknown as CompilationTrackExportRow;
+    const parsed = JSON.parse(serializeCompilationTracksNdjson([rowWithExtra]));
+    expect(Object.keys(parsed).sort()).toEqual(['artist_name', 'legacy_release_id', 'track_title'].sort());
+    expect(parsed).not.toHaveProperty('id');
+    expect(parsed).not.toHaveProperty('library_id');
+    expect(parsed).not.toHaveProperty('track_position');
+  });
+
+  it('preserves a null track_title as JSON null', () => {
+    const parsed = JSON.parse(serializeCompilationTracksNdjson([ctaRow({ track_title: null })]));
+    expect(parsed).toHaveProperty('track_title', null);
+  });
+
+  it('serializes an empty CTA export to an empty string', () => {
+    expect(serializeCompilationTracksNdjson([])).toBe('');
   });
 });

--- a/tests/unit/services/catalog-export.serialize.test.ts
+++ b/tests/unit/services/catalog-export.serialize.test.ts
@@ -18,7 +18,7 @@ const sampleRow = (overrides: Partial<CatalogExportRow> = {}): CatalogExportRow 
   artist_name: 'Juana Molina',
   alternate_artist_name: null,
   album_artist: null,
-  cross_reference_names: null,
+  cross_reference_names: [],
   album_title: 'DOGA',
   code_letters: 'MO',
   code_number: 42,
@@ -111,26 +111,60 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
     expect(parsed).toHaveProperty('popularity', null);
   });
 
-  it('round-trips the BS#1965 producer fields, keeping the nullable trio as JSON null when unset', () => {
-    // legacy_release_id is required (non-null); the three curated free-text fields
-    // are genuine library gaps and must ship as JSON null, not be dropped.
+  it('round-trips the BS#1965 producer fields, keeping the nullable pair as JSON null when unset', () => {
+    // legacy_release_id is required (non-null server-side); the two curated
+    // free-text fields are genuine library gaps and must ship as JSON null, not
+    // be dropped. cross_reference_names is the third producer field but is never
+    // null on the wire — see the empty-array test below.
     const populated = sampleRow({
       legacy_release_id: 1_234_567,
       album_artist: 'Various',
       alternate_artist_name: 'V/A',
-      cross_reference_names: 'Grouper | Liz Harris',
     });
     const parsedPopulated = JSON.parse(serializeCatalogNdjson([populated]));
     expect(parsedPopulated.legacy_release_id).toBe(1_234_567);
     expect(parsedPopulated.album_artist).toBe('Various');
     expect(parsedPopulated.alternate_artist_name).toBe('V/A');
-    expect(parsedPopulated.cross_reference_names).toBe('Grouper | Liz Harris');
 
-    const unset = sampleRow({ album_artist: null, alternate_artist_name: null, cross_reference_names: null });
+    const unset = sampleRow({ album_artist: null, alternate_artist_name: null });
     const parsedUnset = JSON.parse(serializeCatalogNdjson([unset]));
     expect(parsedUnset).toHaveProperty('album_artist', null);
     expect(parsedUnset).toHaveProperty('alternate_artist_name', null);
-    expect(parsedUnset).toHaveProperty('cross_reference_names', null);
+  });
+
+  it('ships cross_reference_names as an ARRAY, never a pipe-joined string', () => {
+    // The wire must not carry the ' | ' delimiter library.db stores: nothing
+    // constrains artists.artist_name from containing '|' or ' | ', so a joined
+    // string would silently split into phantom aliases downstream (LML splits
+    // this field on the pipe) with no escaping rule to recover from. The
+    // producer does the join itself when it writes the SQLite column.
+    const row = sampleRow({ cross_reference_names: ['Grouper', 'Liz Harris'] });
+    const parsed = JSON.parse(serializeCatalogNdjson([row]));
+
+    expect(Array.isArray(parsed.cross_reference_names)).toBe(true);
+    expect(parsed.cross_reference_names).toEqual(['Grouper', 'Liz Harris']);
+  });
+
+  it('round-trips an alias containing a pipe as ONE name — the reason the wire is an array', () => {
+    // The regression this shape exists to prevent. A single alias whose text
+    // contains the legacy delimiter survives as one element; under the old
+    // pipe-joined string it was indistinguishable from two aliases.
+    const row = sampleRow({ cross_reference_names: ['Godspeed You! Black Emperor | GY!BE'] });
+    const parsed = JSON.parse(serializeCatalogNdjson([row]));
+
+    expect(parsed.cross_reference_names).toHaveLength(1);
+    expect(parsed.cross_reference_names[0]).toBe('Godspeed You! Black Emperor | GY!BE');
+  });
+
+  it('ships an EMPTY ARRAY (not null, not absent) for an artist with no cross-references', () => {
+    // Contract: "Empty array when the artist has no cross-references" — the
+    // server COALESCEs the LEFT JOIN null away so the producer never has to
+    // distinguish "no aliases" from "field absent".
+    const parsed = JSON.parse(serializeCatalogNdjson([sampleRow({ cross_reference_names: [] })]));
+
+    expect(parsed).toHaveProperty('cross_reference_names');
+    expect(parsed.cross_reference_names).toEqual([]);
+    expect(parsed.cross_reference_names).not.toBeNull();
   });
 });
 

--- a/tests/unit/services/catalog-export.sql-invariants.test.ts
+++ b/tests/unit/services/catalog-export.sql-invariants.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Source-level guards on the two catalog-export queries (BS#1965).
+ *
+ * # Why these are source greps and not runtime assertions
+ *
+ * The pg integration spec (`tests/integration/library-catalog-producer-export.spec.js`)
+ * asserts the OBSERVABLE result of these queries, which is the right primary
+ * signal. But for the `COLLATE "C"` ordering it cannot be the ONLY signal,
+ * because the test environment is physically unable to distinguish a query that
+ * pins the collation from one that does not:
+ *
+ *   CI and dev run `postgres:18.0-alpine` (`.github/workflows/test.yml`,
+ *   `dev_env/docker-compose.yml`). Alpine is musl. musl does not implement
+ *   glibc locales, so a database created with `en_US.utf8` reports
+ *   `datcollate=en_US.utf8` but collates by BYTE ORDER — which is exactly what
+ *   `COLLATE "C"` produces. Measured on `postgres:18.0-alpine` with the
+ *   integration spec's own fixture names:
+ *
+ *     without COLLATE "C" -> {BS1965 Xref Beta, BS1965 Xref Gamma, bs1965 Xref Delta}
+ *     with    COLLATE "C" -> {BS1965 Xref Beta, BS1965 Xref Gamma, bs1965 Xref Delta}
+ *
+ *   Identical. Deleting the COLLATE from the query leaves the integration spec
+ *   green. On prod (RDS PostgreSQL 14.22, glibc) the same names give:
+ *
+ *     without COLLATE "C" -> {BS1965 Xref Beta, bs1965 Xref Delta, BS1965 Xref Gamma}
+ *     with    COLLATE "C" -> {BS1965 Xref Beta, BS1965 Xref Gamma, bs1965 Xref Delta}
+ *
+ *   They differ. So the collation does real work exactly where no test runs, and
+ *   its removal is invisible everywhere a test does run.
+ *
+ * That asymmetry is why this file exists. The SSOT (wxyc-shared api.yaml,
+ * CatalogExportRow.cross_reference_names) MANDATES code-point ordering, and the
+ * library.db producer (discogs-etl#351) joins these names with `" | "` into a
+ * SQLite column that discogs-etl#346's byte-parity gate compares. A silent
+ * reordering breaks that gate with no failing test in between.
+ *
+ * Same idiom as the BS#1477 parity guard (`catalog-export.parity.test.ts`),
+ * which reads its source artifacts as text for the same reason: the unit suite
+ * runs through ts-jest with `isolatedModules: true`, so nothing here is
+ * type-checked at run time and the grep is the assertion that actually fails CI.
+ *
+ * If a future change makes the export environment glibc (or pins an ICU
+ * collation), replace these greps with a real behavioral assertion — a runtime
+ * check that can actually fail is strictly better than a source grep.
+ */
+
+const SERVICE_SRC = readFileSync(
+  resolve(__dirname, '../../../apps/backend/services/catalog-export.service.ts'),
+  'utf-8'
+);
+
+/**
+ * Body of a named exported query function, up to its closing template literal.
+ * Throws (rather than using `expect`) because this runs at module scope during
+ * collection, where jest's `expect` is not available.
+ */
+function queryBody(fnName: string): string {
+  const start = SERVICE_SRC.indexOf(`export const ${fnName}`);
+  if (start === -1) {
+    throw new Error(`${fnName} not found in catalog-export.service.ts — did the query get renamed?`);
+  }
+  const body = SERVICE_SRC.slice(start);
+  const end = body.indexOf('`);');
+  if (end === -1) {
+    throw new Error(`${fnName}'s SQL template literal is not terminated`);
+  }
+  return stripSqlComments(body.slice(0, end));
+}
+
+/**
+ * Drop `--` line comments so these greps assert on the SQL that actually
+ * executes, not on prose about it. Without this, the comment explaining why the
+ * wire value is NOT `' | '`-joined would itself match a grep for `' | '`.
+ */
+function stripSqlComments(sql: string): string {
+  return sql
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+}
+
+describe('catalog-export.service SQL invariants (BS#1965)', () => {
+  describe('cross_reference_names ordering is collation-pinned', () => {
+    const sql = queryBody('getCatalogExportRows');
+
+    it('aggregates cross_reference_names with array_agg, not a pipe-joined string_agg', () => {
+      // A regression to string_agg would reintroduce the delimiter the wire
+      // contract removed: artist names may contain '|' or ' | ', which would
+      // split into phantom aliases downstream (LML splits this field on the pipe).
+      expect(sql).toContain('array_agg(DISTINCT');
+      expect(sql).not.toMatch(/string_agg\s*\(\s*DISTINCT/);
+      expect(sql).not.toContain("' | '");
+    });
+
+    it('pins COLLATE "C" on BOTH the aggregate argument and its ORDER BY', () => {
+      // Postgres requires an aggregate's ORDER BY expression to appear in its
+      // argument list, and a bare column is a DIFFERENT expression from that
+      // column COLLATE "C" — so the collation must appear twice or the query
+      // fails to plan. Both occurrences are load-bearing; assert the pair.
+      const match = sql.match(/array_agg\(DISTINCT[\s\S]*?\)\s*\n?\s*AS cross_reference_names/);
+      expect(match).not.toBeNull(); // array_agg(...) AS cross_reference_names
+      const aggregate = match === null ? '' : match[0];
+
+      const collateCount = (aggregate.match(/COLLATE "C"/g) ?? []).length;
+      expect(collateCount).toBe(2);
+      expect(aggregate).toMatch(/ORDER BY[\s\S]*COLLATE "C"/);
+    });
+
+    it('COALESCEs a missing alias set to an empty array, never null', () => {
+      // Contract: "Empty array when the artist has no cross-references."
+      expect(sql).toMatch(/COALESCE\([\s\S]*?cross_reference_names,\s*ARRAY\[\]::varchar\[\]\)/);
+    });
+  });
+
+  describe('the CTA export repeats the catalog export row-eligibility predicate', () => {
+    const catalogSql = queryBody('getCatalogExportRows');
+    const ctaSql = queryBody('getCompilationTrackExportRows');
+
+    // The four INNER JOINs that decide whether a library row is exportable. An
+    // unfiltered CTA export ships library_release_id values that join to nothing
+    // in the library.db `library` table the sibling endpoint produces.
+    const ELIGIBILITY_TABLES = ['artists', 'format', 'genres', 'genre_artist_crossreference'];
+
+    it.each(ELIGIBILITY_TABLES)('both queries INNER JOIN %s', (table) => {
+      const pattern = new RegExp(`INNER JOIN \\$\\{${table}\\}`);
+      expect(catalogSql).toMatch(pattern);
+      expect(ctaSql).toMatch(pattern);
+    });
+
+    it('joins genre_artist_crossreference on the artist_id + genre_id PAIR in both', () => {
+      // The pair is what makes this predicate able to drop rows at all — a
+      // single-column join would match far more broadly and silently stop
+      // filtering, defeating the guard while still looking like one.
+      const pair =
+        /genre_artist_crossreference\.artist_id\}\s*=\s*\$\{library\.artist_id\}[\s\S]{0,120}genre_artist_crossreference\.genre_id\}\s*=\s*\$\{library\.genre_id\}/;
+      expect(catalogSql).toMatch(pair);
+      expect(ctaSql).toMatch(pair);
+    });
+  });
+});


### PR DESCRIPTION
## What

The Backend-Service arm of BS#1965: extend `GET /library/catalog` and add a sibling `GET /library/catalog/compilation-tracks` so the Backend-sourced `library.db` producer (discogs-etl#351) can build a byte-parity `library.db` over HTTPS instead of a direct Postgres read. This is the last piece the daily `library.db` needs to survive after `/wxycdb` goes dark (WXYC/wiki#89, tubafrenzy turndown).

## Contract

Depends on the already-merged + published SSOT: **`@wxyc/shared@3.3.0`** (WXYC/wxyc-shared#293). The BS#1477 parity guard binds the private `CatalogExportRow` key set to the installed SSOT, so this PR bumps `@wxyc/shared` to `^3.3.0` across the workspaces.

## Changes

**`GET /library/catalog`** gains four producer fields:
- `legacy_release_id` — the producer emits it AS library.db's `library.id` (BS serials collide with the tubafrenzy id space; total since the BS#1963 mint + backfill).
- `album_artist`, `alternate_artist_name` — raw `library` columns.
- `cross_reference_names` — a `string[]` **array**, folded from `artist_crossreference` in both FK directions via a UNION CTE, `array_agg(DISTINCT … COLLATE "C" ORDER BY … COLLATE "C")` (deterministic byte-ordered dedup, locale-independent), self-reference excluded, `COALESCE`'d to `[]`. It ships as an array, not the pipe-joined string library.db stores, because artist names can contain `|`/` | ` and a joined wire value would split into phantom aliases downstream (LML splits on the pipe). The producer does the `" | "` join itself when it writes SQLite.

**`GET /library/catalog/compilation-tracks`** (new sibling, `catalog:read`, gzipped NDJSON, same watermark conditional-GET) — flat `{legacy_release_id, artist_name, track_title}` rows feeding library.db's `compilation_track_artist` table. It repeats `/library/catalog`'s four INNER JOINs as a **row-eligibility predicate** so no CTA key joins to nothing in the produced library.db.

**Migration 0138** attaches the existing `touch_library_watermark()` trigger to `artist_crossreference` and `compilation_track_artist`. Neither is one of the seven tables 0104/0105 cover, so a write to either was **silently and unboundedly invisible** to the conditional GET (not a lag): the CTA POST always follows the library add it would ride, so the cached body for that watermark never contains the tracks, and post-turndown no daily sync remains to bump it. (The bulk of the diff is the auto-generated `0138_snapshot.json`.)

## Testing

- Unit: `catalog-export.serialize` + `catalog-export.parity` (key set now equals the 3.3.0 SSOT) green; full unit suite 6245/6245.
- pg integration (`library-catalog-producer-export.spec.js`) pins the array shape, `COLLATE "C"` ordering (via a lowercase-initial collation probe that disagrees with the DB default), self-reference exclusion, the eligibility drop + a whole-body "every CTA key resolves to a catalog row" invariant, and both watermark-coverage paths (crossref-write → 200, CTA-write → 200).
- The two reworked queries verified against real PostgreSQL 18.
- Local gates green: typecheck (all workspaces), `lint:migrations`, eslint (0 errors), `format:check`.

## Cache sizing (the api.yaml "size it before shipping" note)

The contract flagged that a second long-lived `createWatermarkCache<Buffer>` is additive on a memory-constrained host and asked for a measurement before shipping, with `?include=compilation_tracks` as the fallback. Measured against the 2026-07-19 prod `library.db` snapshot's real artist/title strings at the prod CTA row count:

| | rows | raw | gzipped (resident) |
|---|---:|---:|---:|
| catalog export | 64,815 | 28.5 MB | 2.6 MB |
| CTA export | 144,778 | 13.1 MB | 3.2 MB |

The CTA buffer is slightly *larger* than the catalog one despite carrying 3 fields instead of 19 — 2.2x the rows outweighs the narrower shape. Resident cost is ~3.2 MB, ~5.8 MB for both.

The steady state isn't the interesting number; the build path is. It materializes every row as a JS object, then the full NDJSON string, then a Buffer before gzip discards all three — a measured **~39 MB heap peak** (plus the ~13 MB off-heap Buffer), ~12x what stays resident. That transient is still *smaller* than the one the catalog export already pays on the same watermark, so this endpoint doesn't raise the process high-water mark; it just reaches it twice.

**Verdict: not material** — keeping the sibling endpoint rather than folding behind `?include=`. Recorded in the service docblock with a revisit trigger (~1M CTA rows). The `?include=` fold stays open.

## Incidental: a test-isolation leak this surfaced

The second commit fixes an unrelated latent bug the new tests exposed. `slack-webhook.spec.js` arms a **persistent** mock slack 500 (`simulateError(..., 500)` with no `count`) in its last test and had only a `beforeEach` reset — nothing cleaned up on the way out, so every suite ordered after it inherited the armed rule and a later `POST /request` came back 200 with `result.success: false`.

That made jest's suite order load-bearing, which is why it stayed hidden: `requestLine.spec.js` happened to be ordered ahead of it. Adding this PR's tests shifted the ordering and `requestLine.spec.js` started failing. Verified it's pre-existing by running the full CI mirror against `origin/main` in a scratch worktree (green there, and green here once the `afterAll` reset was added). Fixed the leak rather than the ordering.

## Downstream

Unblocks discogs-etl#351 (the Option-B HTTP producer), then discogs-etl#346 (the operational cutover, HITL/parity-gated).

Closes #1965
