### PR TITLE
fix(catalog-search): tier alias-only rows after real trigram matches

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -13,7 +13,7 @@ import type { ArtistMatchHint, ArtistSearchAliasSource } from './requestLine/typ
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import WxycError from '../utils/error.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte, buildFuzzyAliasTier } from '../utils/alias-hits.js';
+import { buildAliasHitsCte, buildAliasOnlyTier } from '../utils/alias-hits.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -213,18 +213,20 @@ export async function searchLibrary(
     // of the page. `FALSE < TRUE` in Postgres, so ASC puts the real matches
     // first; the caller's own sort follows, unchanged, within each tier.
     //
-    // The tier is deliberately "is it a fuzzy alias-only hit", NOT
-    // `alias_max_sim DESC`: the score never reaches the wire shape, so
-    // `sortAlbumRows` (which re-sorts this same row set in memory when the
-    // cascade fires) could not reproduce a score-based order and the two
-    // would drift. The boolean survives that round trip; a score does not.
+    // The tier is deliberately "is it alias-only", NOT `alias_max_sim DESC`:
+    // the score never reaches the wire shape, so `sortAlbumRows` (which
+    // re-sorts this same row set in memory when the cascade fires) could not
+    // reproduce a score-based order and the two would drift. The boolean
+    // survives that round trip; a score does not.
     //
