### PR TITLE
fix(va-apple-music-url-remediation): bind the album_metadata id list as a PG array literal

### DIFF
--- a/jobs/va-apple-music-url-remediation/README.md
+++ b/jobs/va-apple-music-url-remediation/README.md
@@ -84,12 +84,30 @@ A control cohort of _non-V/A_ rows was considered and rejected: LML#1139's purge
 ## Write mechanics
 
 - Batched VALUES-join UPDATE per page + `ANALYZE` after the write pass (`docs/bulk-update-playbook.md`). **No CI check covers this for a TS job** — `scripts/check-bulk-update-analyze.mjs` scans `.sql` only — so the pairing is pinned by a unit test.
-- `flowsheet` UPDATE **omits `updated_at`**: trigger `bump_flowsheet_updated_at` (migration 0084) owns it. `album_metadata` sets it (writer convention).
-- **Compare-and-set:** `AND t.apple_music_url IS NOT DISTINCT FROM v.old_url`. Unlike the fill-only siblings (which guard on `IS NULL`), this job overwrites a non-null value, and under cooperative pause a page can sit unwritten a long time. Two other writers touch the column — the hourly `flowsheet-metadata-backfill` and the long-running `apps/enrichment-worker`, the latter _not_ covered by the "sibling crons Exited" pre-flight. Rejects are reported as `skipped_changed_under_us`.
+- `flowsheet` UPDATE **omits `updated_at`**: trigger `bump_flowsheet_updated_at` (migration 0084) owns it. That trigger is flowsheet-only, so the `album_metadata` UPDATE sets `updated_at` explicitly — nothing else would, and the BS#1915 re-ask sweep reads that freshness signal.
+- **Compare-and-set, on both arms:** `AND t.apple_music_url IS NOT DISTINCT FROM v.old_url`. Unlike the fill-only siblings (which guard on `IS NULL`), this job overwrites a non-null value, and under cooperative pause a page can sit unwritten a long time. Two other writers touch the column — the hourly `flowsheet-metadata-backfill` and the long-running `apps/enrichment-worker`, the latter _not_ covered by the "sibling crons Exited" pre-flight. On `flowsheet`, rejects are reported as `skipped_changed_under_us`. On `album_metadata` the reject is silent (it simply lowers `invalidated`), and the race it closes is specifically the worker re-verifying an album through LML's post-#1139 guarded matcher and writing the CORRECT url as `'verified'` — a bare `IS NOT NULL` predicate would null that fresh value and reset its re-ask budget, opening a DJ-visible window through `flowsheet.service.ts`'s coalesce until the sweep re-healed it.
 - Not `DB_SYNCHRONOUS_COMMIT=off`, unlike the BS#1715 donor: a re-verified row stays in the candidate net whether or not its write landed, so a lost write is invisible to any re-scan while the cursor has advanced past it. Durable commits are the cheaper side of that trade.
 - Id-cursor resume: `VA_REMEDIATION_FLOWSHEET_AFTER_ID` / `VA_REMEDIATION_ALBUM_AFTER_ID`, advancing only after a page's write commits.
 
 **Re-running is a full re-adjudication, not a cheap no-op.** A remediated row stays net-matched (still V/A, still non-null), so "adjudicated" is not recorded at rest. That is precisely why the cursors exist. Verification is run-internal: `scanned == written_url + written_null + skipped_changed_under_us` with `indeterminate == 0`.
