### PR TITLE
test(integration): pre-clean fixture rows by stable marker, not in-memory ids

### DIFF
--- a/tests/integration/artist-unicode-dedup-merge.spec.js
+++ b/tests/integration/artist-unicode-dedup-merge.spec.js
@@ -60,8 +60,37 @@ describe('artist-unicode-dedup mergeGroup — REAL functions (real PG, BS#1897 M
   let sql;
   const artistIds = [];
 
-  beforeAll(() => {
+  beforeAll(async () => {
     sql = getTestDb();
+    // Recovery path (BS#2011): `afterEach` below narrows the crash window to
+    // one in-flight test, but a process death still skips it — routine under
+    // `jest.config.json`'s `forceExit: true`. A crashed prior run leaves
+    // genuinely fold-duplicate `artists` rows (the fixture shape under test),
+    // which `jobs/artist-unicode-dedup`'s `--dry-run` sizing would then
+    // silently count as real merge candidates on a persistent dev DB. Delete
+    // by the stable `ZZMERGE` marker every seeded name in this file carries
+    // (`forms()` always prefixes with a `ZZMERGE...` test id), with no prior
+    // knowledge required. Same child-then-parent order as `afterEach`.
+    const marker = 'ZZMERGE%';
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.artist_crossreference
+       WHERE source_artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+          OR target_artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.artist_search_alias
+       WHERE artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+          OR related_artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.genre_artist_crossreference
+       WHERE artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.library
+       WHERE artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker}`;
   });
 
   afterEach(async () => {

--- a/tests/integration/artist-unicode-dedup.spec.js
+++ b/tests/integration/artist-unicode-dedup.spec.js
@@ -108,8 +108,29 @@ describe('Unicode-form artist matcher + dedup (real PG, BS#1897)', () => {
   let sql;
   const artistIds = [];
 
-  beforeAll(() => {
+  beforeAll(async () => {
     sql = getTestDb();
+    // Recovery path (BS#2011): `afterAll` below only knows about the
+    // in-memory `artistIds`, lost if the process dies before it runs —
+    // routine under `jest.config.json`'s `forceExit: true`. A crashed prior
+    // run of this file leaves genuinely fold-duplicate `artists` rows (that's
+    // the fixture shape under test), which `jobs/artist-unicode-dedup`'s
+    // `--dry-run` sizing would then silently count as real merge candidates
+    // on a persistent dev DB. Delete by the stable `ZZDEDUP ` marker every
+    // seeded name here carries, with no prior knowledge required.
+    // `library.artist_id` has no `onDelete: 'cascade'` in this schema (the
+    // upstream tubafrenzy-derived NOT NULL FK — see the `library` table
+    // comment), so children go first — same order as the `afterAll` below.
+    const marker = 'ZZDEDUP %';
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.library
+       WHERE artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.genre_artist_crossreference
+       WHERE artist_id IN (SELECT id FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker})
+    `;
+    await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE artist_name LIKE ${marker}`;
   });
 
   afterAll(async () => {

--- a/tests/integration/enrichment-worker-streaming-reask.spec.js
+++ b/tests/integration/enrichment-worker-streaming-reask.spec.js
@@ -143,8 +143,16 @@ describe('enrichment-worker streaming self-heal — BS#1915 candidate query + wr
   let sql;
   const insertedAlbumIds = [];
 
-  beforeAll(() => {
+  beforeAll(async () => {
     sql = getTestDb();
+    // Recovery path (BS#2011): `afterAll` below only knows about
+    // `insertedAlbumIds`, an in-memory array lost if the process dies before
+    // it runs — routine under `jest.config.json`'s `forceExit: true`. Delete
+    // by the stable `bs1915-reask-test-` marker `insertLibraryAlbum` stamps
+    // into `library.album_title` instead, so a prior crashed run's orphans
+    // are found with no prior knowledge. Cascades to `album_metadata` via its
+    // `album_id` FK (`onDelete: 'cascade'`, `shared/database/src/schema.ts`).
+    await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE album_title LIKE ${'bs1915-reask-test-%'}`;
   });
 
   afterAll(async () => {
@@ -321,8 +329,12 @@ describe('enrichment-worker streaming self-heal — Bandcamp de-freeze candidate
   const insertedAlbumIds = [];
   const priorFlag = process.env.ENRICHMENT_BANDCAMP_REASK;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     sql = getTestDb();
+    // Same recovery path as the describe block above — `insertFrozenBandcampRow`
+    // routes through the same `insertLibraryAlbum` helper and marker prefix.
+    // Pre-cleaning here too keeps this block self-sufficient (e.g. `.only`).
+    await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE album_title LIKE ${'bs1915-reask-test-%'}`;
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Closes #2011

## Problem

`tests/integration/enrichment-worker-streaming-reask.spec.js` cleans up its fixture rows only in `afterAll`, keyed on an in-memory `insertedAlbumIds` array. If the process dies before `afterAll` runs — routine under `jest.config.json`'s `forceExit: true` — the array is lost and the rows survive.

The orphans aren't inert. They're `library` rows with a Various-Artists-shaped `artist_name` joined to `album_metadata` rows carrying a non-null `apple_music_url`, which satisfies `jobs/va-apple-music-url-remediation`'s `albumMetadataNet` exactly. On a persistent dev database, a later local `--dry-run` sizing of that job silently counts leftover test fixtures as production candidates — defeating the entire point of a dry-run.

## Fix

Added a `beforeAll` pre-clean to each affected `describe` block that deletes by the distinctive fixture marker already present in the seeded data, instead of relying on the in-memory id array:

- `enrichment-worker-streaming-reask.spec.js` (both `describe` blocks) — `library.album_title LIKE 'bs1915-reask-test-%'`. `album_metadata.album_id` cascades from `library.id` (verified against `information_schema`, not assumed), so one `DELETE FROM library` covers both tables.
- `artist-unicode-dedup.spec.js` — `artists.artist_name LIKE 'ZZDEDUP %'`
- `artist-unicode-dedup-merge.spec.js` — `artists.artist_name LIKE 'ZZMERGE%'`

The existing `afterAll`/`afterEach` cleanup is untouched — the pre-clean is a recovery path, not a replacement for cleaning up after yourself. No change to what any spec asserts.

### Why the two `artist-unicode-dedup` specs

The issue named `enrichment-worker-streaming-reask.spec.js` as the donor and asked for a sweep of `tests/integration/` for the same shape. Most `afterAll`/`afterEach`-only specs don't correspond to a coarse, unwindowed candidate net the way this pattern does. Two clear matches turned up:

- **`artist-unicode-dedup.spec.js`** and **`artist-unicode-dedup-merge.spec.js`** seed genuinely fold-duplicate `artists` rows (that's the fixture under test) for `jobs/artist-unicode-dedup` — a one-shot job with the identical dry-run-then-`--execute` shape as `va-apple-music-url-remediation`. A crashed run leaves real merge candidates behind for the next local `--dry-run` sizing to silently count.
- **`flowsheet-ghost-row-sweep.spec.js`** looked like a candidate (same job shape, same table family) but turned out to already be immune: every test runs inside `withRollback`, so a crashed process loses the whole transaction along with the rows. No change needed.

The remaining ~65 files matching a bare `afterAll`/`afterEach` grep are almost all recurring-cron fixtures (concerts, catalog-popularity, flowsheet-metadata-backfill, etc.) whose production jobs run on a schedule rather than via an operator-eyeballed `--dry-run` count, or already scope their own candidate queries with an explicit id/scope predicate. Left alone here rather than ballooning this diff; flagging as a candidate follow-up if the convention proves worth generalizing further.

### A finding along the way

The issue said to verify the `album_metadata`-cascades-from-`library` claim against the migration rather than assume it — that held. Applying the same discipline to the `artists`-referencing tables in the two dedup specs surfaced a real discrepancy: `shared/database/src/schema.ts` declares `genre_artist_crossreference.artist_id` as `onDelete: 'cascade'`, but querying `information_schema.referential_constraints` against a real migrated database shows `NO ACTION`. I didn't chase that down further — the two new pre-cleans sidestep it entirely by deleting children before parents explicitly (mirroring the order each file's own existing cleanup hook already uses), the same defensive posture the `artist-unicode-dedup-merge.spec.js` file's existing comment already took for exactly this reason. Worth its own look if the schema/migration drift is unexpected.

## Verification

Ran directly against real Postgres (migrations applied, real FK constraints) rather than trusting the SQL by inspection: inserted fixture rows matching each new marker to simulate a crashed run, ran each new pre-clean statement, and confirmed the rows (and cascaded/child rows) are gone, the statements are idempotent on a second run, and unrelated seed data is untouched. Separately confirmed a naive parent-first delete on the dedup fixture genuinely fails with a `foreign_key_violation`, so the child-then-parent ordering is load-bearing, not decorative.

**Could not run the actual Jest integration suite end to end.** `npm run ci:env`'s Docker image build for `apps/backend`/`apps/auth` fails at `npm install --omit=dev` with `401 Unauthorized … npm.pkg.github.com/@wxyc/shared` — a stale local `NPM_TOKEN`, not a code problem, and it does not predict CI. `jest`'s `globalSetup` gates every integration spec (including a pure-DB one) on backend:8081 + auth:8083 health, so there was no way to run the actual spec files without those images. The Postgres-only verification above is a real substitute for correctness of the SQL, but it is not the same as the specs passing, and I did not run the "twice in a row with `afterAll` disabled" acceptance check against the real spec files.

## Checks run

| Check | Result |
| --- | --- |
| `npm run format:check` | pass |
| `npm run lint` | pass (0 errors, 835 pre-existing warnings) |
| `npm run typecheck` | pass |
| `node --check` on all three touched files | pass |
| Manual Postgres simulation (see above) | pass |
| `npm run ci:testmock` / real Jest integration run | **not run** — local `NPM_TOKEN` auth failure blocks the Docker image build (see above) |

GitHub Actions is in a confirmed `major_outage` as of 2026-08-06 ~11:30 PT — this PR will show zero checks and none were re-triggered or polled.

## Follow-up for PR #2008

#2008 adds `tests/integration/va-apple-music-url-remediation-invalidate.spec.js`, which inherits the same `afterAll`-only pattern from this donor. Left commented on that PR to adopt this convention on rebase, per the sequencing in #2011 — not stacked, since #2008 is already blocked on the CI outage.