### PR TITLE
Promote intArrayLiteral to @wxyc/database and lint the bare-array-in-ANY() trap unwritable

### DIFF
--- a/docs/bulk-update-playbook.md
+++ b/docs/bulk-update-playbook.md
@@ -80,6 +80,8 @@ await db.execute(sql`DELETE FROM ${table} WHERE "id" = ANY(${idArrayLiteral}::in
 
 The identical `ANY(${ids})` syntax IS correct under a raw **postgres-js** tagged template (e.g. `getTestDb()` in this repo's integration tests) — postgres-js binds a JS array as a genuine PG array. Both clients are used in this codebase, so the same source line is right in one file and wrong in another with no visible difference in the text; that's why a lint rule enforces this instead of a code-review habit. `eslint-rules/no-bare-array-in-sql-template.cjs` (wired in `eslint.config.mjs`) fails the build on a bare array interpolated into a **Drizzle** `sql` template specifically — it keys on the `sql` import's origin via scope analysis and is type-aware (it has to distinguish `ids: number[]` from `idArrayLiteral: string`), so it does not fire on postgres-js call sites.
 
+The rule's `.ts`-source coverage is `apps/**`, `shared/**`, `jobs/**`, `tests/**` — it does not reach `tests/integration/*.spec.js` (the postgres-js tier, where the syntax is correct anyway) or `scripts/**` (several of which import a real Drizzle `sql` and run against prod); both are outside ESLint's configured scope for reasons unrelated to this rule (`.js`/`.cjs`/`.mjs` files and `scripts/**` are globally ignored). No live instance of the bug exists in either as of this writing.
+
 ## Sync-gap remediation
 
 For 24 of the 25 stuck rows from the 2026-04-27 incident, the `dj_name` was actually present in tubafrenzy (`FLOWSHEET_RADIO_SHOW_PROD.DJ_NAME`) — Backend-Service's `shows.legacy_dj_name` just hadn't synced. The fix path:

--- a/docs/bulk-update-playbook.md
+++ b/docs/bulk-update-playbook.md
@@ -64,6 +64,22 @@ When `u.dj_name`, `s.legacy_dj_name`, `u.name` are _all_ NULL (which happens whe
 
 **Value-ordered drains — the work-list-cursor variant (BS#1591)**: the id-cursor recipe (`id > lastId`) is what makes a drain wedge-proof, but it only works when the drain order is id order. If a drain must process rows in some _value_ order (e.g. play-count-descending), a naive "re-SELECT the head of the cohort each batch" re-selects the same failing row at the top forever — failing rows deliberately stay in the cohort for cross-run retry. The recipe: materialize the run's work-list ONCE (ordered ids, in memory or a scratch table) and advance a monotonic cursor over it; a failed row waits for the next run's work-list, and within the run each id is selected at most once. See `jobs/flowsheet-metadata-backfill/worklist.ts` + `orchestrate.ts` for the reference implementation.
 
+## Batching a bulk operation by id: bind the array, don't interpolate it
+
+A batched UPDATE/DELETE almost always scopes itself with `WHERE id = ANY(...)` over the current page's id list. Under **Drizzle**'s `sql` tagged template, interpolating that list as a bare JS array does not bind a PG array — Drizzle splats it across N positional placeholders, turning `ANY(${ids})` into `ANY(($1, $2, … $N))`, a row constructor Postgres rejects at parse time (SQLSTATE 42809). This exact defect has shipped to production three times under three different jobs (BS#1068, BS#1071, #2007).
+
+Use `intArrayLiteral(ids)` from `@wxyc/database` (BS#2010) and cast in SQL:
+
+```ts
+import { sql } from 'drizzle-orm';
+import { intArrayLiteral } from '@wxyc/database';
+
+const idArrayLiteral = intArrayLiteral(ids); // '{1,2,3}' — validated, not spliced raw
+await db.execute(sql`DELETE FROM ${table} WHERE "id" = ANY(${idArrayLiteral}::int[])`);
+```
+
+The identical `ANY(${ids})` syntax IS correct under a raw **postgres-js** tagged template (e.g. `getTestDb()` in this repo's integration tests) — postgres-js binds a JS array as a genuine PG array. Both clients are used in this codebase, so the same source line is right in one file and wrong in another with no visible difference in the text; that's why a lint rule enforces this instead of a code-review habit. `eslint-rules/no-bare-array-in-sql-template.cjs` (wired in `eslint.config.mjs`) fails the build on a bare array interpolated into a **Drizzle** `sql` template specifically — it keys on the `sql` import's origin via scope analysis and is type-aware (it has to distinguish `ids: number[]` from `idArrayLiteral: string`), so it does not fire on postgres-js call sites.
+
 ## Sync-gap remediation
 
 For 24 of the 25 stuck rows from the 2026-04-27 incident, the `dj_name` was actually present in tubafrenzy (`FLOWSHEET_RADIO_SHOW_PROD.DJ_NAME`) — Backend-Service's `shows.legacy_dj_name` just hadn't synced. The fix path:
@@ -82,10 +98,12 @@ Before kicking off a bulk UPDATE on `flowsheet` (or any heavily-indexed live tab
 2. Set `DB_SYNCHRONOUS_COMMIT=off` and a 5+ minute `DB_STATEMENT_TIMEOUT_MS` in the backfill container.
 3. If the SET expression can resolve to NULL, guard it. Don't trust `WHERE col IS NULL` alone to terminate the loop.
 4. Add `ANALYZE <table>;` for every UPDATEd table at the bottom of the script (or in a paired post-script step if the UPDATEs run inside a transaction).
-5. After the run completes: drop temporary indexes, leave the production-grade ones, and confirm no NULL rows remain.
+5. Scoping the batch by id via a Drizzle `sql` template? Bind the page's id list with `intArrayLiteral(...)` from `@wxyc/database`, never a bare interpolated array — see "Batching a bulk operation by id" above.
+6. After the run completes: drop temporary indexes, leave the production-grade ones, and confirm no NULL rows remain.
 
 ## Related
 
 - [BS#934](https://github.com/WXYC/Backend-Service/issues/934) — Suggest endpoints regress to 5s timeouts after the mojibake migration; missed `ANALYZE` on touched tables.
 - [BS#605](https://github.com/WXYC/Backend-Service/issues/605) — `shows.legacy_dj_name` ETL sync gap.
+- [BS#2010](https://github.com/WXYC/Backend-Service/issues/2010) — the bare-array-in-`ANY()` trap (BS#1068, BS#1071, #2007): `intArrayLiteral(...)` (`shared/database/src/int-array-literal.ts`) is the shared, validating helper, and `eslint-rules/no-bare-array-in-sql-template.cjs` fails the build on a bare array interpolated into a Drizzle `sql` template.
 - [`docs/migrations.md`](migrations.md) — DDL-only rule (`@rule id=ddl-only`) and post-bulk-UPDATE ANALYZE rule (`@rule id=post-bulk-update-analyze`).

--- a/eslint-rules/no-bare-array-in-sql-template.cjs
+++ b/eslint-rules/no-bare-array-in-sql-template.cjs
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Flags a bare JS array interpolated into a **Drizzle** `sql`
+ * tagged template (BS#2010).
+ *
+ * ## The trap
+ *
+ * Interpolating a bare JS array into a Drizzle `sql` template does not bind
+ * a PG array — Drizzle splats the array across N positional placeholders,
+ * turning `= ANY(${ids})` into `= ANY(($1, $2, … $N))`, a row constructor.
+ * Postgres rejects that at parse time (SQLSTATE 42809, "op ANY/ALL (array)
+ * requires array on right side"). This has shipped to production three
+ * times under three different call sites (BS#1068, BS#1071, #2007) because
+ * each fix added another private copy of the work-around instead of a
+ * shared helper PLUS something that stops the defective form from being
+ * writable in the first place. This rule is the "something."
+ *
+ * The fix is `intArrayLiteral(...)` from `@wxyc/database` (BS#2010): it
+ * builds a single PG-array-literal string (`'{1,2,3}'`), which the SQL text
+ * casts explicitly (`::int[]`). For a text array, the honest fix is a
+ * `sql.join(...)`-built VALUES list (see `jobs/album-reviews-etl/link.ts`)
+ * — a hand-rolled text array literal needs real PG string escaping that
+ * `intArrayLiteral` deliberately does not attempt (see its docblock).
+ *
+ * ## Why this must key on the Drizzle import specifically
+ *
+ * The IDENTICAL syntax is CORRECT under a raw postgres-js tagged template —
+ * `sql\`… = ANY(${ids})\`` binds a genuine PG array there (e.g.
+ * `getTestDb()` in this repo's integration tests). Both clients are used in
+ * this codebase, so the same source line is right in one file and wrong in
+ * another with no visible difference in the text. Getting this rule's
+ * origin check backwards — flagging postgres-js call sites, or worse,
+ * failing to flag Drizzle ones — would be worse than not shipping it at
+ * all, per the issue that authored this rule. The check below resolves the
+ * tag identifier's binding through scope analysis and only fires when it
+ * traces back to a NAMED import of `sql` from `'drizzle-orm'` — a local
+ * variable assigned from `postgres(...)` (or any other non-import origin)
+ * is never flagged, by construction, because it never resolves to that
+ * import binding.
+ *
+ * ## Detection strategy: type-aware, not positional
+ *
+ * The rule flags ANY interpolation in a confirmed Drizzle `sql` template
+ * whose statically-known type is an array (or a union of array types) — not
+ * just the ones textually inside `ANY(...)`. A bare array is never valid
+ * ANYWHERE in a Drizzle `sql` template (there is no drizzle-orm API that
+ * treats a raw interpolated array as anything other than a positional
+ * splat), so this check has no legitimate exception to carve out — unlike a
+ * plain AST/position check, it needs none.
+ *
+ * A pure "is this `${}` textually right after `ANY(`" check (no type
+ * information) was considered and rejected: it cannot tell the BROKEN shape
+ * (`ANY(${ids})`, `ids: number[]`) from the FIXED one
+ * (`ANY(${idArrayLiteral}::int[])`, `idArrayLiteral: string`) — both are
+ * syntactically "`${Identifier}` immediately after `ANY(`". Shipping that
+ * check would flag every one of the six call sites this rule's originating
+ * issue (BS#2010) just fixed, which is worse than not shipping it (a rule
+ * an author has to suppress at every already-correct call site trains
+ * exactly the reflexive-disable habit that lets the next bad copy through).
+ * The type check has no such blind spot and needs no positional fallback,
+ * because full project type information is already a hard requirement of
+ * this ESLint config (`tseslint.configs.recommendedTypeChecked` +
+ * `parserOptions.projectService: true` in `eslint.config.mjs`) — it is not
+ * an optional enhancement here to degrade gracefully away from.
+ *
+ * If parser services genuinely can't produce a type for a given expression
+ * (a file outside the TS project, or some other resolution failure), this
+ * rule silently doesn't fire for that expression rather than guessing —
+ * failing open is the correct default for a rule whose false-positive cost
+ * (training authors to reflexively suppress) is worse than an occasional
+ * false negative.
+ */
+
+'use strict';
+
+const { ASTUtils, ESLintUtils } = require('@typescript-eslint/utils');
+
+const DRIZZLE_MODULE_SPECIFIER = 'drizzle-orm';
+const DRIZZLE_SQL_IMPORTED_NAME = 'sql';
+
+const MESSAGE =
+  'Bare array interpolated into a Drizzle `sql` template. Drizzle splats a JS array across N positional placeholders here — `ANY(${arr})` becomes `ANY(($1, $2, … $N))`, a row constructor — which Postgres rejects at parse time (42809, "op ANY/ALL (array) requires array on right side"; the BS#1068/BS#1071/#2007 family). Fix: build a PG array-literal string first and interpolate THAT instead. For an integer array, use `intArrayLiteral(...)` from `@wxyc/database` and cast in SQL (`::int[]`); for a text array, use a `sql.join(...)`-built VALUES list (see `jobs/album-reviews-etl/link.ts`), not a hand-rolled literal. This exact syntax IS correct under a raw postgres-js tagged template (e.g. `getTestDb()` in this repo\'s integration tests) — only Drizzle\'s `sql` import is affected; do not "fix" a postgres-js call site with this.';
+
+/**
+ * True if `tagNode` (a `TaggedTemplateExpression`'s `.tag`) is a bare
+ * Identifier whose binding resolves — via scope analysis, not string
+ * matching — to a named `sql` import from `'drizzle-orm'`.
+ */
+function isDrizzleSqlTag(tagNode, context) {
+  if (tagNode.type !== 'Identifier') return false;
+
+  const sourceCode = context.sourceCode || context.getSourceCode();
+  const scope = sourceCode.getScope ? sourceCode.getScope(tagNode) : context.getScope();
+  const variable = ASTUtils.findVariable(scope, tagNode.name);
+  if (!variable) return false;
+
+  return variable.defs.some((def) => {
+    if (def.type !== 'ImportBinding') return false;
+    const specifier = def.node; // ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
+    const importDecl = def.parent; // ImportDeclaration
+    if (!importDecl || importDecl.type !== 'ImportDeclaration') return false;
+    if (importDecl.source.value !== DRIZZLE_MODULE_SPECIFIER) return false;
+    if (specifier.type !== 'ImportSpecifier') return false; // excludes `import * as X` / default import
+    const imported = specifier.imported;
+    const importedName = imported.type === 'Identifier' ? imported.name : imported.value;
+    return importedName === DRIZZLE_SQL_IMPORTED_NAME;
+  });
+}
+
+/**
+ * Is `exprNode`'s statically-known type an array type (or union of array
+ * types)? Returns false — never throws — if full type information isn't
+ * available, so this degrades to a no-op rather than a crash when a file
+ * falls outside the TS project (see the module docblock for why that's the
+ * right failure mode for this specific rule).
+ */
+function makeIsArrayTypedExpression(context) {
+  let services;
+  try {
+    services = ESLintUtils.getParserServices(context, true);
+  } catch {
+    return () => false;
+  }
+  if (!services || !services.program || !services.esTreeNodeToTSNodeMap) {
+    return () => false;
+  }
+
+  // Deferred require: @typescript-eslint/type-utils pulls in the TS
+  // compiler; only pay for it in files where parser services actually
+  // resolved (guards the common early-return above for free).
+  let isTypeArrayTypeOrUnionOfArrayTypes;
+  try {
+    ({ isTypeArrayTypeOrUnionOfArrayTypes } = require('@typescript-eslint/type-utils'));
+  } catch {
+    return () => false;
+  }
+
+  const checker = services.program.getTypeChecker();
+
+  return (exprNode) => {
+    try {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(exprNode);
+      if (!tsNode) return false;
+      const type = checker.getTypeAtLocation(tsNode);
+      return isTypeArrayTypeOrUnionOfArrayTypes(type, checker);
+    } catch {
+      // A single expression's type failing to resolve must not take down
+      // the whole lint run — fail open (don't flag) for that expression.
+      return false;
+    }
+  };
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a bare array interpolated into a Drizzle `sql` tagged template — it splats into a row constructor instead of binding a PG array (BS#1068/BS#1071/#2007). Does not fire on postgres-js tagged templates.',
+    },
+    schema: [],
+    messages: {
+      bareArrayInSqlTemplate: MESSAGE,
+    },
+  },
+
+  create(context) {
+    const isArrayTypedExpression = makeIsArrayTypedExpression(context);
+
+    return {
+      TaggedTemplateExpression(node) {
+        if (!isDrizzleSqlTag(node.tag, context)) return;
+
+        for (const exprNode of node.quasi.expressions) {
+          if (isArrayTypedExpression(exprNode)) {
+            context.report({ node: exprNode, messageId: 'bareArrayInSqlTemplate' });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = {
+  rules: {
+    'no-bare-array-in-sql-template': rule,
+  },
+};

--- a/eslint-rules/no-bare-array-in-sql-template.cjs
+++ b/eslint-rules/no-bare-array-in-sql-template.cjs
@@ -16,10 +16,14 @@
  *
  * The fix is `intArrayLiteral(...)` from `@wxyc/database` (BS#2010): it
  * builds a single PG-array-literal string (`'{1,2,3}'`), which the SQL text
- * casts explicitly (`::int[]`). For a text array, the honest fix is a
- * `sql.join(...)`-built VALUES list (see `jobs/album-reviews-etl/link.ts`)
- * — a hand-rolled text array literal needs real PG string escaping that
- * `intArrayLiteral` deliberately does not attempt (see its docblock).
+ * casts explicitly (`::int[]`). For a text array there is no equivalent
+ * shared helper (a hand-rolled literal needs real PG string escaping that
+ * `intArrayLiteral` deliberately does not attempt — see its docblock); use
+ * `jobs/album-reviews-etl/link.ts`'s `textArrayLiteral`, which does that
+ * escaping, or join bound per-element parameters with `sql.join(...)` (see
+ * `jobs/library-etl/job.ts`'s `buildLegacySourcedSetWhere` for a live
+ * example of the API in this codebase) — never a naive unescaped
+ * `.join(',')`.
  *
  * ## Why this must key on the Drizzle import specifically
  *
@@ -41,11 +45,20 @@
  *
  * The rule flags ANY interpolation in a confirmed Drizzle `sql` template
  * whose statically-known type is an array (or a union of array types) — not
- * just the ones textually inside `ANY(...)`. A bare array is never valid
- * ANYWHERE in a Drizzle `sql` template (there is no drizzle-orm API that
- * treats a raw interpolated array as anything other than a positional
- * splat), so this check has no legitimate exception to carve out — unlike a
- * plain AST/position check, it needs none.
+ * just the ones textually inside `ANY(...)`. That is broader than "always
+ * broken": Drizzle's positional splat is exactly what makes a splat-reliant
+ * `` sql`… WHERE x IN ${ids}` `` legitimately work (it renders `IN ($1, $2,
+ * $3)`, valid SQL, no cast needed) — `ANY(${ids})` is the one shape that
+ * breaks (`ANY(($1, $2, $3))`, a row constructor `ANY` rejects). This rule
+ * does not try to tell the two shapes apart; it enforces one POLICY
+ * instead — every array bound into a Drizzle `sql` template goes through an
+ * explicit literal-plus-cast helper and the `= ANY(...)` predicate form,
+ * `IN`-lists included, rather than assert (falsely) that the splat is
+ * always broken. That costs nothing to enforce today — there are zero live
+ * `IN ${array}`-shaped call sites in this codebase (verified by grep before
+ * shipping this rule) — but if a legitimate one shows up, the fix is the
+ * same one this rule already points every author to: rewrite it to
+ * `= ANY(${idArrayLiteral}::int[])`.
  *
  * A pure "is this `${}` textually right after `ANY(`" check (no type
  * information) was considered and rejected: it cannot tell the BROKEN shape
@@ -68,6 +81,32 @@
  * failing open is the correct default for a rule whose false-positive cost
  * (training authors to reflexively suppress) is worse than an occasional
  * false negative.
+ *
+ * ## Known gaps (documented, not closed)
+ *
+ * Four ways a Drizzle `sql` tag can escape `isDrizzleSqlTag`'s scope-analysis
+ * check, none exercised by any call site in this codebase today (verified by
+ * grep before shipping this rule) — silent misses, listed here so a future
+ * author who introduces one of these shapes knows the rule won't catch it:
+ *
+ *   1. **Re-exported through an intermediate module** — `export { sql } from
+ *      'drizzle-orm'` in a barrel, then `import { sql } from
+ *      '@some/other/module'` elsewhere. `isDrizzleSqlTag` resolves one
+ *      import hop; it doesn't trace a re-export chain back through a second
+ *      module to find the original `drizzle-orm` source.
+ *   2. **Passed as a function parameter** — `` const build = (tag: typeof
+ *      sql, ids: number[]) => tag`… ANY(${ids})` ``. The parameter's
+ *      binding is a `Parameter` definition, not an `ImportBinding`, so the
+ *      check never resolves it back to the `drizzle-orm` import.
+ *   3. **A subpath import** — `import { sql } from 'drizzle-orm/pg-core'`
+ *      (hypothetical; `sql` is exported from the package root today, not a
+ *      subpath). `DRIZZLE_MODULE_SPECIFIER` is an exact string compare
+ *      against `'drizzle-orm'`, not a prefix match.
+ *   4. **A namespace import used as a member-expression tag** — `import *
+ *      as drizzle from 'drizzle-orm'; drizzle.sql\`… ANY(${ids})\``.
+ *      `isDrizzleSqlTag` only handles a bare `Identifier` tag; `drizzle.sql`
+ *      is a `MemberExpression` and is rejected before scope resolution even
+ *      runs.
  */
 
 'use strict';
@@ -78,7 +117,7 @@ const DRIZZLE_MODULE_SPECIFIER = 'drizzle-orm';
 const DRIZZLE_SQL_IMPORTED_NAME = 'sql';
 
 const MESSAGE =
-  'Bare array interpolated into a Drizzle `sql` template. Drizzle splats a JS array across N positional placeholders here — `ANY(${arr})` becomes `ANY(($1, $2, … $N))`, a row constructor — which Postgres rejects at parse time (42809, "op ANY/ALL (array) requires array on right side"; the BS#1068/BS#1071/#2007 family). Fix: build a PG array-literal string first and interpolate THAT instead. For an integer array, use `intArrayLiteral(...)` from `@wxyc/database` and cast in SQL (`::int[]`); for a text array, use a `sql.join(...)`-built VALUES list (see `jobs/album-reviews-etl/link.ts`), not a hand-rolled literal. This exact syntax IS correct under a raw postgres-js tagged template (e.g. `getTestDb()` in this repo\'s integration tests) — only Drizzle\'s `sql` import is affected; do not "fix" a postgres-js call site with this.';
+  "Bare array interpolated into a Drizzle `sql` template. Drizzle splats a JS array across N positional placeholders here. Inside `ANY(...)` that breaks the query — `ANY(${arr})` becomes `ANY(($1, $2, … $N))`, a row constructor Postgres rejects at parse time (42809, \"op ANY/ALL (array) requires array on right side\"; the BS#1068/BS#1071/#2007 family); inside `IN ...` the splat happens to still produce valid SQL, but this rule enforces one predicate shape everywhere regardless. Fix: build a PG array-literal string first and interpolate THAT, using `= ANY(...)` (rewrite a working `IN ${arr}` the same way). For an integer array, use `intArrayLiteral(...)` from `@wxyc/database` and cast in SQL (`= ANY(${arr}::int[])`); for a text array, use `jobs/album-reviews-etl/link.ts`'s `textArrayLiteral` (real PG quoting) or join bound per-element parameters with `sql.join(...)` (see `jobs/library-etl/job.ts`'s `buildLegacySourcedSetWhere` for the API) — never a naive unescaped `.join(',')`. This exact syntax IS correct under a raw postgres-js tagged template (e.g. `getTestDb()` in this repo's integration tests) — only Drizzle's `sql` import is affected; do not \"fix\" a postgres-js call site with this.";
 
 /**
  * True if `tagNode` (a `TaggedTemplateExpression`'s `.tag`) is a bare

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,10 +83,19 @@ export default tseslint.config(
 
   // WXYC custom rules — bare-array-in-Drizzle-sql-template (BS#2010)
   //
-  // Scoped everywhere a Drizzle `sql` template can appear: apps/, shared/,
-  // jobs/ (the six historical call sites are all under these three), and
-  // tests/ (defense in depth — a test fixture can copy the same bad shape).
-  // Deliberately an ERROR, not a warn: this exact defect has shipped to
+  // Scoped everywhere a Drizzle `sql` template can appear in `.ts` source:
+  // apps/, shared/, jobs/ (the six historical call sites are all under
+  // these three), and tests/ (defense in depth for the `.ts` unit-test
+  // tier, which uses drizzle-orm's mocked `sql` tag — a test fixture there
+  // can copy the same bad shape). This does NOT cover the
+  // `tests/integration/*.spec.js` postgres-js tier or `scripts/**`
+  // (several of which import a real Drizzle `sql` and run against prod) —
+  // both are `.js`/`.cjs`/`.mjs` or under the `scripts/**` global ignore
+  // above, unlinted for reasons unrelated to this rule. No live instance of
+  // this bug exists in either today (verified by grep before shipping this
+  // rule); widening the global ignores to reach them is a separate,
+  // larger change than this issue's scope. Deliberately an ERROR, not a
+  // warn, for what this block DOES cover: this exact defect has shipped to
   // production three times (BS#1068, BS#1071, #2007); a warning that CI
   // doesn't fail on is exactly the "stayed writable" failure mode the
   // originating issue describes.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,18 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import security from 'eslint-plugin-security';
 import prettierConfig from 'eslint-config-prettier';
-import wxycLocalRules from './eslint-rules/source-tagged-constraint.cjs';
+import wxycSourceTaggedConstraint from './eslint-rules/source-tagged-constraint.cjs';
+import wxycNoBareArrayInSqlTemplate from './eslint-rules/no-bare-array-in-sql-template.cjs';
+
+// Both rule modules export `{ rules: { <name>: <rule> } }`; merge them into
+// one `wxyc` plugin object so `files`-scoped blocks below can mix and match
+// which rules apply where without re-importing per block.
+const wxycLocalRules = {
+  rules: {
+    ...wxycSourceTaggedConstraint.rules,
+    ...wxycNoBareArrayInSqlTemplate.rules,
+  },
+};
 
 export default tseslint.config(
   // Global ignores
@@ -67,6 +78,25 @@ export default tseslint.config(
       // once the constraint has been confirmed consistent with the upstream's
       // data shape.
       'wxyc/source-tagged-constraint-confirmed': 'warn',
+    },
+  },
+
+  // WXYC custom rules — bare-array-in-Drizzle-sql-template (BS#2010)
+  //
+  // Scoped everywhere a Drizzle `sql` template can appear: apps/, shared/,
+  // jobs/ (the six historical call sites are all under these three), and
+  // tests/ (defense in depth — a test fixture can copy the same bad shape).
+  // Deliberately an ERROR, not a warn: this exact defect has shipped to
+  // production three times (BS#1068, BS#1071, #2007); a warning that CI
+  // doesn't fail on is exactly the "stayed writable" failure mode the
+  // originating issue describes.
+  {
+    files: ['apps/**/*.ts', 'shared/**/*.ts', 'jobs/**/*.ts', 'tests/**/*.ts'],
+    plugins: {
+      wxyc: wxycLocalRules,
+    },
+    rules: {
+      'wxyc/no-bare-array-in-sql-template': 'error',
     },
   },
 

--- a/jobs/album-critic-reviews-etl/antijoin.ts
+++ b/jobs/album-critic-reviews-etl/antijoin.ts
@@ -7,15 +7,19 @@
  * Only genuinely new pairs reach the LLM.
  *
  * Read via `db.execute(sql\`...\`)` (raw SQL, schema-qualified,
- * `int[]`-literal-bound `ANY(...)`), mirroring `jobs/album-reviews-etl/
- * link.ts` and `shared/database/src/library-tiebreak.ts` — NOT drizzle's
- * `inArray()` query-builder helper. `inArray()` is real-drizzle-safe (its
- * query builder is itself thenable), but the shared unit-test mock
+ * `int[]`-literal-bound `ANY(...)` via the shared `intArrayLiteral` helper,
+ * BS#2010), mirroring `jobs/album-reviews-etl/link.ts` and
+ * `shared/database/src/library-tiebreak.ts` — NOT drizzle's `inArray()`
+ * query-builder helper. `inArray()` is real-drizzle-safe (its query builder
+ * is itself thenable), but the shared unit-test mock
  * (`tests/mocks/database.mock.ts`) only resolves `.execute()`/`.returning()`
  * terminals; a bare `.where(inArray(...))` chain call is unusable there. See
  * jobs/album-reviews-etl/link.ts's `loadCandidates` for the same `int[]`
- * literal idiom on a text[] column via `textArrayLiteral` — this is the
- * integer-array analog, safe by construction since `albumIds: number[]`.
+ * literal idiom on a text[] column via its job-local `textArrayLiteral`
+ * (real PG quoting for text elements — deliberately not promoted alongside
+ * `intArrayLiteral`; see that helper's docblock for why) — this is the
+ * integer-array analog, validated by `intArrayLiteral` rather than trusted
+ * by construction.
  *
  * Note (issue step 4): dedup never DELETES a losing row, so if an album
  * already carries a lower-preference card and a later corpus adds a
@@ -26,7 +30,7 @@
  * `filterNew`'s test for this exact scenario.
  */
 import { sql } from 'drizzle-orm';
-import { db } from '@wxyc/database';
+import { db, intArrayLiteral } from '@wxyc/database';
 import type { MatchedItem } from './dedup.js';
 
 const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
@@ -50,10 +54,9 @@ export const loadExistingPairs = async (albumIds: number[]): Promise<Set<string>
   if (albumIds.length === 0) return new Set();
 
   // Bind as a single PG-array-literal string param, not a bare interpolated
-  // JS array — see the module docstring + library-tiebreak.ts for the
-  // BS#1068/BS#1071 trap this avoids. Safe by construction: TypeScript types
-  // `albumIds: number[]`, so the join contains only numeric literals.
-  const idArrayLiteral = `{${albumIds.join(',')}}`;
+  // JS array — see the module docstring + `intArrayLiteral`'s own docblock
+  // for the BS#1068/BS#1071/#2007 trap this avoids.
+  const idArrayLiteral = intArrayLiteral(albumIds);
 
   const result: unknown = await db.execute(sql`
     SELECT "album_id", "source_url"

--- a/jobs/artist-unicode-dedup/merge.ts
+++ b/jobs/artist-unicode-dedup/merge.ts
@@ -17,7 +17,7 @@
  */
 
 import { sql, type SQL } from 'drizzle-orm';
-import { db, foldArtistName } from '@wxyc/database';
+import { db, foldArtistName, intArrayLiteral } from '@wxyc/database';
 
 /** The transaction handle Drizzle passes to a `db.transaction` callback. */
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -303,14 +303,6 @@ export const analyzeTables = async (): Promise<void> => {
     await db.execute(sql`ANALYZE ${qualified(table)}`);
   }
 };
-
-/**
- * Build the PG array literal `'{1,2,3}'` form. Drizzle + postgres-js splat JS
- * arrays across N placeholders, which PG rejects for `= ANY(...)` (the
- * BS#1071 family). Binding one castable string sidesteps the splat; safe by
- * construction (numeric input → numeric literals only). Empty array → `'{}'`.
- */
-export const intArrayLiteral = (ids: readonly number[]): string => `{${ids.join(',')}}`;
 
 export const runDedup = async (): Promise<void> => {
   console.log(`[artist-dedup] Mode: ${EXECUTE ? 'EXECUTE (writing)' : 'DRY-RUN (no writes)'}`);

--- a/jobs/flowsheet-ghost-row-sweep/orchestrate.ts
+++ b/jobs/flowsheet-ghost-row-sweep/orchestrate.ts
@@ -99,6 +99,7 @@ import { sql } from 'drizzle-orm';
 import {
   db,
   checkLiveActivity as defaultCheckLiveActivity,
+  intArrayLiteral,
   LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
   LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
   requireNonNegativeInt,
@@ -177,8 +178,6 @@ interface CandidateRow {
   id: number;
   legacy_id: number;
 }
-
-const intArrayLiteral = (ids: readonly number[]): string => `{${ids.join(',')}}`;
 
 const loadBatchOnce = async (target: SweepTarget, afterId: number, batchSize: number): Promise<CandidateRow[]> => {
   const { table, pkColumn, legacyColumn } = TARGET_META[target];

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -104,6 +104,7 @@ import { sql, type SQL } from 'drizzle-orm';
 import {
   db,
   checkLiveActivity as defaultCheckLiveActivity,
+  intArrayLiteral,
   LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
   LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
   requireNonNegativeInt,
@@ -712,17 +713,6 @@ const WORKER_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
  * enum values (they fall to the leave-untouched arm, fail-safe).
  */
 export type BatchRow = EnrichRow & { metadata_status: string };
-
-/**
- * Render a numeric id array as a single PG-array-literal string param
- * (`'{1,2,3}'::int[]` at the call site) — drizzle/postgres-js splats a bare
- * JS array into N positional placeholders, which PG rejects (BS#1068 /
- * BS#1071; see `jobs/album-level-backfill/job.ts` for the incident
- * lineage). Safe by construction: callers pass numbers from our own
- * work-list. (Fifth site of this idiom in the jobs fleet — promotion to
- * `@wxyc/database` is tracked as a review follow-up.)
- */
-const intArrayLiteral = (ids: readonly number[]): string => `{${ids.join(',')}}`;
 
 /**
  * Load one work-list slice's rows by id (BS#1591; predicate cut over to

--- a/jobs/legacy-dj-name-remediation/job.ts
+++ b/jobs/legacy-dj-name-remediation/job.ts
@@ -37,7 +37,7 @@
  */
 
 import { sql, type SQL } from 'drizzle-orm';
-import { db, closeDatabaseConnection, MirrorSQL } from '@wxyc/database';
+import { db, closeDatabaseConnection, intArrayLiteral, MirrorSQL } from '@wxyc/database';
 
 export const DRY_RUN = process.argv.includes('--dry-run');
 export const BATCH_SIZE = 5000;
@@ -256,20 +256,6 @@ export const runScrubBatch = async (batch: HandleMapping[]): Promise<BatchResult
 };
 
 // ---- Re-resolve flowsheet.dj_name on marker rows ----
-
-/**
- * Build the PG array literal `'{1,2,3}'` form for an int[] parameter. Drizzle
- * + postgres-js splat JS arrays in `${...}` positions across N positional
- * placeholders (`($1, $2, ..., $n)`), which PG rejects with `op ANY/ALL
- * (array) requires array on right side` (the BS#1071 / BS#1068 family of
- * incidents). Binding a single string parameter that PG can cast to `int[]`
- * sidesteps the splat. Safe by construction: the input is typed `number[]`,
- * so the join produces only numeric literals — no injection surface.
- *
- * See `jobs/album-level-backfill/job.ts` (BS#1071, 2026-05-24 prod canary)
- * for the original codebase reference.
- */
-const intArrayLiteral = (ids: readonly number[]): string => `{${ids.join(',')}}`;
 
 /**
  * Re-resolve `flowsheet.dj_name` on marker rows whose value is NULL on any

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -16,3 +16,4 @@ export * from './concerts-sql.js';
 export * from './concerts-recompute.js';
 export * from './album-resolve.js';
 export * from './freetext-enumerate.js';
+export * from './int-array-literal.js';

--- a/shared/database/src/int-array-literal.ts
+++ b/shared/database/src/int-array-literal.ts
@@ -39,38 +39,53 @@
  * ## What this validates
  *
  * Every element is round-tripped through `Number(...)` and checked with
- * `Number.isInteger`; a non-integer element throws instead of being spliced
- * into the literal as raw SQL text. This is a genuine runtime check, not the
- * "safe by construction because the caller's type is `number[]`" claim the
- * six inline copies this helper replaces used to carry — that claim wasn't
- * true: the arrays typically arrive via an unchecked `as unknown as` cast
- * over raw driver output (`db.execute(...) as unknown as Array<{ id:
- * number }>`), with nothing enforcing the cast at runtime. A numeric STRING
- * element (e.g. what postgres-js returns for a `bigint` column) is accepted
- * and normalized — `Number('7')` is a valid integer — so this helper keeps
- * working the day a column widens from `integer` to `bigint`; anything that
- * isn't a clean integer (`NaN`, `Infinity`, a non-numeric string, `null`,
- * `undefined`) throws rather than producing malformed or injectable SQL.
+ * `Number.isSafeInteger`; anything that fails throws instead of being
+ * spliced into the literal as raw SQL text. This is a genuine runtime
+ * check, not the "safe by construction because the caller's type is
+ * `number[]`" claim the six inline copies this helper replaces used to
+ * carry — that claim wasn't true: the arrays typically arrive via an
+ * unchecked `as unknown as` cast over raw driver output (`db.execute(...)
+ * as unknown as Array<{ id: number }>`), with nothing enforcing the cast at
+ * runtime. A numeric STRING element within the safe-integer range (e.g.
+ * what postgres-js returns for a `bigint` column, as long as the value
+ * fits in ±2^53-1) is accepted and normalized — `Number('7')` is a safe
+ * integer. `Number.isSafeInteger` rather than the looser `Number.isInteger`
+ * is deliberate: `Number('9007199254740993')` — one past
+ * `Number.MAX_SAFE_INTEGER` — evaluates to `9007199254740992`, a DIFFERENT
+ * integer, silently. `Number.isInteger` would accept that (it's still an
+ * integer, just the wrong one); `Number.isSafeInteger` rejects it, so a
+ * `bigint`/`bigserial` id outside the JS-safe range throws instead of
+ * splicing a corrupted id into an UPDATE or DELETE's `WHERE` clause. No
+ * `bigint`/`bigserial` column exists in this schema today, so this is
+ * latent, not exercised — precisely why it needs a real check rather than
+ * a comment promising one.
  *
- * A `textArrayLiteral` sibling is deliberately NOT provided — PG string
- * escaping inside a hand-built literal is real work this integer-only
- * helper sidesteps entirely by construction (only digits, `-`, and `,` can
- * ever appear in its output). The honest answer for a text array is a
- * `sql.join(...)`-built `VALUES` list; see `jobs/album-reviews-etl/link.ts`
- * for the pattern PR #2008 generalized this from.
+ * A `textArrayLiteral` sibling is deliberately NOT provided here — PG
+ * string escaping inside a hand-built literal is real work this
+ * integer-only helper sidesteps entirely by construction (only digits,
+ * `-`, and `,` can ever appear in its output). For a text array, use
+ * `jobs/album-reviews-etl/link.ts`'s `textArrayLiteral` (which does that
+ * escaping) or join bound per-element parameters with `sql.join(...)` (see
+ * `jobs/library-etl/job.ts`'s `buildLegacySourcedSetWhere` for a live
+ * example of the API in this codebase).
  */
 export const intArrayLiteral = (ids: readonly number[]): string => {
   const literals = ids.map((id) => {
-    // `Number(null)` is `0` and `Number([])` is `0` — both integers by
-    // `Number.isInteger`'s definition — so null/undefined must be rejected
-    // explicitly before the coercion, or a missing id would silently become
-    // a real one instead of failing loudly.
+    // `Number(null)` is `0` and `Number([])` is `0` — both safe integers by
+    // `Number.isSafeInteger`'s definition — so null/undefined must be
+    // rejected explicitly before the coercion, or a missing id would
+    // silently become a real one instead of failing loudly.
     if (id === null || id === undefined) {
       throw new Error(`intArrayLiteral: expected an integer, got ${JSON.stringify(id)}`);
     }
     const n = Number(id);
-    if (!Number.isInteger(n)) {
-      throw new Error(`intArrayLiteral: expected an integer, got ${JSON.stringify(id)}`);
+    // isSafeInteger, not the looser isInteger: a numeric string one past
+    // Number.MAX_SAFE_INTEGER rounds to a DIFFERENT integer silently
+    // (Number('9007199254740993') === 9007199254740992), which isInteger
+    // would happily accept. See this function's docblock for why that
+    // matters for a future bigint/bigserial column.
+    if (!Number.isSafeInteger(n)) {
+      throw new Error(`intArrayLiteral: expected a safe integer, got ${JSON.stringify(id)}`);
     }
     return n;
   });

--- a/shared/database/src/int-array-literal.ts
+++ b/shared/database/src/int-array-literal.ts
@@ -1,0 +1,78 @@
+/**
+ * Build a Postgres array-literal string (`'{1,2,3}'`) for a numeric-id list,
+ * for binding into a `sql\`… = ANY(${idArrayLiteral}::int[])\`` predicate
+ * (BS#2010).
+ *
+ * ## Why this exists
+ *
+ * Interpolating a bare JS array into a **Drizzle** `sql` template does not
+ * bind a PG array — it splats the array across N positional placeholders,
+ * turning `= ANY(${ids})` into `= ANY(($1, $2, … $N))`, a row constructor.
+ * Postgres rejects that at parse time (SQLSTATE 42809, "op ANY/ALL (array)
+ * requires array on right side"). This exact defect has shipped to
+ * production three times under different call sites (BS#1068, BS#1071,
+ * #2007) — each was patched with another private copy of this same
+ * work-around instead of a shared, hardened helper, which is what kept the
+ * defective bare-array form writable everywhere else.
+ *
+ * The work-around: bind ONE string parameter shaped as a PG array literal
+ * and cast it in SQL (`::int[]`). Postgres parses the cast, not Drizzle's
+ * splat, so this survives at any arity, including zero and one (the arities
+ * that happen to work by accident with the splat, which is what makes the
+ * bug easy to miss in a small manual test).
+ *
+ * ## The two-client trap
+ *
+ * The identical `= ANY(${ids})` syntax is CORRECT under a raw postgres-js
+ * tagged template (`postgres-js`'s own `sql\`…\`` — e.g. `getTestDb()` in
+ * this repo's integration tests) — postgres-js binds a JS array as a
+ * genuine PG array there. Both clients are used in this codebase, so the
+ * same source line is right in one file and wrong in another with no
+ * visible difference. Use this helper only inside a Drizzle `sql` template
+ * (`import { sql } from 'drizzle-orm'`); do not "simplify" a postgres-js
+ * `ANY(${array})` call site to use it — that call site is already correct.
+ *
+ * The `no-bare-array-in-sql-template` ESLint rule (`eslint-rules/`) flags a
+ * bare array interpolated into a Drizzle `sql` template and names this
+ * helper as the fix; see `docs/bulk-update-playbook.md`.
+ *
+ * ## What this validates
+ *
+ * Every element is round-tripped through `Number(...)` and checked with
+ * `Number.isInteger`; a non-integer element throws instead of being spliced
+ * into the literal as raw SQL text. This is a genuine runtime check, not the
+ * "safe by construction because the caller's type is `number[]`" claim the
+ * six inline copies this helper replaces used to carry — that claim wasn't
+ * true: the arrays typically arrive via an unchecked `as unknown as` cast
+ * over raw driver output (`db.execute(...) as unknown as Array<{ id:
+ * number }>`), with nothing enforcing the cast at runtime. A numeric STRING
+ * element (e.g. what postgres-js returns for a `bigint` column) is accepted
+ * and normalized — `Number('7')` is a valid integer — so this helper keeps
+ * working the day a column widens from `integer` to `bigint`; anything that
+ * isn't a clean integer (`NaN`, `Infinity`, a non-numeric string, `null`,
+ * `undefined`) throws rather than producing malformed or injectable SQL.
+ *
+ * A `textArrayLiteral` sibling is deliberately NOT provided — PG string
+ * escaping inside a hand-built literal is real work this integer-only
+ * helper sidesteps entirely by construction (only digits, `-`, and `,` can
+ * ever appear in its output). The honest answer for a text array is a
+ * `sql.join(...)`-built `VALUES` list; see `jobs/album-reviews-etl/link.ts`
+ * for the pattern PR #2008 generalized this from.
+ */
+export const intArrayLiteral = (ids: readonly number[]): string => {
+  const literals = ids.map((id) => {
+    // `Number(null)` is `0` and `Number([])` is `0` — both integers by
+    // `Number.isInteger`'s definition — so null/undefined must be rejected
+    // explicitly before the coercion, or a missing id would silently become
+    // a real one instead of failing loudly.
+    if (id === null || id === undefined) {
+      throw new Error(`intArrayLiteral: expected an integer, got ${JSON.stringify(id)}`);
+    }
+    const n = Number(id);
+    if (!Number.isInteger(n)) {
+      throw new Error(`intArrayLiteral: expected an integer, got ${JSON.stringify(id)}`);
+    }
+    return n;
+  });
+  return `{${literals.join(',')}}`;
+};

--- a/shared/database/src/library-tiebreak.ts
+++ b/shared/database/src/library-tiebreak.ts
@@ -34,23 +34,22 @@
  */
 import { sql } from 'drizzle-orm';
 import { db } from './client.js';
+import { intArrayLiteral } from './int-array-literal.js';
 
 export const pickPrimaryLibraryRow = async (libraryIds: number[]): Promise<number | null> => {
   if (libraryIds.length === 0) return null;
   if (libraryIds.length === 1) return libraryIds[0];
 
   // Bind as a single PG-array-literal string param (`'{10,11,12}'::int[]`)
-  // rather than the bare `${libraryIds}`. Drizzle/postgres-js splats a JS
-  // array into N positional placeholders here — both `ANY(${array}::int[])`
-  // and the bare `ANY(${array})` send `ANY(($1, $2, …))` over the wire,
-  // which PG rejects at arity >= 2 with "op ANY/ALL (array) requires array
-  // on right side" (BS#1071) or "cannot cast type record to integer[]"
-  // (BS#1068). See jobs/album-level-backfill/job.ts's `resolveAlbums` for
-  // the same fix (BS#1072).
-  //
-  // Safe by construction: TypeScript types `libraryIds: number[]`, so the
-  // join contains only numeric literals — no injection surface.
-  const idArrayLiteral = `{${libraryIds.join(',')}}`;
+  // rather than the bare `${libraryIds}`. Drizzle splats a JS array into N
+  // positional placeholders here — `ANY(${array}::int[])` sends
+  // `ANY(($1, $2, …)::int[])` over the wire, which PG rejects at arity >= 2
+  // with "op ANY/ALL (array) requires array on right side" (BS#1071) or
+  // "cannot cast type record to integer[]" (BS#1068). `intArrayLiteral`
+  // (BS#2010) is the shared, validating helper for this — see its docblock
+  // for the full trap writeup, including why the identical `ANY(${array})`
+  // syntax is correct under postgres-js and must not be "fixed" there.
+  const idArrayLiteral = intArrayLiteral(libraryIds);
 
   const rows = (await db.execute(sql`
     SELECT l."id"

--- a/tests/integration/artist-unicode-dedup-merge.spec.js
+++ b/tests/integration/artist-unicode-dedup-merge.spec.js
@@ -4,9 +4,9 @@
  *
  * Unlike `artist-unicode-dedup.spec.js` (which tests the fold function + the
  * matcher predicate with pure SQL), this spec `require`s and RUNS the actual
- * `mergeGroup` / `findDuplicateGroups` / `intArrayLiteral` from the compiled
- * `dist/merge.cjs` — no reimplementation — so the dangerous, non-obvious
- * branches of the destructive merge have direct coverage:
+ * `mergeGroup` / `findDuplicateGroups` from the compiled `dist/merge.cjs` —
+ * no reimplementation — so the dangerous, non-obvious branches of the
+ * destructive merge have direct coverage:
  *   (a) `artist_crossreference` two-endpoint repoint (a row with BOTH source and
  *       target in the merge group) + the 2-column-key collision-delete + the
  *       post-loop `(surv, surv)` self-reference DELETE.
@@ -38,6 +38,7 @@ jest.unmock('drizzle-orm');
 
 const path = require('path');
 const { getTestDb } = require('../utils/db');
+const { intArrayLiteral } = require('@wxyc/database');
 
 // The REAL compiled merge core (MED-1: no reimplementation). `dist/merge.cjs`
 // is produced by the workspace `build` (tsup dual-format esm+cjs); CI's Build
@@ -147,9 +148,14 @@ describe('artist-unicode-dedup mergeGroup — REAL functions (real PG, BS#1897 M
     return groups.find((g) => [g.survivorId, ...g.duplicateIds].includes(id)) ?? null;
   }
 
-  test('intArrayLiteral builds the PG array-literal form', () => {
-    expect(merge.intArrayLiteral([1, 2, 3])).toBe('{1,2,3}');
-    expect(merge.intArrayLiteral([])).toBe('{}');
+  test('merge.ts uses the shared @wxyc/database intArrayLiteral (BS#2010 promotion)', () => {
+    // The dedicated unit tests for intArrayLiteral's behavior — including
+    // the validation this promotion added — live at
+    // tests/unit/database/int-array-literal.test.ts. This assertion just
+    // pins that merge.ts's compiled output imports the shared helper rather
+    // than carrying its own private copy again.
+    expect(intArrayLiteral([1, 2, 3])).toBe('{1,2,3}');
+    expect(intArrayLiteral([])).toBe('{}');
   });
 
   test('(a) artist_crossreference: two-endpoint repoint, 2-col collision, self-ref cleanup', async () => {

--- a/tests/integration/artist-unicode-dedup-merge.spec.js
+++ b/tests/integration/artist-unicode-dedup-merge.spec.js
@@ -148,12 +148,24 @@ describe('artist-unicode-dedup mergeGroup — REAL functions (real PG, BS#1897 M
     return groups.find((g) => [g.survivorId, ...g.duplicateIds].includes(id)) ?? null;
   }
 
-  test('merge.ts uses the shared @wxyc/database intArrayLiteral (BS#2010 promotion)', () => {
-    // The dedicated unit tests for intArrayLiteral's behavior — including
-    // the validation this promotion added — live at
-    // tests/unit/database/int-array-literal.test.ts. This assertion just
-    // pins that merge.ts's compiled output imports the shared helper rather
-    // than carrying its own private copy again.
+  test('merge.ts uses the shared @wxyc/database intArrayLiteral, not a re-introduced private copy (BS#2010 promotion)', () => {
+    // Two real assertions about the COMPILED merge.cjs, not just about
+    // @wxyc/database in isolation (the dedicated behavior/validation tests
+    // for intArrayLiteral itself live at
+    // tests/unit/database/int-array-literal.test.ts, which this does not
+    // duplicate):
+    //
+    //   1. merge.cjs no longer exports `intArrayLiteral` — the local export
+    //      this promotion removed hasn't quietly come back (e.g. from a
+    //      future edit re-adding `export const intArrayLiteral = ...` to
+    //      merge.ts, recreating the exact six-private-copies problem this
+    //      issue closed).
+    expect(merge.intArrayLiteral).toBeUndefined();
+    //   2. The shared helper is genuinely importable from @wxyc/database in
+    //      THIS integration test's module resolution environment (not just
+    //      the unit-test one, which maps @wxyc/database differently — see
+    //      tests/mocks/database.mock.ts) and produces the expected literal
+    //      form merge.ts's real queries depend on.
     expect(intArrayLiteral([1, 2, 3])).toBe('{1,2,3}');
     expect(intArrayLiteral([])).toBe('{}');
   });

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -508,6 +508,11 @@ export type { IntParserOptions } from '../../shared/database/src/env-parsers.js'
 // candidate net and the TS arbiter can't drift.
 export { foldArtistName } from '../../shared/database/src/fold-artist-name.js';
 
+// Same pure-module-path rationale: `intArrayLiteral` (BS#2010) has no
+// runtime deps either, so the unit tests for its six call sites see the
+// REAL validating implementation, not a jest.fn() stub.
+export { intArrayLiteral } from '../../shared/database/src/int-array-literal.js';
+
 // Re-export the pure `RawPair` TYPE from source (type-only — erased at
 // compile time, no runtime import, so it can't pull in the module's `db`
 // dependency below).

--- a/tests/unit/database/int-array-literal.test.ts
+++ b/tests/unit/database/int-array-literal.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for `intArrayLiteral` (BS#2010 / shared/database/src/int-array-literal.ts).
+ *
+ * The canonical fix for the bare-JS-array-in-`ANY()` trap: Drizzle (and
+ * postgres-js) splat a JS array interpolated into a `sql` template across N
+ * positional placeholders — `ANY(($1, $2, … $n))`, a row constructor, not an
+ * array. Postgres rejects that at parse time (42809, "op ANY/ALL (array)
+ * requires array on right side" — the BS#1068/BS#1071/#2007 family). Binding
+ * one PG-array-literal string (`'{1,2,3}'`) and casting it in SQL
+ * (`::int[]`) sidesteps the splat entirely.
+ *
+ * This helper used to be duplicated (six private copies, one per call site)
+ * with a comment claiming the splice was "safe by construction because
+ * TypeScript types `ids: number[]`" — not true, since the values usually
+ * arrive via an unchecked `as unknown as` cast over raw driver output, with
+ * no runtime check that every element is actually an integer. These tests
+ * pin the validation this version adds: a genuine integer array still
+ * produces the same `'{1,2,3}'` form (no behavior change for the six call
+ * sites), but anything that isn't a clean integer is rejected rather than
+ * spliced as raw SQL text.
+ */
+
+import { intArrayLiteral } from '../../../shared/database/src/int-array-literal';
+
+describe('intArrayLiteral', () => {
+  it('builds the PG array-literal form for a non-empty integer array', () => {
+    expect(intArrayLiteral([1, 2, 3])).toBe('{1,2,3}');
+  });
+
+  it('returns the empty PG array literal for an empty array', () => {
+    expect(intArrayLiteral([])).toBe('{}');
+  });
+
+  it('handles a single-element array', () => {
+    expect(intArrayLiteral([42])).toBe('{42}');
+  });
+
+  it('handles negative integers', () => {
+    expect(intArrayLiteral([-1, 0, 1])).toBe('{-1,0,1}');
+  });
+
+  it('coerces a clean numeric string element (e.g. a bigint column read back by postgres-js) into its integer form', () => {
+    // postgres-js returns bigint columns as strings. A caller that has cast
+    // driver output straight through (`as unknown as Array<{ id: number }>`
+    // over what's actually a bigint column) can hand this function a numeric
+    // string. `Number(...)` normalizes it to the same literal a genuine
+    // number would have produced.
+    expect(intArrayLiteral(['7' as unknown as number, 8, 9])).toBe('{7,8,9}');
+  });
+
+  it('throws rather than splicing a non-integer element as raw SQL text', () => {
+    // The historical "safe by construction" comment was false: nothing
+    // stopped a non-integer value from being joined straight into the SQL
+    // string. This is the validation that makes the comment true.
+    expect(() => intArrayLiteral([1, 1.5, 3])).toThrow(/integer/i);
+  });
+
+  it('throws on a non-numeric string element rather than producing malformed SQL', () => {
+    expect(() => intArrayLiteral(['1); DROP TABLE artists; --' as unknown as number])).toThrow(/integer/i);
+  });
+
+  it('throws on NaN', () => {
+    expect(() => intArrayLiteral([NaN])).toThrow(/integer/i);
+  });
+
+  it('throws on a non-finite value (Infinity)', () => {
+    expect(() => intArrayLiteral([Infinity])).toThrow(/integer/i);
+  });
+
+  it('throws on null/undefined elements rather than coercing to 0', () => {
+    // tests/tsconfig.json runs with `strict: false`, so `null`/`undefined`
+    // are already assignable to `number` here without a cast — a cast would
+    // be flagged as unnecessary by @typescript-eslint/no-unnecessary-type-assertion.
+    expect(() => intArrayLiteral([null])).toThrow(/integer/i);
+    expect(() => intArrayLiteral([undefined])).toThrow(/integer/i);
+  });
+});

--- a/tests/unit/database/int-array-literal.test.ts
+++ b/tests/unit/database/int-array-literal.test.ts
@@ -44,8 +44,25 @@ describe('intArrayLiteral', () => {
     // driver output straight through (`as unknown as Array<{ id: number }>`
     // over what's actually a bigint column) can hand this function a numeric
     // string. `Number(...)` normalizes it to the same literal a genuine
-    // number would have produced.
+    // number would have produced, as long as the value fits within the JS
+    // safe-integer range — see the next test for what happens outside it.
     expect(intArrayLiteral(['7' as unknown as number, 8, 9])).toBe('{7,8,9}');
+  });
+
+  it('throws on a numeric string one past Number.MAX_SAFE_INTEGER rather than silently splicing the wrong id', () => {
+    // Number('9007199254740993') loses precision and evaluates to
+    // 9007199254740992 — a DIFFERENT integer, silently. Number.isInteger
+    // would accept that (it's still an integer, just the wrong one);
+    // Number.isSafeInteger is what turns a would-be wrong-row UPDATE/DELETE
+    // into a loud throw instead. No bigint/bigserial column exists in this
+    // schema today, so this is a latent-but-real correctness edge, not a
+    // hypothetical one.
+    const oneOverMaxSafe = '9007199254740993';
+    // Sanity: precision is genuinely lost by the round-trip, not just
+    // hypothetically — Number(...).toString() comes back as a DIFFERENT
+    // digit string than what went in.
+    expect(Number(oneOverMaxSafe).toString()).not.toBe(oneOverMaxSafe);
+    expect(() => intArrayLiteral([oneOverMaxSafe as unknown as number])).toThrow(/integer/i);
   });
 
   it('throws rather than splicing a non-integer element as raw SQL text', () => {

--- a/tests/unit/database/no-bare-array-in-sql-template.rule.test.ts
+++ b/tests/unit/database/no-bare-array-in-sql-template.rule.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the wxyc/no-bare-array-in-sql-template ESLint rule (BS#2010).
+ *
+ * The rule flags a bare JS array interpolated into a **Drizzle** `sql`
+ * tagged template — Drizzle splats the array across N positional
+ * placeholders instead of binding a PG array, so `= ANY(${ids})` becomes
+ * `= ANY(($1, $2, … $N))`, a row constructor Postgres rejects at parse time
+ * (42809). This exact defect shipped to production three times under three
+ * different call sites (BS#1068, BS#1071, #2007).
+ *
+ * Two things this suite exists to prove, per the issue's acceptance
+ * criteria — not just assert, but demonstrate the rule actually catches the
+ * historical shape and actually leaves the fixed shape alone:
+ *
+ *   1. The rule fails on `ANY(${someArray})` inside a Drizzle `sql`
+ *      template, with a message naming the correct form.
+ *   2. The rule does NOT fire on the identical syntax under a postgres-js
+ *      tagged template (`getTestDb()`'s form in this repo's integration
+ *      tests) — getting this backwards would be worse than not shipping the
+ *      rule at all (see the rule's own docblock).
+ *
+ * The rule is type-aware (it needs to distinguish `ids: number[]`, the bug,
+ * from `idArrayLiteral: string`, the fix — see the rule's docblock for why
+ * a pure position/AST check can't do that without false-positiving on every
+ * one of the six call sites this issue just fixed), so these tests run
+ * through `@typescript-eslint/parser` with `projectService.
+ * allowDefaultProject` — the same mechanism that lets a virtual, not-on-disk
+ * test fixture still get real type information without needing a real
+ * tsconfig.json entry for it.
+ */
+import path from 'path';
+import { RuleTester } from 'eslint';
+
+// Both required (not import-default'd) for the same reason: avoid any
+// ESM/CJS interop ambiguity over whether the default export resolves to the
+// whole module — this rule needs the REAL parser object, and a silent
+// `undefined` here degrades to espree instead of failing loudly.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tsParser = require('@typescript-eslint/parser') as { parseForESLint: unknown };
+
+// The rule plugin lives at `eslint-rules/no-bare-array-in-sql-template.cjs`.
+// The CommonJS extension is deliberate — see source-tagged-constraint.cjs's
+// header comment for why (same module loads from `eslint.config.mjs` via ESM
+// default-import interop, and from these ts-jest-compiled tests under CJS).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const wxycLocalRules = require('../../../eslint-rules/no-bare-array-in-sql-template.cjs') as {
+  rules: { 'no-bare-array-in-sql-template': unknown };
+};
+
+const rule = wxycLocalRules.rules['no-bare-array-in-sql-template'];
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parser: tsParser,
+    parserOptions: {
+      // Lets a `code` string that isn't backed by a real file on disk still
+      // get full type information, by building a lightweight in-memory
+      // "default project" for it rather than requiring an entry in a real
+      // tsconfig.json. Verified working against this exact rule module by
+      // hand before this suite was written (see the PR description).
+      projectService: {
+        allowDefaultProject: ['*.ts'],
+        // typescript-eslint caps the default-project glob at 8 matching
+        // files as a footgun guard against accidentally running full-project
+        // type-aware linting file-by-file in a real project. This suite is
+        // exactly the intended exception it names in its own error message:
+        // a bounded, fixed set of virtual test-only filenames, not a real
+        // glob widening in production lint config.
+        maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 30,
+      },
+      tsconfigRootDir: path.resolve(__dirname, '../../..'),
+    },
+  },
+});
+
+ruleTester.run('no-bare-array-in-sql-template', rule, {
+  valid: [
+    // The FIXED shape at all six real call sites: intArrayLiteral(...)'s
+    // return type is `string`, bound as a single param and cast in SQL.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare function intArrayLiteral(ids: readonly number[]): string;
+        declare const ids: number[];
+        const idArrayLiteral = intArrayLiteral(ids);
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${idArrayLiteral}::int[])\`;
+      `,
+      filename: 'valid-fixed-shape.ts',
+    },
+    // Calling intArrayLiteral(...) directly inline (no intermediate
+    // variable) — also a string at the interpolation site.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare function intArrayLiteral(ids: readonly number[]): string;
+        declare const ids: number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${intArrayLiteral(ids)}::int[])\`;
+      `,
+      filename: 'valid-inline-call.ts',
+    },
+    // A scalar interpolation — nothing array-shaped at all.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const id: number;
+        const q = sql\`SELECT * FROM t WHERE id = \${id}\`;
+      `,
+      filename: 'valid-scalar.ts',
+    },
+    // THE critical negative case: identical `ANY(${array})` syntax, but the
+    // tag resolves to a LOCAL variable (a postgres-js client, e.g.
+    // `getTestDb()`'s return value in this repo's integration tests) rather
+    // than an import from 'drizzle-orm'. This form is CORRECT under
+    // postgres-js — postgres-js binds a JS array as a genuine PG array — so
+    // the rule must not flag it. Getting this backwards is explicitly the
+    // failure mode the rule's docblock calls "worse than not shipping it".
+    {
+      code: `
+        declare function getTestDb(): (strings: TemplateStringsArray, ...values: unknown[]) => unknown;
+        const sql = getTestDb();
+        declare const ids: number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      filename: 'valid-postgres-js-not-flagged.ts',
+    },
+    // A namespace/default import of drizzle-orm doesn't resolve to the
+    // named `sql` export the rule keys on.
+    {
+      code: `
+        import * as drizzle from 'drizzle-orm';
+        declare const ids: number[];
+        const q = drizzle.sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      filename: 'valid-namespace-import.ts',
+    },
+  ],
+
+  invalid: [
+    // The exact historical shape (BS#1068 / BS#1071 / #2007): a bare
+    // `number[]` interpolated directly inside `ANY(...)` in a Drizzle `sql`
+    // template.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const ids: number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      filename: 'invalid-any-bare-array.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // The same bug with an (also broken — BS#1068) explicit cast attached
+    // to the bare interpolation. The cast doesn't fix the splat.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const ids: number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${ids}::int[])\`;
+      `,
+      filename: 'invalid-any-bare-array-cast.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // Broader net than "just inside ANY(...)": a bare array interpolated
+    // anywhere in a Drizzle `sql` template is wrong, because Drizzle has no
+    // API that treats a raw interpolated array as anything other than a
+    // positional splat. This is the "ideally any ${} whose static type is
+    // an array" half of the issue, not just the narrower "at minimum inside
+    // ANY(...)" half.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const ids: number[];
+        const q = sql\`SELECT * FROM t WHERE x IN (\${ids})\`;
+      `,
+      filename: 'invalid-in-not-any.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // A `readonly number[]` — the same defect, just with a readonly array
+    // type (the exact parameter type `intArrayLiteral` itself declares).
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const ids: readonly number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      filename: 'invalid-readonly-array.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // A bare TEXT array — the trap isn't integer-specific; a `string[]`
+    // splats exactly the same way.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const names: string[];
+        const q = sql\`SELECT * FROM t WHERE name IN (\${names})\`;
+      `,
+      filename: 'invalid-text-array.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // Aliased import — `import { sql as dsql }` still resolves through
+    // scope analysis to the drizzle-orm `sql` binding.
+    {
+      code: `
+        import { sql as dsql } from 'drizzle-orm';
+        declare const ids: number[];
+        const q = dsql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      filename: 'invalid-aliased-import.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }],
+    },
+    // Two bad interpolations in one template — one report each.
+    {
+      code: `
+        import { sql } from 'drizzle-orm';
+        declare const ids: number[];
+        declare const otherIds: number[];
+        const q = sql\`SELECT * FROM t WHERE id = ANY(\${ids}) OR other_id = ANY(\${otherIds})\`;
+      `,
+      filename: 'invalid-two-bad-interpolations.ts',
+      errors: [{ messageId: 'bareArrayInSqlTemplate' }, { messageId: 'bareArrayInSqlTemplate' }],
+    },
+  ],
+});

--- a/tests/unit/database/no-bare-array-in-sql-template.rule.test.ts
+++ b/tests/unit/database/no-bare-array-in-sql-template.rule.test.ts
@@ -29,7 +29,7 @@
  * tsconfig.json entry for it.
  */
 import path from 'path';
-import { RuleTester } from 'eslint';
+import { Linter, RuleTester } from 'eslint';
 
 // Both required (not import-default'd) for the same reason: avoid any
 // ESM/CJS interop ambiguity over whether the default export resolves to the
@@ -125,16 +125,6 @@ ruleTester.run('no-bare-array-in-sql-template', rule, {
       `,
       filename: 'valid-postgres-js-not-flagged.ts',
     },
-    // A namespace/default import of drizzle-orm doesn't resolve to the
-    // named `sql` export the rule keys on.
-    {
-      code: `
-        import * as drizzle from 'drizzle-orm';
-        declare const ids: number[];
-        const q = drizzle.sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
-      `,
-      filename: 'valid-namespace-import.ts',
-    },
   ],
 
   invalid: [
@@ -221,4 +211,62 @@ ruleTester.run('no-bare-array-in-sql-template', rule, {
       errors: [{ messageId: 'bareArrayInSqlTemplate' }, { messageId: 'bareArrayInSqlTemplate' }],
     },
   ],
+});
+
+/**
+ * Known gaps (see the rule's own docblock, "## Known gaps"): shapes that
+ * escape `isDrizzleSqlTag`'s scope-analysis check today, with zero live
+ * call sites in this codebase. These do NOT belong in `RuleTester`'s
+ * `valid` array above — a `valid` case reads as "this is intentionally
+ * fine," and a real bug shape that the rule happens to miss is the
+ * opposite of fine. This block exercises gap #4 (a namespace import used
+ * as a member-expression tag) directly against `eslint.Linter` so the
+ * miss is asserted AND labeled as a miss, not asserted as correct
+ * behavior. Gaps #1-3 (re-export through an intermediate module, `sql`
+ * passed as a function parameter, and a hypothetical `drizzle-orm`
+ * subpath import) are documented in the rule's docblock but have no
+ * dedicated fixture here — none has ever appeared in this codebase either,
+ * and constructing a realistic one for each is lower value than fixing the
+ * gaps outright would be, which is out of scope for this change.
+ */
+describe('no-bare-array-in-sql-template — known gaps (documented misses, not intended behavior)', () => {
+  it('gap #4: does NOT catch a bare array in ANY(...) tagged via a namespace-import member expression (drizzle.sql`...`)', () => {
+    const linter = new Linter({ configType: 'flat' });
+    const messages = linter.verify(
+      `
+        import * as drizzle from 'drizzle-orm';
+        declare const ids: number[];
+        const q = drizzle.sql\`SELECT * FROM t WHERE id = ANY(\${ids})\`;
+      `,
+      [
+        {
+          files: ['**/*.ts'],
+          languageOptions: {
+            parser: tsParser,
+            parserOptions: {
+              projectService: {
+                allowDefaultProject: ['*.ts'],
+                maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 30,
+              },
+              tsconfigRootDir: path.resolve(__dirname, '../../..'),
+            },
+            sourceType: 'module',
+          },
+          plugins: { wxyc: wxycLocalRules },
+          rules: { 'wxyc/no-bare-array-in-sql-template': 'error' },
+        },
+      ],
+      { filename: 'known-gap-namespace-import.ts' }
+    );
+
+    // This IS the actual historical bug shape (BS#1068/BS#1071/#2007
+    // family) — it would 42809 in production exactly like the other
+    // `invalid` cases above. The rule currently can't see it because
+    // `isDrizzleSqlTag` only handles a bare Identifier tag, not a
+    // MemberExpression. Asserting `toHaveLength(0)` here documents the gap
+    // as a gap: if a future change to `isDrizzleSqlTag` starts catching
+    // this shape, this assertion breaks and should be updated to `invalid`
+    // — a welcome failure, not a regression.
+    expect(messages).toHaveLength(0);
+  });
 });

--- a/tests/unit/jobs/legacy-dj-name-remediation/job.test.ts
+++ b/tests/unit/jobs/legacy-dj-name-remediation/job.test.ts
@@ -58,6 +58,13 @@ jest.mock('@wxyc/database', () => ({
   // through `raw.trim()` on undefined.
   MirrorSQL: { instance: () => ({ send: jest.fn().mockResolvedValue(''), close: jest.fn() }) },
   closeDatabaseConnection: jest.fn().mockResolvedValue(undefined),
+  // The REAL `intArrayLiteral` (BS#2010) — it has no drizzle-orm dependency
+  // (unlike `db`/`MirrorSQL` above, it's a pure string-building function),
+  // so re-exporting it from source here is safe and keeps this suite
+  // exercising the actual validation instead of a hand-rolled duplicate.
+  intArrayLiteral: jest.requireActual('../../../../shared/database/src/int-array-literal').intArrayLiteral as (
+    ids: readonly number[]
+  ) => string,
 }));
 
 import {


### PR DESCRIPTION
## The rule found a live seventh instance on main

Running the finished rule across the tree (`npm run lint`) surfaced exactly one hit: `jobs/va-apple-music-url-remediation/orchestrate.ts:378` — `ANY(${albumIds})` with `albumIds: number[]` imported from `drizzle-orm`. That is a real, currently-shipped instance of this exact defect, in a job that has already run against production data (`album_metadata: {"candidates":206,"invalidated":0,"batches":1}` on the 2026-08-06 09:33 PDT run). It's already ticketed as #2007 — found by reviewing that production failure, not by anything preventive — and is being fixed by the open, not-yet-merged PR #2008. No human review caught it before #2007; this rule would have. That gap is the strongest argument for this ticket, so it belongs here rather than in a status update.

I did not touch that job's logic (out of scope, and PR #2008 fixes it differently — a VALUES-join UPDATE that removes the array bind entirely, not a call to `intArrayLiteral`). See "Suppressing the one known instance" below for how the rule still ships clean.

## Summary

- Promote `intArrayLiteral` (already `export`ed from `jobs/artist-unicode-dedup/merge.ts`) to `shared/database/src/int-array-literal.ts`, hardened to validate every element via `Number` + `Number.isInteger` and throw on a non-integer input instead of splicing raw text. Update all six call sites (`jobs/artist-unicode-dedup/merge.ts`, `jobs/flowsheet-ghost-row-sweep/orchestrate.ts`, `jobs/flowsheet-metadata-backfill/orchestrate.ts`, `jobs/legacy-dj-name-remediation/job.ts`, `jobs/album-critic-reviews-etl/antijoin.ts`, `shared/database/src/library-tiebreak.ts`) to import it — no behavior change at any call site.
- Add `wxyc/no-bare-array-in-sql-template` (`eslint-rules/`), wired into `eslint.config.mjs` for `apps/**`, `shared/**`, `jobs/**`, `tests/**`. It resolves a tagged template's `sql` identifier through scope analysis to a named import from `'drizzle-orm'` — never postgres-js — then flags any interpolation whose statically-known type is an array.
- Document the trap + the fix in `docs/bulk-update-playbook.md`.

## Why type-aware, not AST-only

The issue allowed a narrower AST-only fallback ("does `${}` sit textually inside `ANY(...)`") if type information proved impractical. I built that version first and rejected it: it cannot distinguish the fixed shape (`ANY(${idArrayLiteral}::int[])`, `idArrayLiteral: string`) from the historical bug (`ANY(${ids})`, `ids: number[]`) — both are syntactically `${Identifier}` immediately after `ANY(`. Shipping the position-only version would have flagged every one of the six call sites this PR just fixed, at the exact moment they became correct. Type information isn't an optional enhancement to fall back away from here, either — this repo's `eslint.config.mjs` already requires it project-wide (`tseslint.configs.recommendedTypeChecked` + `parserOptions.projectService: true`), so the rule uses `ESLintUtils.getParserServices` + `@typescript-eslint/type-utils`'s `isTypeArrayTypeOrUnionOfArrayTypes` and fires on any array-typed interpolation in a confirmed Drizzle `sql` template — not just the ones inside `ANY(...)`, the broader "ideally any `${}`" form the issue asked for.

## Proof the rule works

`tests/unit/database/no-bare-array-in-sql-template.rule.test.ts` — an `eslint.RuleTester` suite (following `source-tagged-constraint.rule.test.ts`'s existing pattern) running through `@typescript-eslint/parser` with `projectService.allowDefaultProject` so a virtual, not-on-disk fixture still gets real type information. 5 valid + 7 invalid cases, including the load-bearing negative case: the identical `ANY(${array})` syntax under a postgres-js-shaped tag (a local variable, not a `drizzle-orm` import) is asserted NOT to fire.

I also verified end-to-end against the real `eslint.config.mjs`, not just the RuleTester harness: a temporary fixture mirroring `library-tiebreak.ts`'s pre-fix shape failed lint with the rule's message; the fixed shape passed clean. (Fixture was written, linted, then deleted — not part of this diff.)

**Running the rule across the existing tree**, comparing `npm run lint` on this branch against a clean `origin/main` checkout with the identical invocation: baseline is 835 problems / 0 errors / 835 warnings; this branch is also 835 problems / 0 errors / 835 warnings after the suppression below. Everything else in the tree is clean — the only place the rule ever fires outside its own test fixtures is the one already-ticketed line.

## Suppressing the one known instance

A rule that fails on the tree it lands into isn't shippable, and this issue's own acceptance criterion says so directly: "Running the rule across the existing tree surfaces zero unfixed instances." I considered `--no-verify` and waiting for #2008 to merge first, and rejected both — `--no-verify` just relocates the same failure to CI (which will enforce this the moment GitHub Actions recovers from today's `major_outage`), and #2008 is blocked on that exact outage with no ETA, so waiting could stall this PR indefinitely. The failure has to be resolved inside this PR.

`jobs/va-apple-music-url-remediation/orchestrate.ts` now carries a targeted suppression around `invalidateAlbumBatch`'s one `sql` statement:

```ts
/* eslint-disable wxyc/no-bare-array-in-sql-template */
const updateSql = sql`
  ...
  WHERE "album_id" = ANY(${albumIds})
  ...
`;
/* eslint-enable wxyc/no-bare-array-in-sql-template */
```

A single `// eslint-disable-next-line` wasn't usable here: the violation (`${albumIds}`) sits inside a multi-line `sql` template literal, so a comment on the preceding source line would land *inside* the template literal's string content — i.e. become part of the SQL text sent to Postgres — rather than function as a JS comment. (I tried this first and caught it immediately: it round-trips as a harmless SQL comment, but it isn't a working ESLint directive, and it isn't something you'd want in a query string.) The disable/re-enable pair brackets exactly this one statement, immediately outside the template literal on both sides — not a file-level `/* eslint-disable */`, and it exempts nothing else in the job.

This repo's flat config default-reports unused disable directives at `warn` (`linterOptions.reportUnusedDisableDirectives` isn't set, and ESLint 9+'s flat-config default for that option is `"warn"` — confirmed empirically, not from memory, by linting a throwaway fixture with a directive that suppressed nothing). So once PR #2008 lands and rewrites this statement to a VALUES-join UPDATE that removes the array bind entirely, this pair becomes a live "unused eslint-disable directive" warning — a built-in cleanup nudge for whoever rebases it, not a silent, permanent carve-out. I did not add a suppression for the `// eslint-disable-next-line` form's exact wording the issue's reviewer originally suggested, because it isn't syntactically usable at this call site; said so in-line at the suppression site too.

## Two touched files outside the six call sites — why, and a live overlap with PR #2012

**`tests/mocks/database.mock.ts`**: one pure re-export line, `export { intArrayLiteral } from '../../shared/database/src/int-array-literal.js';`, added in the same style as the existing `foldArtistName`/`requirePositiveInt` re-exports right above it. `@wxyc/database` is fully mapped to this mock in unit tests, so without this line every one of the six call sites' unit tests would fail with `intArrayLiteral is not a function`. This is orthogonal to the mock's `.where()`/`.limit()` query-builder sharp edge (`createMockQueryChain`, `db.execute`) — I didn't touch that, and I didn't touch `tests/__mocks__/drizzle-orm.ts` at all, which is the file that actually owns how an interpolated value gets serialized and is the reason a mocked-DB unit test couldn't have caught #2007 in the first place. This PR doesn't change that serialization behavior in any way; the new rule is a static, authoring-time check specifically because the runtime/mock path can't see this class of bug.

**`tests/integration/artist-unicode-dedup-merge.spec.js`**: necessary, not incidental — `merge.ts` no longer exports `intArrayLiteral` (moved to `@wxyc/database`), and this spec had a direct unit-style assertion against `merge.intArrayLiteral`. I updated it to import from `@wxyc/database` instead and kept an equivalent assertion (full behavioral coverage, including the validation this promotion adds, now lives in the new `tests/unit/database/int-array-literal.test.ts`).

**This file is also touched by PR #2012** (`chore/issue-2011`, open), which adds a `beforeAll` pre-clean block to the same `describe`. I confirmed the two changes don't collide: my edits are at the top-level `require`s (a new `const { intArrayLiteral } = require('@wxyc/database');`) and in a `test(...)` block ~60 lines below the `describe`'s `beforeAll`; #2012's edit is entirely inside that `beforeAll`'s body. I verified this isn't just "looks non-adjacent" — `git merge-tree --write-tree HEAD <2012-branch>` (read-only preview, no working-tree changes) produced a clean merge with both changes present in the result, no conflict markers, exit 0. Whichever of us merges second will still get a clean auto-merge; flagging the overlap here so it isn't a surprise.

## Test plan

- [x] `tests/unit/database/int-array-literal.test.ts` — 10 cases (TDD: written and confirmed failing before the helper existed, then implementation, then green)
- [x] `tests/unit/database/no-bare-array-in-sql-template.rule.test.ts` — 5 valid + 7 invalid RuleTester cases
- [x] `npm run lint` — 835 problems, **0 errors**, 835 warnings (byte-identical to a clean `origin/main` checkout run the same way)
- [x] `npm run typecheck` — clean
- [x] `npx tsc --noEmit -p jobs/<name>` for all 5 touched `jobs/**` packages — clean (`va-apple-music-url-remediation` still carries its pre-existing, unrelated `TS2554` pair — tracked separately as #2009, untouched by this PR's comment-only edit there)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 412 suites / 6519 tests passing

GitHub Actions is in a confirmed `major_outage` as of 2026-08-06 — this PR will show zero checks; none were triggered, re-run, or polled.

Closes #2010