+
+### Running phase 2 alone
+
+`runRemediation` always runs the flowsheet phase first, and gates phase 2 on `!flowsheet.failed` (nulling `album_metadata` unmasks flowsheet's value, so phase 2 must not run while flowsheet is still known-polluted). There is no `--album-only` flag. **When the flowsheet arm has already completed and only `album_metadata` needs a run — the exact situation after the 2026-08-06 run below — the supported way to skip phase 1 is to park its cursor past the end of the table:**
+
+```bash
+# The id ceiling: SELECT max(id) FROM wxyc_schema.flowsheet;
+VA_REMEDIATION_FLOWSHEET_AFTER_ID=<max_flowsheet_id> ... --execute
+```
+
+Phase 1 then selects zero candidates, finishes clean, and phase 2 runs against its own `VA_REMEDIATION_ALBUM_AFTER_ID` cursor.
+
+Do this rather than re-running both phases, for two reasons:
+
+1. **Cost.** Phase 1 re-adjudicates every surviving triple from scratch — up to `NULL_CONFIRMATION_PASSES` (3) LML lookups each, separated by `VA_REMEDIATION_SECOND_PASS_DELAY_MS` (15 s). The 56 triples the 2026-08-06 run verified and kept would all be re-spent.
+2. **Risk.** Phase 2 is skipped entirely if phase 1 fails — including on a rescue-rate abort or a write error. A re-run that trips either leaves `album_metadata` untouched for a second time, which is the failure mode that kept the 206 rows polluted in the first place.
+
+Set the ceiling from a live `max(id)` read, not from the previous run's `last_id`: `last_id` is the last row the phase _scanned_, which is only the table max if that run reached the end.
 
 ## Downstream interaction
 
@@ -118,4 +136,9 @@ docker run --rm --name va-apple-music-url-remediation --env-file .env \
 
 ## Run result
 
-_Not yet run — pending LML#1139 deploy + purge. Record counts here._
+**2026-08-06 09:33 PDT — `run_id 47dfff79-44d7-4768-8a18-3dd49278dc67`. Flowsheet arm complete; album arm did not run.**
+
+- `flowsheet`: 52 rows nulled, 56 triples re-verified and kept, 10 indeterminate.
+- `album_metadata`: `{"candidates":206,"invalidated":0,"batches":1}` — **failed**. Every page threw `42809 op ANY/ALL (array) requires array on right side`: the id list was bound as a bare JS array, which drizzle expands into a parameter list, so Postgres received `ANY(($1, $2, … $202))`, a row constructor. Fixed in #2007; the statement is now covered by `tests/integration/va-apple-music-url-remediation-invalidate.spec.js`, which runs the real compiled function against Postgres.
+
+The corrective re-run needs **phase 2 only** — see "Running phase 2 alone" above. Record its counts here.

--- a/jobs/va-apple-music-url-remediation/orchestrate.ts
+++ b/jobs/va-apple-music-url-remediation/orchestrate.ts
@@ -356,6 +356,15 @@ export const applyFlowsheetBatch = async (fixes: FlowsheetFix[], updateTimeoutMs
 };
 
 /**
+ * One album_metadata row to invalidate: its id plus the polluted url observed
+ * for it in this page's SELECT, which the UPDATE requires to still be there.
+ */
+export interface AlbumInvalidation {
+  albumId: number;
+  oldUrl: string | null;
+}
+
+/**
  * Invalidate one page of `album_metadata` V/A rows.
  *
  * Sets the URL null, flips `apple_music_status` to `'unresolved'`, and RESETS
@@ -367,24 +376,46 @@ export const applyFlowsheetBatch = async (fixes: FlowsheetFix[], updateTimeoutMs
  *
  * No LML here — the sweep owns the re-ask, through the now-guarded matcher.
  */
-export const invalidateAlbumBatch = async (albumIds: number[], updateTimeoutMs: number): Promise<number> => {
-  if (albumIds.length === 0) return 0;
-  // Bind as a single PG-array-literal string param, not a bare interpolated JS
-  // array — the BS#1068/BS#1071 trap (see `jobs/album-critic-reviews-etl/antijoin.ts`).
-  // Drizzle expands a JS array into a comma-separated parameter list, so
-  // `ANY(${albumIds})` reaches Postgres as `ANY(($1, $2, … $202))` — a row
-  // constructor, which `ANY` rejects at parse time (42809). Safe by
-  // construction: TypeScript types `albumIds: number[]`, so the join contains
-  // only numeric literals.
-  const idArrayLiteral = `{${albumIds.join(',')}}`;
+export const invalidateAlbumBatch = async (targets: AlbumInvalidation[], updateTimeoutMs: number): Promise<number> => {
+  if (targets.length === 0) return 0;
+  // A VALUES join, not `ANY(<id list>)`, for two reasons.
+  //
+  // 1. It carries the compare-and-set. `IS NOT DISTINCT FROM v."old_url"` is the
+  //    same guard `applyFlowsheetBatch` uses above, for the same reason: this
+  //    job overwrites a NON-NULL value while two other writers touch this
+  //    column. Between this page's SELECT and this UPDATE, the enrichment
+  //    worker can re-verify the album through LML's post-#1139 guarded matcher
+  //    and write the CORRECT url with `apple_music_status='verified'`. A bare
+  //    `apple_music_url IS NOT NULL` predicate would null that fresh, correct
+  //    value and reset its re-ask budget — self-healing via the BS#1915 sweep,
+  //    but only after a DJ-visible null window through `flowsheet.service.ts`'s
+  //    coalesce.
+  //
+  // 2. It binds each id and url as its own parameter, so nothing here has to
+  //    hand-roll a PG array literal. That matters: the original defect was
+  //    `ANY(${albumIds})` with a bare `number[]`, which drizzle expands into a
+  //    comma-separated parameter list — Postgres receives
+  //    `ANY(($1, $2, … $202))`, a row constructor, and rejects it at parse time
+  //    (42809). The array-literal-plus-cast idiom fixes that for ints (see
+  //    `jobs/album-critic-reviews-etl/antijoin.ts`, the BS#1068/BS#1071 trap),
+  //    but urls are text and would need real array-literal escaping.
+  //
+  // `updated_at` is set explicitly: migration 0084's BEFORE UPDATE trigger is
+  // flowsheet-only, so nothing stamps `album_metadata` for us, and the BS#1915
+  // re-ask sweep reads that freshness signal.
+  const values = sql.join(
+    targets.map((t) => sql`(${t.albumId}::int, ${t.oldUrl}::varchar)`),
+    sql`, `
+  );
   const updateSql = sql`
-    UPDATE ${ALBUM_METADATA_TABLE}
+    UPDATE ${ALBUM_METADATA_TABLE} AS t
     SET "apple_music_url" = NULL,
         "apple_music_status" = 'unresolved',
         "streaming_reask_attempts" = 0,
         "updated_at" = NOW()
-    WHERE "album_id" = ANY(${idArrayLiteral}::int[])
-      AND "apple_music_url" IS NOT NULL
+    FROM (VALUES ${values}) AS v("album_id", "old_url")
+    WHERE t."album_id" = v."album_id"
+      AND t."apple_music_url" IS NOT DISTINCT FROM v."old_url"
   `;
   const result = await db.transaction(async (tx) => {
     await tx.execute(sql`SET LOCAL statement_timeout = ${sql.raw(String(updateTimeoutMs))}`);
@@ -480,7 +511,7 @@ export interface RunOptions {
   lookup?: LookupFn;
   checkLiveActivityFn?: CheckLiveActivityFn;
   applyBatchFn?: (fixes: FlowsheetFix[], timeoutMs: number) => Promise<number>;
-  invalidateAlbumFn?: (ids: number[], timeoutMs: number) => Promise<number>;
+  invalidateAlbumFn?: (targets: AlbumInvalidation[], timeoutMs: number) => Promise<number>;
   analyzeFn?: (table: 'flowsheet' | 'album_metadata', timeoutMs: number) => Promise<void>;
 }
 
@@ -652,7 +683,7 @@ const runFlowsheetPhase = async (
 const runAlbumPhase = async (opts: {
   dryRun: boolean;
   checkLive: CheckLiveActivityFn;
-  invalidate: (ids: number[], timeoutMs: number) => Promise<number>;
+  invalidate: (targets: AlbumInvalidation[], timeoutMs: number) => Promise<number>;
   batchSize: number;
   afterId: number;
   updateTimeoutMs: number;
@@ -676,23 +707,28 @@ const runAlbumPhase = async (opts: {
   });
 
   while (!stopRequested) {
+    // `apple_music_url` rides along so the UPDATE can compare-and-set against
+    // the exact value this SELECT observed.
     const rows = (await db.execute(sql`
       SELECT am."album_id" AS "album_id",
+             am."apple_music_url" AS "apple_music_url",
              COALESCE(l."artist_name", ar."artist_name") AS "artist_name"
       ${albumMetadataFrom}
       WHERE ${albumMetadataNet} AND am."album_id" > ${cursor}
       ORDER BY am."album_id" ASC
       LIMIT ${opts.batchSize}
-    `)) as unknown as Array<{ album_id: number; artist_name: string | null }>;
+    `)) as unknown as Array<{ album_id: number; apple_music_url: string | null; artist_name: string | null }>;
     if (!rows || rows.length === 0) break;
     totals.batches += 1;
 
     if (opts.pauseMs > 0) await opts.checkLive(opts.lookbackSeconds, opts.pauseMs);
 
-    const ids = rows.filter((r) => isVariousArtistsCredit(r.artist_name)).map((r) => r.album_id);
-    if (!opts.dryRun && ids.length > 0) {
+    const targets: AlbumInvalidation[] = rows
+      .filter((r) => isVariousArtistsCredit(r.artist_name))
+      .map((r) => ({ albumId: r.album_id, oldUrl: r.apple_music_url }));
+    if (!opts.dryRun && targets.length > 0) {
       try {
-        totals.invalidated += await opts.invalidate(ids, opts.updateTimeoutMs);
+        totals.invalidated += await opts.invalidate(targets, opts.updateTimeoutMs);
       } catch (error) {
         log('error', 'write_failed', 'album_metadata invalidation failed', {
           after_id: cursor,
@@ -703,7 +739,7 @@ const runAlbumPhase = async (opts: {
         break;
       }
     } else if (opts.dryRun) {
-      totals.invalidated += ids.length;
+      totals.invalidated += targets.length;
     }
 
     cursor = rows[rows.length - 1].album_id;

--- a/jobs/va-apple-music-url-remediation/orchestrate.ts
+++ b/jobs/va-apple-music-url-remediation/orchestrate.ts
@@ -369,13 +369,21 @@ export const applyFlowsheetBatch = async (fixes: FlowsheetFix[], updateTimeoutMs
  */
 export const invalidateAlbumBatch = async (albumIds: number[], updateTimeoutMs: number): Promise<number> => {
   if (albumIds.length === 0) return 0;
+  // Bind as a single PG-array-literal string param, not a bare interpolated JS
+  // array — the BS#1068/BS#1071 trap (see `jobs/album-critic-reviews-etl/antijoin.ts`).
+  // Drizzle expands a JS array into a comma-separated parameter list, so
+  // `ANY(${albumIds})` reaches Postgres as `ANY(($1, $2, … $202))` — a row
+  // constructor, which `ANY` rejects at parse time (42809). Safe by
+  // construction: TypeScript types `albumIds: number[]`, so the join contains
+  // only numeric literals.
+  const idArrayLiteral = `{${albumIds.join(',')}}`;
   const updateSql = sql`
     UPDATE ${ALBUM_METADATA_TABLE}
     SET "apple_music_url" = NULL,
         "apple_music_status" = 'unresolved',
         "streaming_reask_attempts" = 0,
         "updated_at" = NOW()
-    WHERE "album_id" = ANY(${albumIds})
+    WHERE "album_id" = ANY(${idArrayLiteral}::int[])
       AND "apple_music_url" IS NOT NULL
   `;
   const result = await db.transaction(async (tx) => {

--- a/jobs/va-apple-music-url-remediation/tsup.config.ts
+++ b/jobs/va-apple-music-url-remediation/tsup.config.ts
@@ -6,8 +6,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig((options) => ({
-  entry: ['job.ts'],
-  format: ['esm'],
+  // `job.ts` is the ESM CLI entrypoint the Docker image runs (dist/job.js).
+  // `orchestrate.ts` also emits a CommonJS bundle (dist/orchestrate.cjs) so the
+  // babel-jest integration spec can `require` and exercise the REAL
+  // `invalidateAlbumBatch` against Postgres without reimplementing its SQL —
+  // the same arrangement `jobs/artist-unicode-dedup` uses for `dist/merge.cjs`
+  // (BS#1897 review MED-1). A hand-mirrored copy of the statement in the spec
+  // would pass even with the shipped defect restored.
+  entry: ['job.ts', 'orchestrate.ts'],
+  format: ['esm', 'cjs'],
   outDir: 'dist',
   clean: true,
   onSuccess: options.watch ? 'node ./dist/job.js' : undefined,

--- a/tests/integration/va-apple-music-url-remediation-invalidate.spec.js
+++ b/tests/integration/va-apple-music-url-remediation-invalidate.spec.js
@@ -1,0 +1,179 @@
+/**
+ * Integration test for BS#2000's `album_metadata` invalidation UPDATE — the
+ * statement `invalidateAlbumBatch` (orchestrate.ts) sends for every page of
+ * phase 2.
+ *
+ * WHY THIS EXISTS. The job shipped with the id list bound as a bare JS array:
+ *
+ *     WHERE "album_id" = ANY(${albumIds})        // albumIds: number[]
+ *
+ * Drizzle expands a JS array inside a `sql` template into a comma-separated
+ * PARAMETER LIST, so Postgres received `ANY(($1, $2, … $202))` — a row
+ * constructor, not an array. `ANY` requires an array, so the statement failed on
+ * every page and the phase reported `{"candidates":206,"invalidated":0}`. The
+ * repo idiom (the BS#1068/BS#1071 trap, documented in
+ * `jobs/album-critic-reviews-etl/antijoin.ts`) is to bind a `{1,2,3}`
+ * array-literal STRING with an explicit `::int[]` cast.
+ *
+ * WHY NO EXISTING TEST CAUGHT IT. `jest.unit.config.ts` maps `@wxyc/database`
+ * to `tests/mocks/database.mock.ts` and `tests/__mocks__/drizzle-orm.ts` stubs
+ * the `sql` tag as `{ sql: strings, values }` — nothing parses SQL, and the
+ * suite's `renderSql` helper splices bound values inline, so the two bindings
+ * are indistinguishable there. Only a real server can reject the bad one.
+ *
+ * Pure SQL — does NOT import the TS job. Same constraint as the sibling
+ * `va-apple-music-url-remediation-net.spec.js` (read its header): the
+ * integration runner is babel-jest with no TypeScript support. `UPDATE_SET` and
+ * `UPDATE_TAIL` below mirror `invalidateAlbumBatch`; when that function is
+ * hand-edited, the SQL here must follow.
+ *
+ * `sql.unsafe` rather than a postgres-js tagged template on purpose: postgres-js
+ * binds a JS array as a genuine PG array and would paper over the very
+ * distinction under test. The text here is what the driver actually receives.
+ *
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
+ *
+ * @see WXYC/Backend-Service#2000
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/** Mirrors `invalidateAlbumBatch`'s SET clause in orchestrate.ts. */
+const UPDATE_SET = `
+  UPDATE "${SCHEMA}"."album_metadata"
+  SET "apple_music_url" = NULL,
+      "apple_music_status" = 'unresolved',
+      "streaming_reask_attempts" = 0,
+      "updated_at" = NOW()
+`;
+
+/** Mirrors the guard that keeps a concurrent write from being clobbered. */
+const UPDATE_TAIL = `AND "apple_music_url" IS NOT NULL`;
+
+/** The FIXED predicate: one param, a PG array literal, explicitly cast. */
+const arrayLiteralStatement = () => `${UPDATE_SET} WHERE "album_id" = ANY($1::int[]) ${UPDATE_TAIL}`;
+
+/** The SHIPPED predicate: what drizzle emits for a bare `number[]`. */
+const rowConstructorStatement = (count) => {
+  const placeholders = Array.from({ length: count }, (_, i) => `$${i + 1}`).join(', ');
+  return `${UPDATE_SET} WHERE "album_id" = ANY((${placeholders})) ${UPDATE_TAIL}`;
+};
+
+/** Mirrors `intArrayLiteral` in the sibling jobs (ghost-row-sweep, metadata-backfill). */
+const intArrayLiteral = (ids) => `{${ids.join(',')}}`;
+
+const APPLE_URL = 'https://music.apple.com/us/song/bs2000-invalidate-fixture/777';
+
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'bs2000-invalidate-' + suffix}, 9997, 'Various Artists')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+async function insertAlbumMetadata(sql, albumId, appleUrl) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, artwork_url, apple_music_url, apple_music_status, streaming_reask_attempts, updated_at)
+    VALUES (${albumId}, 'https://i.discogs.com/x.jpg', ${appleUrl}, ${appleUrl ? 'verified' : 'unresolved'}, 3, NOW())
+  `;
+}
+
+async function readRow(sql, albumId) {
+  const [row] = await sql`
+    SELECT apple_music_url, apple_music_status, streaming_reask_attempts
+      FROM ${sql(SCHEMA)}.album_metadata
+     WHERE album_id = ${albumId}
+  `;
+  return row;
+}
+
+describe('BS#2000 album_metadata invalidation UPDATE (real Postgres)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+
+  const seed = async (suffix, appleUrl = APPLE_URL) => {
+    const albumId = await insertLibraryAlbum(sql, suffix);
+    insertedAlbumIds.push(albumId);
+    await insertAlbumMetadata(sql, albumId, appleUrl);
+    return albumId;
+  };
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  it('REGRESSION: the row-constructor predicate is rejected outright by Postgres', async () => {
+    const target = await seed('row-constructor');
+
+    // Parse-time failure (make_scalar_array_op), so it is dataset-independent:
+    // the shipped statement could never have invalidated a row, on any page,
+    // for any input. That is the whole content of the production log line
+    // `album_metadata: {"candidates":206,"invalidated":0,"batches":1}`.
+    await expect(sql.unsafe(rowConstructorStatement(2), [target, target + 1])).rejects.toMatchObject({
+      code: '42809',
+    });
+
+    // …and the row it was supposed to clean is untouched.
+    const row = await readRow(sql, target);
+    expect(row.apple_music_url).toBe(APPLE_URL);
+    expect(row.streaming_reask_attempts).toBe(3);
+  });
+
+  it('the array-literal predicate invalidates exactly the targeted rows', async () => {
+    const target = await seed('literal-target');
+    const untargeted = await seed('literal-untargeted');
+
+    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral([target])]);
+    expect(result.count).toBe(1);
+
+    // Handed to the BS#1915 hourly re-ask sweep: url cleared, status flipped to
+    // 'unresolved', and the exhausted attempt budget reset so the sweep will
+    // actually pick the row up.
+    const cleaned = await readRow(sql, target);
+    expect(cleaned.apple_music_url).toBeNull();
+    expect(cleaned.apple_music_status).toBe('unresolved');
+    expect(cleaned.streaming_reask_attempts).toBe(0);
+
+    const spared = await readRow(sql, untargeted);
+    expect(spared.apple_music_url).toBe(APPLE_URL);
+    expect(spared.apple_music_status).toBe('verified');
+    expect(spared.streaming_reask_attempts).toBe(3);
+  });
+
+  it('the IS NOT NULL guard skips an already-null row inside the id list', async () => {
+    const alreadyNull = await seed('literal-already-null', null);
+    const withUrl = await seed('literal-with-url');
+
+    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral([alreadyNull, withUrl])]);
+    // Both ids are in the list; only the one carrying a URL is written.
+    expect(result.count).toBe(1);
+
+    const untouched = await readRow(sql, alreadyNull);
+    expect(untouched.streaming_reask_attempts).toBe(3);
+  });
+
+  it('the array literal carries a full production-width page', async () => {
+    const target = await seed('literal-wide-page');
+
+    // The failing run paged 202 ids at once — the width at which the row
+    // constructor became `ANY(($1, $2, … $202))` in the production log.
+    const ids = Array.from({ length: 201 }, (_, i) => -1 - i).concat(target);
+    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral(ids)]);
+    expect(result.count).toBe(1);
+    expect((await readRow(sql, target)).apple_music_url).toBeNull();
+  });
+});

--- a/tests/integration/va-apple-music-url-remediation-invalidate.spec.js
+++ b/tests/integration/va-apple-music-url-remediation-invalidate.spec.js
@@ -1,68 +1,66 @@
 /**
- * Integration test for BS#2000's `album_metadata` invalidation UPDATE — the
- * statement `invalidateAlbumBatch` (orchestrate.ts) sends for every page of
- * phase 2.
+ * Integration tests for the REAL shipped `invalidateAlbumBatch` of
+ * `jobs/va-apple-music-url-remediation` — phase 2 of the BS#2000 remediation.
  *
- * WHY THIS EXISTS. The job shipped with the id list bound as a bare JS array:
+ * WHY THIS RUNS THE REAL FUNCTION. The job shipped with its id list bound as a
+ * bare JS array:
  *
  *     WHERE "album_id" = ANY(${albumIds})        // albumIds: number[]
  *
  * Drizzle expands a JS array inside a `sql` template into a comma-separated
  * PARAMETER LIST, so Postgres received `ANY(($1, $2, … $202))` — a row
- * constructor, not an array. `ANY` requires an array, so the statement failed on
- * every page and the phase reported `{"candidates":206,"invalidated":0}`. The
- * repo idiom (the BS#1068/BS#1071 trap, documented in
- * `jobs/album-critic-reviews-etl/antijoin.ts`) is to bind a `{1,2,3}`
- * array-literal STRING with an explicit `::int[]` cast.
+ * constructor, not an array — and rejected it at parse time (42809,
+ * `op ANY/ALL (array) requires array on right side`). Being a parse error, it
+ * was dataset-independent: the statement could never have written a row, on any
+ * page, for any input. Production reported
+ * `album_metadata: {"candidates":206,"invalidated":0,"batches":1}`.
+ *
+ * A hand-mirrored copy of the statement in this file would NOT have caught
+ * that, and would not catch its return: the mirror passes no matter what
+ * `orchestrate.ts` actually sends. So this spec `require`s the compiled
+ * `dist/orchestrate.cjs` and calls the real exported function — the same
+ * arrangement `artist-unicode-dedup-merge.spec.js` uses for `dist/merge.cjs`
+ * (BS#1897 review MED-1). Revert the fix and these tests fail.
  *
  * WHY NO EXISTING TEST CAUGHT IT. `jest.unit.config.ts` maps `@wxyc/database`
  * to `tests/mocks/database.mock.ts` and `tests/__mocks__/drizzle-orm.ts` stubs
- * the `sql` tag as `{ sql: strings, values }` — nothing parses SQL, and the
- * suite's `renderSql` helper splices bound values inline, so the two bindings
- * are indistinguishable there. Only a real server can reject the bad one.
+ * the `sql` tag as `{ sql: strings, values }` — nothing in the unit tier parses
+ * SQL, and the suite's `renderSql` helper splices bound values inline, so a
+ * mis-parameterized bind is invisible there. Only a real server can reject it.
  *
- * Pure SQL — does NOT import the TS job. Same constraint as the sibling
- * `va-apple-music-url-remediation-net.spec.js` (read its header): the
- * integration runner is babel-jest with no TypeScript support. `UPDATE_SET` and
- * `UPDATE_TAIL` below mirror `invalidateAlbumBatch`; when that function is
- * hand-edited, the SQL here must follow.
+ * `dist/orchestrate.cjs` is produced by the workspace `build` (tsup dual-format
+ * esm+cjs); CI's Build step runs `npm run build` — which covers `jobs/**` —
+ * before the integration tier. Rebuild after editing `orchestrate.ts`
+ * (`npm run build --workspace=@wxyc/va-apple-music-url-remediation`).
  *
- * `sql.unsafe` rather than a postgres-js tagged template on purpose: postgres-js
- * binds a JS array as a genuine PG array and would paper over the very
- * distinction under test. The text here is what the driver actually receives.
+ * The real function uses the `@wxyc/database` `db` singleton (its own pool,
+ * DB_* env); this spec seeds and asserts via `getTestDb()`, a separate pool on
+ * the same database. All writes commit, so the two pools see each other's rows.
  *
  * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
  *
  * @see WXYC/Backend-Service#2000
  */
 
+// The repo-wide `tests/__mocks__/drizzle-orm.ts` manual mock (written for the
+// ts-jest unit tier) is AUTOMATICALLY applied to every `drizzle-orm` require —
+// no `jest.mock(...)` needed — including here in the integration tier. Our
+// compiled `dist/orchestrate.cjs` requires the REAL drizzle-orm (its `sql`
+// template builds the UPDATE that `@wxyc/database`'s postgres-js driver runs),
+// so unmock it (same pattern as `artist-unicode-dedup-merge.spec.js`). Hoisted
+// above the requires below by babel-plugin-jest-hoist.
+jest.unmock('drizzle-orm');
+
+const path = require('path');
 const { getTestDb } = require('../utils/db');
 
+// The REAL compiled statement — no reimplementation.
+const { invalidateAlbumBatch } = require(
+  path.join(__dirname, '..', '..', 'jobs', 'va-apple-music-url-remediation', 'dist', 'orchestrate.cjs')
+);
+
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-
-/** Mirrors `invalidateAlbumBatch`'s SET clause in orchestrate.ts. */
-const UPDATE_SET = `
-  UPDATE "${SCHEMA}"."album_metadata"
-  SET "apple_music_url" = NULL,
-      "apple_music_status" = 'unresolved',
-      "streaming_reask_attempts" = 0,
-      "updated_at" = NOW()
-`;
-
-/** Mirrors the guard that keeps a concurrent write from being clobbered. */
-const UPDATE_TAIL = `AND "apple_music_url" IS NOT NULL`;
-
-/** The FIXED predicate: one param, a PG array literal, explicitly cast. */
-const arrayLiteralStatement = () => `${UPDATE_SET} WHERE "album_id" = ANY($1::int[]) ${UPDATE_TAIL}`;
-
-/** The SHIPPED predicate: what drizzle emits for a bare `number[]`. */
-const rowConstructorStatement = (count) => {
-  const placeholders = Array.from({ length: count }, (_, i) => `$${i + 1}`).join(', ');
-  return `${UPDATE_SET} WHERE "album_id" = ANY((${placeholders})) ${UPDATE_TAIL}`;
-};
-
-/** Mirrors `intArrayLiteral` in the sibling jobs (ghost-row-sweep, metadata-backfill). */
-const intArrayLiteral = (ids) => `{${ids.join(',')}}`;
+const UPDATE_TIMEOUT_MS = 30_000;
 
 const APPLE_URL = 'https://music.apple.com/us/song/bs2000-invalidate-fixture/777';
 
@@ -81,20 +79,23 @@ async function insertAlbumMetadata(sql, albumId, appleUrl) {
   await sql`
     INSERT INTO ${sql(SCHEMA)}.album_metadata
       (album_id, artwork_url, apple_music_url, apple_music_status, streaming_reask_attempts, updated_at)
-    VALUES (${albumId}, 'https://i.discogs.com/x.jpg', ${appleUrl}, ${appleUrl ? 'verified' : 'unresolved'}, 3, NOW())
+    VALUES (
+      ${albumId}, 'https://i.discogs.com/x.jpg', ${appleUrl},
+      ${appleUrl ? 'verified' : 'unresolved'}, 3, NOW() - INTERVAL '7 days'
+    )
   `;
 }
 
 async function readRow(sql, albumId) {
   const [row] = await sql`
-    SELECT apple_music_url, apple_music_status, streaming_reask_attempts
+    SELECT apple_music_url, apple_music_status, streaming_reask_attempts, updated_at
       FROM ${sql(SCHEMA)}.album_metadata
      WHERE album_id = ${albumId}
   `;
   return row;
 }
 
-describe('BS#2000 album_metadata invalidation UPDATE (real Postgres)', () => {
+describe('va-apple-music-url-remediation invalidateAlbumBatch — REAL function (real PG, BS#2000)', () => {
   let sql;
   const insertedAlbumIds = [];
 
@@ -116,29 +117,14 @@ describe('BS#2000 album_metadata invalidation UPDATE (real Postgres)', () => {
     }
   });
 
-  it('REGRESSION: the row-constructor predicate is rejected outright by Postgres', async () => {
-    const target = await seed('row-constructor');
+  it('REGRESSION: the statement executes and actually invalidates its targets', async () => {
+    // This is the test the shipped defect failed: the UPDATE threw 42809 and
+    // wrote nothing. Restore `ANY(${albumIds})` and this goes red again.
+    const target = await seed('executes');
+    const untargeted = await seed('untargeted');
 
-    // Parse-time failure (make_scalar_array_op), so it is dataset-independent:
-    // the shipped statement could never have invalidated a row, on any page,
-    // for any input. That is the whole content of the production log line
-    // `album_metadata: {"candidates":206,"invalidated":0,"batches":1}`.
-    await expect(sql.unsafe(rowConstructorStatement(2), [target, target + 1])).rejects.toMatchObject({
-      code: '42809',
-    });
-
-    // …and the row it was supposed to clean is untouched.
-    const row = await readRow(sql, target);
-    expect(row.apple_music_url).toBe(APPLE_URL);
-    expect(row.streaming_reask_attempts).toBe(3);
-  });
-
-  it('the array-literal predicate invalidates exactly the targeted rows', async () => {
-    const target = await seed('literal-target');
-    const untargeted = await seed('literal-untargeted');
-
-    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral([target])]);
-    expect(result.count).toBe(1);
+    const written = await invalidateAlbumBatch([{ albumId: target, oldUrl: APPLE_URL }], UPDATE_TIMEOUT_MS);
+    expect(written).toBe(1);
 
     // Handed to the BS#1915 hourly re-ask sweep: url cleared, status flipped to
     // 'unresolved', and the exhausted attempt budget reset so the sweep will
@@ -154,26 +140,82 @@ describe('BS#2000 album_metadata invalidation UPDATE (real Postgres)', () => {
     expect(spared.streaming_reask_attempts).toBe(3);
   });
 
-  it('the IS NOT NULL guard skips an already-null row inside the id list', async () => {
-    const alreadyNull = await seed('literal-already-null', null);
-    const withUrl = await seed('literal-with-url');
+  it('stamps updated_at — no trigger does it for album_metadata', async () => {
+    // Migration 0084's bump_flowsheet_updated_at is flowsheet-only. Without the
+    // explicit SET, the freshness signal the BS#1915 sweep and the CDC
+    // consumers read would stay frozen at its pre-remediation value (seeded
+    // here 7 days in the past).
+    const target = await seed('updated-at');
+    const before = (await readRow(sql, target)).updated_at;
 
-    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral([alreadyNull, withUrl])]);
-    // Both ids are in the list; only the one carrying a URL is written.
-    expect(result.count).toBe(1);
+    await invalidateAlbumBatch([{ albumId: target, oldUrl: APPLE_URL }], UPDATE_TIMEOUT_MS);
 
-    const untouched = await readRow(sql, alreadyNull);
-    expect(untouched.streaming_reask_attempts).toBe(3);
+    const after = (await readRow(sql, target)).updated_at;
+    expect(after.getTime()).toBeGreaterThan(before.getTime());
   });
 
-  it('the array literal carries a full production-width page', async () => {
-    const target = await seed('literal-wide-page');
+  it('COMPARE-AND-SET: a url that changed under us is left alone', async () => {
+    // The race this guard closes: between phase 2's page SELECT and this
+    // UPDATE, `apps/enrichment-worker/enrich.ts` re-verifies the album through
+    // LML's post-#1139 guarded matcher and writes the CORRECT url as
+    // 'verified'. Nulling that would open a DJ-visible window through
+    // `flowsheet.service.ts`'s coalesce until the BS#1915 sweep re-healed it.
+    const target = await seed('cas-changed');
+    const REVERIFIED = 'https://music.apple.com/us/song/correct-after-lml-1139/999';
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET apple_music_url = ${REVERIFIED}, apple_music_status = 'verified'
+       WHERE album_id = ${target}
+    `;
 
+    // We still hold the STALE url we observed at SELECT time.
+    const written = await invalidateAlbumBatch([{ albumId: target, oldUrl: APPLE_URL }], UPDATE_TIMEOUT_MS);
+    expect(written).toBe(0);
+
+    const row = await readRow(sql, target);
+    expect(row.apple_music_url).toBe(REVERIFIED);
+    expect(row.apple_music_status).toBe('verified');
+    expect(row.streaming_reask_attempts).toBe(3);
+  });
+
+  it('COMPARE-AND-SET: a mixed page writes only the rows that still match', async () => {
+    const stable = await seed('cas-mixed-stable');
+    const raced = await seed('cas-mixed-raced');
+    const MOVED = 'https://music.apple.com/us/song/moved/1';
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET apple_music_url = ${MOVED}
+       WHERE album_id = ${raced}
+    `;
+
+    const written = await invalidateAlbumBatch(
+      [
+        { albumId: stable, oldUrl: APPLE_URL },
+        { albumId: raced, oldUrl: APPLE_URL },
+      ],
+      UPDATE_TIMEOUT_MS
+    );
+    expect(written).toBe(1);
+
+    expect((await readRow(sql, stable)).apple_music_url).toBeNull();
+    expect((await readRow(sql, raced)).apple_music_url).toBe(MOVED);
+  });
+
+  it('carries a full production-width page', async () => {
     // The failing run paged 202 ids at once — the width at which the row
     // constructor became `ANY(($1, $2, … $202))` in the production log.
-    const ids = Array.from({ length: 201 }, (_, i) => -1 - i).concat(target);
-    const result = await sql.unsafe(arrayLiteralStatement(), [intArrayLiteral(ids)]);
-    expect(result.count).toBe(1);
+    const target = await seed('wide-page');
+    const filler = Array.from({ length: 201 }, (_, i) => ({ albumId: -1 - i, oldUrl: APPLE_URL }));
+
+    const written = await invalidateAlbumBatch(
+      filler.concat([{ albumId: target, oldUrl: APPLE_URL }]),
+      UPDATE_TIMEOUT_MS
+    );
+    expect(written).toBe(1);
     expect((await readRow(sql, target)).apple_music_url).toBeNull();
+  });
+
+  it('is a no-op on an empty page', async () => {
+    await expect(invalidateAlbumBatch([], UPDATE_TIMEOUT_MS)).resolves.toBe(0);
   });
 });

--- a/tests/unit/jobs/va-apple-music-url-remediation/orchestrate.test.ts
+++ b/tests/unit/jobs/va-apple-music-url-remediation/orchestrate.test.ts
@@ -35,6 +35,13 @@ import {
   type FlowsheetFix,
 } from '../../../../jobs/va-apple-music-url-remediation/orchestrate';
 
+/**
+ * Renders a drizzle SQL object for *text* assertions (column names, guards,
+ * ordering). It splices bound values inline, so it is deliberately BLIND to how
+ * a value is actually PARAMETERIZED — `ANY(${[7, 8]})` and `ANY(${'{7,8}'}::int[])`
+ * both render as plausible-looking text here. Anything about the wire shape of a
+ * bound parameter must go through `findExecuteQuery` below instead.
+ */
 type SqlLike = { sql?: string | string[]; values?: unknown[]; raw?: string; join?: unknown[]; sep?: unknown };
 const renderSql = (value: unknown): string => {
   if (value === null || value === undefined) return '';
@@ -57,6 +64,17 @@ const queueExecute = (...results: unknown[]): void => {
 
 const findExecuteCall = (pattern: RegExp): string =>
   (db.execute as jest.Mock).mock.calls.map((c) => renderSql(c?.[0])).find((s) => pattern.test(s)) ?? '';
+
+/**
+ * The raw values bound into the first captured statement whose rendered text
+ * matches. `tests/__mocks__/drizzle-orm.ts` stubs the `sql` tag as
+ * `{ sql: strings, values }`, so it cannot serialize a statement — but it does
+ * preserve each bound value verbatim, which is enough to tell a PG array
+ * LITERAL apart from a bare JS array. That distinction is invisible to
+ * `renderSql`, and it is the whole bug.
+ */
+const findExecuteValues = (pattern: RegExp): unknown[] =>
+  (db.execute as jest.Mock).mock.calls.find((c) => pattern.test(renderSql(c?.[0])))?.[0]?.values ?? [];
 
 const APPLE_URL = 'https://music.apple.com/us/song/im-on-my-way/777';
 const NEW_URL = 'https://music.apple.com/us/song/im-on-my-way/999';
@@ -345,6 +363,34 @@ describe('invalidateAlbumBatch SQL', () => {
     expect(updateSql).toMatch(/apple_music_url" = NULL/);
     // Guarded so a concurrent write can't be clobbered.
     expect(updateSql).toMatch(/apple_music_url" IS NOT NULL/);
+  });
+
+  it('binds the id list as a PG array literal, never as a bare JS array', async () => {
+    // The shipped defect: `ANY(${albumIds})` with a bare `number[]`. Drizzle
+    // expands a JS array inside a `sql` template into a comma-separated
+    // PARAMETER LIST, so Postgres received `ANY(($1, $2, … $202))` — a row
+    // constructor, which `ANY` will not accept — and every page of the
+    // album_metadata phase failed at runtime. The repo idiom (BS#1068/BS#1071;
+    // see `jobs/album-critic-reviews-etl/antijoin.ts`) is to bind a `{1,2,3}`
+    // array-literal STRING with an explicit `::int[]` cast.
+    //
+    // This assertion is only as strong as the mock allows: the stub `sql` tag
+    // does not parse SQL, so what is pinned here is the bound VALUE and the
+    // cast, not the wire-level statement. The statement itself is executed
+    // against real Postgres in
+    // `tests/integration/va-apple-music-url-remediation-invalidate.spec.js`.
+    (db.transaction as jest.Mock).mockImplementation((cb: (tx: unknown) => unknown) =>
+      Promise.resolve(cb({ execute: db.execute }))
+    );
+    queueExecute({ count: 1 }, { count: 1 });
+
+    await invalidateAlbumBatch([7, 8], 1000);
+
+    expect(findExecuteCall(/UPDATE/)).toMatch(/= ANY\(\{7,8\}::int\[\]\)/);
+    const bound = findExecuteValues(/UPDATE/);
+    expect(bound).toContain('{7,8}');
+    // A bare array reaching the driver is the defect itself.
+    expect(bound.some((v) => Array.isArray(v))).toBe(false);
   });
 });
 

--- a/tests/unit/jobs/va-apple-music-url-remediation/orchestrate.test.ts
+++ b/tests/unit/jobs/va-apple-music-url-remediation/orchestrate.test.ts
@@ -25,6 +25,7 @@ import {
   analyzeTable,
   applyFlowsheetBatch,
   invalidateAlbumBatch,
+  type AlbumInvalidation,
   resolveAfterId,
   resolveBatchSize,
   resolveDryRun,
@@ -66,15 +67,38 @@ const findExecuteCall = (pattern: RegExp): string =>
   (db.execute as jest.Mock).mock.calls.map((c) => renderSql(c?.[0])).find((s) => pattern.test(s)) ?? '';
 
 /**
- * The raw values bound into the first captured statement whose rendered text
- * matches. `tests/__mocks__/drizzle-orm.ts` stubs the `sql` tag as
+ * Every leaf value bound into the first captured statement whose rendered text
+ * matches, flattened across nested `sql.join(...)` fragments.
+ * `tests/__mocks__/drizzle-orm.ts` stubs the `sql` tag as
  * `{ sql: strings, values }`, so it cannot serialize a statement — but it does
- * preserve each bound value verbatim, which is enough to tell a PG array
- * LITERAL apart from a bare JS array. That distinction is invisible to
- * `renderSql`, and it is the whole bug.
+ * preserve each bound value verbatim, which is enough to tell a scalar bind
+ * apart from a bare JS array. That distinction is invisible to `renderSql`
+ * (which splices values inline), and it is the whole bug.
  */
-const findExecuteValues = (pattern: RegExp): unknown[] =>
-  (db.execute as jest.Mock).mock.calls.find((c) => pattern.test(renderSql(c?.[0])))?.[0]?.values ?? [];
+const collectValues = (node: unknown, out: unknown[]): void => {
+  if (node === null || typeof node !== 'object') {
+    if (node !== undefined) out.push(node);
+    return;
+  }
+  const obj = node as SqlLike;
+  if (Array.isArray(obj.join)) {
+    obj.join.forEach((fragment) => collectValues(fragment, out));
+    return;
+  }
+  if (Array.isArray(obj.values)) {
+    obj.values.forEach((value) => collectValues(value, out));
+    return;
+  }
+  if (typeof obj.raw === 'string') return;
+  out.push(node);
+};
+
+const findExecuteValues = (pattern: RegExp): unknown[] => {
+  const chunk = (db.execute as jest.Mock).mock.calls.find((c) => pattern.test(renderSql(c?.[0])))?.[0];
+  const out: unknown[] = [];
+  collectValues(chunk, out);
+  return out;
+};
 
 const APPLE_URL = 'https://music.apple.com/us/song/im-on-my-way/777';
 const NEW_URL = 'https://music.apple.com/us/song/im-on-my-way/999';
@@ -96,7 +120,12 @@ const queueSinglePageRun = (rows: unknown[]) => queueExecute([{ count: rows.leng
 
 const noopAnalyze = jest.fn(async () => {});
 const passThroughApply = jest.fn((fixes: FlowsheetFix[]) => Promise.resolve(fixes.length));
-const noopInvalidate = jest.fn((ids: number[]) => Promise.resolve(ids.length));
+const noopInvalidate = jest.fn((targets: AlbumInvalidation[]) => Promise.resolve(targets.length));
+
+const albumTargets: AlbumInvalidation[] = [
+  { albumId: 7, oldUrl: APPLE_URL },
+  { albumId: 8, oldUrl: APPLE_URL },
+];
 
 const baseOpts = (overrides: Record<string, unknown> = {}) => ({
   dryRun: false,
@@ -291,9 +320,9 @@ describe('phase order', () => {
       order.push('flowsheet');
       return Promise.resolve(f.length);
     });
-    const invalidate = jest.fn((ids: number[]) => {
+    const invalidate = jest.fn((targets: AlbumInvalidation[]) => {
       order.push('album');
-      return Promise.resolve(ids.length);
+      return Promise.resolve(targets.length);
     });
 
     await runRemediation(
@@ -352,7 +381,7 @@ describe('invalidateAlbumBatch SQL', () => {
     );
     queueExecute({ count: 1 }, { count: 1 });
 
-    await invalidateAlbumBatch([7, 8], 1000);
+    await invalidateAlbumBatch(albumTargets, 1000);
 
     const updateSql = findExecuteCall(/UPDATE/);
     // Handing the row to the BS#1915 hourly re-ask sweep rather than
@@ -361,35 +390,63 @@ describe('invalidateAlbumBatch SQL', () => {
     expect(updateSql).toMatch(/apple_music_status" = 'unresolved'/);
     expect(updateSql).toMatch(/streaming_reask_attempts" = 0/);
     expect(updateSql).toMatch(/apple_music_url" = NULL/);
-    // Guarded so a concurrent write can't be clobbered.
-    expect(updateSql).toMatch(/apple_music_url" IS NOT NULL/);
   });
 
-  it('binds the id list as a PG array literal, never as a bare JS array', async () => {
-    // The shipped defect: `ANY(${albumIds})` with a bare `number[]`. Drizzle
+  it('is a compare-and-set on the observed url', async () => {
+    // The album arm overwrites a NON-NULL value while the enrichment worker and
+    // the BS#1915 sweep touch the same column, so a bare `IS NOT NULL` is not
+    // enough: it would null a url the worker had just re-verified through the
+    // post-#1139 guarded matcher. Mirrors applyFlowsheetBatch's guard.
+    (db.transaction as jest.Mock).mockImplementation((cb: (tx: unknown) => unknown) =>
+      Promise.resolve(cb({ execute: db.execute }))
+    );
+    queueExecute({ count: 1 }, { count: 1 });
+
+    await invalidateAlbumBatch(albumTargets, 1000);
+
+    const updateSql = findExecuteCall(/UPDATE/);
+    expect(updateSql).toMatch(/IS NOT DISTINCT FROM v\."old_url"/);
+    expect(updateSql).toMatch(/t\."album_id" = v\."album_id"/);
+    // The old predicate would silently re-admit the race this guard closes.
+    expect(updateSql).not.toMatch(/apple_music_url" IS NOT NULL/);
+  });
+
+  it('stamps updated_at, which no trigger does for album_metadata', async () => {
+    // Migration 0084's bump_flowsheet_updated_at is flowsheet-ONLY (the mirror
+    // image of applyFlowsheetBatch's `not.toMatch(/updated_at/)` assertion).
+    // Drop this SET and the row's freshness signal — which the BS#1915 re-ask
+    // sweep and the CDC consumers read — freezes at its pre-remediation value.
+    (db.transaction as jest.Mock).mockImplementation((cb: (tx: unknown) => unknown) =>
+      Promise.resolve(cb({ execute: db.execute }))
+    );
+    queueExecute({ count: 1 }, { count: 1 });
+
+    await invalidateAlbumBatch(albumTargets, 1000);
+
+    expect(findExecuteCall(/UPDATE/)).toMatch(/"updated_at" = NOW\(\)/);
+  });
+
+  it('never binds a bare JS array', async () => {
+    // The shipped defect was `ANY(${albumIds})` with a bare `number[]`: drizzle
     // expands a JS array inside a `sql` template into a comma-separated
     // PARAMETER LIST, so Postgres received `ANY(($1, $2, … $202))` — a row
-    // constructor, which `ANY` will not accept — and every page of the
-    // album_metadata phase failed at runtime. The repo idiom (BS#1068/BS#1071;
-    // see `jobs/album-critic-reviews-etl/antijoin.ts`) is to bind a `{1,2,3}`
-    // array-literal STRING with an explicit `::int[]` cast.
+    // constructor, which `ANY` rejects at parse time (42809) — and every page
+    // of the album_metadata phase failed. The VALUES join binds each id and url
+    // as its own parameter, so no array is bound at all; this pins that.
     //
-    // This assertion is only as strong as the mock allows: the stub `sql` tag
-    // does not parse SQL, so what is pinned here is the bound VALUE and the
-    // cast, not the wire-level statement. The statement itself is executed
-    // against real Postgres in
+    // Only as strong as the mock allows: `tests/__mocks__/drizzle-orm.ts` stubs
+    // the `sql` tag, so nothing here parses SQL. The statement is executed for
+    // real — by requiring the compiled function — in
     // `tests/integration/va-apple-music-url-remediation-invalidate.spec.js`.
     (db.transaction as jest.Mock).mockImplementation((cb: (tx: unknown) => unknown) =>
       Promise.resolve(cb({ execute: db.execute }))
     );
     queueExecute({ count: 1 }, { count: 1 });
 
-    await invalidateAlbumBatch([7, 8], 1000);
+    await invalidateAlbumBatch(albumTargets, 1000);
 
-    expect(findExecuteCall(/UPDATE/)).toMatch(/= ANY\(\{7,8\}::int\[\]\)/);
     const bound = findExecuteValues(/UPDATE/);
-    expect(bound).toContain('{7,8}');
-    // A bare array reaching the driver is the defect itself.
+    expect(bound.length).toBeGreaterThan(0);
     expect(bound.some((v) => Array.isArray(v))).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #2007

## What was broken

`jobs/va-apple-music-url-remediation/orchestrate.ts`'s `invalidateAlbumBatch` bound its id list as a bare JS array:

```ts
WHERE "album_id" = ANY(${albumIds})   // albumIds: number[]
```

Drizzle expands a JS array inside a `sql` template into a comma-separated **parameter list**, so Postgres received `ANY(($1, $2, ... $202))` — a row constructor, not an array. `ANY` requires an array, and the rejection happens at **parse time** (SQLSTATE `42809`, `op ANY/ALL (array) requires array on right side`), which makes it dataset-independent: the shipped statement could never have invalidated a row, on any page, for any input.

The 2026-08-06 09:33 PDT run (`run_id` `47dfff79-44d7-4768-8a18-3dd49278dc67`) reported `album_metadata: {"candidates":206,"invalidated":0,"batches":1}`. The flowsheet phase of that same run completed correctly (52 nulled, 56 verified and kept, 10 indeterminate) — only the `album_metadata` arm is broken, and it is the DJ-visible one, since `flowsheet.service.ts` serves `coalesce(album_metadata.apple_music_url, flowsheet.apple_music_url)`.

## The fix

`invalidateAlbumBatch` now sends a **VALUES-join UPDATE**, mirroring `applyFlowsheetBatch` twenty lines above it in the same file. The page SELECT carries each row's observed `apple_music_url` along with its id.

This does two things at once. It removes the array bind entirely rather than repairing it — each id and url is its own parameter, so nothing has to hand-roll a PG array literal (urls are text and would need real escaping, which is the same class of hazard the original bug came from). And it carries the compare-and-set the album arm was missing.

> **Design note.** The first revision of this PR used the array-literal-plus-`::int[]` idiom from `jobs/album-critic-reviews-etl/antijoin.ts`. Review required a compare-and-set, which needs a per-row payload, and once each row carries `(id, old_url)` the id predicate is inherent to the join — an `ANY(...)` on top would be dead weight. #2007's end-state text has been updated to match.

**Audited the rest of the job:** `ANY(` appeared exactly once in `jobs/va-apple-music-url-remediation/`, and no longer appears at all. Every other binding in `orchestrate.ts` is a scalar; no other file in the job contains SQL.

### Compare-and-set (review finding 2)

The album arm had only `apple_music_url IS NOT NULL`, which merely skips already-null rows. The race that guards against nothing: phase 2 SELECTs album 4711 with its polluted url → `apps/enrichment-worker/enrich.ts` re-verifies it through LML's post-#1139 guarded matcher and writes the **correct** url with `apple_music_status='verified'` → our UPDATE nulls it and resets `streaming_reask_attempts` to 0. It self-heals through the BS#1915 sweep, but it is an avoidable round-trip and a DJ-visible null window.

Now `AND t."apple_music_url" IS NOT DISTINCT FROM v."old_url"`, the same guard and the same rationale as the flowsheet arm. Everything else is unchanged: still `apple_music_status='unresolved'`, still `streaming_reask_attempts=0`.

### `updated_at` (review finding 3)

Migration 0084's BEFORE UPDATE trigger is flowsheet-only, so nothing stamps `album_metadata` for us. Dropping `"updated_at" = NOW()` would have silently frozen the freshness signal the BS#1915 `streaming-reask.ts` sweep and the CDC consumers read, and every test would still have passed. Now asserted in both tiers — the mirror image of the flowsheet arm's `expect(updateSql).not.toMatch(/updated_at/)`.

### README: the phase-2-only re-run (review finding 4)

`runRemediation` always runs the flowsheet phase first and gates phase 2 on `!flowsheet.failed`. Production already completed the flowsheet arm, so a naive corrective re-run would re-spend LML on the ~56 surviving triples at up to 3 passes each with a 15 s inter-pass delay — and if the rescue-rate detector or a write error tripped, `album_phase_skipped` would fire and the 206 rows would be skipped a second time.

Parking `VA_REMEDIATION_FLOWSHEET_AFTER_ID` past `max(flowsheet.id)` is now documented under **Running phase 2 alone**, with both reasons and the warning to read the ceiling from a live `max(id)` rather than the previous run's `last_id` (which is only the table max if that run reached the end). The 2026-08-06 result is recorded under **Run result**.

## Test coverage

**The previous revision's regression test did not test the code.** Its `UPDATE_SET` / `arrayLiteralStatement` were string constants that no code path in `orchestrate.ts` read: reverting the fix, switching to `::bigint[]`, or swapping in drizzle's `inArray()` all left it green. The only coupling to the shipped statement was a comment.

Rebuilt on the precedent already in this repo: `tests/integration/artist-unicode-dedup-merge.spec.js` `require`s the compiled `dist/merge.cjs` and runs the real exported functions (added for BS#1897 review MED-1 — the same finding, litigated here once before). So:

- `jobs/va-apple-music-url-remediation/tsup.config.ts` now emits `orchestrate.ts` in both formats, producing `dist/orchestrate.cjs` beside the ESM `dist/job.js` entrypoint. Byte-for-byte the arrangement `jobs/artist-unicode-dedup` uses, including the shared `chunk-*.js` the ESM entry now imports; `Dockerfile.va-apple-music-url-remediation` copies the whole `dist/` directory, so `ENTRYPOINT ["node", ".../dist/job.js"]` is unaffected.
- The spec `require`s that bundle, `jest.unmock('drizzle-orm')` (the repo-wide manual mock is auto-applied even in the integration tier — same line the dedup spec carries), and calls the **real** `invalidateAlbumBatch`.
- Root `npm run build` covers `jobs/**`, and CI's integration job runs it before the DB init, so `dist/orchestrate.cjs` exists in CI. Documented in the spec header for local runs.

Six tests: the statement executes and invalidates its targets while sparing an untargeted row; `updated_at` advances; a url that changed under us is left alone; a mixed page writes only the still-matching rows; a full 202-wide production page; empty-page no-op.

**Verified in both directions.** With the bare-array bind restored and the bundle rebuilt, 5 of the 6 fail with `PostgresError: op ANY/ALL (array) requires array on right side` (the sixth is the empty-page no-op, which short-circuits before the SQL). Restored and rebuilt, all 6 pass. Two unit assertions also flip red on the same revert.

**Unit tier limits, stated plainly.** `tests/__mocks__/drizzle-orm.ts` stubs the `sql` tag as `{ sql: strings, values }` and `@wxyc/database` resolves to `tests/mocks/database.mock.ts`, so nothing in the unit suite serializes or parses SQL — there is no unit-level view of the wire shape. The suite's `renderSql` helper additionally splices bound values inline, which is why the pre-existing `invalidateAlbumBatch SQL` test stayed green through the entire broken run: it rendered the defective predicate as `ANY()`, the array collapsing to an empty string. `renderSql` now carries a comment saying so. The unit assertions that remain (compare-and-set, `updated_at`, no bare-array bind) are real, but the proof that the statement is *valid SQL that writes the right rows* comes only from the integration spec.

## Checks run

| Check | Result |
| --- | --- |
| `npm run lint` | pass (0 errors, 835 pre-existing warnings) |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npx tsc --noEmit -p jobs/va-apple-music-url-remediation/tsconfig.json` | 2 pre-existing errors, unchanged by this PR (see below) |
| `npm run test:unit` | pass — 410 suites, 6500 tests |
| `tests/integration/va-apple-music-url-remediation-invalidate.spec.js` | **pass, 6/6** — run against a throwaway local Postgres 18 (migrations applied by hand, minimal FK fixture), not the Docker CI stack |
| `npm run test:integration` (full tier) | **not run — no Docker daemon on this machine.** Only the new spec was executed, and only against the scratch database above. CI remains the first full-tier run. |

GitHub Actions is still in a `major_outage` (critical incident opened 2026-08-06 08:22 PDT), so CI has not run and was not re-triggered — run [31121659641](https://github.com/WXYC/Backend-Service/actions/runs/31121659641)'s bootstrap jobs were cancelled with no runner ever allocated. **This must go green before merge**, in particular the new integration spec under the real CI fixture.

## Pre-existing job typecheck errors — not noise

`npm run typecheck` does not cover `jobs/**`, so the job was checked directly. Its two `TS2554` errors are **the dead cooperative-pause bug**, not incidental: `CheckLiveActivityFn` is `(lookbackSeconds: number) => Promise<boolean>` — a detector, not a pause — but `orchestrate.ts` calls `await opts.checkLive(opts.lookbackSeconds, opts.pauseMs)` and discards the boolean, so the job never defers to a live DJ. Because the typecheck script skips `jobs/**`, **CI is green on a job that does not compile.** Left alone here at the reviewer's direction; it is going into a separate ticket along with the unguarded `checkLive` throw, the per-row-vs-per-page probe asymmetry, the seventh inline `intArrayLiteral` copy, the `as unknown as` hardening, and the fixture pre-clean. The rescue-rate detector is #2006's scope and is untouched.