-    // BS#2020 narrowed it to *fuzzy* hits — an exact variant is not the typo
-    // collision this was aimed at. That mattered urgently on the two
-    // non-paginated paths in `library.service.ts` and only mildly here, but
-    // the tier is built by one shared helper so it cannot come to mean
-    // different things on endpoints that answer the same question.
-    const orderBy = sql`${buildFuzzyAliasTier()}, ${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
+    // It stays UNCONDITIONAL here. BS#2020 narrowed the equivalent tier on the
+    // two relevance-ranked paths in `library.service.ts` to fuzzy hits only,
+    // which does not transfer: this ORDER BY has no relevance term for an
+    // exempted row to be ranked by, so exempting one would merely alphabetize
+    // it among the real matches — an exact-variant artist with 30
+    // early-alphabet albums would take page 0 outright. The narrowing is
+    // justified there by the absence of an OFFSET, which this path has.
+    const orderBy = sql`${buildAliasOnlyTier()}, ${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
 
     // BS#2018 Fix 2 (the `similarity(...) >= floor` post-filter) lives inside
     // the shared builder in `utils/alias-hits.ts`, so this path and the two in
@@ -486,8 +488,10 @@ async function runCascade(params: LibraryQueryParams, q: string): Promise<AlbumS
  * alias/cascade merge (BS#1885), which re-sorts a combined row set after
  * `runCascade` and the primary alias rows are spliced together.
  *
- * `isAliasOnly` is the in-memory mirror of the SQL tier `alias_max_sim IS NOT
- * NULL` (BS#2018 Fix 1), and callers pass it explicitly rather than letting
+ * `isAliasOnly` is the in-memory mirror of `buildAliasOnlyTier()` (BS#2018
+ * Fix 1) — this path's SQL tier, which BS#2020 deliberately left
+ * unconditional; the narrowed `buildFuzzyAliasTier()` is not used here, so the
+ * mirror stays exact. Callers pass it explicitly rather than letting
  * this function infer it from the row's fields. Inference was tried and is
  * wrong: `matched_via` is set on a Track-2 cascade row only when LML returned
  * a non-empty hint list, so a real cascade answer can arrive bare, and if it

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -13,7 +13,7 @@ import type { ArtistMatchHint, ArtistSearchAliasSource } from './requestLine/typ
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import WxycError from '../utils/error.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte } from '../utils/alias-hits.js';
+import { buildAliasHitsCte, buildFuzzyAliasTier } from '../utils/alias-hits.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -213,11 +213,18 @@ export async function searchLibrary(
     // of the page. `FALSE < TRUE` in Postgres, so ASC puts the real matches
     // first; the caller's own sort follows, unchanged, within each tier.
     //
-    // The tier is deliberately "is it alias-only", NOT `alias_max_sim DESC`:
-    // the score never reaches the wire shape, so `sortAlbumRows` (which
-    // re-sorts this same row set in memory when the cascade fires) could not
-    // reproduce a score-based order and the two would drift.
-    const orderBy = sql`(alias_max_sim IS NOT NULL) ASC, ${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
+    // The tier is deliberately "is it a fuzzy alias-only hit", NOT
+    // `alias_max_sim DESC`: the score never reaches the wire shape, so
+    // `sortAlbumRows` (which re-sorts this same row set in memory when the
+    // cascade fires) could not reproduce a score-based order and the two
+    // would drift. The boolean survives that round trip; a score does not.
+    //
+    // BS#2020 narrowed it to *fuzzy* hits — an exact variant is not the typo
+    // collision this was aimed at. That mattered urgently on the two
+    // non-paginated paths in `library.service.ts` and only mildly here, but
+    // the tier is built by one shared helper so it cannot come to mean
+    // different things on endpoints that answer the same question.
+    const orderBy = sql`${buildFuzzyAliasTier()}, ${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
 
     // BS#2018 Fix 2 (the `similarity(...) >= floor` post-filter) lives inside
     // the shared builder in `utils/alias-hits.ts`, so this path and the two in

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1517,6 +1517,20 @@ async function searchLibraryByTrigramBoth(
   // `alias_max_sim`. Postgres forbids expression-shaped ORDER BY directly on
   // a UNION result (column names only); the subquery lifts the union's
   // columns into a scope where `similarity(...)` is a legal ORDER BY term.
+  //
+  // BS#2020: alias-only rows are tiered LAST, ahead of the relevance sort.
+  // Ranking both branches on one `GREATEST(...)` scale let a single
+  // mid-scoring variant displace real matches wholesale — branch (b) INNER
+  // JOINs on `artist_id`, so one hit admits an artist's entire discography at
+  // that score. Branch (b) rows are selected under `NOT (trigramPredicate)`,
+  // so their own similarity is by construction sub-threshold and `GREATEST`
+  // always collapses to `alias_max_sim` for them; there was no signal
+  // separating "matched the query text" from "matched a fuzzy variant".
+  // `FALSE < TRUE` in Postgres, so ASC puts real matches first, and the
+  // strongest alias hit still leads within the alias tier.
+  //
+  // `id ASC` breaks ties: every row of one artist shares an identical
+  // `alias_max_sim`, so without it their order is whatever the plan emits.
   const streamingClause = on_streaming !== undefined ? sql`AND ${library.on_streaming} = ${on_streaming}` : sql``;
   const trigramPredicate = sql`(${library.artist_name} % ${query} OR ${library.album_title} % ${query})`;
   const rows = (await db.execute(sql`
@@ -1539,11 +1553,11 @@ async function searchLibraryByTrigramBoth(
         ${streamingClause}
       )
     ) alias_search
-    ORDER BY GREATEST(
+    ORDER BY (alias_max_sim IS NOT NULL) ASC, GREATEST(
       similarity(artist_name, ${query}),
       similarity(album_title, ${query}),
       COALESCE(alias_max_sim, 0)
-    ) DESC
+    ) DESC, id ASC
     LIMIT ${n}
   `)) as unknown as (LibraryArtistViewEntry & AliasHitFields)[];
 
@@ -2723,6 +2737,11 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
   // Wrap the UNION ALL in a subquery so the outer ORDER BY can use
   // expression-shaped terms (`similarity(...)`); Postgres forbids
   // expression ORDER BY directly on a UNION result.
+  //
+  // BS#2020: same alias-last tier as `searchLibraryByTrigramBoth`, and it
+  // bites harder here — this path has no `album_title` term to rank on and
+  // its default `limit` is 5, so one artist's alias fan-out can exceed the
+  // whole response. See that function for the full rationale.
   const trigramPredicate = sql`${library.artist_name} % ${artistName}`;
   const rows = (await db.execute(sql`
     ${buildAliasHitsCte(artistName, aliasMinSimilarity)}
@@ -2742,10 +2761,10 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
         WHERE NOT ${trigramPredicate}
       )
     ) alias_search
-    ORDER BY GREATEST(
+    ORDER BY (alias_max_sim IS NOT NULL) ASC, GREATEST(
       similarity(artist_name, ${artistName}),
       COALESCE(alias_max_sim, 0)
-    ) DESC
+    ) DESC, id ASC
     LIMIT ${limit}
   `)) as unknown as (LibraryArtistViewEntry & AliasHitFields)[];
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -50,7 +50,7 @@ import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrack
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import { isCompilationArtist } from './requestLine/matching/index.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte } from '../utils/alias-hits.js';
+import { buildAliasHitsCte, buildFuzzyAliasTier } from '../utils/alias-hits.js';
 import { recordCacheLookup, recordCacheEviction, type RegisteredCache } from './observability/cache-stats.js';
 
 // Schema-qualified reference to the `fold_artist_name(text)` SQL function
@@ -1518,16 +1518,24 @@ async function searchLibraryByTrigramBoth(
   // a UNION result (column names only); the subquery lifts the union's
   // columns into a scope where `similarity(...)` is a legal ORDER BY term.
   //
-  // BS#2020: alias-only rows are tiered LAST, ahead of the relevance sort.
-  // Ranking both branches on one `GREATEST(...)` scale let a single
+  // BS#2020: fuzzy alias-only rows are tiered LAST, ahead of the relevance
+  // sort. Ranking both branches on one `GREATEST(...)` scale let a single
   // mid-scoring variant displace real matches wholesale — branch (b) INNER
   // JOINs on `artist_id`, so one hit admits an artist's entire discography at
-  // that score. Branch (b) rows are selected under `NOT (trigramPredicate)`,
-  // so their own similarity is by construction sub-threshold and `GREATEST`
-  // always collapses to `alias_max_sim` for them; there was no signal
-  // separating "matched the query text" from "matched a fuzzy variant".
-  // `FALSE < TRUE` in Postgres, so ASC puts real matches first, and the
-  // strongest alias hit still leads within the alias tier.
+  // that score, and nothing in the sort separated "matched the query text"
+  // from "matched a fuzzy variant". `FALSE < TRUE` in Postgres, so ASC puts
+  // the non-demoted rows first; `GREATEST` is untouched, so the strongest hit
+  // still leads within each tier. Exact variants are exempt from the demotion
+  // — see `buildFuzzyAliasTier` for why, and why the guard belongs in the
+  // tier rather than in `GREATEST`.
+  //
+  // `GREATEST` deliberately keeps all three terms rather than collapsing to
+  // `alias_max_sim` for branch (b). It is tempting to argue the branch-(b)
+  // similarity is sub-threshold by construction (the rows are selected under
+  // `NOT (trigramPredicate)`), but that predicate reads `library.artist_name`
+  // while the projection below emits `artists.artist_name` — a denormalized
+  // pair that BS#1092's drift check exists precisely because it can diverge.
+  // `GREATEST` stays correct either way; a hand-collapsed form would not.
   //
   // `id ASC` breaks ties: every row of one artist shares an identical
   // `alias_max_sim`, so without it their order is whatever the plan emits.
@@ -1553,7 +1561,7 @@ async function searchLibraryByTrigramBoth(
         ${streamingClause}
       )
     ) alias_search
-    ORDER BY (alias_max_sim IS NOT NULL) ASC, GREATEST(
+    ORDER BY ${buildFuzzyAliasTier()}, GREATEST(
       similarity(artist_name, ${query}),
       similarity(album_title, ${query}),
       COALESCE(alias_max_sim, 0)
@@ -2738,10 +2746,12 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
   // expression-shaped terms (`similarity(...)`); Postgres forbids
   // expression ORDER BY directly on a UNION result.
   //
-  // BS#2020: same alias-last tier as `searchLibraryByTrigramBoth`, and it
-  // bites harder here — this path has no `album_title` term to rank on and
+  // BS#2020: same fuzzy-alias-last tier as `searchLibraryByTrigramBoth`, and
+  // it bites harder here — this path has no `album_title` term to rank on and
   // its default `limit` is 5, so one artist's alias fan-out can exceed the
-  // whole response. See that function for the full rationale.
+  // whole response. That cuts both ways, which is why the tier exempts exact
+  // variants: with no OFFSET on this path, demoting one deletes it. See that
+  // function and `buildFuzzyAliasTier` for the full rationale.
   const trigramPredicate = sql`${library.artist_name} % ${artistName}`;
   const rows = (await db.execute(sql`
     ${buildAliasHitsCte(artistName, aliasMinSimilarity)}
@@ -2761,7 +2771,7 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
         WHERE NOT ${trigramPredicate}
       )
     ) alias_search
-    ORDER BY (alias_max_sim IS NOT NULL) ASC, GREATEST(
+    ORDER BY ${buildFuzzyAliasTier()}, GREATEST(
       similarity(artist_name, ${artistName}),
       COALESCE(alias_max_sim, 0)
     ) DESC, id ASC

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -50,7 +50,7 @@ import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrack
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import { isCompilationArtist } from './requestLine/matching/index.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte, buildFuzzyAliasTier } from '../utils/alias-hits.js';
+import { buildAliasHitsCte, buildFuzzyAliasTier, buildDirectMatchTieBreak } from '../utils/alias-hits.js';
 import { recordCacheLookup, recordCacheEviction, type RegisteredCache } from './observability/cache-stats.js';
 
 // Schema-qualified reference to the `fold_artist_name(text)` SQL function
@@ -1537,8 +1537,15 @@ async function searchLibraryByTrigramBoth(
   // pair that BS#1092's drift check exists precisely because it can diverge.
   // `GREATEST` stays correct either way; a hand-collapsed form would not.
   //
-  // `id ASC` breaks ties: every row of one artist shares an identical
-  // `alias_max_sim`, so without it their order is whatever the plan emits.
+  // `buildDirectMatchTieBreak` sits AFTER the score, not before it: at equal
+  // relevance a row that matched the query text outranks one that matched a
+  // variant. The guard above removed the only signal that distinguished them
+  // once both reach 1.0, which would otherwise leave `id ASC` — catalog age —
+  // to decide between an artist and a band that lists them as a member.
+  //
+  // `id ASC` breaks the remaining ties: every row of one artist shares an
+  // identical `alias_max_sim`, so without it their order is whatever the plan
+  // emits.
   const streamingClause = on_streaming !== undefined ? sql`AND ${library.on_streaming} = ${on_streaming}` : sql``;
   const trigramPredicate = sql`(${library.artist_name} % ${query} OR ${library.album_title} % ${query})`;
   const rows = (await db.execute(sql`
@@ -1565,7 +1572,7 @@ async function searchLibraryByTrigramBoth(
       similarity(artist_name, ${query}),
       similarity(album_title, ${query}),
       COALESCE(alias_max_sim, 0)
-    ) DESC, id ASC
+    ) DESC, ${buildDirectMatchTieBreak()}, id ASC
     LIMIT ${n}
   `)) as unknown as (LibraryArtistViewEntry & AliasHitFields)[];
 
@@ -2774,7 +2781,7 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
     ORDER BY ${buildFuzzyAliasTier()}, GREATEST(
       similarity(artist_name, ${artistName}),
       COALESCE(alias_max_sim, 0)
-    ) DESC, id ASC
+    ) DESC, ${buildDirectMatchTieBreak()}, id ASC
     LIMIT ${limit}
   `)) as unknown as (LibraryArtistViewEntry & AliasHitFields)[];
 

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -57,3 +57,44 @@ export function buildAliasHitsCte(query: string, minSimilarity: number) {
     GROUP BY asa.artist_id
   )`;
 }
+
+/**
+ * Leading ORDER BY term for every alias-aware read path: sort rows that
+ * matched ONLY through a *fuzzy* alias variant after everything else.
+ *
+ * `FALSE < TRUE` in Postgres, so ASC puts the non-demoted rows first. Branch
+ * (a) rows have a NULL `alias_max_sim`, and `FALSE AND NULL` short-circuits to
+ * FALSE, so they land in the leading tier without a COALESCE.
+ *
+ * ## Why the `< 1` guard
+ *
+ * BS#2018 introduced this tier unconditionally, against a 0.333 typo collision
+ * ("Monore" for a `monolake` query) that sorted identically to an exact hit.
+ * The complaint was always about *fuzzy* variants; demoting exact ones was
+ * collateral. `similarity()` returns exactly 1 only when the query string and
+ * the variant are the same string modulo case and trigram padding — i.e. the
+ * query IS a registered name for that artist. That is a stronger claim than a
+ * 0.31 trigram smear across some unrelated canonical name, so tiering it below
+ * one inverts the ranking the alias substrate exists to provide.
+ *
+ * On `/library/query` the collateral was survivable: it paginates, so a
+ * demoted row is on a later page. The two `library.service.ts` paths emit a
+ * bare `LIMIT` with no OFFSET, so for them demoted means *deleted* — measured
+ * on a prod-shaped clone, a `monolake` query has 13 real rows scoring <= 0.40
+ * ahead of the tier, which pushes a 1.0 alias hit past position 13 on a
+ * surface whose default limit is 5. BS#1383's `discogs_member` fixture (an
+ * exact variant on a different artist) is exactly that case.
+ *
+ * ## Why one shared builder
+ *
+ * All three alias-aware paths lead their sort with this term, and the tier
+ * has to mean the same thing in all three or the same query ranks differently
+ * on two endpoints that are supposed to agree. Hand-copying the literal is
+ * how BS#2018 shipped with the floor applied to one path and not the others.
+ *
+ * Returns a fresh `SQL` per call rather than a module-level constant so
+ * callers can never share mutable builder state.
+ */
+export function buildFuzzyAliasTier() {
+  return sql`(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC`;
+}

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -59,42 +59,99 @@ export function buildAliasHitsCte(query: string, minSimilarity: number) {
 }
 
 /**
- * Leading ORDER BY term for every alias-aware read path: sort rows that
- * matched ONLY through a *fuzzy* alias variant after everything else.
+ * Leading ORDER BY term for alias-aware paths that sort by a caller-chosen
+ * column: sort every alias-only row after every row that matched the query
+ * text itself (BS#2018 Fix 1).
  *
- * `FALSE < TRUE` in Postgres, so ASC puts the non-demoted rows first. Branch
- * (a) rows have a NULL `alias_max_sim`, and `FALSE AND NULL` short-circuits to
- * FALSE, so they land in the leading tier without a COALESCE.
+ * `FALSE < TRUE` in Postgres, so ASC puts the non-alias rows first. Branch (a)
+ * rows have a NULL `alias_max_sim`, so the predicate is FALSE for them.
  *
- * ## Why the `< 1` guard
+ * Used by `/library/query` only. See `buildFuzzyAliasTier` for the narrowed
+ * form the two relevance-ranked paths use, and why the two deliberately differ
+ * rather than being unified.
+ */
+export function buildAliasOnlyTier() {
+  return sql`(alias_max_sim IS NOT NULL) ASC`;
+}
+
+/**
+ * Leading ORDER BY term for alias-aware paths that sort by RELEVANCE: demote
+ * rows that matched only through a *fuzzy* alias variant, and leave exact ones
+ * where their score puts them.
  *
- * BS#2018 introduced this tier unconditionally, against a 0.333 typo collision
+ * Same shape as `buildAliasOnlyTier` plus a `< 1` guard, and `FALSE AND NULL`
+ * short-circuits to FALSE so branch (a) still needs no COALESCE.
+ *
+ * ## Why the guard
+ *
+ * BS#2018 introduced the tier unconditionally, against a 0.333 typo collision
  * ("Monore" for a `monolake` query) that sorted identically to an exact hit.
  * The complaint was always about *fuzzy* variants; demoting exact ones was
- * collateral. `similarity()` returns exactly 1 only when the query string and
- * the variant are the same string modulo case and trigram padding — i.e. the
- * query IS a registered name for that artist. That is a stronger claim than a
- * 0.31 trigram smear across some unrelated canonical name, so tiering it below
- * one inverts the ranking the alias substrate exists to provide.
+ * collateral. On `/library/query` that collateral is survivable — it
+ * paginates, so a demoted row is on a later page. These two paths emit a bare
+ * `LIMIT` with no OFFSET, so demoted means *deleted*: measured on a
+ * prod-shaped clone, a `monolake` query has 13 real rows scoring <= 0.40 ahead
+ * of the tier, which pushes a 1.0 alias hit past position 13 on a surface
+ * whose default limit is 5. BS#1383's `discogs_member` fixture — an exact
+ * variant on a different artist — is exactly that case.
  *
- * On `/library/query` the collateral was survivable: it paginates, so a
- * demoted row is on a later page. The two `library.service.ts` paths emit a
- * bare `LIMIT` with no OFFSET, so for them demoted means *deleted* — measured
- * on a prod-shaped clone, a `monolake` query has 13 real rows scoring <= 0.40
- * ahead of the tier, which pushes a 1.0 alias hit past position 13 on a
- * surface whose default limit is 5. BS#1383's `discogs_member` fixture (an
- * exact variant on a different artist) is exactly that case.
+ * ## Why NOT on `/library/query`
  *
- * ## Why one shared builder
+ * An exemption is only meaningful if something ranks the exempted row
+ * afterwards. That path orders by the caller's `sort` column, so an exempt row
+ * is not "ranked on its merits", it is alphabetized among the real matches —
+ * one exact-variant artist with 30 early-alphabet albums would fill page 0.
+ * The two forms are separate builders, not one parameterized builder, so that
+ * asymmetry is visible at both call sites instead of hiding behind a boolean.
  *
- * All three alias-aware paths lead their sort with this term, and the tier
- * has to mean the same thing in all three or the same query ranks differently
- * on two endpoints that are supposed to agree. Hand-copying the literal is
- * how BS#2018 shipped with the floor applied to one path and not the others.
+ * ## What `alias_max_sim = 1` actually means
  *
- * Returns a fresh `SQL` per call rather than a module-level constant so
- * callers can never share mutable builder state.
+ * Less than it looks. pg_trgm splits on non-alphanumerics, pads each word, and
+ * unions the trigrams into a DEDUPLICATED set, so equality of trigram sets is
+ * not equality of strings: `similarity('Duke Ellington', 'Ellington Duke')`
+ * and `similarity('The The', 'the')` are both exactly 1. A query that merely
+ * permutes a registered variant, or that is one repeated word of it, is
+ * therefore treated as exact here.
+ *
+ * That is wider than the argument above, and accepted rather than overlooked.
+ * Tightening it would mean comparing normalized strings instead of scores,
+ * which is a different match semantics than the `%` operator the GIN index
+ * answers (BS#1318) and would not survive the `MAX(...)` aggregation in the
+ * CTE. The failure mode is bounded: a permuted variant is still a variant of
+ * that artist, so the row is relevant — it is only the *confidence* that is
+ * overstated, and `buildDirectMatchTieBreak` keeps it behind a genuine
+ * text match at equal score.
  */
 export function buildFuzzyAliasTier() {
   return sql`(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC`;
+}
+
+/**
+ * Trailing ORDER BY term for the relevance-ranked paths: at EQUAL relevance,
+ * prefer the row that matched the query text over one that matched a variant.
+ *
+ * Belongs after the `GREATEST(...)` term, never before it — ahead of the score
+ * it would be a second unconditional tier and undo `buildFuzzyAliasTier`.
+ *
+ * `buildFuzzyAliasTier` removed the only signal separating a direct match from
+ * an alias match once both reach 1.0 (real: `similarity(artist_name, q) = 1`;
+ * alias: `alias_max_sim = 1`). Without this term every preceding term ties and
+ * `id ASC` decides — that is, catalog age decides. The concrete shape is a
+ * `discogs_member` variant naming a band member who also has solo records:
+ * query the member's name and the band's whole discography ties with the
+ * member's own, resolved by whichever ids are lower.
+ *
+ * On both current callers this is unreachable, and deliberately kept anyway.
+ * `searchLibraryByTrigramBoth` runs only after the tsvector tier returns zero
+ * rows, and any real row scoring 1.0 on trigram necessarily matches
+ * `websearch_to_tsquery` too (identical trigram sets imply the same word set),
+ * so the tsvector tier short-circuits before this SQL is ever reached.
+ * `searchByArtist` has no tsvector tier and no callers (BS#2022). The guard
+ * costs one ORDER BY term and holds the invariant locally, rather than
+ * borrowing it from a different subsystem's short-circuit — which is the kind
+ * of load-bearing coupling that breaks silently when the other subsystem
+ * changes.
+ */
+export function buildDirectMatchTieBreak() {
+  return sql`(alias_max_sim IS NOT NULL) ASC`;
 }

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -306,8 +306,9 @@ describe('GET /library/query — alias-only primary no longer suppresses the cas
  *   - CONTROL ('Gerhard Behles'), a `discogs_member` variant of exactly the
  *     query string. Similarity 1.0, so it clears any floor, and its canonical
  *     name doesn't ILIKE-match, so it can ONLY arrive via branch (b). BS#2020
- *     later made it the exemption case as well: an exact variant is not the
- *     fuzzy collision the tier was aimed at, so it is no longer demoted.
+ *     exempted rows like this one from the tier on the two relevance-ranked
+ *     paths in `library.service.ts`, but NOT here — this endpoint has no
+ *     relevance term to rank an exempted row by. See `buildAliasOnlyTier`.
  *
  * The CONTROL row is what makes these assertions mean anything. `Monolake`
  * ILIKE-matches `monolake` on the plain legacy path, so keying a skip-guard on
@@ -441,14 +442,13 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
     expect(res.body.results.filter((r) => NOISE_LIBRARY_IDS.includes(r.id))).toEqual([]);
   });
 
-  test('Fix 1 (as narrowed by BS#2020): the EXACT variant is not demoted', async () => {
-    // Sort explicitly, and DESC, because the tier is only observable when it
-    // disagrees with the caller's sort. The default is album ASC, under which
-    // REAL ('Gravity') precedes CONTROL ('Layering Buddha') either way — a
-    // tiered CONTROL and an untiered one look identical. Reversing the sort
-    // separates them: the tier is hardcoded ASC and is NOT reversed by
-    // `order`, so a tiered CONTROL still trails REAL, while an untiered one
-    // leads it on album title alone.
+  test('Fix 1: an alias-only row that clears the floor still sorts after every real match', async () => {
+    // Sort explicitly, and DESC, so the tier has to disagree with the caller's
+    // sort for this to pass. Under the default (album ASC) REAL ('Gravity')
+    // precedes CONTROL ('Layering Buddha') on title alone, and the assertion
+    // would hold with no tier at all — a vacuous guard. Reversed, only the
+    // tier can produce this order, because the tier is hardcoded ASC and is
+    // NOT reversed by `order`.
     const res = await auth
       .get('/library/query')
       .query({ q: QUERY, limit: 50, sort: 'album', order: 'desc' })
@@ -458,50 +458,41 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
     const realIndex = res.body.results.findIndex((r) => r.id === REAL_LIBRARY_ID);
     const controlIndex = res.body.results.findIndex((r) => r.id === CONTROL_LIBRARY_ID);
     expect(realIndex).toBeGreaterThanOrEqual(0);
-    expect(controlIndex).toBeGreaterThanOrEqual(0);
+    expect(controlIndex).toBeGreaterThan(realIndex);
 
-    // This assertion is inverted from what BS#2018 originally shipped, and
-    // deliberately so. CONTROL's variant IS the query string (similarity 1.0),
-    // so demoting it was never what Fix 1 was aimed at — the complaint was a
-    // 0.333 typo collision ranking like an exact hit, and the unconditional
-    // tier swept up the exact hit as collateral. BS#2020 found that collateral
-    // fatal on the two `library.service.ts` paths, which emit a bare LIMIT: a
-    // demoted row there is deleted, not paginated. The tier is shared, so it
-    // is narrowed here too.
-    expect(controlIndex).toBeLessThan(realIndex);
-
-    // The demotion half of Fix 1 is NOT tested by this fixture, because this
-    // fixture has no fuzzy-but-above-floor alias row: NOISE sits at 0.333,
-    // deliberately under the floor, so it contributes nothing to order. The
-    // BS#2020 suite below carries a 0.6429 variant and asserts the demotion
-    // against this same endpoint.
+    // BS#2020 narrowed the equivalent tier on the two relevance-ranked paths
+    // in `library.service.ts` so an exact variant like CONTROL is NOT demoted
+    // there. It did not narrow this one — see `buildAliasOnlyTier` — so the
+    // assertion above still reads as it did when Fix 1 shipped. The two paths
+    // now deliberately disagree about CONTROL, which is why they use
+    // separately-named builders rather than one shared expression.
   });
 });
 
 /**
  * BS#2020 fixture — alias-only rows displacing REAL trigram matches on the
- * two `library.service.ts` alias paths (`GET /library/` Both-mode and
- * `GET /library/search`), plus the exact-variant exemption that the same
- * ticket's first cut got wrong.
+ * two relevance-ranked `library.service.ts` alias paths (`GET /library/`
+ * Both-mode and `GET /library/search`), plus the exact-variant exemption that
+ * the same ticket's first cut got wrong in the other direction.
  *
- * Four artists, all reachable on one query (`deerhoof`):
+ * Four artists, all reachable on one query (`skarnvold`):
  *
- *   - NOISE ('Wolf Eyes'), 4 albums, alias variant 'Deerhoof Live'.
- *     Similarity 0.6429 — an utterly ordinary name variation, comfortably
+ *   - NOISE ('Havnrot'), 4 albums, alias variant 'Skarnvold Live'.
+ *     Similarity 0.6667 — an utterly ordinary name variation, comfortably
  *     ABOVE BS#2018's 0.40 floor, which is why that floor cannot reach this
  *     defect. Neither its canonical name nor any album title trigram-matches,
  *     so all 4 rows arrive only via branch (b), which INNER JOINs on
  *     `artist_id` and admits the whole discography at that one score.
- *   - REAL ('Deerhunter'), 1 album, matches on branch (a) at 0.3333 — a
+ *   - REAL ('Skarnholt'), 1 album, matches on branch (a) at 0.3333 — a
  *     genuine match that scores BELOW the alias hit. That gap is the defect.
- *   - CONTROL ('Black Dice'), 1 album, alias variant EXACTLY the query.
- *     Similarity 1.0, canonical name unmatched (0.053), so it too can only
- *     arrive via branch (b) — but the query string IS a registered name for
- *     this artist, so it is a better answer than REAL, not a worse one.
+ *   - CONTROL ('Tidal Ossuary'), 1 album, alias variant EXACTLY the query.
+ *     Similarity 1.0, canonical name unmatched, so it too can only arrive via
+ *     branch (b) — but the query string IS a registered name for this artist,
+ *     so it is a better answer than REAL, not a worse one.
  *
  * The two failure modes are opposites and this fixture holds both at once:
  *
- *   - No tier at all → NOISE (0.6429) outranks REAL (0.3333) wholesale.
+ *   - No tier at all → NOISE (0.6667) outranks REAL (0.3333) wholesale.
  *   - An unconditional tier → CONTROL (1.0) is demoted with NOISE, and since
  *     neither of these paths emits an OFFSET, demoted means deleted.
  *
@@ -510,12 +501,25 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
  * misordered row falls off the page entirely rather than merely sorting late
  * — the reported symptom rather than a proxy for it.
  *
- * The query is deliberately disjoint from BS#2018's (`monolake`). That suite
- * seeds an artist whose canonical name IS its query, which tsvector-matches
- * and short-circuits Both-mode before the trigram tier ever runs; sharing the
- * string left this suite's outcome depending on describe execution order.
+ * ## Why the strings are invented
  *
- * `searchByArtist` carries the same fix but has no HTTP route, so its
+ * Every name here is synthetic, which departs from the repo convention of
+ * using WXYC-representative artists in fixtures. It has to: this suite needs
+ * a query that matches NOTHING in the catalog except its own seeds, and the
+ * convention's whole point is that its names are real WXYC artists — exactly
+ * the ones a real catalog contains.
+ *
+ * That is not hypothetical. `dev_env/seed-clone.sql` is a ~14 MB snapshot of
+ * prod's artists/library, loaded whenever `LOAD_CLONE_FIXTURE=true` (the dev
+ * profile; CI skips it), and BS#1728 exists specifically so `test:integration`
+ * can run against it. A query colliding with a clone row is not merely noisy
+ * here — `library.search_doc` covers artist_name and album_title, so one
+ * colliding row makes the tsvector tier non-empty and `searchLibraryBothMode`
+ * short-circuits before the trigram tier this suite is entirely about. Every
+ * string below is verified absent from that clone. (`monolake`, used by the
+ * BS#2018 suite above, is not — 7 occurrences. Pre-existing, not fixed here.)
+ *
+ * `searchByArtist` carries the same ordering but has no HTTP route, so its
  * coverage is the unit suite (`tests/unit/services/library-search-alias.test.ts`).
  */
 const BS2020 = {
@@ -525,14 +529,14 @@ const BS2020 = {
   REAL_LIBRARY_ID: 9305,
   CONTROL_ARTIST_ID: 9306,
   CONTROL_LIBRARY_ID: 9306,
-  // similarity('Deerhoof Live', 'deerhoof') = 0.6429 — over the 0.40 floor.
-  ALIAS_VARIANT: 'Deerhoof Live',
-  // similarity('Deerhunter', 'deerhoof') = 0.3333 — over pg_trgm's 0.30, so
+  // similarity('Skarnvold Live', 'skarnvold') = 0.6667 — over the 0.40 floor.
+  ALIAS_VARIANT: 'Skarnvold Live',
+  // similarity('Skarnholt', 'skarnvold') = 0.3333 — over pg_trgm's 0.30, so
   // it is a real branch-(a) match, but under the alias hit's score.
-  REAL_ARTIST_NAME: 'Deerhunter',
-  NOISE_ARTIST_NAME: 'Wolf Eyes',
-  CONTROL_ARTIST_NAME: 'Black Dice',
-  QUERY: 'deerhoof',
+  REAL_ARTIST_NAME: 'Skarnholt',
+  NOISE_ARTIST_NAME: 'Havnrot',
+  CONTROL_ARTIST_NAME: 'Tidal Ossuary',
+  QUERY: 'skarnvold',
 };
 
 describe('alias-only rows no longer displace real trigram matches (BS#2020)', () => {
@@ -561,9 +565,11 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
     throw new Error(
       `[BS#2020] Expected all ${aliasOnlyIds.length} alias-only rows (library ids ${aliasOnlyIds.join(', ')}) on an ` +
         `n=50 page, got ${seen.length}. These rows are unreachable without the alias branch, so the ordering ` +
-        'assertions in this suite would not be exercising anything. Almost certainly the backend is running ' +
+        'assertions in this suite would not be exercising anything. Two likely causes: (1) the backend is running ' +
         'without CATALOG_SEARCH_ALIAS_ENABLED=true — set it on the backend service in ' +
-        'dev_env/docker-compose.yml, or in .env for local `npm run dev`.'
+        'dev_env/docker-compose.yml, or in .env for local `npm run dev`; (2) the database contains a row matching ' +
+        `"${QUERY}" on artist_name or album_title, which makes the tsvector tier non-empty and short-circuits ` +
+        'Both-mode before the trigram tier ever runs.'
     );
   }
 
@@ -574,9 +580,9 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
 
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
-       VALUES ($1, $4, $4, 'WO'),
-              ($2, $5, $5, 'DE'),
-              ($3, $6, $6, 'BL')
+       VALUES ($1, $4, $4, 'HA'),
+              ($2, $5, $5, 'SK'),
+              ($3, $6, $6, 'TI')
        ON CONFLICT (id) DO NOTHING`,
       [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID, NOISE_ARTIST_NAME, REAL_ARTIST_NAME, CONTROL_ARTIST_NAME]
     );
@@ -589,11 +595,16 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
     // No album title may trigram-match the query, or the row would arrive on
     // branch (a) and stop being an alias-only row. Pinned by the first test.
     //
+    // Titles are also chosen so REAL's ('Marrowfield') sorts LAST among the
+    // six alphabetically. `/library/query` defaults to album ASC, so under a
+    // missing tier REAL would land at position 5; the tier is what puts it
+    // first, and the test below would pass for the wrong reason otherwise.
+    //
     // REAL's label is the one deliberate oddity. The three alias paths do not
     // agree on what a branch-(a) match IS: `library.service.ts` uses trigram
     // over artist_name/album_title, while `/library/query` uses ILIKE-contains
     // over artist_name/album_title/**label**. So REAL is a real match on the
-    // first two via 'Deerhunter', and needs the label to be one on the third.
+    // first two via 'Skarnholt', and needs the label to be one on the third.
     // Label is the only column that can do this without side effects: it is
     // absent from `library.search_doc` (see `buildAllFieldMatch`'s note), so
     // it cannot make Both-mode short-circuit on the tsvector tier before the
@@ -603,17 +614,17 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
     // Without it, `/library/query` sees a result set that is 100% alias-only,
     // which triggers the BS#1885 cascade and hands final ordering to
     // `sortAlbumRows`'s in-memory tier — a different predicate (cascade-vs-
-    // alias, not fuzzy-vs-exact) that would mask the SQL tier entirely.
+    // alias) that would mask the SQL tier entirely.
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.library
          (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
        VALUES
-         ($1, $5, $9, $10, 'Burned Mind', 1, $12, 'Sub Pop', NULL, 65930),
-         ($2, $5, $9, $10, 'Human Animal', 2, $12, 'Sub Pop', NULL, 65931),
-         ($3, $5, $9, $10, 'Dread', 3, $12, 'Bulb', NULL, 65932),
-         ($4, $5, $9, $10, 'No Answer Lower Floors', 4, $12, 'De Stijl', NULL, 65933),
-         ($6, $7, $9, $10, 'Microcastle', 1, $11, 'Deerhoof Recordings', NULL, 65934),
-         ($8, $13, $9, $10, 'Beaches and Canyons', 1, $14, 'DFA', NULL, 65935)
+         ($1, $5, $9, $10, 'Blackthorn Ledger', 1, $12, 'Ferrous Tapes', NULL, 65930),
+         ($2, $5, $9, $10, 'Cinder Verses', 2, $12, 'Ferrous Tapes', NULL, 65931),
+         ($3, $5, $9, $10, 'Drownings', 3, $12, 'Ferrous Tapes', NULL, 65932),
+         ($4, $5, $9, $10, 'Erlking', 4, $12, 'Ferrous Tapes', NULL, 65933),
+         ($6, $7, $9, $10, 'Marrowfield', 1, $11, 'Skarnvold Recordings', NULL, 65934),
+         ($8, $13, $9, $10, 'Ambergris', 1, $14, 'Pale Harvest', NULL, 65935)
        ON CONFLICT (id) DO NOTHING`,
       [
         NOISE_LIBRARY_IDS[0],
@@ -671,7 +682,7 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
     // is what makes `assertAliasBranchLive` a valid liveness check.
     expect(row.noise_matches_directly).toBe(false);
     expect(row.control_matches_directly).toBe(false);
-    // And the CONTROL variant is exact — a `< 1` guard is a guard on this
+    // And the CONTROL variant is exact — the `< 1` guard is a guard on this
     // number, so pin it rather than inferring it from the variant string.
     const [exact] = await sql.unsafe(`SELECT similarity($1::text, $2::text) AS sim`, [QUERY, QUERY]);
     expect(Number(exact.sim)).toBe(1);
@@ -695,8 +706,12 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
   });
 
   test('GET /library/search: the fuzzy fan-out no longer pushes real matches off the page', async () => {
-    // limit 4 = exactly the fuzzy fan-out size. Pre-tier the page is all Wolf
-    // Eyes and both better answers are simply gone — the reported symptom.
+    // limit 4 = exactly the fuzzy fan-out size, so the page cannot hold both
+    // better answers AND the noise. The assertion discriminates against both
+    // wrong orderings:
+    //   - no tier (rank on GREATEST alone) -> [CONTROL, 3x Havnrot]; REAL gone
+    //   - unconditional tier               -> [REAL, CONTROL, 2x Havnrot]
+    //   - as shipped                       -> [CONTROL, REAL, 2x Havnrot]
     const res = await auth.get('/library/search').query({ query: QUERY, limit: 4 }).expect(200);
 
     const ids = res.body.results.map((r) => r.id);
@@ -706,28 +721,29 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
   test('GET /library/search: an exact variant survives even a single-row page', async () => {
     // The inverse regression, at its sharpest. This path emits a bare LIMIT
     // with no OFFSET, so an unconditionally-tiered exact hit is not demoted
-    // to page 2 — there is no page 2, and it is simply absent.
+    // to page 2 — there is no page 2, and it is simply absent. (This one does
+    // not discriminate against the no-tier state, which also puts CONTROL
+    // first on score; the test above is what covers that.)
     const res = await auth.get('/library/search').query({ query: QUERY, limit: 1 }).expect(200);
 
     expect(res.body.results.map((r) => r.id)).toEqual([CONTROL_LIBRARY_ID]);
   });
 
-  test('GET /library/query: the same tier, on the paginated catalog surface', async () => {
-    // The third alias-aware path, and the reason the tier is built by one
-    // shared helper: the same query must not rank differently on two
-    // endpoints that answer the same question.
+  test('GET /library/query: the tier there is unconditional, and stays that way', async () => {
+    // The third alias-aware path, and the one BS#2020 deliberately did NOT
+    // narrow. It orders by the caller's sort column, so an exempted row would
+    // not be "ranked on its merits" — it would just be alphabetized among the
+    // real matches. Default sort is album ASC and REAL's 'Marrowfield' sorts
+    // LAST of the six, so only the tier can put it first.
     //
-    // The default sort here is album title ASC ('Beaches and Canyons' <
-    // 'Burned Mind' < 'Dread' < 'Human Animal' < 'Microcastle' < 'No Answer
-    // Lower Floors'), so post-fix CONTROL leads on the caller's sort as well
-    // as the tier and the assertion can look tautological. It isn't: pre-fix
-    // the tier overrode that sort entirely and put 'Microcastle' — the only
-    // tier-0 row — first, which is what this caught before the guard existed.
+    // This is the assertion BS#2018's own suite cannot make: its noise variant
+    // sits at 0.333, under the floor, so it contributes no rows at all. This
+    // fixture's 0.6667 variant is what actually exercises the demotion.
     const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
 
     const ids = res.body.results.map((r) => r.id);
-    expect(ids.indexOf(CONTROL_LIBRARY_ID)).toBeGreaterThanOrEqual(0);
-    expect(ids.indexOf(CONTROL_LIBRARY_ID)).toBeLessThan(ids.indexOf(REAL_LIBRARY_ID));
+    expect(ids.indexOf(REAL_LIBRARY_ID)).toBe(0);
+    expect(ids.indexOf(REAL_LIBRARY_ID)).toBeLessThan(ids.indexOf(CONTROL_LIBRARY_ID));
     expect(ids.indexOf(REAL_LIBRARY_ID)).toBeLessThan(ids.indexOf(NOISE_LIBRARY_IDS[0]));
   });
 

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -305,7 +305,9 @@ describe('GET /library/query — alias-only primary no longer suppresses the cas
  *     branch (a) with no alias involvement at all.
  *   - CONTROL ('Gerhard Behles'), a `discogs_member` variant of exactly the
  *     query string. Similarity 1.0, so it clears any floor, and its canonical
- *     name doesn't ILIKE-match, so it can ONLY arrive via branch (b).
+ *     name doesn't ILIKE-match, so it can ONLY arrive via branch (b). BS#2020
+ *     later made it the exemption case as well: an exact variant is not the
+ *     fuzzy collision the tier was aimed at, so it is no longer demoted.
  *
  * The CONTROL row is what makes these assertions mean anything. `Monolake`
  * ILIKE-matches `monolake` on the plain legacy path, so keying a skip-guard on
@@ -372,10 +374,12 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
        ON CONFLICT (artist_id, genre_id) DO NOTHING`,
       [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID, TEST_GENRE_ID]
     );
-    // Both alias-reachable artists sort BEFORE 'Monolake' on the default
-    // artist-name ASC ('Bill Monroe' < 'Gerhard Behles' < 'Monolake'), so a
-    // regression in either fix re-floods the TOP of the page. The failure is
-    // then visible in results[0] rather than buried in the tail.
+    // Both alias-reachable artists sort BEFORE 'Monolake' by artist name
+    // ('Bill Monroe' < 'Gerhard Behles' < 'Monolake'), so a regression in
+    // either fix re-floods the TOP of the page and the failure is visible in
+    // results[0] rather than buried in the tail. Note the endpoint's DEFAULT
+    // sort is album ASC, not artist — tests that need the artist ordering
+    // above to be load-bearing have to ask for `sort=artist` explicitly.
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.library
          (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
@@ -437,55 +441,98 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
     expect(res.body.results.filter((r) => NOISE_LIBRARY_IDS.includes(r.id))).toEqual([]);
   });
 
-  test('Fix 1: an alias-only row that clears the floor still sorts after every real match', async () => {
-    const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+  test('Fix 1 (as narrowed by BS#2020): the EXACT variant is not demoted', async () => {
+    // Sort explicitly, and DESC, because the tier is only observable when it
+    // disagrees with the caller's sort. The default is album ASC, under which
+    // REAL ('Gravity') precedes CONTROL ('Layering Buddha') either way — a
+    // tiered CONTROL and an untiered one look identical. Reversing the sort
+    // separates them: the tier is hardcoded ASC and is NOT reversed by
+    // `order`, so a tiered CONTROL still trails REAL, while an untiered one
+    // leads it on album title alone.
+    const res = await auth
+      .get('/library/query')
+      .query({ q: QUERY, limit: 50, sort: 'album', order: 'desc' })
+      .expect(200);
     requireAliasActive(res.body.results);
 
     const realIndex = res.body.results.findIndex((r) => r.id === REAL_LIBRARY_ID);
     const controlIndex = res.body.results.findIndex((r) => r.id === CONTROL_LIBRARY_ID);
-    // 'Gerhard Behles' sorts before 'Monolake' by name, so this ordering can
-    // only hold if the alias tier — not the caller's sort — decides it.
     expect(realIndex).toBeGreaterThanOrEqual(0);
-    expect(controlIndex).toBeGreaterThan(realIndex);
+    expect(controlIndex).toBeGreaterThanOrEqual(0);
+
+    // This assertion is inverted from what BS#2018 originally shipped, and
+    // deliberately so. CONTROL's variant IS the query string (similarity 1.0),
+    // so demoting it was never what Fix 1 was aimed at — the complaint was a
+    // 0.333 typo collision ranking like an exact hit, and the unconditional
+    // tier swept up the exact hit as collateral. BS#2020 found that collateral
+    // fatal on the two `library.service.ts` paths, which emit a bare LIMIT: a
+    // demoted row there is deleted, not paginated. The tier is shared, so it
+    // is narrowed here too.
+    expect(controlIndex).toBeLessThan(realIndex);
+
+    // The demotion half of Fix 1 is NOT tested by this fixture, because this
+    // fixture has no fuzzy-but-above-floor alias row: NOISE sits at 0.333,
+    // deliberately under the floor, so it contributes nothing to order. The
+    // BS#2020 suite below carries a 0.6429 variant and asserts the demotion
+    // against this same endpoint.
   });
 });
 
 /**
  * BS#2020 fixture — alias-only rows displacing REAL trigram matches on the
  * two `library.service.ts` alias paths (`GET /library/` Both-mode and
- * `GET /library/search`). Distinct from BS#2018, which fixed `/library/query`.
+ * `GET /library/search`), plus the exact-variant exemption that the same
+ * ticket's first cut got wrong.
  *
- * The inversion needs a score gap, not a bad score, which is why BS#2018's
- * 0.40 floor doesn't reach it:
+ * Four artists, all reachable on one query (`deerhoof`):
  *
- *   - NOISE ('Bill Monroe'), 4 albums, alias variant 'Monolake Live'.
- *     Similarity 0.6429 against `monolake` — an utterly ordinary name
- *     variation, comfortably ABOVE the floor. Its canonical name and album
- *     titles do NOT trigram-match, so all 4 rows can arrive only via branch
- *     (b), which INNER JOINs on `artist_id` and so admits the whole
- *     discography at that one score.
- *   - REAL ('Monolord'), 1 album, matches on branch (a) at 0.3846 — a
- *     genuine match that scores BELOW the alias hit.
+ *   - NOISE ('Wolf Eyes'), 4 albums, alias variant 'Deerhoof Live'.
+ *     Similarity 0.6429 — an utterly ordinary name variation, comfortably
+ *     ABOVE BS#2018's 0.40 floor, which is why that floor cannot reach this
+ *     defect. Neither its canonical name nor any album title trigram-matches,
+ *     so all 4 rows arrive only via branch (b), which INNER JOINs on
+ *     `artist_id` and admits the whole discography at that one score.
+ *   - REAL ('Deerhunter'), 1 album, matches on branch (a) at 0.3333 — a
+ *     genuine match that scores BELOW the alias hit. That gap is the defect.
+ *   - CONTROL ('Black Dice'), 1 album, alias variant EXACTLY the query.
+ *     Similarity 1.0, canonical name unmatched (0.053), so it too can only
+ *     arrive via branch (b) — but the query string IS a registered name for
+ *     this artist, so it is a better answer than REAL, not a worse one.
  *
- * Pre-fix, both rank on one `GREATEST(...)` scale, so all 4 wrong rows sort
- * ahead of the right one. The `n`/`limit` values below are deliberately tight
- * enough that the real match falls off the page entirely, which is the
- * reported symptom rather than a proxy for it.
+ * The two failure modes are opposites and this fixture holds both at once:
+ *
+ *   - No tier at all → NOISE (0.6429) outranks REAL (0.3333) wholesale.
+ *   - An unconditional tier → CONTROL (1.0) is demoted with NOISE, and since
+ *     neither of these paths emits an OFFSET, demoted means deleted.
+ *
+ * So the invariant under test is a three-way order, CONTROL < REAL < NOISE,
+ * and the `n`/`limit` values below are deliberately tight enough that a
+ * misordered row falls off the page entirely rather than merely sorting late
+ * — the reported symptom rather than a proxy for it.
+ *
+ * The query is deliberately disjoint from BS#2018's (`monolake`). That suite
+ * seeds an artist whose canonical name IS its query, which tsvector-matches
+ * and short-circuits Both-mode before the trigram tier ever runs; sharing the
+ * string left this suite's outcome depending on describe execution order.
  *
  * `searchByArtist` carries the same fix but has no HTTP route, so its
- * coverage is the unit suite (`tests/unit/services/library-search-alias.ts`).
+ * coverage is the unit suite (`tests/unit/services/library-search-alias.test.ts`).
  */
 const BS2020 = {
   NOISE_ARTIST_ID: 9301,
   NOISE_LIBRARY_IDS: [9301, 9302, 9303, 9304],
   REAL_ARTIST_ID: 9305,
   REAL_LIBRARY_ID: 9305,
-  // similarity('Monolake Live', 'monolake') = 0.6429.
-  ALIAS_VARIANT: 'Monolake Live',
-  // similarity('Monolord', 'monolake') = 0.3846 — over pg_trgm's 0.30, so it
-  // is a real branch-(a) match, but under the alias hit's score.
-  REAL_ARTIST_NAME: 'Monolord',
-  QUERY: 'monolake',
+  CONTROL_ARTIST_ID: 9306,
+  CONTROL_LIBRARY_ID: 9306,
+  // similarity('Deerhoof Live', 'deerhoof') = 0.6429 — over the 0.40 floor.
+  ALIAS_VARIANT: 'Deerhoof Live',
+  // similarity('Deerhunter', 'deerhoof') = 0.3333 — over pg_trgm's 0.30, so
+  // it is a real branch-(a) match, but under the alias hit's score.
+  REAL_ARTIST_NAME: 'Deerhunter',
+  NOISE_ARTIST_NAME: 'Wolf Eyes',
+  CONTROL_ARTIST_NAME: 'Black Dice',
+  QUERY: 'deerhoof',
 };
 
 describe('alias-only rows no longer displace real trigram matches (BS#2020)', () => {
@@ -493,19 +540,28 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
   let sql;
   const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
   const { NOISE_ARTIST_ID, NOISE_LIBRARY_IDS, REAL_ARTIST_ID, REAL_LIBRARY_ID } = BS2020;
-  const { ALIAS_VARIANT, REAL_ARTIST_NAME, QUERY } = BS2020;
+  const { CONTROL_ARTIST_ID, CONTROL_LIBRARY_ID, ALIAS_VARIANT, QUERY } = BS2020;
+  const { REAL_ARTIST_NAME, NOISE_ARTIST_NAME, CONTROL_ARTIST_NAME } = BS2020;
 
   /**
-   * Assert the alias branch ran. The NOISE rows are unreachable without it
-   * (pinned by the first test below), so their absence means the feature is
-   * off and every ordering assertion here would pass vacuously. Throws rather
-   * than warn-skipping, matching the BS#2018 suite above.
+   * Prove the alias branch actually executed, ONCE, on a page wide enough to
+   * hold every fixture row. Both alias-only groups here are unreachable
+   * without it, so their presence on an unbounded page is a sound liveness
+   * signal — but their presence on the *bounded* pages the ordering tests
+   * assert against is not, because this fix moves both groups by design. A
+   * per-test guard would therefore report "the feature flag is off" for the
+   * one outcome that means the fix works, which is the most expensive
+   * possible way to be wrong about a failing test.
    */
-  function requireAliasActive(results) {
-    if (results.some((r) => NOISE_LIBRARY_IDS.includes(r.id))) return;
+  async function assertAliasBranchLive() {
+    const res = await auth.get('/library/').query({ artist_name: QUERY, album_title: QUERY, n: 50 }).expect(200);
+    const aliasOnlyIds = [...NOISE_LIBRARY_IDS, CONTROL_LIBRARY_ID];
+    const seen = res.body.filter((r) => aliasOnlyIds.includes(r.id));
+    if (seen.length === aliasOnlyIds.length) return;
     throw new Error(
-      `[BS#2020] No alias-only rows (library ids ${NOISE_LIBRARY_IDS.join(', ')}) came back, so the ordering ` +
-        'assertions in this suite are not exercising anything. Almost certainly the backend is running ' +
+      `[BS#2020] Expected all ${aliasOnlyIds.length} alias-only rows (library ids ${aliasOnlyIds.join(', ')}) on an ` +
+        `n=50 page, got ${seen.length}. These rows are unreachable without the alias branch, so the ordering ` +
+        'assertions in this suite would not be exercising anything. Almost certainly the backend is running ' +
         'without CATALOG_SEARCH_ALIAS_ENABLED=true — set it on the backend service in ' +
         'dev_env/docker-compose.yml, or in .env for local `npm run dev`.'
     );
@@ -518,28 +574,46 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
 
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
-       VALUES ($1, 'Bill Monroe', 'Monroe, Bill', 'MO'),
-              ($2, $3, $3, 'MO')
+       VALUES ($1, $4, $4, 'WO'),
+              ($2, $5, $5, 'DE'),
+              ($3, $6, $6, 'BL')
        ON CONFLICT (id) DO NOTHING`,
-      [NOISE_ARTIST_ID, REAL_ARTIST_ID, REAL_ARTIST_NAME]
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID, NOISE_ARTIST_NAME, REAL_ARTIST_NAME, CONTROL_ARTIST_NAME]
     );
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-       VALUES ($1, $3, 9301), ($2, $3, 9305)
+       VALUES ($1, $4, 9301), ($2, $4, 9305), ($3, $4, 9306)
        ON CONFLICT (artist_id, genre_id) DO NOTHING`,
-      [NOISE_ARTIST_ID, REAL_ARTIST_ID, TEST_GENRE_ID]
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, CONTROL_ARTIST_ID, TEST_GENRE_ID]
     );
     // No album title may trigram-match the query, or the row would arrive on
-    // branch (a) and stop being an alias-only row.
+    // branch (a) and stop being an alias-only row. Pinned by the first test.
+    //
+    // REAL's label is the one deliberate oddity. The three alias paths do not
+    // agree on what a branch-(a) match IS: `library.service.ts` uses trigram
+    // over artist_name/album_title, while `/library/query` uses ILIKE-contains
+    // over artist_name/album_title/**label**. So REAL is a real match on the
+    // first two via 'Deerhunter', and needs the label to be one on the third.
+    // Label is the only column that can do this without side effects: it is
+    // absent from `library.search_doc` (see `buildAllFieldMatch`'s note), so
+    // it cannot make Both-mode short-circuit on the tsvector tier before the
+    // trigram tier this suite is about ever runs, and it is absent from the
+    // trigram predicate, so it cannot change REAL's 0.3333 score.
+    //
+    // Without it, `/library/query` sees a result set that is 100% alias-only,
+    // which triggers the BS#1885 cascade and hands final ordering to
+    // `sortAlbumRows`'s in-memory tier — a different predicate (cascade-vs-
+    // alias, not fuzzy-vs-exact) that would mask the SQL tier entirely.
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.library
          (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
        VALUES
-         ($1, $5, $7, $8, 'Bluegrass Ramble', 1, 'Bill Monroe', 'Decca', NULL, 65930),
-         ($2, $5, $7, $8, 'Blue Moon of Kentucky', 2, 'Bill Monroe', 'Decca', NULL, 65931),
-         ($3, $5, $7, $8, 'Master of Bluegrass', 3, 'Bill Monroe', 'MCA', NULL, 65932),
-         ($4, $5, $7, $8, 'Bean Blossom', 4, 'Bill Monroe', 'MCA', NULL, 65933),
-         ($6, $9, $7, $8, 'Empress Rising', 1, $10, 'Easy Rider', NULL, 65934)
+         ($1, $5, $9, $10, 'Burned Mind', 1, $12, 'Sub Pop', NULL, 65930),
+         ($2, $5, $9, $10, 'Human Animal', 2, $12, 'Sub Pop', NULL, 65931),
+         ($3, $5, $9, $10, 'Dread', 3, $12, 'Bulb', NULL, 65932),
+         ($4, $5, $9, $10, 'No Answer Lower Floors', 4, $12, 'De Stijl', NULL, 65933),
+         ($6, $7, $9, $10, 'Microcastle', 1, $11, 'Deerhoof Recordings', NULL, 65934),
+         ($8, $13, $9, $10, 'Beaches and Canyons', 1, $14, 'DFA', NULL, 65935)
        ON CONFLICT (id) DO NOTHING`,
       [
         NOISE_LIBRARY_IDS[0],
@@ -548,71 +622,117 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
         NOISE_LIBRARY_IDS[3],
         NOISE_ARTIST_ID,
         REAL_LIBRARY_ID,
+        REAL_ARTIST_ID,
+        CONTROL_LIBRARY_ID,
         TEST_GENRE_ID,
         TEST_FORMAT_ID,
-        REAL_ARTIST_ID,
         REAL_ARTIST_NAME,
+        NOISE_ARTIST_NAME,
+        CONTROL_ARTIST_ID,
+        CONTROL_ARTIST_NAME,
       ]
     );
     await sql.unsafe(
       `INSERT INTO ${wxycSchema}.artist_search_alias
          (artist_id, source, variant, related_artist_id, external_subject_id,
           external_object_id, active, method, confidence, last_verified_at)
-       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW()),
+              ($3, 'discogs_member', $4, NULL, NULL, NULL, NULL, 'member_group', 0.9, NOW())
        ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
-      [NOISE_ARTIST_ID, ALIAS_VARIANT]
+      [NOISE_ARTIST_ID, ALIAS_VARIANT, CONTROL_ARTIST_ID, QUERY]
     );
+
+    await assertAliasBranchLive();
   });
 
   afterAll(async () => {
     await cleanupBs2020Rows(sql, wxycSchema);
   });
 
-  test('the inversion setup is real: alias hit clears the floor and outscores a genuine match', async () => {
-    // Pins every number the fixture depends on. If pg_trgm's scoring shifts,
-    // this fails FIRST and explains why the ordering tests did.
+  test('the fixture is real: one alias hit outscores a genuine match, another is exact', async () => {
+    // Pins every number the ordering tests depend on. If pg_trgm's scoring
+    // shifts, this fails FIRST and explains why the rest did.
     const [row] = await sql.unsafe(
-      `SELECT similarity($1::text, $3::text)  AS alias_sim,
-              similarity($2::text, $3::text)  AS real_sim,
-              ($2::text % $3::text)           AS real_matches_directly,
-              ($4::text % $3::text)           AS noise_matches_directly`,
-      [ALIAS_VARIANT, REAL_ARTIST_NAME, QUERY, 'Bill Monroe']
+      `SELECT similarity($1::text, $5::text) AS alias_sim,
+              similarity($2::text, $5::text) AS real_sim,
+              similarity($3::text, $5::text) AS control_sim,
+              ($2::text % $5::text)          AS real_matches_directly,
+              ($4::text % $5::text)          AS noise_matches_directly,
+              ($3::text % $5::text)          AS control_matches_directly`,
+      [ALIAS_VARIANT, REAL_ARTIST_NAME, CONTROL_ARTIST_NAME, NOISE_ARTIST_NAME, QUERY]
     );
-    // BS#2018's floor cannot help here — the alias hit is well over it.
+    // BS#2018's floor cannot help here — the fuzzy alias hit is well over it.
     expect(Number(row.alias_sim)).toBeGreaterThanOrEqual(0.4);
     // The real match is genuine (branch a) but scores lower. That gap is the
     // whole defect.
     expect(row.real_matches_directly).toBe(true);
     expect(Number(row.real_sim)).toBeLessThan(Number(row.alias_sim));
-    // And the noise artist is reachable ONLY through the alias branch, which
-    // is what makes `requireAliasActive` a valid liveness check.
+    // Both alias artists are reachable ONLY through the alias branch, which
+    // is what makes `assertAliasBranchLive` a valid liveness check.
     expect(row.noise_matches_directly).toBe(false);
+    expect(row.control_matches_directly).toBe(false);
+    // And the CONTROL variant is exact — a `< 1` guard is a guard on this
+    // number, so pin it rather than inferring it from the variant string.
+    const [exact] = await sql.unsafe(`SELECT similarity($1::text, $2::text) AS sim`, [QUERY, QUERY]);
+    expect(Number(exact.sim)).toBe(1);
   });
 
-  test('GET /library/ (Both-mode): the real match outranks every alias-only row', async () => {
+  test('GET /library/ (Both-mode): exact variant, then real match, then fuzzy alias rows', async () => {
     // dj-site Classic sends the same string as artist_name and album_title,
     // which is what routes this through the Both-mode alias path.
     const res = await auth.get('/library/').query({ artist_name: QUERY, album_title: QUERY, n: 10 }).expect(200);
-    requireAliasActive(res.body);
 
+    const controlIndex = res.body.findIndex((r) => r.id === CONTROL_LIBRARY_ID);
     const realIndex = res.body.findIndex((r) => r.id === REAL_LIBRARY_ID);
     const firstNoiseIndex = res.body.findIndex((r) => NOISE_LIBRARY_IDS.includes(r.id));
-    expect(realIndex).toBeGreaterThanOrEqual(0);
+
+    expect(controlIndex).toBeGreaterThanOrEqual(0);
+    // Exempt from the tier: an exact variant is a stronger claim on this
+    // query than a 0.33 trigram smear, so it leads on relevance.
+    expect(controlIndex).toBeLessThan(realIndex);
+    // ...and the fuzzy alias fan-out is still tiered behind both.
     expect(realIndex).toBeLessThan(firstNoiseIndex);
   });
 
-  test('GET /library/search: alias fan-out no longer pushes the real match off the page', async () => {
-    // limit 4 = exactly the alias fan-out size. Pre-fix the page is all Bill
-    // Monroe and the real match is simply gone — the reported symptom.
+  test('GET /library/search: the fuzzy fan-out no longer pushes real matches off the page', async () => {
+    // limit 4 = exactly the fuzzy fan-out size. Pre-tier the page is all Wolf
+    // Eyes and both better answers are simply gone — the reported symptom.
     const res = await auth.get('/library/search').query({ query: QUERY, limit: 4 }).expect(200);
-    requireAliasActive(res.body.results);
 
-    expect(res.body.results[0].id).toBe(REAL_LIBRARY_ID);
+    const ids = res.body.results.map((r) => r.id);
+    expect(ids.slice(0, 2)).toEqual([CONTROL_LIBRARY_ID, REAL_LIBRARY_ID]);
+  });
+
+  test('GET /library/search: an exact variant survives even a single-row page', async () => {
+    // The inverse regression, at its sharpest. This path emits a bare LIMIT
+    // with no OFFSET, so an unconditionally-tiered exact hit is not demoted
+    // to page 2 — there is no page 2, and it is simply absent.
+    const res = await auth.get('/library/search').query({ query: QUERY, limit: 1 }).expect(200);
+
+    expect(res.body.results.map((r) => r.id)).toEqual([CONTROL_LIBRARY_ID]);
+  });
+
+  test('GET /library/query: the same tier, on the paginated catalog surface', async () => {
+    // The third alias-aware path, and the reason the tier is built by one
+    // shared helper: the same query must not rank differently on two
+    // endpoints that answer the same question.
+    //
+    // The default sort here is album title ASC ('Beaches and Canyons' <
+    // 'Burned Mind' < 'Dread' < 'Human Animal' < 'Microcastle' < 'No Answer
+    // Lower Floors'), so post-fix CONTROL leads on the caller's sort as well
+    // as the tier and the assertion can look tautological. It isn't: pre-fix
+    // the tier overrode that sort entirely and put 'Microcastle' — the only
+    // tier-0 row — first, which is what this caught before the guard existed.
+    const res = await auth.get('/library/query').query({ q: QUERY, limit: 50 }).expect(200);
+
+    const ids = res.body.results.map((r) => r.id);
+    expect(ids.indexOf(CONTROL_LIBRARY_ID)).toBeGreaterThanOrEqual(0);
+    expect(ids.indexOf(CONTROL_LIBRARY_ID)).toBeLessThan(ids.indexOf(REAL_LIBRARY_ID));
+    expect(ids.indexOf(REAL_LIBRARY_ID)).toBeLessThan(ids.indexOf(NOISE_LIBRARY_IDS[0]));
   });
 
   test('alias-only rows still carry matched_via_alias, and tie-break on id (BS#1318 wire contract)', async () => {
     const res = await auth.get('/library/').query({ artist_name: QUERY, album_title: QUERY, n: 10 }).expect(200);
-    requireAliasActive(res.body);
 
     // Demoted, not dropped: the alias feature still surfaces them, still
     // labelled, and dj-site/iOS still read the hint.
@@ -621,6 +741,10 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
     expect(noiseRows[0].matched_via_alias).toEqual([
       { matched_variant: ALIAS_VARIANT, source: 'discogs_name_variation' },
     ]);
+    // The exempt row keeps its hint too — exemption is a ranking decision,
+    // not a claim that the row matched the query text directly.
+    const control = res.body.find((r) => r.id === CONTROL_LIBRARY_ID);
+    expect(control.matched_via_alias).toEqual([{ matched_variant: QUERY, source: 'discogs_member' }]);
     // Pins the intra-tier order. Note this assertion does NOT prove the
     // `id ASC` tie-break is load-bearing — it passes against a build without
     // it, because an unordered plan may still emit id order by luck. Nothing
@@ -631,8 +755,8 @@ describe('alias-only rows no longer displace real trigram matches (BS#2020)', ()
 });
 
 async function cleanupBs2020Rows(sql, wxycSchema) {
-  const artistIds = [BS2020.NOISE_ARTIST_ID, BS2020.REAL_ARTIST_ID];
-  const libraryIds = [...BS2020.NOISE_LIBRARY_IDS, BS2020.REAL_LIBRARY_ID];
+  const artistIds = [BS2020.NOISE_ARTIST_ID, BS2020.REAL_ARTIST_ID, BS2020.CONTROL_ARTIST_ID];
+  const libraryIds = [...BS2020.NOISE_LIBRARY_IDS, BS2020.REAL_LIBRARY_ID, BS2020.CONTROL_LIBRARY_ID];
   await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = ANY($1::int[])`, [artistIds]);
   await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id = ANY($1::int[])`, [libraryIds]);
   await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id = ANY($1::int[])`, [

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -450,6 +450,197 @@ describe('GET /library/query — fuzzy alias hits no longer flood results (BS#20
   });
 });
 
+/**
+ * BS#2020 fixture — alias-only rows displacing REAL trigram matches on the
+ * two `library.service.ts` alias paths (`GET /library/` Both-mode and
+ * `GET /library/search`). Distinct from BS#2018, which fixed `/library/query`.
+ *
+ * The inversion needs a score gap, not a bad score, which is why BS#2018's
+ * 0.40 floor doesn't reach it:
+ *
+ *   - NOISE ('Bill Monroe'), 4 albums, alias variant 'Monolake Live'.
+ *     Similarity 0.6429 against `monolake` — an utterly ordinary name
+ *     variation, comfortably ABOVE the floor. Its canonical name and album
+ *     titles do NOT trigram-match, so all 4 rows can arrive only via branch
+ *     (b), which INNER JOINs on `artist_id` and so admits the whole
+ *     discography at that one score.
+ *   - REAL ('Monolord'), 1 album, matches on branch (a) at 0.3846 — a
+ *     genuine match that scores BELOW the alias hit.
+ *
+ * Pre-fix, both rank on one `GREATEST(...)` scale, so all 4 wrong rows sort
+ * ahead of the right one. The `n`/`limit` values below are deliberately tight
+ * enough that the real match falls off the page entirely, which is the
+ * reported symptom rather than a proxy for it.
+ *
+ * `searchByArtist` carries the same fix but has no HTTP route, so its
+ * coverage is the unit suite (`tests/unit/services/library-search-alias.ts`).
+ */
+const BS2020 = {
+  NOISE_ARTIST_ID: 9301,
+  NOISE_LIBRARY_IDS: [9301, 9302, 9303, 9304],
+  REAL_ARTIST_ID: 9305,
+  REAL_LIBRARY_ID: 9305,
+  // similarity('Monolake Live', 'monolake') = 0.6429.
+  ALIAS_VARIANT: 'Monolake Live',
+  // similarity('Monolord', 'monolake') = 0.3846 — over pg_trgm's 0.30, so it
+  // is a real branch-(a) match, but under the alias hit's score.
+  REAL_ARTIST_NAME: 'Monolord',
+  QUERY: 'monolake',
+};
+
+describe('alias-only rows no longer displace real trigram matches (BS#2020)', () => {
+  let auth;
+  let sql;
+  const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+  const { NOISE_ARTIST_ID, NOISE_LIBRARY_IDS, REAL_ARTIST_ID, REAL_LIBRARY_ID } = BS2020;
+  const { ALIAS_VARIANT, REAL_ARTIST_NAME, QUERY } = BS2020;
+
+  /**
+   * Assert the alias branch ran. The NOISE rows are unreachable without it
+   * (pinned by the first test below), so their absence means the feature is
+   * off and every ordering assertion here would pass vacuously. Throws rather
+   * than warn-skipping, matching the BS#2018 suite above.
+   */
+  function requireAliasActive(results) {
+    if (results.some((r) => NOISE_LIBRARY_IDS.includes(r.id))) return;
+    throw new Error(
+      `[BS#2020] No alias-only rows (library ids ${NOISE_LIBRARY_IDS.join(', ')}) came back, so the ordering ` +
+        'assertions in this suite are not exercising anything. Almost certainly the backend is running ' +
+        'without CATALOG_SEARCH_ALIAS_ENABLED=true — set it on the backend service in ' +
+        'dev_env/docker-compose.yml, or in .env for local `npm run dev`.'
+    );
+  }
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+    await cleanupBs2020Rows(sql, wxycSchema);
+
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
+       VALUES ($1, 'Bill Monroe', 'Monroe, Bill', 'MO'),
+              ($2, $3, $3, 'MO')
+       ON CONFLICT (id) DO NOTHING`,
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, REAL_ARTIST_NAME]
+    );
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+       VALUES ($1, $3, 9301), ($2, $3, 9305)
+       ON CONFLICT (artist_id, genre_id) DO NOTHING`,
+      [NOISE_ARTIST_ID, REAL_ARTIST_ID, TEST_GENRE_ID]
+    );
+    // No album title may trigram-match the query, or the row would arrive on
+    // branch (a) and stop being an alias-only row.
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
+       VALUES
+         ($1, $5, $7, $8, 'Bluegrass Ramble', 1, 'Bill Monroe', 'Decca', NULL, 65930),
+         ($2, $5, $7, $8, 'Blue Moon of Kentucky', 2, 'Bill Monroe', 'Decca', NULL, 65931),
+         ($3, $5, $7, $8, 'Master of Bluegrass', 3, 'Bill Monroe', 'MCA', NULL, 65932),
+         ($4, $5, $7, $8, 'Bean Blossom', 4, 'Bill Monroe', 'MCA', NULL, 65933),
+         ($6, $9, $7, $8, 'Empress Rising', 1, $10, 'Easy Rider', NULL, 65934)
+       ON CONFLICT (id) DO NOTHING`,
+      [
+        NOISE_LIBRARY_IDS[0],
+        NOISE_LIBRARY_IDS[1],
+        NOISE_LIBRARY_IDS[2],
+        NOISE_LIBRARY_IDS[3],
+        NOISE_ARTIST_ID,
+        REAL_LIBRARY_ID,
+        TEST_GENRE_ID,
+        TEST_FORMAT_ID,
+        REAL_ARTIST_ID,
+        REAL_ARTIST_NAME,
+      ]
+    );
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artist_search_alias
+         (artist_id, source, variant, related_artist_id, external_subject_id,
+          external_object_id, active, method, confidence, last_verified_at)
+       VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+       ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
+      [NOISE_ARTIST_ID, ALIAS_VARIANT]
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupBs2020Rows(sql, wxycSchema);
+  });
+
+  test('the inversion setup is real: alias hit clears the floor and outscores a genuine match', async () => {
+    // Pins every number the fixture depends on. If pg_trgm's scoring shifts,
+    // this fails FIRST and explains why the ordering tests did.
+    const [row] = await sql.unsafe(
+      `SELECT similarity($1::text, $3::text)  AS alias_sim,
+              similarity($2::text, $3::text)  AS real_sim,
+              ($2::text % $3::text)           AS real_matches_directly,
+              ($4::text % $3::text)           AS noise_matches_directly`,
+      [ALIAS_VARIANT, REAL_ARTIST_NAME, QUERY, 'Bill Monroe']
+    );
+    // BS#2018's floor cannot help here — the alias hit is well over it.
+    expect(Number(row.alias_sim)).toBeGreaterThanOrEqual(0.4);
+    // The real match is genuine (branch a) but scores lower. That gap is the
+    // whole defect.
+    expect(row.real_matches_directly).toBe(true);
+    expect(Number(row.real_sim)).toBeLessThan(Number(row.alias_sim));
+    // And the noise artist is reachable ONLY through the alias branch, which
+    // is what makes `requireAliasActive` a valid liveness check.
+    expect(row.noise_matches_directly).toBe(false);
+  });
+
+  test('GET /library/ (Both-mode): the real match outranks every alias-only row', async () => {
+    // dj-site Classic sends the same string as artist_name and album_title,
+    // which is what routes this through the Both-mode alias path.
+    const res = await auth.get('/library/').query({ artist_name: QUERY, album_title: QUERY, n: 10 }).expect(200);
+    requireAliasActive(res.body);
+
+    const realIndex = res.body.findIndex((r) => r.id === REAL_LIBRARY_ID);
+    const firstNoiseIndex = res.body.findIndex((r) => NOISE_LIBRARY_IDS.includes(r.id));
+    expect(realIndex).toBeGreaterThanOrEqual(0);
+    expect(realIndex).toBeLessThan(firstNoiseIndex);
+  });
+
+  test('GET /library/search: alias fan-out no longer pushes the real match off the page', async () => {
+    // limit 4 = exactly the alias fan-out size. Pre-fix the page is all Bill
+    // Monroe and the real match is simply gone — the reported symptom.
+    const res = await auth.get('/library/search').query({ query: QUERY, limit: 4 }).expect(200);
+    requireAliasActive(res.body.results);
+
+    expect(res.body.results[0].id).toBe(REAL_LIBRARY_ID);
+  });
+
+  test('alias-only rows still carry matched_via_alias, and tie-break on id (BS#1318 wire contract)', async () => {
+    const res = await auth.get('/library/').query({ artist_name: QUERY, album_title: QUERY, n: 10 }).expect(200);
+    requireAliasActive(res.body);
+
+    // Demoted, not dropped: the alias feature still surfaces them, still
+    // labelled, and dj-site/iOS still read the hint.
+    const noiseRows = res.body.filter((r) => NOISE_LIBRARY_IDS.includes(r.id));
+    expect(noiseRows).toHaveLength(NOISE_LIBRARY_IDS.length);
+    expect(noiseRows[0].matched_via_alias).toEqual([
+      { matched_variant: ALIAS_VARIANT, source: 'discogs_name_variation' },
+    ]);
+    // Pins the intra-tier order. Note this assertion does NOT prove the
+    // `id ASC` tie-break is load-bearing — it passes against a build without
+    // it, because an unordered plan may still emit id order by luck. Nothing
+    // observable can prove determinism; what this catches is a future change
+    // that perturbs the order on purpose.
+    expect(noiseRows.map((r) => r.id)).toEqual([...NOISE_LIBRARY_IDS].sort((a, b) => a - b));
+  });
+});
+
+async function cleanupBs2020Rows(sql, wxycSchema) {
+  const artistIds = [BS2020.NOISE_ARTIST_ID, BS2020.REAL_ARTIST_ID];
+  const libraryIds = [...BS2020.NOISE_LIBRARY_IDS, BS2020.REAL_LIBRARY_ID];
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = ANY($1::int[])`, [artistIds]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id = ANY($1::int[])`, [libraryIds]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id = ANY($1::int[])`, [
+    artistIds,
+  ]);
+  await sql.unsafe(`DELETE FROM ${wxycSchema}.artists WHERE id = ANY($1::int[])`, [artistIds]);
+}
+
 async function cleanupBs2018Rows(sql, wxycSchema) {
   const artistIds = [BS2018.NOISE_ARTIST_ID, BS2018.REAL_ARTIST_ID, BS2018.CONTROL_ARTIST_ID];
   const libraryIds = [...BS2018.NOISE_LIBRARY_IDS, BS2018.REAL_LIBRARY_ID, BS2018.CONTROL_LIBRARY_ID];

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -1019,4 +1019,132 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       expect(rendered).not.toContain('LEFT JOIN LATERAL');
     });
   });
+
+  // -----------------------------------------------------------------------
+  // BS#2020 — alias-only rows could displace real trigram matches.
+  //
+  // Both alias-aware paths in `library.service.ts` ranked alias-only rows and
+  // real matches on a single `GREATEST(...)` scale. Branch (b) INNER JOINs on
+  // `artist_id`, so ONE mid-scoring variant admits its artist's entire
+  // discography at that score, and every one of those rows outranks any real
+  // match scoring below it. Measured against a prod-shaped clone: the variant
+  // "Monolake Live" (similarity 0.6429 vs `monolake` — an ordinary name
+  // variation, comfortably over BS#2018's 0.40 floor) put 6 Bill Monroe
+  // albums on the page and pushed Mono (0.400), Monolord (0.385), Monos
+  // (0.364), Midlake / Monokle / Monopot (0.308) off it entirely.
+  //
+  // Distinct from BS#2018, which fixed `/library/query` — a path whose
+  // ORDER BY had no relevance term at all. Here relevance ordering already
+  // exists and must be PRESERVED inside each tier, not replaced.
+  //
+  // `id ASC` is new on both sites: neither had any tie-break, and within the
+  // alias tier every row of one artist shares an identical `alias_max_sim`,
+  // so their relative order was whatever the plan happened to emit.
+  // -----------------------------------------------------------------------
+  describe('BS#2020 alias-only rows tier after real trigram matches', () => {
+    const ALIAS_ONLY_TIER = '(alias_max_sim IS NOT NULL) ASC';
+    const flat = (text: string) => text.replace(/\s+/g, ' ');
+
+    beforeEach(() => {
+      process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+      resetCatalogSearchAliasConfig();
+    });
+
+    /** Render the alias-aware SQL emitted by the Both-mode trigram tier. */
+    async function renderBothModeSql(query = 'monolake'): Promise<string> {
+      // tsvector tier must return 0 rows so the trigram tier fires.
+      const tsvectorChain = createMockQueryChain([]);
+      tsvectorChain.limit = jest.fn().mockResolvedValue([]);
+      db.select.mockReset();
+      db.select.mockReturnValue(tsvectorChain);
+      db.execute.mockReset();
+      db.execute.mockResolvedValue([]);
+
+      await searchLibrary(query);
+
+      const aliasCall = db.execute.mock.calls.find((call) => JSON.stringify(call[0] ?? '').includes('alias_hits'));
+      expect(aliasCall).toBeDefined();
+      return flat(renderSqlWithParams(aliasCall?.[0]));
+    }
+
+    /** Render the alias-aware SQL emitted by the request-line artist path. */
+    async function renderByArtistSql(query = 'monolake'): Promise<string> {
+      db.select.mockReset();
+      db.execute.mockReset();
+      db.execute.mockResolvedValue([]);
+
+      await searchByArtist(query);
+
+      const aliasCall = db.execute.mock.calls.find((call) => JSON.stringify(call[0] ?? '').includes('alias_hits'));
+      expect(aliasCall).toBeDefined();
+      return flat(renderSqlWithParams(aliasCall?.[0]));
+    }
+
+    it('Both-mode: the tier leads the ORDER BY, relevance still ranks inside it', async () => {
+      const rendered = await renderBothModeSql();
+
+      // Tier FIRST, or a 0.64 alias row still outranks a 0.40 real one.
+      expect(rendered).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, GREATEST(`);
+      // GREATEST must survive intact: within a tier the strongest hit leads.
+      expect(rendered).toContain('similarity(artist_name, monolake)');
+      expect(rendered).toContain('similarity(album_title, monolake)');
+      expect(rendered).toContain('COALESCE(alias_max_sim, 0)');
+      expect(rendered).toContain(') DESC, id ASC');
+    });
+
+    it('request-line: the tier leads the ORDER BY (single-column relevance)', async () => {
+      const rendered = await renderByArtistSql();
+
+      expect(rendered).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, GREATEST(`);
+      expect(rendered).toContain('similarity(artist_name, monolake)');
+      expect(rendered).toContain('COALESCE(alias_max_sim, 0)');
+      expect(rendered).toContain(') DESC, id ASC');
+      // No album_title predicate on this path, so none in the ranking either.
+      expect(rendered).not.toContain('similarity(album_title');
+    });
+
+    it.each([
+      ['Both-mode', renderBothModeSql],
+      ['request-line', renderByArtistSql],
+    ])('%s: the tier sorts ASC so real matches come first (FALSE < TRUE)', async (_label, render) => {
+      const rendered = await render();
+
+      // Assert presence before absence. A bare `not.toContain` here would
+      // pass against a build with no tier at all — the vacuous-guard trap
+      // BS#2019 shipped and had to fix.
+      expect(rendered).toContain(ALIAS_ONLY_TIER);
+      // The single most reversible mistake: DESC inverts the fix and
+      // promotes every alias row above every real match.
+      expect(rendered).not.toContain('(alias_max_sim IS NOT NULL) DESC');
+    });
+
+    it('Both-mode alias OFF: the legacy chained-builder ordering is untouched', async () => {
+      delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+      resetCatalogSearchAliasConfig();
+
+      const tsvectorChain = createMockQueryChain([]);
+      tsvectorChain.limit = jest.fn().mockResolvedValue([]);
+      const trigramChain = createMockQueryChain([]);
+      trigramChain.limit = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? tsvectorChain : trigramChain;
+        callIndex += 1;
+        return chain;
+      });
+      db.execute.mockReset();
+      db.execute.mockResolvedValue([]);
+
+      await searchLibrary('monolake');
+
+      // BS#1318 requires the alias-OFF path stay byte-identical so the
+      // planner keeps reaching the per-column GIN trigram indexes. The tier
+      // references a column that branch (a) alone does not project.
+      const ordering = trigramChain.orderBy.mock.calls.flat().map(renderSqlWithParams).join(' | ');
+      expect(ordering).not.toContain('alias_max_sim');
+      const aliasCall = db.execute.mock.calls.find((call) => JSON.stringify(call[0] ?? '').includes('alias_hits'));
+      expect(aliasCall).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -823,15 +823,17 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
     // Fix 1 tiers the sort (alias-only rows always after non-alias rows).
     // Fix 2 raises the alias match floor to 0.40.
     //
-    // BS#2020 narrowed Fix 1's tier here to FUZZY alias-only rows. The
-    // complaint above is about a 0.333 typo collision sorting like an exact
-    // hit; demoting the exact hit too was collateral, not the goal. This path
-    // paginates, so the collateral was survivable here and fatal on the two
-    // `library.service.ts` paths — but the tier means one thing in all three
-    // places, which is why it is built by one shared helper.
+    // This tier stays UNCONDITIONAL, unlike the two relevance-ranked paths in
+    // `library.service.ts` that BS#2020 narrowed to fuzzy hits only. The
+    // narrowing buys nothing here and costs something: this endpoint orders by
+    // the caller's chosen column, so an exempted row is not "ranked on its
+    // merits", it is merely alphabetized among the real matches — one
+    // exact-variant artist with 30 early-alphabet albums would fill page 0.
+    // And the argument that justifies exempting elsewhere (no OFFSET, so
+    // demoted means deleted) does not apply to a paginated surface.
     // ---------------------------------------------------------------------
     describe('BS#2018 alias-noise floor + rank tiering', () => {
-      const FUZZY_ALIAS_TIER = '(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC';
+      const ALIAS_ONLY_TIER = '(alias_max_sim IS NOT NULL) ASC';
 
       function runAliasQuery(
         params: { sort?: CatalogSort; order?: CatalogOrder } = {}
@@ -891,7 +893,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         // The tier key must lead the ORDER BY, and the caller's own sort must
         // still follow it intact. `FALSE < TRUE` in Postgres, so ASC puts the
         // non-alias rows first.
-        expect(data).toContain(`ORDER BY ${FUZZY_ALIAS_TIER}, artist_name ASC, album_title ASC, id ASC`);
+        expect(data).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, artist_name ASC, album_title ASC, id ASC`);
       });
 
       const SORT_EXPECTATIONS: [CatalogSort, string, string][] = [
@@ -908,7 +910,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       )('Fix 1: tier leads the ORDER BY for sort=$sort order=$order', async ({ sort, order, primary, secondary }) => {
         const { data } = await runAliasQuery({ sort, order });
 
-        const expected = `ORDER BY ${FUZZY_ALIAS_TIER}, ${primary} ${order.toUpperCase()}, ${secondary} ASC, id ASC`;
+        const expected = `ORDER BY ${ALIAS_ONLY_TIER}, ${primary} ${order.toUpperCase()}, ${secondary} ASC, id ASC`;
         expect(data).toContain(expected);
       });
 
@@ -919,7 +921,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         // survives; perturbing it changes the surfaced rotation bin. The
         // tier belongs on the OUTER sort only.
         expect(data).toContain('ORDER BY id ASC, CASE rotation_bin');
-        expect(data.slice(0, data.indexOf('ORDER BY id ASC, CASE rotation_bin'))).not.toContain(FUZZY_ALIAS_TIER);
+        expect(data.slice(0, data.indexOf('ORDER BY id ASC, CASE rotation_bin'))).not.toContain(ALIAS_ONLY_TIER);
       });
 
       it('alias OFF: neither the floor nor the tier appears (legacy path unchanged)', async () => {
@@ -929,7 +931,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         const { data, count } = await runAliasQuery();
 
         expect(data).not.toContain('similarity(asa.variant');
-        expect(data).not.toContain(FUZZY_ALIAS_TIER);
+        expect(data).not.toContain(ALIAS_ONLY_TIER);
         expect(data).not.toContain('alias_max_sim');
         expect(count).not.toContain('similarity(asa.variant');
         expect(data).toContain('ORDER BY artist_name ASC, album_title ASC, id ASC');
@@ -1042,20 +1044,27 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
   //
   // Distinct from BS#2018, which fixed `/library/query` — a path whose
   // ORDER BY had no relevance term at all. Here relevance ordering already
-  // exists and must be PRESERVED inside each tier, not replaced.
+  // exists and must be PRESERVED inside each tier, not replaced. That
+  // difference is also why only these two paths narrow the tier to fuzzy
+  // hits: an exemption is only meaningful where something ranks the exempted
+  // row afterwards. See `buildFuzzyAliasTier` for the full argument.
   //
-  // The tier demotes FUZZY alias hits only. An `alias_max_sim` of 1 means the
-  // query string IS a registered name for that artist, which is at least as
-  // strong a claim as a 0.31 trigram smear on a canonical name; demoting it
-  // on these two paths would delete it, not reorder it, because neither emits
-  // an OFFSET. See `buildFuzzyAliasTier` for the full argument.
+  // The full ORDER BY is four terms, and each earns its place:
   //
-  // `id ASC` is new on both sites: neither had any tie-break, and within the
-  // alias tier every row of one artist shares an identical `alias_max_sim`,
-  // so their relative order was whatever the plan happened to emit.
+  //   1. fuzzy-alias tier   — a 0.64 variant must not outrank a 0.40 real hit
+  //   2. GREATEST(...) DESC — relevance, preserved from before the fix
+  //   3. direct-match tie   — at EQUAL relevance, prefer the row that matched
+  //                           the query text over one that matched a variant
+  //   4. id ASC             — determinism
+  //
+  // Term 3 exists because term 1's guard removed the only signal separating a
+  // direct match from an alias match once both score 1.0, which would have
+  // left `id ASC` — catalog age — to decide. See the builder for why that is
+  // currently unreachable on this path and kept anyway.
   // -----------------------------------------------------------------------
   describe('BS#2020 alias-only rows tier after real trigram matches', () => {
     const FUZZY_ALIAS_TIER = '(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC';
+    const DIRECT_MATCH_TIE_BREAK = '(alias_max_sim IS NOT NULL) ASC';
     const flat = (text: string) => text.replace(/\s+/g, ' ');
 
     beforeEach(() => {
@@ -1102,7 +1111,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       expect(rendered).toContain('similarity(artist_name, monolake)');
       expect(rendered).toContain('similarity(album_title, monolake)');
       expect(rendered).toContain('COALESCE(alias_max_sim, 0)');
-      expect(rendered).toContain(') DESC, id ASC');
+      expect(rendered).toContain(`) DESC, ${DIRECT_MATCH_TIE_BREAK}, id ASC`);
     });
 
     it('request-line: the tier leads the ORDER BY (single-column relevance)', async () => {
@@ -1111,7 +1120,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       expect(rendered).toContain(`ORDER BY ${FUZZY_ALIAS_TIER}, GREATEST(`);
       expect(rendered).toContain('similarity(artist_name, monolake)');
       expect(rendered).toContain('COALESCE(alias_max_sim, 0)');
-      expect(rendered).toContain(') DESC, id ASC');
+      expect(rendered).toContain(`) DESC, ${DIRECT_MATCH_TIE_BREAK}, id ASC`);
       // No album_title predicate on this path, so none in the ranking either.
       expect(rendered).not.toContain('similarity(album_title');
     });
@@ -1134,17 +1143,18 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
     it.each([
       ['Both-mode', renderBothModeSql],
       ['request-line', renderByArtistSql],
-    ])('%s: an exact-variant hit is exempt from the tier, not merely ranked high', async (_label, render) => {
+    ])('%s: the exemption and the tie-break appear in that order, not swapped', async (_label, render) => {
       const rendered = await render();
 
-      // The exemption has to live in the TIER, not in the relevance term.
-      // `GREATEST` already promotes a 1.0 alias hit to the top of its tier —
-      // and that is exactly what is not enough: an unconditional tier puts
-      // the whole alias group behind every real match, and on these two
-      // paths (bare LIMIT, no OFFSET) behind means gone. So assert the
-      // score guard is part of the tier predicate itself.
-      expect(rendered).toContain('alias_max_sim < 1');
-      expect(rendered).not.toContain('ORDER BY (alias_max_sim IS NOT NULL) ASC');
+      // Both terms are the same substring apart from the guard, so the thing
+      // worth pinning is their POSITIONS: the guarded form must lead and the
+      // bare form must trail. Swapped, the bare form becomes the tier and the
+      // fix silently reverts to demoting exact variants — which the string
+      // assertions above would not catch, since both strings are still there.
+      const tierAt = rendered.indexOf(`ORDER BY ${FUZZY_ALIAS_TIER}`);
+      const tieBreakAt = rendered.indexOf(`) DESC, ${DIRECT_MATCH_TIE_BREAK}`);
+      expect(tierAt).toBeGreaterThanOrEqual(0);
+      expect(tieBreakAt).toBeGreaterThan(tierAt);
     });
 
     it('Both-mode alias OFF: the legacy chained-builder ordering is untouched', async () => {

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -822,9 +822,16 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
     //
     // Fix 1 tiers the sort (alias-only rows always after non-alias rows).
     // Fix 2 raises the alias match floor to 0.40.
+    //
+    // BS#2020 narrowed Fix 1's tier here to FUZZY alias-only rows. The
+    // complaint above is about a 0.333 typo collision sorting like an exact
+    // hit; demoting the exact hit too was collateral, not the goal. This path
+    // paginates, so the collateral was survivable here and fatal on the two
+    // `library.service.ts` paths — but the tier means one thing in all three
+    // places, which is why it is built by one shared helper.
     // ---------------------------------------------------------------------
     describe('BS#2018 alias-noise floor + rank tiering', () => {
-      const ALIAS_ONLY_TIER = '(alias_max_sim IS NOT NULL) ASC';
+      const FUZZY_ALIAS_TIER = '(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC';
 
       function runAliasQuery(
         params: { sort?: CatalogSort; order?: CatalogOrder } = {}
@@ -884,7 +891,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         // The tier key must lead the ORDER BY, and the caller's own sort must
         // still follow it intact. `FALSE < TRUE` in Postgres, so ASC puts the
         // non-alias rows first.
-        expect(data).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, artist_name ASC, album_title ASC, id ASC`);
+        expect(data).toContain(`ORDER BY ${FUZZY_ALIAS_TIER}, artist_name ASC, album_title ASC, id ASC`);
       });
 
       const SORT_EXPECTATIONS: [CatalogSort, string, string][] = [
@@ -901,7 +908,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       )('Fix 1: tier leads the ORDER BY for sort=$sort order=$order', async ({ sort, order, primary, secondary }) => {
         const { data } = await runAliasQuery({ sort, order });
 
-        const expected = `ORDER BY ${ALIAS_ONLY_TIER}, ${primary} ${order.toUpperCase()}, ${secondary} ASC, id ASC`;
+        const expected = `ORDER BY ${FUZZY_ALIAS_TIER}, ${primary} ${order.toUpperCase()}, ${secondary} ASC, id ASC`;
         expect(data).toContain(expected);
       });
 
@@ -912,7 +919,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         // survives; perturbing it changes the surfaced rotation bin. The
         // tier belongs on the OUTER sort only.
         expect(data).toContain('ORDER BY id ASC, CASE rotation_bin');
-        expect(data.slice(0, data.indexOf('ORDER BY id ASC, CASE rotation_bin'))).not.toContain(ALIAS_ONLY_TIER);
+        expect(data.slice(0, data.indexOf('ORDER BY id ASC, CASE rotation_bin'))).not.toContain(FUZZY_ALIAS_TIER);
       });
 
       it('alias OFF: neither the floor nor the tier appears (legacy path unchanged)', async () => {
@@ -922,7 +929,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
         const { data, count } = await runAliasQuery();
 
         expect(data).not.toContain('similarity(asa.variant');
-        expect(data).not.toContain(ALIAS_ONLY_TIER);
+        expect(data).not.toContain(FUZZY_ALIAS_TIER);
         expect(data).not.toContain('alias_max_sim');
         expect(count).not.toContain('similarity(asa.variant');
         expect(data).toContain('ORDER BY artist_name ASC, album_title ASC, id ASC');
@@ -1037,12 +1044,18 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
   // ORDER BY had no relevance term at all. Here relevance ordering already
   // exists and must be PRESERVED inside each tier, not replaced.
   //
+  // The tier demotes FUZZY alias hits only. An `alias_max_sim` of 1 means the
+  // query string IS a registered name for that artist, which is at least as
+  // strong a claim as a 0.31 trigram smear on a canonical name; demoting it
+  // on these two paths would delete it, not reorder it, because neither emits
+  // an OFFSET. See `buildFuzzyAliasTier` for the full argument.
+  //
   // `id ASC` is new on both sites: neither had any tie-break, and within the
   // alias tier every row of one artist shares an identical `alias_max_sim`,
   // so their relative order was whatever the plan happened to emit.
   // -----------------------------------------------------------------------
   describe('BS#2020 alias-only rows tier after real trigram matches', () => {
-    const ALIAS_ONLY_TIER = '(alias_max_sim IS NOT NULL) ASC';
+    const FUZZY_ALIAS_TIER = '(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC';
     const flat = (text: string) => text.replace(/\s+/g, ' ');
 
     beforeEach(() => {
@@ -1084,7 +1097,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       const rendered = await renderBothModeSql();
 
       // Tier FIRST, or a 0.64 alias row still outranks a 0.40 real one.
-      expect(rendered).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, GREATEST(`);
+      expect(rendered).toContain(`ORDER BY ${FUZZY_ALIAS_TIER}, GREATEST(`);
       // GREATEST must survive intact: within a tier the strongest hit leads.
       expect(rendered).toContain('similarity(artist_name, monolake)');
       expect(rendered).toContain('similarity(album_title, monolake)');
@@ -1095,7 +1108,7 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
     it('request-line: the tier leads the ORDER BY (single-column relevance)', async () => {
       const rendered = await renderByArtistSql();
 
-      expect(rendered).toContain(`ORDER BY ${ALIAS_ONLY_TIER}, GREATEST(`);
+      expect(rendered).toContain(`ORDER BY ${FUZZY_ALIAS_TIER}, GREATEST(`);
       expect(rendered).toContain('similarity(artist_name, monolake)');
       expect(rendered).toContain('COALESCE(alias_max_sim, 0)');
       expect(rendered).toContain(') DESC, id ASC');
@@ -1112,10 +1125,26 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       // Assert presence before absence. A bare `not.toContain` here would
       // pass against a build with no tier at all — the vacuous-guard trap
       // BS#2019 shipped and had to fix.
-      expect(rendered).toContain(ALIAS_ONLY_TIER);
+      expect(rendered).toContain(FUZZY_ALIAS_TIER);
       // The single most reversible mistake: DESC inverts the fix and
       // promotes every alias row above every real match.
-      expect(rendered).not.toContain('(alias_max_sim IS NOT NULL) DESC');
+      expect(rendered).not.toContain('(alias_max_sim IS NOT NULL AND alias_max_sim < 1) DESC');
+    });
+
+    it.each([
+      ['Both-mode', renderBothModeSql],
+      ['request-line', renderByArtistSql],
+    ])('%s: an exact-variant hit is exempt from the tier, not merely ranked high', async (_label, render) => {
+      const rendered = await render();
+
+      // The exemption has to live in the TIER, not in the relevance term.
+      // `GREATEST` already promotes a 1.0 alias hit to the top of its tier —
+      // and that is exactly what is not enough: an unconditional tier puts
+      // the whole alias group behind every real match, and on these two
+      // paths (bare LIMIT, no OFFSET) behind means gone. So assert the
+      // score guard is part of the tier predicate itself.
+      expect(rendered).toContain('alias_max_sim < 1');
+      expect(rendered).not.toContain('ORDER BY (alias_max_sim IS NOT NULL) ASC');
     });
 
     it('Both-mode alias OFF: the legacy chained-builder ordering is untouched', async () => {


### PR DESCRIPTION
One alias variant scoring *moderately* well put an entire unrelated discography ahead of every real match. Same family as #2018, different mechanism, different surfaces.

Closes #2020

## The defect

Both alias-aware paths in `library.service.ts` ranked alias-only rows and real matches on a single `GREATEST(...)` scale. Branch (b) INNER JOINs on `artist_id`, so one hit admits its artist's whole catalog at that one score, and every one of those rows outranks any real match scoring below it. Nothing separated "matched the query text" from "matched a fuzzy variant" — only the raw number.

Measured against a prod-shaped clone. The variant `Monolake Live` scores 0.6429 against `monolake` — an utterly ordinary name variation, well clear of #2018's 0.40 floor — and one of them on Bill Monroe is enough:

| | |
|---|---|
| returned at `limit=12` | 6 Monolake albums, then 6 Bill Monroe alias rows |
| displaced off the page entirely | Mono (0.400), Monolord (0.385), Monos (0.364), Midlake / Monokle / Monopot (0.308) |

## The fix

The outer `ORDER BY` on both sites now leads with a tier that demotes **fuzzy** alias-only rows, keeping the existing relevance ordering *inside* each tier rather than replacing it. `FALSE < TRUE` in Postgres, so real matches come first and the strongest hit still leads within each tier.

`id ASC` is new on both sites. Neither had any tie-break, and within the alias tier every row of one artist carries an identical `alias_max_sim`, so their relative order was whatever the plan happened to emit.

### Why the tier is guarded on exact variants

The first cut of this PR demoted alias-only rows unconditionally, inheriting #2018's shape. That is right for the fuzzy collisions both tickets were aimed at and wrong for an exact one — `similarity() = 1` means the query string *is* a registered name for that artist, a stronger claim on the query than a 0.31 trigram smear across some unrelated canonical name.

It also failed worst exactly where it was newly applied. `/library/query` paginates, so a demoted row is on a later page; `searchLibraryByTrigramBoth` and `searchByArtist` emit a bare `LIMIT` with no `OFFSET`, so demoted means **deleted**. Measured on the same clone: `monolake` has 13 real rows scoring ≤ 0.40 ahead of the tier, which puts a 1.0 alias hit past position 13 on a surface whose default `limit` is 5. That is #1383's `discogs_member` case — the alias feature's own showcase — made invisible. The inverse of the reported bug, on the surface where it bites hardest.

So the tier is `(alias_max_sim IS NOT NULL AND alias_max_sim < 1) ASC`.

### One tier, or two

The tier is built by named helpers in `apps/backend/utils/alias-hits.ts` rather than hand-copied at three sites, which is the drift #2019 hoisted the shared CTE builder to prevent. But it is **two** helpers, not one, because the three paths do not all mean the same thing by it:

| | ORDER BY after the tier | Tier |
|---|---|---|
| `searchLibraryByTrigramBoth`, `searchByArtist` | `GREATEST(similarity...)` — relevance | `buildFuzzyAliasTier` — exact variants exempt |
| `/library/query` | the caller's `sort` column | `buildAliasOnlyTier` — unconditional, as #2018 shipped |

The first cut of this PR unified them and narrowed all three. That was wrong for `/library/query`: an exemption only means something if *something ranks the exempted row afterwards*, and there it would merely be alphabetized among the real matches — an exact-variant artist with 30 early-alphabet albums would take page 0 outright. The narrowing is justified by the absence of an OFFSET, which that path has. Keeping it unconditional also leaves `sortAlbumRows`'s in-memory tier an exact mirror rather than a deliberate disagreement.

Separate names, not one helper with a boolean, so the asymmetry is visible at both call sites.

### The tie-break

`buildFuzzyAliasTier` removes the only signal separating a direct match from an alias match once both reach 1.0 — real via `similarity(artist_name, q) = 1`, alias via `alias_max_sim = 1` — leaving `id ASC`, i.e. catalog age, to decide. Reproduced in SQL: a `discogs_member` variant "Kim Gordon" on Sonic Youth puts three Sonic Youth rows ahead of the Kim Gordon album.

`buildDirectMatchTieBreak` sits *after* `GREATEST` so a text match wins at equal relevance. It is unreachable on both current callers and kept anyway: `searchLibraryByTrigramBoth` runs only after the tsvector tier returns zero rows, and any real row scoring 1.0 on trigram necessarily matches `websearch_to_tsquery` too (identical trigram sets imply the same word set), so the short-circuit fires first — verified against a seeded row. `searchByArtist` has no tsvector tier and no callers. One ORDER BY term holds the invariant locally rather than borrowing it from another subsystem's short-circuit.

### What `alias_max_sim = 1` actually means

Less than it looks, and the builder now says so. pg_trgm compares deduplicated, word-split trigram sets, so `similarity('Duke Ellington','Ellington Duke')` and `similarity('The The','the')` are both exactly 1 — a permuted variant, or a repeated word of one, is treated as exact. Accepted rather than overlooked: tightening it means comparing normalized strings instead of scores, which is different match semantics from the `%` operator the GIN index answers (#1318) and would not survive the `MAX(...)` in the CTE. A permuted variant is still a variant of that artist, so the row is relevant — only the confidence is overstated, and the tie-break keeps it behind a genuine text match.

## Three things the fixtures turned up

**`sortAlbumRows` carries a second tier, in TypeScript.** When `/library/query`'s result set is 100% alias-only, the #1885 cascade fires and an in-memory tier decides final order, masking the SQL tier completely. The fixture gives REAL a `label` containing the query so a non-alias row exists and the cascade short-circuits; `label` is the only column that can do this, being in `/library/query`'s ILIKE fan-out but absent from `library.search_doc` and from the trigram predicate.

**The three paths disagree about what a branch-(a) match is.** `library.service.ts` matches by trigram over artist/album; `/library/query` matches by ILIKE-contains over artist/album/**label**. Undocumented, and filed as #2027.

**`/library/query` defaults to `sort=album`, not `sort=artist`.** An existing fixture comment claimed otherwise. Under the default sort a tiered and an untiered exact-variant row are indistinguishable, so #2018's Fix-1 test now sorts `album DESC` — the tier is hardcoded ASC and is not reversed by `order`, which is what separates them. Comment corrected.

## Two corrections to the ticket, made while implementing

**#2020 named the wrong function.** It claimed `searchByArtist` backs `GET /library/search`. It does not — `searchByArtist` has no production callers at all, and `git log -S` shows it never has: added in `5a193c3c` (2026-01-19), never called. The real topology:

```
GET /library/search  ->  searchLibrary(query, artist, title, limit=5)
                           |- query given   -> searchLibraryBothMode -> searchLibraryByTrigramBoth   <- alias path
                           \- artist/title  -> fuzzySearchLibrary                                    <- no alias branch
GET /library/         ->  fuzzySearchLibrary (artist_name === album_title) -> searchLibraryBothMode -> same function
```

So there is **one** live defective site, and it is itself what returns the 5-row request-line response — the tight-`limit` concern the ticket pinned on `searchByArtist` belongs to `searchLibraryByTrigramBoth`. The ticket body has been corrected inline.

`searchByArtist` gets the same change anyway, for parity: leaving one of three alias sites inconsistent is exactly the drift #2019 exists to prevent. Its deletion is filed separately (#2022) rather than expanding this diff.

**No cap on alias-only rows**, which #2020 left as an open question. The correction above is what decides it: both surfaces are the same function, so a cap cannot be scoped to the request line without threading a parameter through solely to weaken one caller, and it would truncate the paginated catalog #1318 exists to serve. #2018's argument transfers intact — fan-out size carries no correctness signal, so a cap cuts off Thee Oh Sees' 13 correct rows to punish Bill Monroe's 14 wrong ones. Tiering alone removes the reported harm; when fewer than `limit` real matches exist, alias rows filling the remainder is the feature working.

## Verification

The integration tests were run against a backend image built **without** the fix, not just with it — twice, the second time after two assertions were rewritten, so the final test text is what was proven:

| | without the guard | with it |
|---|---|---|
| `/library/` Both-mode | exact variant demoted behind the real match | exact, then real, then fuzzy alias |
| `/library/search?limit=4` | real match first, exact variant absent | exact and real take the first two slots |
| `/library/search?limit=1` | the one row is the 0.33 real match | the exact variant |
| `/library/query` | exact variant tiered below the real match | ordered on its merits |
| `/library/query` | exact variant exempted (wrong — see above) | tiered, as #2018 shipped |

The fixture also moved off `monolake`, which collided with #2018's seeded `Monolake` artist — that name tsvector-matches and short-circuits Both-mode before the trigram tier runs, so the two suites' outcomes depended on describe execution order. It then moved off its first replacement too: `deerhoof` appears 19 times in `dev_env/seed-clone.sql`, and while CI skips that clone, #1728 exists so `test:integration` can run against it. Every string is now verified absent from it, and the liveness error names that cause alongside the feature flag. (`monolake` has 7 occurrences and the same exposure — pre-existing, not fixed here.)

Liveness also moved out of the ordering tests into one probe on an unbounded page: keying it on the rows this fix moves reported "the feature flag is off" for the one outcome that means the fix works.

Worth stating plainly: the test pinning intra-tier `id` order **passes against the unfixed build too**, because the plan happened to emit id order by luck. Its comment says so. Nothing observable can prove determinism; what that assertion actually guards is a future deliberate reordering, and claiming more for it would be the same vacuous-guard trap #2019 had to fix.

Green: 413 unit suites / 6591 tests, 90 integration suites / 850 tests (exit 0), typecheck, eslint (0 errors), prettier, `lint:env`.

No migration; ordering only. The `alias_hits` CTE and the `%` predicate that drives `artist_search_alias_variant_trgm_idx` are untouched, so #1318's plan is unaffected.

## Follow-ups filed rather than folded in

- #2022 — delete `searchByArtist` (no callers, three rounds of maintenance for zero production effect)
- #2026 — the two `library.service.ts` paths lack `/library/query`'s `DISTINCT ON (id)`, so a rotation-duplicated album eats two slots of a 5-row page. Pre-existing.
- #2027 — `docs/catalog-search/README.md` still documents the pre-alias trigram query
- #2031 — branch (b) dedupes with `NOT()` rather than #1557's NULL-safe `IS NOT TRUE`, dropping NULL-`artist_name` rows from both branches. Pre-existing, from #1318.

## Related

WXYC/Backend-Service#2018, WXYC/Backend-Service#2019, WXYC/Backend-Service#1318, WXYC/Backend-Service#1273, WXYC/Backend-Service#1383, WXYC/Backend-Service#1885, WXYC/Backend-Service#1092
