### PR TITLE
fix(catalog-search): stop fuzzy alias hits from flooding /library/query

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,8 +191,11 @@ CATALOG_SEARCH_ALIAS_ENABLED=false
 # every known collision while keeping every known real match — the tightest of
 # which ("oh sees" -> "Osees") sits at exactly 0.40, so do NOT round this up
 # without re-running the table in
-# tests/unit/config/catalog-search-alias-config.test.ts. Unset or unparseable
-# falls back to 0.40.
+# tests/unit/config/catalog-search-alias-config.test.ts.
+#
+# Anything that is not a number in [0, 1] falls back to 0.40 and logs a warning
+# — including `40`, which looks like a percentage but is not one. A value below
+# 0.30 is accepted but does nothing, and also warns.
 CATALOG_SEARCH_ALIAS_MIN_SIMILARITY=0.4
 
 ### OIDC trustedClients (better-auth oidcProvider)

--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,29 @@ BS_USE_LIBRARY_IDENTITY_WRITES=false
 CATALOG_TRACK_SEARCH_CTA_ENABLED=false
 CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=false
 
+### Alias-aware catalog search
+# Plan: Backend-Service/plans/artist-search-alias.md PR 5.
+# Widens the three trigram read paths (/library/query, Both-mode trigram,
+# request-line searchByArtist) with a CTE over artist_search_alias, so a query
+# for a Discogs name variation / alias / member finds the canonical artist.
+# Strict-`true` gated; defaults false. ON in production and in dev_env.
+CATALOG_SEARCH_ALIAS_ENABLED=false
+# Minimum trigram similarity for an alias variant to count as a match (BS#2018).
+# Layered on top of pg_trgm's `%` operator, which is what drives the GIN index —
+# so this can only TIGHTEN matching, never loosen it. Values at or below
+# pg_trgm's own 0.30 threshold are a no-op.
+#
+# pg_trgm's 0.30 is far too permissive for short variants: the misprint "Monore"
+# (one of Bill Monroe's 42 Discogs name variations) scores 0.333 against
+# "monolake", and because the alias branch joins on artist_id, that one row put
+# all 14 Bill Monroe albums into a Monolake search. 0.40 was measured to exclude
+# every known collision while keeping every known real match — the tightest of
+# which ("oh sees" -> "Osees") sits at exactly 0.40, so do NOT round this up
+# without re-running the table in
+# tests/unit/config/catalog-search-alias-config.test.ts. Unset or unparseable
+# falls back to 0.40.
+CATALOG_SEARCH_ALIAS_MIN_SIMILARITY=0.4
+
 ### OIDC trustedClients (better-auth oidcProvider)
 # Each downstream app that authenticates against api.wxyc.org/auth via the
 # OIDC code + PKCE flow needs a `trustedClient` entry. The entry is built in

--- a/apps/backend/config/catalogSearchAlias.ts
+++ b/apps/backend/config/catalogSearchAlias.ts
@@ -62,14 +62,33 @@ export interface CatalogSearchAliasConfig {
  * shipped default rather than clamping: clamping a plausible "percent" typo
  * (`40`) to 1.0 would match nothing and silently disable the alias feature
  * outright, which is a far worse failure than ignoring the override.
+ *
+ * Both the fallback and the below-`%`-threshold no-op are logged. This knob
+ * exists so an operator can back the calibration out mid-incident; a typo
+ * that silently leaves the shipped default in place would read to them as
+ * "the floor wasn't the cause," which is the worst possible wrong conclusion
+ * to hand someone at that moment.
  */
 function parseMinSimilarity(raw: string | undefined): number {
   if (raw === undefined) return DEFAULT_ALIAS_MIN_SIMILARITY;
-  const parsed = Number(raw.trim());
-  // `Number('')` is 0, which is a legal-looking but meaningless floor, so the
-  // empty-string case is caught by the blank guard rather than the range one.
-  if (raw.trim() === '' || !Number.isFinite(parsed)) return DEFAULT_ALIAS_MIN_SIMILARITY;
-  if (parsed < 0 || parsed > 1) return DEFAULT_ALIAS_MIN_SIMILARITY;
+  const trimmed = raw.trim();
+  const parsed = Number(trimmed);
+  if (trimmed === '' || !Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    console.warn(
+      `[catalogSearchAlias] CATALOG_SEARCH_ALIAS_MIN_SIMILARITY=${JSON.stringify(raw)} is not a number in [0, 1]; ` +
+        `falling back to ${DEFAULT_ALIAS_MIN_SIMILARITY}. The floor is a similarity ratio, not a percentage — ` +
+        `use 0.4, not 40.`
+    );
+    return DEFAULT_ALIAS_MIN_SIMILARITY;
+  }
+  if (parsed < PG_TRGM_DEFAULT_THRESHOLD) {
+    console.warn(
+      `[catalogSearchAlias] CATALOG_SEARCH_ALIAS_MIN_SIMILARITY=${parsed} is below pg_trgm's own ` +
+        `similarity_threshold (${PG_TRGM_DEFAULT_THRESHOLD}) and therefore has no effect: the indexable \`%\` ` +
+        `predicate still rejects everything under ${PG_TRGM_DEFAULT_THRESHOLD}. This knob can only tighten alias ` +
+        `matching, never loosen it.`
+    );
+  }
   return parsed;
 }
 

--- a/apps/backend/config/catalogSearchAlias.ts
+++ b/apps/backend/config/catalogSearchAlias.ts
@@ -3,20 +3,94 @@
  *
  * When enabled, the three trigram read paths
  * (`searchLibraryByTrigramBoth`, `searchByArtist`, `/library/query`) extend
- * their SQL with a `LEFT JOIN LATERAL` over `artist_search_alias` keyed on
- * `library.artist_id`. The flag is strict-`true` gated so an accidental
- * `CATALOG_SEARCH_ALIAS_ENABLED=1` does not silently widen the search path.
+ * their SQL with a `WITH alias_hits` CTE over `artist_search_alias` joined on
+ * `library.artist_id` (BS#1318 ALT1). The flag is strict-`true` gated so an
+ * accidental `CATALOG_SEARCH_ALIAS_ENABLED=1` does not silently widen the
+ * search path.
  *
  * Defaults to `false` so production behavior is unchanged until an operator
  * opts in. See: `Backend-Service/plans/artist-search-alias.md` §PR 5.
  *
- * The singleton mechanics (strict-`true` parse, lazy cache, `resetConfig` test
- * hook) come from the shared {@link createEnvFlagConfig} factory. Tests that
- * mutate `process.env.CATALOG_SEARCH_ALIAS_ENABLED` between cases must call
- * `resetConfig()` in `beforeEach` so the next `getConfig()` re-reads the env.
+ * Tests that mutate either env var between cases must call `resetConfig()` in
+ * `beforeEach` so the next `getConfig()` re-reads the environment.
  */
-import { createEnvFlagConfig, type EnvFlagConfig } from './envFlag.js';
 
-export type CatalogSearchAliasConfig = EnvFlagConfig;
+/**
+ * pg_trgm's own `similarity_threshold` default — the bar the `%` operator
+ * applies. Named here because the BS#2018 floor is layered ON TOP of `%`,
+ * never in place of it: the `%` predicate is what drives the GIN index
+ * (`artist_search_alias_variant_trgm_idx`), so setting `minSimilarity` below
+ * this value cannot widen matching. The knob only ever tightens.
+ */
+export const PG_TRGM_DEFAULT_THRESHOLD = 0.3;
 
-export const { loadConfig, getConfig, resetConfig } = createEnvFlagConfig('CATALOG_SEARCH_ALIAS_ENABLED');
+/**
+ * BS#2018 default alias-match floor.
+ *
+ * pg_trgm's 0.30 is far too permissive for short alias variants, whose
+ * trigram sets are small enough that unrelated strings collide at a fixed
+ * ratio. Because the alias branch INNER JOINs on `artist_id`, ONE colliding
+ * variant admits an artist's entire discography — `similarity('Monore',
+ * 'monolake') = 0.333` (a misprint among Discogs artist 450691's 42 name
+ * variations) put all 14 Bill Monroe albums into a search for Monolake.
+ *
+ * 0.40 was picked by measuring every known collision against every known
+ * legitimate match rather than by feel; the table lives in
+ * `tests/unit/config/catalog-search-alias-config.test.ts`, which fails if
+ * this constant moves out from between them. The margin is thin — the
+ * tightest true positive (`oh sees` -> `Osees`) sits at exactly 0.40, so
+ * 0.50 is NOT a safe "rounder" choice. Re-measure before changing this.
+ */
+export const DEFAULT_ALIAS_MIN_SIMILARITY = 0.4;
+
+export interface CatalogSearchAliasConfig {
+  /** Strict-`true` gate on the whole alias-aware search path. */
+  enabled: boolean;
+
+  /**
+   * Minimum `similarity(artist_search_alias.variant, q)` for an alias row to
+   * count as a match, applied as a filter on top of the indexable `%`
+   * predicate. Operator-tunable via `CATALOG_SEARCH_ALIAS_MIN_SIMILARITY` so
+   * the calibration can be backed out without a code change if it turns out
+   * to suppress legitimate matches in production.
+   */
+  minSimilarity: number;
+}
+
+/**
+ * Parse the floor from its env var. An unusable value falls back to the
+ * shipped default rather than clamping: clamping a plausible "percent" typo
+ * (`40`) to 1.0 would match nothing and silently disable the alias feature
+ * outright, which is a far worse failure than ignoring the override.
+ */
+function parseMinSimilarity(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_ALIAS_MIN_SIMILARITY;
+  const parsed = Number(raw.trim());
+  // `Number('')` is 0, which is a legal-looking but meaningless floor, so the
+  // empty-string case is caught by the blank guard rather than the range one.
+  if (raw.trim() === '' || !Number.isFinite(parsed)) return DEFAULT_ALIAS_MIN_SIMILARITY;
+  if (parsed < 0 || parsed > 1) return DEFAULT_ALIAS_MIN_SIMILARITY;
+  return parsed;
+}
+
+/** Read the config fresh from the environment. */
+export function loadConfig(): CatalogSearchAliasConfig {
+  return {
+    enabled: process.env.CATALOG_SEARCH_ALIAS_ENABLED === 'true',
+    minSimilarity: parseMinSimilarity(process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY),
+  };
+}
+
+let _config: CatalogSearchAliasConfig | null = null;
+
+export function getConfig(): CatalogSearchAliasConfig {
+  if (!_config) {
+    _config = loadConfig();
+  }
+  return _config;
+}
+
+/** Drop the cached singleton so the next `getConfig()` re-reads the env. */
+export function resetConfig(): void {
+  _config = null;
+}

--- a/apps/backend/config/envFlag.ts
+++ b/apps/backend/config/envFlag.ts
@@ -1,15 +1,17 @@
 /**
  * Factory for the single-boolean, strict-`true`-gated, lazily-cached
  * environment-flag config that several feature gates share verbatim
- * (`criticReviews`, `catalogSearchAlias`). Each returned config is a small
- * singleton over one env var; `getConfig()` reads the environment once and
- * caches, `loadConfig()` reads it fresh every call, and `resetConfig()` drops
- * the cache so a test that mutated the env var in `beforeEach` re-reads it.
+ * (`criticReviews`). Each returned config is a small singleton over one env
+ * var; `getConfig()` reads the environment once and caches, `loadConfig()`
+ * reads it fresh every call, and `resetConfig()` drops the cache so a test
+ * that mutated the env var in `beforeEach` re-reads it.
  *
  * The strict `=== 'true'` comparison is the point of the shared helper: a flag
  * that gates an extra query or a widened SQL path must not silently enable on
- * `=1`/`TRUE`/`yes`. Callers that need more than one flag (e.g.
- * `catalogTrackSearch`, which carries two) don't use this factory.
+ * `=1`/`TRUE`/`yes`. Callers that need more than one setting don't use this
+ * factory — `catalogTrackSearch` carries two flags, and `catalogSearchAlias`
+ * pairs its flag with the BS#2018 `minSimilarity` floor — but they hand-roll
+ * the same strict-`true` comparison for their boolean members.
  *
  * The returned functions close over a factory-local cache, so they stay
  * correct when destructured and re-exported as standalone named bindings

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,14 +1,6 @@
 import * as Sentry from '@sentry/node';
 import { inArray, sql, type SQL } from 'drizzle-orm';
-import {
-  db,
-  library,
-  library_artist_view,
-  genres,
-  format as formatTable,
-  artist_search_alias,
-  album_plays,
-} from '@wxyc/database';
+import { db, library, library_artist_view, genres, format as formatTable, album_plays } from '@wxyc/database';
 import type { TrackMatchHint } from '@wxyc/shared/dtos';
 import {
   parseSearchQuery,
@@ -21,6 +13,7 @@ import type { ArtistMatchHint, ArtistSearchAliasSource } from './requestLine/typ
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import WxycError from '../utils/error.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
+import { buildAliasHitsCte } from '../utils/alias-hits.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -210,18 +203,25 @@ export async function searchLibrary(
     const dedupeWhere = queryWhereAliasOff ? sql`(${queryWhereAliasOff}) IS NOT TRUE` : sql`FALSE`;
     const branchBWhere = combineWhere(dedupeWhere, filterWhere);
 
-    const orderBy = sql`${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
+    // BS#2018 Fix 1: tier the sort so branch-(b) rows — matched only through
+    // a fuzzy alias variant — always land after branch-(a) rows, which matched
+    // the query text itself. `alias_max_sim` was computed and projected from
+    // day one but never ordered on, so a 0.333 typo collision ("Monore" for a
+    // "monolake" query) sorted identically to an exact hit and, via the
+    // `artist_id` INNER JOIN, put an entire unrelated discography at the top
+    // of the page. `FALSE < TRUE` in Postgres, so ASC puts the real matches
+    // first; the caller's own sort follows, unchanged, within each tier.
+    //
+    // The tier is deliberately "is it alias-only", NOT `alias_max_sim DESC`:
+    // the score never reaches the wire shape, so `sortAlbumRows` (which
+    // re-sorts this same row set in memory when the cascade fires) could not
+    // reproduce a score-based order and the two would drift.
+    const orderBy = sql`(alias_max_sim IS NOT NULL) ASC, ${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
 
-    const cte = sql`WITH alias_hits AS (
-      SELECT
-        asa.artist_id,
-        MAX(similarity(asa.variant, ${params.q})) AS max_sim,
-        (array_agg(asa.variant ORDER BY similarity(asa.variant, ${params.q}) DESC))[1] AS matched_variant,
-        (array_agg(asa.source ORDER BY similarity(asa.variant, ${params.q}) DESC))[1] AS matched_source
-      FROM ${artist_search_alias} asa
-      WHERE asa.variant % ${params.q}
-      GROUP BY asa.artist_id
-    )`;
+    // BS#2018 Fix 2 (the `similarity(...) >= floor` post-filter) lives inside
+    // the shared builder in `utils/alias-hits.ts`, so this path and the two in
+    // `library.service.ts` can't drift on what counts as an alias match.
+    const cte = buildAliasHitsCte(params.q);
 
     const branchAProjection = sql`
       ${library_artist_view.id} AS id,
@@ -466,11 +466,29 @@ async function runCascade(params: LibraryQueryParams, q: string): Promise<AlbumS
 }
 
 /**
- * Sort album rows by the caller's `sort`/`order`, with the same secondary
- * tiebreak + id tiebreak the catalog's primary SQL query uses. Shared by the
- * cascade (whose rows never touch SQL `ORDER BY`) and the alias/cascade merge
- * (BS#1885), which re-sorts a combined row set after `runCascade` and the
- * primary alias rows are spliced together.
+ * In-memory mirror of the SQL `ORDER BY`'s alias tier (BS#2018 Fix 1).
+ *
+ * A row is alias-only when the ALIAS branch is the ONLY reason it is here:
+ * it carries an alias hint and nothing matched it for real. The `matched_via`
+ * check is load-bearing — the BS#1885 merge copies `matched_via_alias` onto a
+ * cascade row when the two collide on `id`, and that row matched for real, so
+ * demoting it would bury the cascade's own answer.
+ *
+ * Keep this predicate equivalent to the SQL tier `alias_max_sim IS NOT NULL`:
+ * SQL rows never carry `matched_via` (only the cascade sets it), and branch
+ * (b)'s dedupe guarantees an `alias_max_sim`-bearing row didn't match branch
+ * (a). The two agree row-for-row.
+ */
+function isAliasOnlyMatch(row: AlbumSearchResultRow): boolean {
+  return row.matched_via_alias !== undefined && row.matched_via === undefined;
+}
+
+/**
+ * Sort album rows by the caller's `sort`/`order`, with the same alias tier,
+ * secondary tiebreak, and id tiebreak the catalog's primary SQL query uses.
+ * Shared by the cascade (whose rows never touch SQL `ORDER BY`) and the
+ * alias/cascade merge (BS#1885), which re-sorts a combined row set after
+ * `runCascade` and the primary alias rows are spliced together.
  */
 function sortAlbumRows(
   rows: AlbumSearchResultRow[],
@@ -481,6 +499,11 @@ function sortAlbumRows(
   const secondaryKey = SECONDARY_SORT_KEYS[params.sort];
   const sorted = [...rows];
   sorted.sort((a, b) => {
+    // Tier first, and independent of `order` — `desc` reverses the ranking
+    // within each tier, never the tiers themselves. Fuzzy alias noise stays
+    // below real matches in both directions.
+    const tier = Number(isAliasOnlyMatch(a)) - Number(isAliasOnlyMatch(b));
+    if (tier !== 0) return tier;
     const primary = compareSortable(a[primaryKey], b[primaryKey]) * direction;
     if (primary !== 0) return primary;
     const secondary = compareSortable(a[secondaryKey], b[secondaryKey]);

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -169,7 +169,8 @@ export async function searchLibrary(
   // scoped against. Preserves pre-#1318 behavior for those paths; opening
   // alias expansion to field-specific queries is a future product call.
   const hasAllFieldCondition = conditions.some((c) => c.field === 'all');
-  const aliasActive = getCatalogSearchAliasConfig().enabled && params.q.trim().length > 0 && hasAllFieldCondition;
+  const aliasConfig = getCatalogSearchAliasConfig();
+  const aliasActive = aliasConfig.enabled && params.q.trim().length > 0 && hasAllFieldCondition;
   const filterWhere = buildFilterClause(params);
 
   const orderDirection = params.order === 'asc' ? sql`ASC` : sql`DESC`;
@@ -221,7 +222,7 @@ export async function searchLibrary(
     // BS#2018 Fix 2 (the `similarity(...) >= floor` post-filter) lives inside
     // the shared builder in `utils/alias-hits.ts`, so this path and the two in
     // `library.service.ts` can't drift on what counts as an alias match.
-    const cte = buildAliasHitsCte(params.q);
+    const cte = buildAliasHitsCte(params.q, aliasConfig.minSimilarity);
 
     const branchAProjection = sql`
       ${library_artist_view.id} AS id,
@@ -412,10 +413,16 @@ export async function searchLibrary(
     return dup?.matched_via_alias ? { ...r, matched_via_alias: dup.matched_via_alias } : r;
   });
   const cascadeIds = new Set(cascadeResults.map((r) => r.id));
-  const merged = sortAlbumRows([...enrichedCascade, ...results.filter((r) => !cascadeIds.has(r.id))], params).slice(
-    0,
-    params.limit
-  );
+  // BS#2018 Fix 1, merge half. We reach here only when `totalNonAlias === 0`,
+  // so every row in `results` matched via alias and nothing else — which makes
+  // "not in `cascadeIds`" an exact statement of alias-only over this row set,
+  // with no dependence on which optional hint fields a cascade row happens to
+  // carry.
+  const merged = sortAlbumRows(
+    [...enrichedCascade, ...results.filter((r) => !cascadeIds.has(r.id))],
+    params,
+    (row) => !cascadeIds.has(row.id)
+  ).slice(0, params.limit);
   const added = cascadeResults.filter((r) => !aliasById.has(r.id)).length;
   // Known imprecision, acceptable: this merge only runs on page 0 (the
   // `page !== 0` guard above returns first), so both a count skew and a
@@ -466,33 +473,27 @@ async function runCascade(params: LibraryQueryParams, q: string): Promise<AlbumS
 }
 
 /**
- * In-memory mirror of the SQL `ORDER BY`'s alias tier (BS#2018 Fix 1).
- *
- * A row is alias-only when the ALIAS branch is the ONLY reason it is here:
- * it carries an alias hint and nothing matched it for real. The `matched_via`
- * check is load-bearing — the BS#1885 merge copies `matched_via_alias` onto a
- * cascade row when the two collide on `id`, and that row matched for real, so
- * demoting it would bury the cascade's own answer.
- *
- * Keep this predicate equivalent to the SQL tier `alias_max_sim IS NOT NULL`:
- * SQL rows never carry `matched_via` (only the cascade sets it), and branch
- * (b)'s dedupe guarantees an `alias_max_sim`-bearing row didn't match branch
- * (a). The two agree row-for-row.
- */
-function isAliasOnlyMatch(row: AlbumSearchResultRow): boolean {
-  return row.matched_via_alias !== undefined && row.matched_via === undefined;
-}
-
-/**
  * Sort album rows by the caller's `sort`/`order`, with the same alias tier,
  * secondary tiebreak, and id tiebreak the catalog's primary SQL query uses.
  * Shared by the cascade (whose rows never touch SQL `ORDER BY`) and the
  * alias/cascade merge (BS#1885), which re-sorts a combined row set after
  * `runCascade` and the primary alias rows are spliced together.
+ *
+ * `isAliasOnly` is the in-memory mirror of the SQL tier `alias_max_sim IS NOT
+ * NULL` (BS#2018 Fix 1), and callers pass it explicitly rather than letting
+ * this function infer it from the row's fields. Inference was tried and is
+ * wrong: `matched_via` is set on a Track-2 cascade row only when LML returned
+ * a non-empty hint list, so a real cascade answer can arrive bare, and if it
+ * also collides on `id` with an alias row the BS#1885 merge copies
+ * `matched_via_alias` onto it — making it indistinguishable from noise by
+ * shape alone. Both call sites know exactly which rows came from where, so
+ * they say so. Defaults to "nothing is alias-only", which is correct for the
+ * pure-cascade path.
  */
 function sortAlbumRows(
   rows: AlbumSearchResultRow[],
-  params: Pick<LibraryQueryParams, 'sort' | 'order'>
+  params: Pick<LibraryQueryParams, 'sort' | 'order'>,
+  isAliasOnly: (row: AlbumSearchResultRow) => boolean = () => false
 ): AlbumSearchResultRow[] {
   const direction = params.order === 'asc' ? 1 : -1;
   const primaryKey = SORT_KEYS[params.sort];
@@ -502,7 +503,7 @@ function sortAlbumRows(
     // Tier first, and independent of `order` — `desc` reverses the ranking
     // within each tier, never the tiers themselves. Fuzzy alias noise stays
     // below real matches in both directions.
-    const tier = Number(isAliasOnlyMatch(a)) - Number(isAliasOnlyMatch(b));
+    const tier = Number(isAliasOnly(a)) - Number(isAliasOnly(b));
     if (tier !== 0) return tier;
     const primary = compareSortable(a[primaryKey], b[primaryKey]) * direction;
     if (primary !== 0) return primary;

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1485,7 +1485,7 @@ async function searchLibraryByTrigramBoth(
   n: number,
   on_streaming?: boolean
 ): Promise<TaggedLibraryViewEntry[]> {
-  const aliasEnabled = getCatalogSearchAliasConfig().enabled;
+  const { enabled: aliasEnabled, minSimilarity: aliasMinSimilarity } = getCatalogSearchAliasConfig();
 
   if (!aliasEnabled) {
     // Byte-identical legacy path. The alias-off branch must stay on the
@@ -1520,7 +1520,7 @@ async function searchLibraryByTrigramBoth(
   const streamingClause = on_streaming !== undefined ? sql`AND ${library.on_streaming} = ${on_streaming}` : sql``;
   const trigramPredicate = sql`(${library.artist_name} % ${query} OR ${library.album_title} % ${query})`;
   const rows = (await db.execute(sql`
-    ${buildAliasHitsCte(query)}
+    ${buildAliasHitsCte(query, aliasMinSimilarity)}
     SELECT * FROM (
       (
         SELECT ${LIBRARY_VIEW_PROJECTION_RAW}${ALIAS_HITS_PROJECTION_NULLS}
@@ -2704,7 +2704,7 @@ export async function searchLibraryByTrack(query: string, limit: number): Promis
 export async function searchByArtist(artistName: string, limit = 5): Promise<EnrichedLibraryResult[]> {
   await checkLibraryArtistNameHealth();
 
-  const aliasEnabled = getCatalogSearchAliasConfig().enabled;
+  const { enabled: aliasEnabled, minSimilarity: aliasMinSimilarity } = getCatalogSearchAliasConfig();
 
   if (!aliasEnabled) {
     const rows = (await libraryViewQuery(false)
@@ -2725,7 +2725,7 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
   // expression ORDER BY directly on a UNION result.
   const trigramPredicate = sql`${library.artist_name} % ${artistName}`;
   const rows = (await db.execute(sql`
-    ${buildAliasHitsCte(artistName)}
+    ${buildAliasHitsCte(artistName, aliasMinSimilarity)}
     SELECT * FROM (
       (
         SELECT ${LIBRARY_VIEW_PROJECTION_RAW}${ALIAS_HITS_PROJECTION_NULLS}

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -14,7 +14,6 @@ import {
   NewGenre,
   RotationRelease,
   album_plays,
-  artist_search_alias,
   artists,
   compilation_track_artist,
   genre_artist_crossreference,
@@ -51,6 +50,7 @@ import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrack
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import { isCompilationArtist } from './requestLine/matching/index.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
+import { buildAliasHitsCte } from '../utils/alias-hits.js';
 import { recordCacheLookup, recordCacheEviction, type RegisteredCache } from './observability/cache-stats.js';
 
 // Schema-qualified reference to the `fold_artist_name(text)` SQL function
@@ -1403,33 +1403,6 @@ const LIBRARY_VIEW_PROJECTION_RAW = sql`
   ${library.discogs_unavailable_note} AS discogs_unavailable_note,
   ${library.last_discogs_recheck_at} AS last_discogs_recheck_at
 `;
-
-/**
- * Build the `alias_hits` CTE used by the UNION ALL alias-aware search paths
- * (BS#1318). The CTE runs the trigram bitmap scan over `artist_search_alias`
- * exactly once and groups by `artist_id`, yielding (artist_id, max_sim,
- * matched_variant, matched_source) for every artist whose alias substrate
- * matches `query`. Callers join this CTE on `artist_id` rather than running
- * a correlated LATERAL per candidate row.
- *
- * Replacement for the previous `LEFT JOIN LATERAL` design: the LATERAL was
- * correlated on `asa.artist_id = library.artist_id`, which steered the
- * planner onto the PK btree and filtered `variant % q` row-by-row, never
- * touching the GIN trigram index. The CTE form lets the planner pick the
- * trigram bitmap scan once and hash-join into the outer query.
- */
-function buildAliasHitsCte(query: string) {
-  return sql`WITH alias_hits AS (
-    SELECT
-      asa.artist_id,
-      MAX(similarity(asa.variant, ${query})) AS max_sim,
-      (array_agg(asa.variant ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_variant,
-      (array_agg(asa.source ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_source
-    FROM ${artist_search_alias} asa
-    WHERE asa.variant % ${query}
-    GROUP BY asa.artist_id
-  )`;
-}
 
 /** Projection columns emitted by the alias branch of a UNION ALL search query. */
 const ALIAS_HITS_PROJECTION = sql`,

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { artist_search_alias } from '@wxyc/database';
+import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 
 /**
  * Build the `alias_hits` CTE used by the UNION ALL alias-aware search paths
@@ -15,16 +16,27 @@ import { artist_search_alias } from '@wxyc/database';
  * touching the GIN trigram index. The CTE form lets the planner pick the
  * trigram bitmap scan once and hash-join into the outer query.
  *
+ * BS#2018 adds the `similarity(...) >= minSimilarity` floor. It is a FILTER
+ * layered on top of `%`, deliberately not a replacement: `%` is the operator
+ * the GIN trigram index (`artist_search_alias_variant_trgm_idx`) answers, so
+ * dropping it would cost the bitmap scan BS#1318 exists to preserve. pg_trgm's
+ * own 0.30 threshold is too loose for short variants — because callers join
+ * this CTE on `artist_id`, ONE colliding variant admits an artist's entire
+ * discography — so the floor re-tightens it. See
+ * `apps/backend/config/catalogSearchAlias.ts` for how 0.40 was calibrated.
+ *
  * This lives in `utils/` rather than beside any one caller because all three
  * alias-aware read paths use it (`/library/query` in
  * `library-search.service.ts`, plus Both-mode trigram and request-line
- * `searchByArtist` in `library.service.ts`). One definition is what keeps the
- * match semantics from drifting between them.
+ * `searchByArtist` in `library.service.ts`). Keeping one definition is what
+ * stops the floor and the match semantics from drifting between them — which
+ * is exactly the class of bug BS#2018 was.
  *
  * @param query Raw user query text, matched against `variant` as a single
  *   string (never tokenized).
  */
 export function buildAliasHitsCte(query: string) {
+  const { minSimilarity } = getCatalogSearchAliasConfig();
   return sql`WITH alias_hits AS (
     SELECT
       asa.artist_id,
@@ -32,7 +44,7 @@ export function buildAliasHitsCte(query: string) {
       (array_agg(asa.variant ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_variant,
       (array_agg(asa.source ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_source
     FROM ${artist_search_alias} asa
-    WHERE asa.variant % ${query}
+    WHERE asa.variant % ${query} AND similarity(asa.variant, ${query}) >= ${minSimilarity}
     GROUP BY asa.artist_id
   )`;
 }

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -1,0 +1,38 @@
+import { sql } from 'drizzle-orm';
+import { artist_search_alias } from '@wxyc/database';
+
+/**
+ * Build the `alias_hits` CTE used by the UNION ALL alias-aware search paths
+ * (BS#1318). The CTE runs the trigram bitmap scan over `artist_search_alias`
+ * exactly once and groups by `artist_id`, yielding (artist_id, max_sim,
+ * matched_variant, matched_source) for every artist whose alias substrate
+ * matches `query`. Callers join this CTE on `artist_id` rather than running
+ * a correlated LATERAL per candidate row.
+ *
+ * Replacement for the previous `LEFT JOIN LATERAL` design: the LATERAL was
+ * correlated on `asa.artist_id = library.artist_id`, which steered the
+ * planner onto the PK btree and filtered `variant % q` row-by-row, never
+ * touching the GIN trigram index. The CTE form lets the planner pick the
+ * trigram bitmap scan once and hash-join into the outer query.
+ *
+ * This lives in `utils/` rather than beside any one caller because all three
+ * alias-aware read paths use it (`/library/query` in
+ * `library-search.service.ts`, plus Both-mode trigram and request-line
+ * `searchByArtist` in `library.service.ts`). One definition is what keeps the
+ * match semantics from drifting between them.
+ *
+ * @param query Raw user query text, matched against `variant` as a single
+ *   string (never tokenized).
+ */
+export function buildAliasHitsCte(query: string) {
+  return sql`WITH alias_hits AS (
+    SELECT
+      asa.artist_id,
+      MAX(similarity(asa.variant, ${query})) AS max_sim,
+      (array_agg(asa.variant ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_variant,
+      (array_agg(asa.source ORDER BY similarity(asa.variant, ${query}) DESC))[1] AS matched_source
+    FROM ${artist_search_alias} asa
+    WHERE asa.variant % ${query}
+    GROUP BY asa.artist_id
+  )`;
+}

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -1,6 +1,5 @@
 import { sql } from 'drizzle-orm';
 import { artist_search_alias } from '@wxyc/database';
-import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 
 /**
  * Build the `alias_hits` CTE used by the UNION ALL alias-aware search paths
@@ -32,11 +31,21 @@ import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearc
  * stops the floor and the match semantics from drifting between them — which
  * is exactly the class of bug BS#2018 was.
  *
+ * Note this reads only `variant`. The substrate also carries `active` and
+ * `confidence` per row, and neither has ever gated catalog search — BS#1383
+ * pins that `discogs_member` rows must surface here even though the concerts
+ * resolver filters them. Narrowing on those columns is a product call about
+ * which alias sources the catalog trusts, not a calibration, so it is out of
+ * scope for the BS#2018 floor and left as-is deliberately.
+ *
  * @param query Raw user query text, matched against `variant` as a single
  *   string (never tokenized).
+ * @param minSimilarity The BS#2018 floor. Passed in rather than read from
+ *   config here so this stays pure, and so `searchLibrary`'s documented
+ *   read-the-config-once-per-request invariant is not quietly broken by a
+ *   helper in another file.
  */
-export function buildAliasHitsCte(query: string) {
-  const { minSimilarity } = getCatalogSearchAliasConfig();
+export function buildAliasHitsCte(query: string, minSimilarity: number) {
   return sql`WITH alias_hits AS (
     SELECT
       asa.artist_id,

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -288,6 +288,19 @@ Feature flags for the fallback cascade in `searchLibrary` (`apps/backend/service
 
 Strict-`true` gating: only the literal string `'true'` enables a layer. Any other value (including `1`, `TRUE`, missing) reads as `false`.
 
+### Alias-aware catalog search
+
+Widens the three trigram read paths (`/library/query`, Both-mode trigram, request-line `searchByArtist`) with a CTE over `artist_search_alias`, so a query for a Discogs name variation, alias, or group member finds the canonical artist. Loaded by `apps/backend/config/catalogSearchAlias.ts`; the shared CTE builder is `apps/backend/utils/alias-hits.ts`. Plan: `Backend-Service/plans/artist-search-alias.md` §PR 5.
+
+- `CATALOG_SEARCH_ALIAS_ENABLED` (default `false`) — the gate. Strict-`true`, same as the cascade flags above. **ON in production** and in `dev_env/docker-compose.yml`.
+- `CATALOG_SEARCH_ALIAS_MIN_SIMILARITY` (default `0.4`) — minimum `similarity(variant, q)` for an alias row to count as a match (BS#2018).
+
+The floor is applied as a filter **on top of** pg_trgm's `%` operator, which stays because it is what the GIN index answers. Consequence: this knob can only tighten alias matching, never loosen it — a value at or below pg_trgm's own `similarity_threshold` (0.30) is accepted but has no effect, and logs a warning saying so.
+
+It exists as an env var so the calibration can be backed out mid-incident without a deploy. Anything that is not a number in `[0, 1]` falls back to `0.4` and warns — including `40`, which reads like a percentage but is not one.
+
+Why 0.4: pg_trgm's 0.30 is far too permissive for short variants. The misprint `Monore` (one of Bill Monroe's 42 Discogs name variations) scores 0.333 against `monolake`, and because the alias branch joins on `artist_id`, that one row put all 14 Bill Monroe albums into a Monolake search. 0.4 was measured to exclude every known collision while keeping every known real match — the tightest of which (`oh sees` → `Osees`) sits at _exactly_ 0.400, so do not round it up. The full measurement table is pinned in `tests/unit/config/catalog-search-alias-config.test.ts`, which fails if the default moves out from between the two groups.
+
 ## Slack
 
 - `SLACK_WXYC_REQUESTS_APP_ID`, `SLACK_WXYC_REQUESTS_CLIENT_ID`

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -297,32 +297,61 @@ describe('GET /library/query — alias-only primary no longer suppresses the cas
  * interleaved with the 6 real hits by album title.
  *
  * This suite runs against real pg_trgm — the numbers are the point, and a
- * mocked DB can't produce them. It seeds the exact production shape:
+ * mocked DB can't produce them. It seeds three artists:
  *
- *   - NOISE artist with two albums and one alias variant 'Monore'
- *   - REAL artist whose canonical name IS the query
+ *   - NOISE ('Bill Monroe'), two albums, alias variant 'Monore'. Similarity
+ *     0.333 against the query: admitted by `%`, rejected by the floor.
+ *   - REAL ('Monolake'), whose canonical name IS the query, so it matches on
+ *     branch (a) with no alias involvement at all.
+ *   - CONTROL ('Gerhard Behles'), a `discogs_member` variant of exactly the
+ *     query string. Similarity 1.0, so it clears any floor, and its canonical
+ *     name doesn't ILIKE-match, so it can ONLY arrive via branch (b).
  *
- * and asserts both halves of the fix:
- *
- *   - Fix 2: at the shipped 0.40 floor the noise artist is absent entirely
- *   - Fix 1: with the floor pushed back to pg_trgm's 0.30 (via a query the
- *     test issues directly, since the backend's floor is process-level), the
- *     noise rows are still admitted by `%` — proving the collision is real and
- *     that Fix 2, not a fixture accident, is what removes them
+ * The CONTROL row is what makes these assertions mean anything. `Monolake`
+ * ILIKE-matches `monolake` on the plain legacy path, so keying a skip-guard on
+ * the REAL row would pass identically with the alias feature switched off —
+ * the Fix-2 assertion (`no noise rows`) would then be vacuously true, and the
+ * Fix-1 assertion would hard-fail with a misleading message. CONTROL cannot
+ * appear unless the alias branch actually executed, so `requireAliasActive`
+ * keys on it and fails fast with an explanation, matching the BS#1383 test
+ * above rather than the warn-skip pattern (which is only appropriate where the
+ * missing signal is a *different* feature flag's).
  */
+const BS2018 = {
+  NOISE_ARTIST_ID: 9201,
+  NOISE_LIBRARY_IDS: [9201, 9202],
+  REAL_ARTIST_ID: 9203,
+  REAL_LIBRARY_ID: 9203,
+  CONTROL_ARTIST_ID: 9204,
+  CONTROL_LIBRARY_ID: 9204,
+  // The real production variant string. similarity('Monore', 'monolake') is
+  // 0.3333 — above pg_trgm's 0.30, below the 0.40 floor.
+  COLLIDING_VARIANT: 'Monore',
+  QUERY: 'monolake',
+};
+
 describe('GET /library/query — fuzzy alias hits no longer flood results (BS#2018)', () => {
   let auth;
   let sql;
   const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+  const { NOISE_ARTIST_ID, NOISE_LIBRARY_IDS, REAL_ARTIST_ID, REAL_LIBRARY_ID } = BS2018;
+  const { CONTROL_ARTIST_ID, CONTROL_LIBRARY_ID, COLLIDING_VARIANT, QUERY } = BS2018;
 
-  const NOISE_ARTIST_ID = 9201;
-  const NOISE_LIBRARY_IDS = [9201, 9202];
-  const REAL_ARTIST_ID = 9203;
-  const REAL_LIBRARY_ID = 9203;
-  // The real production variant string. similarity('Monore', 'monolake') is
-  // 0.3333 — above pg_trgm's 0.30, below the 0.40 floor.
-  const COLLIDING_VARIANT = 'Monore';
-  const QUERY = 'monolake';
+  /**
+   * Assert the alias branch ran at all, by requiring the row that only it can
+   * produce. Throws rather than warn-skipping: every assertion in this suite
+   * is about alias behavior, so a silent pass with the feature off would be a
+   * green run that proves nothing.
+   */
+  function requireAliasActive(results) {
+    if (results.some((r) => r.id === CONTROL_LIBRARY_ID)) return;
+    throw new Error(
+      `[BS#2018] The control row (library id ${CONTROL_LIBRARY_ID}, reachable ONLY through the alias ` +
+        'branch) is absent, so nothing in this suite is being exercised. Almost certainly the backend is ' +
+        'running without CATALOG_SEARCH_ALIAS_ENABLED=true — set it on the backend service in ' +
+        'dev_env/docker-compose.yml, or in .env for local `npm run dev`.'
+    );
+  }
 
   beforeAll(async () => {
     auth = createAuthRequest(request, global.access_token);
@@ -331,26 +360,30 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
 
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
-       VALUES ($1, 'Bill Monroe', 'Monroe, Bill', 'MO'), ($2, 'Monolake', 'Monolake', 'MO')
+       VALUES ($1, 'Bill Monroe', 'Monroe, Bill', 'MO'),
+              ($2, 'Monolake', 'Monolake', 'MO'),
+              ($3, 'Gerhard Behles', 'Behles, Gerhard', 'BE')
        ON CONFLICT (id) DO NOTHING`,
-      [NOISE_ARTIST_ID, REAL_ARTIST_ID]
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID]
     );
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-       VALUES ($1, $3, 9201), ($2, $3, 9203)
+       VALUES ($1, $4, 9201), ($2, $4, 9203), ($3, $4, 9204)
        ON CONFLICT (artist_id, genre_id) DO NOTHING`,
-      [NOISE_ARTIST_ID, REAL_ARTIST_ID, TEST_GENRE_ID]
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID, TEST_GENRE_ID]
     );
-    // Album titles chosen to sort BEFORE the real hit on the default
-    // artist-name sort, so a regression re-floods the top of the page rather
-    // than the tail — the failure is then visible in `results[0]`.
+    // Both alias-reachable artists sort BEFORE 'Monolake' on the default
+    // artist-name ASC ('Bill Monroe' < 'Gerhard Behles' < 'Monolake'), so a
+    // regression in either fix re-floods the TOP of the page. The failure is
+    // then visible in results[0] rather than buried in the tail.
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.library
          (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
        VALUES
-         ($1, $3, $6, $7, 'Bluegrass Ramble', 1, 'Bill Monroe', 'Decca', NULL, 65920),
-         ($2, $3, $6, $7, 'Blue Moon of Kentucky', 2, 'Bill Monroe', 'Decca', NULL, 65921),
-         ($4, $5, $6, $7, 'Gravity', 1, 'Monolake', 'Imbalance Computer Music', NULL, 65922)
+         ($1, $3, $8, $9, 'Bluegrass Ramble', 1, 'Bill Monroe', 'Decca', NULL, 65920),
+         ($2, $3, $8, $9, 'Blue Moon of Kentucky', 2, 'Bill Monroe', 'Decca', NULL, 65921),
+         ($4, $5, $8, $9, 'Gravity', 1, 'Monolake', 'Imbalance Computer Music', NULL, 65922),
+         ($6, $7, $8, $9, 'Layering Buddha', 1, 'Gerhard Behles', 'Imbalance Computer Music', NULL, 65923)
        ON CONFLICT (id) DO NOTHING`,
       [
         NOISE_LIBRARY_IDS[0],
@@ -358,6 +391,8 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
         NOISE_ARTIST_ID,
         REAL_LIBRARY_ID,
         REAL_ARTIST_ID,
+        CONTROL_LIBRARY_ID,
+        CONTROL_ARTIST_ID,
         TEST_GENRE_ID,
         TEST_FORMAT_ID,
       ]
@@ -366,9 +401,10 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
       `INSERT INTO ${wxycSchema}.artist_search_alias
          (artist_id, source, variant, related_artist_id, external_subject_id,
           external_object_id, active, method, confidence, last_verified_at)
-       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW()),
+              ($3, 'discogs_member', $4, NULL, NULL, NULL, NULL, 'member_group', 0.9, NOW())
        ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
-      [NOISE_ARTIST_ID, COLLIDING_VARIANT]
+      [NOISE_ARTIST_ID, COLLIDING_VARIANT, CONTROL_ARTIST_ID, QUERY]
     );
   });
 
@@ -388,75 +424,43 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
     expect(Number(row.sim)).toBeLessThan(0.4);
   });
 
-  test('Fix 2: the query returns the real artist and NO rows from the colliding artist', async () => {
+  test('Fix 2: the sub-floor collision contributes no rows, while a real alias hit still does', async () => {
     const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+    requireAliasActive(res.body.results);
 
-    const realHit = res.body.results.find((r) => r.id === REAL_LIBRARY_ID);
-    if (realHit === undefined) {
-      // Warn-skip mirrors the sibling suites: an empty result set here means
-      // the backend is running without the alias flag, not a regression.
-      console.warn(
-        '[BS#2018] /library/query returned no row for the canonical "Monolake" artist. Likely the ' +
-          'backend is running without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart.'
-      );
-      return;
-    }
-
-    const noiseHits = res.body.results.filter((r) => NOISE_LIBRARY_IDS.includes(r.id));
-    expect(noiseHits).toEqual([]);
+    // The canonical artist is here on its own merits (branch a)...
+    expect(res.body.results.some((r) => r.id === REAL_LIBRARY_ID)).toBe(true);
+    // ...the 1.0-similarity member variant is here via the alias branch...
+    const control = res.body.results.find((r) => r.id === CONTROL_LIBRARY_ID);
+    expect(control.matched_via_alias).toEqual([{ matched_variant: QUERY, source: 'discogs_member' }]);
+    // ...and the 0.333 collision brought in none of its artist's discography.
+    expect(res.body.results.filter((r) => NOISE_LIBRARY_IDS.includes(r.id))).toEqual([]);
   });
 
-  test('Fix 1: any alias-only row that survives the floor sorts after every real match', async () => {
-    // Exact-variant seed: similarity 1.0, so it clears the floor no matter how
-    // the floor is tuned. Its artist name ('Bill Monroe') sorts before
-    // 'Monolake' on the default artist ASC, so pre-Fix-1 it led the page.
-    // This is the only way to observe the tier once Fix 2 hides the 0.333
-    // collision — the AC in BS#2018 that Fix 2 would otherwise mask.
-    await sql.unsafe(
-      `INSERT INTO ${wxycSchema}.artist_search_alias
-         (artist_id, source, variant, related_artist_id, external_subject_id,
-          external_object_id, active, method, confidence, last_verified_at)
-       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
-       ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
-      [NOISE_ARTIST_ID, QUERY]
-    );
+  test('Fix 1: an alias-only row that clears the floor still sorts after every real match', async () => {
+    const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+    requireAliasActive(res.body.results);
 
-    try {
-      const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
-
-      const realIndex = res.body.results.findIndex((r) => r.id === REAL_LIBRARY_ID);
-      if (realIndex === -1) {
-        console.warn(
-          '[BS#2018] /library/query returned no row for the canonical "Monolake" artist. Likely the ' +
-            'backend is running without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart.'
-        );
-        return;
-      }
-
-      const aliasIndexes = res.body.results
-        .map((r, i) => (NOISE_LIBRARY_IDS.includes(r.id) ? i : -1))
-        .filter((i) => i !== -1);
-      // The alias rows must be present (the exact variant matched) AND every
-      // one of them must sit below the real hit.
-      expect(aliasIndexes.length).toBe(NOISE_LIBRARY_IDS.length);
-      aliasIndexes.forEach((i) => expect(i).toBeGreaterThan(realIndex));
-      res.body.results
-        .filter((r) => NOISE_LIBRARY_IDS.includes(r.id))
-        .forEach((r) => expect(r.matched_via_alias).toBeDefined());
-    } finally {
-      await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1 AND variant = $2`, [
-        NOISE_ARTIST_ID,
-        QUERY,
-      ]);
-    }
+    const realIndex = res.body.results.findIndex((r) => r.id === REAL_LIBRARY_ID);
+    const controlIndex = res.body.results.findIndex((r) => r.id === CONTROL_LIBRARY_ID);
+    // 'Gerhard Behles' sorts before 'Monolake' by name, so this ordering can
+    // only hold if the alias tier — not the caller's sort — decides it.
+    expect(realIndex).toBeGreaterThanOrEqual(0);
+    expect(controlIndex).toBeGreaterThan(realIndex);
   });
 });
 
 async function cleanupBs2018Rows(sql, wxycSchema) {
-  await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id IN (9201, 9203)`);
-  await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id IN (9201, 9202, 9203)`);
-  await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id IN (9201, 9203)`);
-  await sql.unsafe(`DELETE FROM ${wxycSchema}.artists WHERE id IN (9201, 9203)`);
+  const artistIds = [BS2018.NOISE_ARTIST_ID, BS2018.REAL_ARTIST_ID, BS2018.CONTROL_ARTIST_ID];
+  const libraryIds = [...BS2018.NOISE_LIBRARY_IDS, BS2018.REAL_LIBRARY_ID, BS2018.CONTROL_LIBRARY_ID];
+  // Delete in FK-safe order, driven by the same constants the seeds use so a
+  // renumbered fixture can't silently leave rows behind for the next run.
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = ANY($1::int[])`, [artistIds]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id = ANY($1::int[])`, [libraryIds]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id = ANY($1::int[])`, [
+    artistIds,
+  ]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artists WHERE id = ANY($1::int[])`, [artistIds]);
 }
 
 async function cleanupBs1885Rows(sql, wxycSchema) {

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -284,6 +284,181 @@ describe('GET /library/query — alias-only primary no longer suppresses the cas
   });
 });
 
+/**
+ * GET /library/query — fuzzy alias hits no longer flood the result set
+ * (BS#2018).
+ *
+ * The alias branch INNER JOINs on `artist_id`, so a SINGLE colliding variant
+ * admits its artist's entire discography. pg_trgm's default `%` threshold of
+ * 0.30 is loose enough for that to happen on unrelated strings: the misprint
+ * "Monore" (one of Discogs artist 450691's 42 `namevariations`) scores 0.333
+ * against "monolake", which put all 14 Bill Monroe albums into a search for
+ * Monolake. `alias_max_sim` was projected but never ordered on, so the noise
+ * interleaved with the 6 real hits by album title.
+ *
+ * This suite runs against real pg_trgm — the numbers are the point, and a
+ * mocked DB can't produce them. It seeds the exact production shape:
+ *
+ *   - NOISE artist with two albums and one alias variant 'Monore'
+ *   - REAL artist whose canonical name IS the query
+ *
+ * and asserts both halves of the fix:
+ *
+ *   - Fix 2: at the shipped 0.40 floor the noise artist is absent entirely
+ *   - Fix 1: with the floor pushed back to pg_trgm's 0.30 (via a query the
+ *     test issues directly, since the backend's floor is process-level), the
+ *     noise rows are still admitted by `%` — proving the collision is real and
+ *     that Fix 2, not a fixture accident, is what removes them
+ */
+describe('GET /library/query — fuzzy alias hits no longer flood results (BS#2018)', () => {
+  let auth;
+  let sql;
+  const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+  const NOISE_ARTIST_ID = 9201;
+  const NOISE_LIBRARY_IDS = [9201, 9202];
+  const REAL_ARTIST_ID = 9203;
+  const REAL_LIBRARY_ID = 9203;
+  // The real production variant string. similarity('Monore', 'monolake') is
+  // 0.3333 — above pg_trgm's 0.30, below the 0.40 floor.
+  const COLLIDING_VARIANT = 'Monore';
+  const QUERY = 'monolake';
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+    await cleanupBs2018Rows(sql, wxycSchema);
+
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
+       VALUES ($1, 'Bill Monroe', 'Monroe, Bill', 'MO'), ($2, 'Monolake', 'Monolake', 'MO')
+       ON CONFLICT (id) DO NOTHING`,
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID]
+    );
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+       VALUES ($1, $3, 9201), ($2, $3, 9203)
+       ON CONFLICT (artist_id, genre_id) DO NOTHING`,
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, TEST_GENRE_ID]
+    );
+    // Album titles chosen to sort BEFORE the real hit on the default
+    // artist-name sort, so a regression re-floods the top of the page rather
+    // than the tail — the failure is then visible in `results[0]`.
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
+       VALUES
+         ($1, $3, $6, $7, 'Bluegrass Ramble', 1, 'Bill Monroe', 'Decca', NULL, 65920),
+         ($2, $3, $6, $7, 'Blue Moon of Kentucky', 2, 'Bill Monroe', 'Decca', NULL, 65921),
+         ($4, $5, $6, $7, 'Gravity', 1, 'Monolake', 'Imbalance Computer Music', NULL, 65922)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        NOISE_LIBRARY_IDS[0],
+        NOISE_LIBRARY_IDS[1],
+        NOISE_ARTIST_ID,
+        REAL_LIBRARY_ID,
+        REAL_ARTIST_ID,
+        TEST_GENRE_ID,
+        TEST_FORMAT_ID,
+      ]
+    );
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artist_search_alias
+         (artist_id, source, variant, related_artist_id, external_subject_id,
+          external_object_id, active, method, confidence, last_verified_at)
+       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+       ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
+      [NOISE_ARTIST_ID, COLLIDING_VARIANT]
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupBs2018Rows(sql, wxycSchema);
+  });
+
+  test('the collision is real: pg_trgm admits the variant, the floor rejects it', async () => {
+    // Pins the two numbers the whole fix is calibrated against. If pg_trgm's
+    // scoring ever changes, this fails FIRST and explains why the rest did.
+    const [row] = await sql.unsafe(
+      `SELECT similarity($1::text, $2::text) AS sim, ($1::text % $2::text) AS passes_pg_trgm`,
+      [COLLIDING_VARIANT, QUERY]
+    );
+    expect(row.passes_pg_trgm).toBe(true);
+    expect(Number(row.sim)).toBeGreaterThanOrEqual(0.3);
+    expect(Number(row.sim)).toBeLessThan(0.4);
+  });
+
+  test('Fix 2: the query returns the real artist and NO rows from the colliding artist', async () => {
+    const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+
+    const realHit = res.body.results.find((r) => r.id === REAL_LIBRARY_ID);
+    if (realHit === undefined) {
+      // Warn-skip mirrors the sibling suites: an empty result set here means
+      // the backend is running without the alias flag, not a regression.
+      console.warn(
+        '[BS#2018] /library/query returned no row for the canonical "Monolake" artist. Likely the ' +
+          'backend is running without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart.'
+      );
+      return;
+    }
+
+    const noiseHits = res.body.results.filter((r) => NOISE_LIBRARY_IDS.includes(r.id));
+    expect(noiseHits).toEqual([]);
+  });
+
+  test('Fix 1: any alias-only row that survives the floor sorts after every real match', async () => {
+    // Exact-variant seed: similarity 1.0, so it clears the floor no matter how
+    // the floor is tuned. Its artist name ('Bill Monroe') sorts before
+    // 'Monolake' on the default artist ASC, so pre-Fix-1 it led the page.
+    // This is the only way to observe the tier once Fix 2 hides the 0.333
+    // collision — the AC in BS#2018 that Fix 2 would otherwise mask.
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artist_search_alias
+         (artist_id, source, variant, related_artist_id, external_subject_id,
+          external_object_id, active, method, confidence, last_verified_at)
+       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+       ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
+      [NOISE_ARTIST_ID, QUERY]
+    );
+
+    try {
+      const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+
+      const realIndex = res.body.results.findIndex((r) => r.id === REAL_LIBRARY_ID);
+      if (realIndex === -1) {
+        console.warn(
+          '[BS#2018] /library/query returned no row for the canonical "Monolake" artist. Likely the ' +
+            'backend is running without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart.'
+        );
+        return;
+      }
+
+      const aliasIndexes = res.body.results
+        .map((r, i) => (NOISE_LIBRARY_IDS.includes(r.id) ? i : -1))
+        .filter((i) => i !== -1);
+      // The alias rows must be present (the exact variant matched) AND every
+      // one of them must sit below the real hit.
+      expect(aliasIndexes.length).toBe(NOISE_LIBRARY_IDS.length);
+      aliasIndexes.forEach((i) => expect(i).toBeGreaterThan(realIndex));
+      res.body.results
+        .filter((r) => NOISE_LIBRARY_IDS.includes(r.id))
+        .forEach((r) => expect(r.matched_via_alias).toBeDefined());
+    } finally {
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1 AND variant = $2`, [
+        NOISE_ARTIST_ID,
+        QUERY,
+      ]);
+    }
+  });
+});
+
+async function cleanupBs2018Rows(sql, wxycSchema) {
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id IN (9201, 9203)`);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id IN (9201, 9202, 9203)`);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id IN (9201, 9203)`);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artists WHERE id IN (9201, 9203)`);
+}
+
 async function cleanupBs1885Rows(sql, wxycSchema) {
   await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id IN (9101, 9102)`);
   await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id IN (9101, 9102)`);

--- a/tests/unit/config/catalog-search-alias-config.test.ts
+++ b/tests/unit/config/catalog-search-alias-config.test.ts
@@ -61,11 +61,17 @@ const MEASURED_TRUE_POSITIVES = [
 describe('catalogSearchAlias config', () => {
   const originalEnabled = process.env.CATALOG_SEARCH_ALIAS_ENABLED;
   const originalFloor = process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
     delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
     resetConfig();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
   });
 
   afterAll(() => {
@@ -128,6 +134,32 @@ describe('catalogSearchAlias config', () => {
         expect(loadConfig().minSimilarity).toBe(DEFAULT_ALIAS_MIN_SIMILARITY);
       }
     );
+
+    // The knob's whole purpose is a mid-incident backout. A typo that leaves
+    // the shipped default silently in place reads to the operator as "the
+    // floor wasn't the cause" — so every rejected override says so out loud.
+    it.each(['abc', '40', '-0.1', '1.5'])('warns that the override %p was rejected', (value) => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = value;
+      loadConfig();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('CATALOG_SEARCH_ALIAS_MIN_SIMILARITY');
+      expect(warnSpy.mock.calls[0][0]).toContain('not a percentage');
+    });
+
+    it('warns that a below-pg_trgm-threshold override is a no-op', () => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.1';
+      // Parsed and honored — it just cannot do anything, because `%` still
+      // rejects everything under pg_trgm's own threshold.
+      expect(loadConfig().minSimilarity).toBe(0.1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('no effect');
+    });
+
+    it('does not warn on a usable override', () => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.45';
+      expect(loadConfig().minSimilarity).toBe(0.45);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
 
     it('caches minSimilarity on the same singleton as enabled', () => {
       process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.5';

--- a/tests/unit/config/catalog-search-alias-config.test.ts
+++ b/tests/unit/config/catalog-search-alias-config.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the catalog-search-alias config (BS#2018).
+ *
+ * Two properties under test:
+ *
+ *   1. `enabled` keeps the strict `=== 'true'` contract it had when this
+ *      config was a bare `createEnvFlagConfig` flag. Widening the catalog
+ *      search path must not happen on `=1`/`TRUE`/`yes`.
+ *   2. `minSimilarity` — the BS#2018 trigram floor applied to
+ *      `artist_search_alias.variant` matches, on top of pg_trgm's `%`
+ *      operator (which is itself pinned at the 0.30 session default).
+ *
+ * The `MEASURED_*` tables below are the load-bearing part. They are real
+ * `similarity()` readings taken against PostgreSQL 18 / pg_trgm on the
+ * prod-shaped alias substrate; the default floor has to sit strictly between
+ * them. A future tuning pass that moves `DEFAULT_ALIAS_MIN_SIMILARITY`
+ * without re-measuring will fail here rather than silently resurrect the
+ * `q=monolake` -> "Bill Monroe" flood, or silently drop `Osees`.
+ */
+import {
+  getConfig,
+  loadConfig,
+  resetConfig,
+  DEFAULT_ALIAS_MIN_SIMILARITY,
+  PG_TRGM_DEFAULT_THRESHOLD,
+} from '../../../apps/backend/config/catalogSearchAlias';
+
+/**
+ * Alias variants that trigram-collide with an unrelated query at pg_trgm's
+ * default 0.30 threshold. Every one of these is a real production false
+ * positive found in the BS#2018 investigation — each admits its artist's
+ * ENTIRE discography into the result set via the branch-(b) INNER JOIN.
+ */
+const MEASURED_FALSE_POSITIVES = [
+  // Discogs artist 450691 (Bill Monroe) carries the misprint "Monore" among
+  // its 42 `namevariations`. This is the screenshot in BS#2018.
+  { variant: 'Monore', query: 'monolake', similarity: 0.33333 },
+  // Same artist, same shape, different query: "William Parker" is a real
+  // WXYC jazz artist whose catalog search returns Bill Monroe today.
+  { variant: 'William Monroe', query: 'William Parker', similarity: 0.36364 },
+  { variant: 'Monroe, William', query: 'William Parker', similarity: 0.36364 },
+] as const;
+
+/**
+ * Alias variants that MUST keep matching — the cases the alias substrate
+ * exists to serve (BS#1273 / BS#1318). Note `oh sees` sits exactly ON the
+ * default floor: raising the floor past 0.40 drops it.
+ */
+const MEASURED_TRUE_POSITIVES = [
+  { variant: 'oh sees', query: 'Osees', similarity: 0.4 },
+  { variant: 'Thee Oh Sees', query: 'theeohsees', similarity: 0.41176 },
+  { variant: 'Stereolab', query: 'stereolb', similarity: 0.58333 },
+  // Diacritic folds — the three Unicode-bearing names in wxyc-shared's
+  // canonical artist pool.
+  { variant: 'Nilufer Yanya', query: 'Nilüfer Yanya', similarity: 0.64706 },
+  { variant: 'Csillagrablok', query: 'Csillagrablók', similarity: 0.64706 },
+  { variant: 'Hermanos Gutierrez', query: 'Hermanos Gutiérrez', similarity: 0.72727 },
+  { variant: 'Robert Henke', query: 'robert henke', similarity: 1.0 },
+] as const;
+
+describe('catalogSearchAlias config', () => {
+  const originalEnabled = process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+  const originalFloor = process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+
+  beforeEach(() => {
+    delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+    resetConfig();
+  });
+
+  afterAll(() => {
+    if (originalEnabled === undefined) delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    else process.env.CATALOG_SEARCH_ALIAS_ENABLED = originalEnabled;
+    if (originalFloor === undefined) delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+    else process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = originalFloor;
+    resetConfig();
+  });
+
+  describe('enabled (unchanged strict-true contract)', () => {
+    it('defaults to disabled when the env var is unset', () => {
+      expect(loadConfig().enabled).toBe(false);
+    });
+
+    it('enables only on the exact string "true"', () => {
+      process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+      expect(loadConfig().enabled).toBe(true);
+    });
+
+    it.each(['1', 'TRUE', 'yes', 'on', ''])('does not enable on non-canonical value %p', (value) => {
+      process.env.CATALOG_SEARCH_ALIAS_ENABLED = value;
+      expect(loadConfig().enabled).toBe(false);
+    });
+
+    it('caches the singleton until resetConfig() is called', () => {
+      process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+      expect(getConfig().enabled).toBe(true);
+      delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+      expect(getConfig().enabled).toBe(true);
+      resetConfig();
+      expect(getConfig().enabled).toBe(false);
+    });
+  });
+
+  describe('minSimilarity (BS#2018 alias trigram floor)', () => {
+    it('defaults to DEFAULT_ALIAS_MIN_SIMILARITY when unset', () => {
+      expect(loadConfig().minSimilarity).toBe(DEFAULT_ALIAS_MIN_SIMILARITY);
+      expect(DEFAULT_ALIAS_MIN_SIMILARITY).toBe(0.4);
+    });
+
+    it('reads a valid override', () => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.35';
+      expect(loadConfig().minSimilarity).toBe(0.35);
+    });
+
+    it('accepts the pg_trgm default, which reverts to pre-BS#2018 behavior', () => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = String(PG_TRGM_DEFAULT_THRESHOLD);
+      expect(loadConfig().minSimilarity).toBe(0.3);
+    });
+
+    // A malformed value must fall back to the default rather than clamp.
+    // Clamping `40` (a plausible "percent" typo) to 1.0 would match nothing
+    // and silently kill the whole alias feature; falling back keeps the
+    // shipped calibration.
+    it.each(['', '   ', 'abc', 'NaN', '40', '-0.1', '1.5', 'Infinity'])(
+      'falls back to the default on unusable value %p',
+      (value) => {
+        process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = value;
+        expect(loadConfig().minSimilarity).toBe(DEFAULT_ALIAS_MIN_SIMILARITY);
+      }
+    );
+
+    it('caches minSimilarity on the same singleton as enabled', () => {
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.5';
+      expect(getConfig().minSimilarity).toBe(0.5);
+      process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.9';
+      expect(getConfig().minSimilarity).toBe(0.5);
+      resetConfig();
+      expect(getConfig().minSimilarity).toBe(0.9);
+    });
+  });
+
+  describe('calibration guard — the default floor separates measured noise from measured signal', () => {
+    it.each(MEASURED_FALSE_POSITIVES)(
+      'excludes the $variant -> $query collision (similarity $similarity)',
+      ({ similarity }) => {
+        // pg_trgm's `%` lets these through today; the floor is what stops them.
+        expect(similarity).toBeGreaterThanOrEqual(PG_TRGM_DEFAULT_THRESHOLD);
+        expect(similarity).toBeLessThan(DEFAULT_ALIAS_MIN_SIMILARITY);
+      }
+    );
+
+    it.each(MEASURED_TRUE_POSITIVES)(
+      'still admits the $variant -> $query match (similarity $similarity)',
+      ({ similarity }) => {
+        expect(similarity).toBeGreaterThanOrEqual(DEFAULT_ALIAS_MIN_SIMILARITY);
+      }
+    );
+
+    it("cannot be loosened below pg_trgm's own threshold in effect", () => {
+      // Documenting an intentional asymmetry: the `%` predicate stays in the
+      // query (it is what drives the GIN index), so setting the env var below
+      // 0.30 cannot widen matching — pg_trgm still floors at its session
+      // threshold. The knob can only tighten.
+      expect(DEFAULT_ALIAS_MIN_SIMILARITY).toBeGreaterThanOrEqual(PG_TRGM_DEFAULT_THRESHOLD);
+    });
+  });
+});

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -44,7 +44,11 @@ import {
   searchByArtist,
   __resetTrackSearchCacheForTests,
 } from '../../../apps/backend/services/library.service';
-import { searchLibrary as searchCatalogQuery } from '../../../apps/backend/services/library-search.service';
+import {
+  searchLibrary as searchCatalogQuery,
+  type CatalogSort,
+  type CatalogOrder,
+} from '../../../apps/backend/services/library-search.service';
 import { resetConfig as resetCatalogSearchAliasConfig } from '../../../apps/backend/config/catalogSearchAlias';
 import { resetConfig as resetCatalogTrackSearchConfig } from '../../../apps/backend/config/catalogTrackSearch';
 
@@ -74,6 +78,34 @@ const baseViewRow = {
   apple_music_artist_id: null,
   bandcamp_id: null,
 };
+
+/**
+ * Flatten the `tests/__mocks__/drizzle-orm.ts` stand-in for a Drizzle `SQL`
+ * object into readable text with its interpolated values inlined, so an
+ * assertion can read like the SQL it pins (`similarity(asa.variant, monolake)
+ * >= 0.4`) instead of like a JSON blob.
+ *
+ * The mocked `sql` tag returns `{ sql: TemplateStringsArray, values }`, and a
+ * nested `sql` fragment shows up as one of those `values` — so rendering is
+ * "interleave the literals with the recursively-rendered values". Columns come
+ * from the mocked `@wxyc/database`, whose tables are plain string maps, so an
+ * unmapped column renders as `undefined`; that's harmless here because every
+ * assertion below targets literal SQL text or an unqualified sort alias.
+ */
+function renderSqlWithParams(node: unknown): string {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') return String(node);
+  const literals = (node as { sql?: unknown }).sql;
+  if (Array.isArray(literals)) {
+    const values = (node as { values?: unknown[] }).values ?? [];
+    return literals
+      .map((text, i) => `${String(text)}${i < values.length ? renderSqlWithParams(values[i]) : ''}`)
+      .join('');
+  }
+  const raw = (node as { raw?: unknown }).raw;
+  if (typeof raw === 'string') return raw;
+  return JSON.stringify(node) ?? '';
+}
 
 describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
   const originalFlag = process.env.CATALOG_SEARCH_ALIAS_ENABLED;
@@ -777,6 +809,118 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       expect(renderedCount).not.toContain('alias_hit ON true');
       expect(renderedData).not.toContain('LEFT JOIN LATERAL');
       expect(renderedCount).not.toContain('LEFT JOIN LATERAL');
+    });
+
+    // ---------------------------------------------------------------------
+    // BS#2018 — alias-branch fuzzy hits flooded the result set.
+    //
+    // `q=monolake` returned all 14 Bill Monroe albums ahead of the 6 Monolake
+    // ones, because (1) Discogs artist 450691 carries the misprint variant
+    // "Monore", which clears pg_trgm's 0.30 `%` threshold against "monolake"
+    // by 0.03, and (2) `alias_max_sim` was projected but never used in ORDER
+    // BY, so a 0.333 typo-collision sorted identically to an exact hit.
+    //
+    // Fix 1 tiers the sort (alias-only rows always after non-alias rows).
+    // Fix 2 raises the alias match floor to 0.40.
+    // ---------------------------------------------------------------------
+    describe('BS#2018 alias-noise floor + rank tiering', () => {
+      const ALIAS_ONLY_TIER = '(alias_max_sim IS NOT NULL) ASC';
+
+      function runAliasQuery(
+        params: { sort?: CatalogSort; order?: CatalogOrder } = {}
+      ): Promise<{ data: string; count: string }> {
+        stubGenreFormatLookups();
+        db.execute.mockReset();
+        db.execute.mockResolvedValueOnce([baseQueryRow]).mockResolvedValueOnce([{ total: 1, total_non_alias: 1 }]);
+        return searchCatalogQuery({ ...baseQueryParams, ...params }).then(() => ({
+          data: renderSqlWithParams(db.execute.mock.calls[0]?.[0]),
+          count: renderSqlWithParams(db.execute.mock.calls[1]?.[0]),
+        }));
+      }
+
+      beforeEach(() => {
+        process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+        delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+        resetCatalogSearchAliasConfig();
+      });
+
+      afterAll(() => {
+        delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+        resetCatalogSearchAliasConfig();
+      });
+
+      it('Fix 2: the alias CTE post-filters on similarity >= the configured floor', async () => {
+        const { data, count } = await runAliasQuery();
+
+        // The `%` predicate stays — it is what drives the GIN trigram index
+        // (`artist_search_alias_variant_trgm_idx`). The floor rides on top of
+        // it as a filter, so the index scan is unchanged (BS#1318).
+        expect(data).toContain('asa.variant % Thee Oh Sees');
+        expect(data).toContain('similarity(asa.variant, Thee Oh Sees) >= 0.4');
+        expect(count).toContain('asa.variant % Thee Oh Sees');
+        expect(count).toContain('similarity(asa.variant, Thee Oh Sees) >= 0.4');
+      });
+
+      it('Fix 2: the floor is operator-tunable via CATALOG_SEARCH_ALIAS_MIN_SIMILARITY', async () => {
+        // The AC for Fix 1 depends on this knob: with the floor back at 0.30
+        // the noise rows return, which is the only way to observe the tiering.
+        process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = '0.3';
+        resetCatalogSearchAliasConfig();
+
+        const { data } = await runAliasQuery();
+
+        expect(data).toContain('similarity(asa.variant, Thee Oh Sees) >= 0.3');
+      });
+
+      it('Fix 1: alias-only rows are tiered last, ahead of the caller sort', async () => {
+        const { data } = await runAliasQuery();
+
+        // The tier key must lead the ORDER BY, and the caller's own sort must
+        // still follow it intact. `FALSE < TRUE` in Postgres, so ASC puts the
+        // non-alias rows first.
+        expect(data).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, artist_name ASC, album_title ASC, id ASC`);
+      });
+
+      const SORT_EXPECTATIONS: [CatalogSort, string, string][] = [
+        ['artist', 'artist_name', 'album_title'],
+        ['album', 'album_title', 'artist_name'],
+        ['plays', 'plays', 'artist_name'],
+        ['date', 'add_date', 'artist_name'],
+      ];
+
+      it.each(
+        SORT_EXPECTATIONS.flatMap(([sort, primary, secondary]) =>
+          (['asc', 'desc'] as const).map((order) => ({ sort, order, primary, secondary }))
+        )
+      )('Fix 1: tier leads the ORDER BY for sort=$sort order=$order', async ({ sort, order, primary, secondary }) => {
+        const { data } = await runAliasQuery({ sort, order });
+
+        const expected = `ORDER BY ${ALIAS_ONLY_TIER}, ${primary} ${order.toUpperCase()}, ${secondary} ASC, id ASC`;
+        expect(data).toContain(expected);
+      });
+
+      it('leaves the inner DISTINCT ON dedupe ordering untouched (BS#1554)', async () => {
+        const { data } = await runAliasQuery();
+
+        // The rotation-bin dedupe ordinal decides WHICH duplicate row
+        // survives; perturbing it changes the surfaced rotation bin. The
+        // tier belongs on the OUTER sort only.
+        expect(data).toContain('ORDER BY id ASC, CASE rotation_bin');
+        expect(data.slice(0, data.indexOf('ORDER BY id ASC, CASE rotation_bin'))).not.toContain(ALIAS_ONLY_TIER);
+      });
+
+      it('alias OFF: neither the floor nor the tier appears (legacy path unchanged)', async () => {
+        delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+        resetCatalogSearchAliasConfig();
+
+        const { data, count } = await runAliasQuery();
+
+        expect(data).not.toContain('similarity(asa.variant');
+        expect(data).not.toContain(ALIAS_ONLY_TIER);
+        expect(data).not.toContain('alias_max_sim');
+        expect(count).not.toContain('similarity(asa.variant');
+        expect(data).toContain('ORDER BY artist_name ASC, album_title ASC, id ASC');
+      });
     });
   });
 

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -844,8 +844,14 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         resetCatalogSearchAliasConfig();
       });
 
+      const originalFloor = process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
       afterAll(() => {
-        delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+        // Restore rather than delete, matching the outer describe's handling of
+        // CATALOG_SEARCH_ALIAS_ENABLED: a developer with the floor exported in
+        // their shell should get their environment back, not a silently unset
+        // var for the rest of the Jest worker.
+        if (originalFloor === undefined) delete process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY;
+        else process.env.CATALOG_SEARCH_ALIAS_MIN_SIMILARITY = originalFloor;
         resetCatalogSearchAliasConfig();
       });
 

--- a/tests/unit/services/library-search.alias-cascade-merge.test.ts
+++ b/tests/unit/services/library-search.alias-cascade-merge.test.ts
@@ -329,6 +329,33 @@ describe('searchLibrary — alias-only rows sort after real matches in the merge
     expect(results.map((r) => r.id)).toEqual([99, 42]);
   });
 
+  it('a colliding cascade row with NO matched_via is still not demoted', async () => {
+    enableAlias();
+    // `searchLibraryByTrackUncachedOrThrow` only sets `matched_via` when LML
+    // returned a non-empty hint list (library.service.ts), so a genuine
+    // Track-2 row can arrive bare. Inferring "alias-only" from the absence of
+    // `matched_via` therefore misreads a real cascade answer as noise — the
+    // tier has to be told which rows came from the cascade, not guess.
+    db.execute
+      .mockResolvedValueOnce([
+        aliasRow({ id: 42, artist_name: 'Zither Ensemble' }, 'Monore'),
+        aliasRow({ id: 43, artist_name: 'Bill Monroe' }, 'Monore'),
+      ])
+      .mockResolvedValueOnce([{ total: 2, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([
+      cascadeRow({ id: 42, artist_name: 'Zither Ensemble', matched_via: undefined }),
+    ]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    // Row 42 is the cascade's real answer (it just carries no hint list) and
+    // must lead, even though 'Bill Monroe' sorts first by name. Demoting it
+    // would put the alias noise above the answer the cascade exists to find.
+    expect(results.map((r) => r.id)).toEqual([42, 43]);
+    expect(results[0].matched_via).toBeUndefined();
+    expect(results[0].matched_via_alias).toBeDefined();
+  });
+
   it('pure-cascade page (no alias rows at all) is unaffected by the tier', async () => {
     enableAlias();
     db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0, total_non_alias: 0 }]);

--- a/tests/unit/services/library-search.alias-cascade-merge.test.ts
+++ b/tests/unit/services/library-search.alias-cascade-merge.test.ts
@@ -222,3 +222,123 @@ describe('searchLibrary — alias-only primary no longer suppresses the cascade 
     expect(total).toBe(1);
   });
 });
+
+/**
+ * BS#2018 Fix 1, merge-path half. The SQL `ORDER BY` tier (pinned in
+ * `library-search-alias.test.ts`) only orders rows the primary query returns.
+ * When the cascade fires, `sortAlbumRows` re-sorts cascade rows spliced
+ * together with the alias rows in memory — and that sort has to apply the
+ * SAME tier, or a fuzzy alias-noise row whose artist name happens to sort
+ * first lands above the cascade's real answer on page 0.
+ *
+ * The two sorts agree on a tier key both can compute: "alias-only", i.e.
+ * `matched_via_alias` present AND `matched_via` absent. `alias_max_sim` is
+ * deliberately NOT part of the ordering — it never reaches the wire shape, so
+ * the in-memory sort could not reproduce it and the two halves would drift.
+ */
+describe('searchLibrary — alias-only rows sort after real matches in the merge (BS#2018)', () => {
+  const originalFlag = process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRunCatalogTrackSearchCascade.mockReset().mockResolvedValue([]);
+    delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    resetCatalogSearchAliasConfig();
+    db.execute.mockReset();
+  });
+
+  afterAll(() => {
+    if (originalFlag === undefined) delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    else process.env.CATALOG_SEARCH_ALIAS_ENABLED = originalFlag;
+    resetCatalogSearchAliasConfig();
+  });
+
+  it('demotes an alias-only row that would otherwise sort ahead of the cascade hit', async () => {
+    enableAlias();
+    // 'Bill Monroe' sorts before 'Chiastic Slide Artist' on artist ASC, so
+    // pre-fix the noise row led the page. Two of them, to prove the tier
+    // moves the whole group rather than just the first row.
+    db.execute
+      .mockResolvedValueOnce([
+        aliasRow({ id: 43, artist_name: 'Bill Monroe', album_title: 'Bluegrass Ramble' }, 'Monore'),
+        aliasRow({ id: 44, artist_name: 'Bill Monroe', album_title: "Can't You Hear Me Callin'" }, 'Monore'),
+      ])
+      .mockResolvedValueOnce([{ total: 2, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeRow({ id: 99 })]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results.map((r) => r.id)).toEqual([99, 43, 44]);
+    expect(results[0].matched_via).toBeDefined();
+    expect(results[0].matched_via_alias).toBeUndefined();
+  });
+
+  it('keeps the caller sort intact WITHIN the alias tier', async () => {
+    enableAlias();
+    db.execute
+      .mockResolvedValueOnce([
+        aliasRow({ id: 43, artist_name: 'Zither Ensemble' }, 'Monore'),
+        aliasRow({ id: 44, artist_name: 'Bill Monroe' }, 'Monore'),
+      ])
+      .mockResolvedValueOnce([{ total: 2, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeRow({ id: 99 })]);
+
+    const { results } = await searchLibrary({ ...PARAMS, sort: 'artist', order: 'asc' });
+
+    // Cascade first (tier), then the alias rows in artist_name order.
+    expect(results.map((r) => r.id)).toEqual([99, 44, 43]);
+  });
+
+  it('order=desc flips the sort inside each tier but not the tier itself', async () => {
+    enableAlias();
+    db.execute
+      .mockResolvedValueOnce([
+        aliasRow({ id: 43, artist_name: 'Zither Ensemble' }, 'Monore'),
+        aliasRow({ id: 44, artist_name: 'Bill Monroe' }, 'Monore'),
+      ])
+      .mockResolvedValueOnce([{ total: 2, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeRow({ id: 99 })]);
+
+    const { results } = await searchLibrary({ ...PARAMS, sort: 'artist', order: 'desc' });
+
+    // 'Chiastic Slide Artist' sorts below both alias artists on desc, so this
+    // case only passes if the tier — not the name — decides the leader.
+    expect(results.map((r) => r.id)).toEqual([99, 43, 44]);
+  });
+
+  it('a cascade row carrying an alias hint is NOT demoted (it matched for real)', async () => {
+    enableAlias();
+    // Id collision: the cascade resolved id 42 for real, and the alias branch
+    // also hit it. `matched_via_alias` gets carried onto the cascade row for
+    // the UI — that must not read as "alias-only" to the sort.
+    db.execute
+      .mockResolvedValueOnce([aliasRow({ id: 42, artist_name: 'Zither Ensemble' }, 'Monore')])
+      .mockResolvedValueOnce([{ total: 2, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([
+      cascadeRow({ id: 42, artist_name: 'Zither Ensemble' }),
+      cascadeRow({ id: 99 }),
+    ]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    const merged = results.find((r) => r.id === 42);
+    expect(merged?.matched_via).toBeDefined();
+    expect(merged?.matched_via_alias).toBeDefined();
+    // Both rows matched for real, so ordinary artist_name ASC applies:
+    // 'Chiastic Slide Artist' (99) before 'Zither Ensemble' (42).
+    expect(results.map((r) => r.id)).toEqual([99, 42]);
+  });
+
+  it('pure-cascade page (no alias rows at all) is unaffected by the tier', async () => {
+    enableAlias();
+    db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0, total_non_alias: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([
+      cascadeRow({ id: 99, artist_name: 'Zither Ensemble' }),
+      cascadeRow({ id: 98, artist_name: 'Bill Monroe' }),
+    ]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results.map((r) => r.id)).toEqual([98, 99]);
+  });
+});


### PR DESCRIPTION
Searching the catalog for `monolake` returned all 14 Bill Monroe albums ahead of the 6 Monolake ones. Two independent defects, both fixed here.

Closes #2018

## Fix 1 — the alias branch had no rank

`alias_max_sim` has been computed and projected since #1318 but was never ordered on; its only consumer was `total_non_alias`. A 0.333 typo collision therefore sorted identically to an exact match, and because the alias branch INNER JOINs on `artist_id`, one colliding variant put an entire unrelated discography at the top of the page.

The union's outer `ORDER BY` now leads with `(alias_max_sim IS NOT NULL) ASC`, so alias-only rows land after rows that matched the query text, with the caller's own sort intact inside each tier. `sortAlbumRows` applies the same tier so the #1885 cascade merge agrees with the SQL.

Two judgment calls that differ from what the ticket sketched:

- **The tier key is "is it alias-only", not `alias_max_sim DESC`.** The score never reaches the wire shape, so a score-based order is one the in-memory sort could not reproduce — the SQL and the merge would drift. Both sides can compute "alias-only", so that is the key.
- **A cascade row that picked up an alias hint on an id collision is deliberately not demoted.** #1885 copies `matched_via_alias` onto a cascade row when the two collide on `id`; that row matched for real, and demoting it would bury the cascade's own answer. The third commit is a review fix here: the first attempt inferred the tier from row shape (`has matched_via_alias`, `lacks matched_via`), which is wrong because LML sets `matched_via` only when it returned a non-empty hint list — a bare Track-2 row colliding with an alias row was misread as noise. `sortAlbumRows` now takes the predicate from the caller, which knows exactly which rows came from where.

The inner `DISTINCT ON` rotation-bin dedupe ordinal (#1554) is untouched — the tier belongs on the outer sort only, and a test asserts it never appears before the dedupe `ORDER BY`.

## Fix 2 — pg_trgm's 0.30 threshold is too loose for short variants

Discogs artist 450691 (Bill Monroe) carries the misprint `Monore` among its 42 name variations, and `similarity('Monore', 'monolake')` is 0.333 — over the bar by 0.03. `William Monroe` scores 0.364 against `William Parker`, a real WXYC jazz artist, so that query returns the same 14 albums today.

The `alias_hits` CTE now applies a `similarity(variant, q) >= 0.40` floor on top of the `%` predicate. `%` stays because it is the operator the GIN trigram index answers — `EXPLAIN` still shows `Bitmap Index Scan on artist_search_alias_variant_trgm_idx` with the floor as a post-index `Filter`, so #1318's plan holds.

0.40 was measured against every known collision and every known real match rather than picked for roundness:

| variant → query | similarity | |
|---|---|---|
| `Monore` → `monolake` | 0.333 | collision |
| `William Monroe` → `William Parker` | 0.364 | collision |
| `Monroe, William` → `William Parker` | 0.364 | collision |
| `oh sees` → `Osees` | **0.400** | real match |
| `Thee Oh Sees` → `theeohsees` | 0.412 | real match |
| `Stereolab` → `stereolb` | 0.583 | real match |
| `Nilufer Yanya` → `Nilüfer Yanya` | 0.647 | real match |
| `Csillagrablok` → `Csillagrablók` | 0.647 | real match |
| `Hermanos Gutierrez` → `Hermanos Gutiérrez` | 0.727 | real match |
| `Robert Henke` → `robert henke` | 1.000 | real match |

The tightest true positive sits at exactly 0.40, so 0.50 is not a safe rounder choice. The table is pinned in `tests/unit/config/catalog-search-alias-config.test.ts`, which fails if `DEFAULT_ALIAS_MIN_SIMILARITY` moves out from between the two groups without a re-measure.

`CATALOG_SEARCH_ALIAS_MIN_SIMILARITY` exposes the floor as an operator knob so the calibration can be backed out without a deploy if it suppresses something legitimate in production. It can only tighten — `%` still floors at pg_trgm's own threshold, so a value below 0.30 is a no-op. It is also what makes Fix 1 testable: at 0.40 the collision no longer produces rows for the tier to order, so verifying the tiering means putting the floor back to 0.30.

## Verification

Against a production-shaped clone (Bill Monroe 14 albums, Monolake 6, William Parker 33), with the real `Monore` variant seeded:

| | result |
|---|---|
| pre-fix ordering, floor 0.30 | 13 Bill Monroe rows before any Monolake row — reproduces the reported bug |
| Fix 1 only, floor 0.30 | all 6 Monolake first, then all 14 Bill Monroe |
| Fix 1 + Fix 2, floor 0.40 | exactly the 6 Monolake albums, nothing else |
| `q=William Parker`, 0.30 → 0.40 | 14 stowaway rows → 0 |

`EXPLAIN (ANALYZE)` over a 72k-row alias substrate keeps the bitmap index scan, with the floor removing 10 rows as a post-index filter. Seeded rows were removed afterward.

Also green: 413 unit suites / 6584 tests, the full 90-suite / 844-test integration run against the docker mock stack, typecheck, eslint (0 errors), prettier, `lint:env`.

## Scope notes

Fix 1 lands on `/library/query` only. That surface had **no relevance term at all** in its `ORDER BY` — an alias hit and an exact match were literally indistinguishable to the sort, which is what let one typo collision take the whole page. The Both-mode and request-line paths do rank on relevance, via `GREATEST(sim(artist), sim(album), COALESCE(alias_max_sim, 0)) DESC`.

To be precise about what that does and does not buy, since an earlier draft of this section overstated it: a *strong* alias hit can still outrank a *weak* real one there — a 0.45 alias variant sorts above a 0.32 canonical-name match. That inversion is real and pre-existing, and it is not addressed here. What is true is that it is bounded by relevance rather than unbounded, and that Fix 2 makes it strictly rarer, not more common: raising the floor only ever *removes* alias rows, so every inversion that survives at 0.40 already occurred at 0.30, and every one caused by a row scoring in [0.30, 0.40) is now gone. Worth its own ticket; out of scope for this one.

The **floor** applies to all three paths, via a shared CTE builder hoisted into `utils/alias-hits.ts` in the first commit (pure move) — `/library/query` had its own byte-identical copy, and two definitions of "what counts as an alias match" is the shape of this bug.

Side effect worth knowing: #1885's motivating collision, `similarity('Duane', 'Nuane')`, is also 0.333, so the floor now suppresses that noise at the source rather than merging around it. The cascade still fires (`total_non_alias` is untouched), and #1885's integration test seeds an exact-variant match, so it still exercises the merge path it was written for.

No migration. `.env.example` documents both `CATALOG_SEARCH_ALIAS_ENABLED` (previously undocumented there) and the new floor.

## Related

WXYC/Backend-Service#1273, WXYC/Backend-Service#1318, WXYC/Backend-Service#1885, WXYC/Backend-Service#1554, WXYC/Backend-Service#1557
