### PR TITLE
Resolve duplicate call-number slots in library ahead of a uniqueness constraint

### DIFF
--- a/Dockerfile.library-call-number-dedup
+++ b/Dockerfile.library-call-number-dedup
@@ -1,0 +1,39 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+WORKDIR /library-call-number-dedup-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/library-call-number-dedup ./jobs/library-call-number-dedup
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/library-call-number-dedup
+
+#Production stage
+FROM node:24-alpine AS prod
+
+WORKDIR /library-call-number-dedup
+
+COPY ./package* ./
+COPY ./jobs/library-call-number-dedup/package* ./jobs/library-call-number-dedup/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./library-call-number-dedup-builder/jobs/library-call-number-dedup/dist ./jobs/library-call-number-dedup/dist
+COPY --from=builder ./library-call-number-dedup-builder/shared/database/dist ./shared/database/dist
+
+# Bulk repoint workload. Async commit is safe: the job is idempotent (a merged
+# slot drops out of the `HAVING count(*) > 1` set) and each slot's writes are
+# one transaction. High statement timeout so a slot under live load does not
+# abort mid-merge.
+ENV DB_APPLICATION_NAME=wxyc-library-call-number-dedup
+ENV DB_STATEMENT_TIMEOUT_MS=900000
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# ENTRYPOINT + empty CMD so docker-level args (e.g. `--execute`) pass through to
+# the job rather than replacing the launcher. node resolves `@wxyc/database` via
+# the standard walk up to /library-call-number-dedup/node_modules.
+ENTRYPOINT ["node", "/library-call-number-dedup/jobs/library-call-number-dedup/dist/job.js"]
+CMD []

--- a/jobs/library-call-number-dedup/README.md
+++ b/jobs/library-call-number-dedup/README.md
@@ -54,11 +54,15 @@ Two tables are deliberately **not** targets: `album_plays` is a materialized vie
 
 ## Safety
 
-- **Dry-run by default.** A dry run SELECTs and reports the whole plan, including the finished relabel worklist, with zero writes.
+- **Dry-run by default.** A dry run SELECTs and reports the whole plan with zero writes, including the child rows a merge would DROP as duplicates — counted separately from the ones it would repoint, so the destructive half of the plan is visible before approval.
 - **Idempotent.** A completed merge drops that slot out of the `HAVING count(*) > 1` set, so a re-run finds nothing to do.
 - **Per-slot atomic.** Each slot's repoints and delete run in one transaction, so a mid-run abort leaves each slot either fully merged or untouched.
 - **Renumbers re-check their destination** inside the transaction and decline rather than collide, since the plan is built from a snapshot and a librarian may file concurrently. Declined renumbers are logged and left for a re-run.
 - **Withheld renumbers.** When the disc that would move already has a same-titled copy elsewhere on the same shelf, giving it a new number would leave one title at three addresses. Which copy is real is a shelf question, so those are reported in the worklist and nothing is changed.
+- **Data is moved before it can be dropped.** The survivor is chosen by inbound reference count, which says nothing about how complete its data is, so a fill-null pass COALESCEs the loser's expensive-to-recollect columns onto the survivor before anything is deleted — the LML identity resolution, curated artwork, and the music director's deliberate "not on Discogs" note, plus the same treatment for `album_metadata`. Without it a merge can delete the only row that carried them.
+- **Refuses to start while a show is on air.** The job writes `flowsheet`, which dj-site polls every 60s. It is a one-shot run in a chosen window, so declining outright is cheaper than pausing mid-pass.
+- **A skipped renumber sets a non-zero exit code** and is kept off the worklist. The catalog row never moved, so telling the librarian to relabel that disc would create the shelf/catalog disagreement this job exists to remove, in reverse.
+- **A slot holding three rows** merges its duplicates and reports the remainder for the librarian, rather than guessing which of two different releases should move.
 - `ANALYZE` on the rewritten tables after an `--execute` run, per `docs/bulk-update-playbook.md`.
 
 ## Sequencing

--- a/jobs/library-call-number-dedup/README.md
+++ b/jobs/library-call-number-dedup/README.md
@@ -37,16 +37,18 @@ Any uniqueness constraint added afterward must use this same key, including the 
 
 ## Order of operations is a data-safety property
 
-Every FK referencing `library.id` is repointed to the survivor **before** the losing row is deleted. That is not stylistic. Of the 13 reference sites, six declare `onDelete: 'cascade'` and two declare `set null`:
+Every FK referencing `library.id` is repointed to the survivor **before** the losing row is deleted. That is not stylistic. Of the 13 reference sites, five cascade and two null out the reference:
 
-| On delete  | Sites                                                                                                                        |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `cascade`  | `rotation`, `album_metadata`, `reviews`, `album_critic_reviews`, `compilation_track_artist`, `artist_library_crossreference` |
-| `set null` | `flowsheet.album_id`, `album_review_submissions.album_id`                                                                    |
-| no action  | `bins`, `library_identity`, `library_identity_source`                                                                        |
-| undeclared | `library_identity_history`, `album_popularity.representative_library_id`                                                     |
+| On delete  | Sites                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| `cascade`  | `rotation`, `album_metadata`, `reviews`, `album_critic_reviews`, `compilation_track_artist` |
+| `set null` | `flowsheet.album_id`, `album_review_submissions.album_id`                                   |
+| no action  | `artist_library_crossreference`, `bins`, `library_identity`, `library_identity_source`      |
+| no FK      | `library_identity_history`, `album_popularity.representative_library_id`                    |
 
 Deleting first would silently destroy rotation history, album metadata, and reviews, and silently unlink plays — no error raised. The no-action sites are the only ones that would fail loudly.
+
+**These actions are the ones the database enforces, not the ones `schema.ts` declares.** The two disagree: `schema.ts` marks `artist_library_crossreference.library_id` as `cascade`, but migration `0022` created it `no action` and nothing since has altered it — one of the four drifted constraints catalogued in [#2015](https://github.com/WXYC/Backend-Service/issues/2015). Reading the schema file alone would put it in the wrong row of that table. Reading only the migration that first _created_ a constraint is also insufficient: `album_metadata.album_id` was created `no action` in `0023`, dropped with its table in `0035`, and recreated `cascade` in `0079`. The live catalog is the authority, which is why `enforced-fk-actions` in the integration spec asserts every row of the table above against `information_schema` rather than against either file.
 
 Two tables are deliberately **not** targets: `album_plays` is a materialized view (refreshed, not repointed), and `specialty_shows` carries no library reference despite the name.
 

--- a/jobs/library-call-number-dedup/README.md
+++ b/jobs/library-call-number-dedup/README.md
@@ -1,0 +1,88 @@
+# library-call-number-dedup
+
+One-shot dedup: resolve duplicate call-number slots in `library` so a uniqueness constraint can be added to the columns that address the shelf.
+
+Dry-run by default. Pass `--execute` to write.
+
+## Why
+
+A WXYC call number addresses a physical slot on the shelf: the artist's genre-scoped code letters, a number, and an optional volume letter for a multi-disc set — rendered `KE 7`. Nothing in the schema enforces that a slot is used once, and `generateAlbumCodeNumber` reads `MAX(code_number)+1` and inserts without a lock, so two adds under one artist at the same moment already produce the same number with no user error involved. Slots accumulated more than one release.
+
+Uniqueness has to be enforced in the database, not in a form: a form check cannot close the unlocked read-then-write. But the constraint cannot be added while the duplicates exist, which is what this job clears.
+
+## The distinction the job turns on
+
+Two rows in one slot are one of two very different things:
+
+- **The same release entered twice.** Merges. Every reference is repointed to a survivor and the other row is deleted. No disc moves.
+- **Two genuinely different releases.** One row is renumbered to a free slot — **and the physical disc has to be relabelled**, or the shelf and the catalog disagree.
+
+Classifying on title equality gets this split wrong by better than 2x, because a release is routinely re-entered under a differently-decorated title. `It's a Party 12"` and `It's a Party cd-single` are one record filed twice, not two records sharing a number; so are a dirty LP and its clean-lyric pressing, and `Volume 1` versus `Volume One`. `classify.ts` strips the decoration that names a _pressing_ rather than a _work_ before comparing.
+
+It deliberately does **not** strip volume or part numbers. `Ethiopiques vol. 21` and `Ethiopiques vol. 22` are different records; folding those together would merge two real releases and delete a catalog row that has plays.
+
+## The slot key
+
+```
+(artist_id, genre_id, code_number, upper(coalesce(code_volume_letters, '')))
+```
+
+Two parts of that are load-bearing and easy to get wrong:
+
+**`genre_id` is in the key** because code letters are genre-scoped — an artist filed under two genres has two shelves, and `BO 3` (Electronic) and `Bo 3` (Rock) are different slots holding different discs. That used to be implicit in there being two `artists` rows. It isn't any more: `jobs/artist-unicode-dedup` merges artist rows **globally across genres**, deliberately, so after it ran the genre is the only thing distinguishing the two shelves. A key of `(artist_id, code_number)` would call those a collision and destroy a correct filing.
+
+**The volume letter is folded to upper case** because `D` and `d` are one slot, not two. The upstream MySQL catalog compares them case-insensitively under its default collation, so duplicates were created there that Postgres — which compares case-sensitively — would otherwise read as distinct and let straight through.
+
+Any uniqueness constraint added afterward must use this same key, including the `coalesce`. Prod is PostgreSQL 14, where `NULLS NOT DISTINCT` is unavailable (PG15+), so a plain multi-column unique index treats every NULL volume letter as distinct — and most rows have a NULL volume letter, which is exactly the population the constraint is meant to cover.
+
+## Order of operations is a data-safety property
+
+Every FK referencing `library.id` is repointed to the survivor **before** the losing row is deleted. That is not stylistic. Of the 13 reference sites, six declare `onDelete: 'cascade'` and two declare `set null`:
+
+| On delete  | Sites                                                                                                                        |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `cascade`  | `rotation`, `album_metadata`, `reviews`, `album_critic_reviews`, `compilation_track_artist`, `artist_library_crossreference` |
+| `set null` | `flowsheet.album_id`, `album_review_submissions.album_id`                                                                    |
+| no action  | `bins`, `library_identity`, `library_identity_source`                                                                        |
+| undeclared | `library_identity_history`, `album_popularity.representative_library_id`                                                     |
+
+Deleting first would silently destroy rotation history, album metadata, and reviews, and silently unlink plays — no error raised. The no-action sites are the only ones that would fail loudly.
+
+Two tables are deliberately **not** targets: `album_plays` is a materialized view (refreshed, not repointed), and `specialty_shows` carries no library reference despite the name.
+
+## Safety
+
+- **Dry-run by default.** A dry run SELECTs and reports the whole plan, including the finished relabel worklist, with zero writes.
+- **Idempotent.** A completed merge drops that slot out of the `HAVING count(*) > 1` set, so a re-run finds nothing to do.
+- **Per-slot atomic.** Each slot's repoints and delete run in one transaction, so a mid-run abort leaves each slot either fully merged or untouched.
+- **Renumbers re-check their destination** inside the transaction and decline rather than collide, since the plan is built from a snapshot and a librarian may file concurrently. Declined renumbers are logged and left for a re-run.
+- **Withheld renumbers.** When the disc that would move already has a same-titled copy elsewhere on the same shelf, giving it a new number would leave one title at three addresses. Which copy is real is a shelf question, so those are reported in the worklist and nothing is changed.
+- `ANALYZE` on the rewritten tables after an `--execute` run, per `docs/bulk-update-playbook.md`.
+
+## Sequencing
+
+**Run this after the tubafrenzy ETL stops.** `jobs/library-etl` upserts on `legacy_release_id` and carries `code_number` in its refresh set, so while that ETL is live it will overwrite a renumber and reinstate a deleted row from the upstream MySQL catalog on its next pass.
+
+Then, in order:
+
+1. Dry run. Review the plan and the worklist.
+2. `--execute`.
+3. Give the worklist to the librarian. Until the discs are relabelled, the shelf and the catalog disagree.
+4. Add the uniqueness constraint, keyed as above.
+
+## Running
+
+Manual Build & Deploy with `target=library-call-number-dedup`, then on EC2:
+
+```bash
+docker run --rm --env-file .env <image>            2>&1 | tee log-dry
+docker run --rm --env-file .env <image> --execute  2>&1 | tee log-exec
+```
+
+Environment: standard `DB_*` connection vars, same as the other one-shots.
+
+## Tests
+
+- `tests/unit/jobs/library-call-number-dedup/classify.test.ts` — the merge/renumber split, over real collisions measured in the production catalog.
+- `tests/unit/jobs/library-call-number-dedup/report.test.ts` — worklist legibility.
+- `tests/integration/library-call-number-dedup-merge.spec.js` — the destructive functions against a real Postgres, including the cascade-ordering invariant.

--- a/jobs/library-call-number-dedup/classify.ts
+++ b/jobs/library-call-number-dedup/classify.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure classification core of the library-call-number-dedup job.
+ *
+ * A WXYC call number addresses a physical shelf slot: the artist's genre-scoped
+ * code letters, a number, and an optional volume letter for a multi-disc set,
+ * rendered "KE 7" or "KE 7 B". Nothing in the schema enforces that a slot is
+ * used once, and `generateAlbumCodeNumber` picks MAX+1 with no lock, so slots
+ * accumulated more than one release.
+ *
+ * Two rows sharing a slot are one of two very different things, and the whole
+ * job turns on telling them apart:
+ *
+ *   - the same release entered twice, which merges; or
+ *   - two different releases that collided, where one must be renumbered AND
+ *     the disc physically relabelled.
+ *
+ * Comparing titles for equality gets this wrong by better than 2x, because a
+ * release is routinely re-entered under a differently-decorated title:
+ * `It's a Party 12"` and `It's a Party cd-single` are one record filed twice.
+ * `titleKey` strips the decoration that distinguishes a pressing from a work so
+ * those land together, and `classifySlot` merges them.
+ *
+ * No database access here — everything is a pure function over row shapes, so
+ * the classification can be exercised exhaustively in unit tests without a
+ * Postgres.
+ */
+
+/**
+ * Decoration that names a *pressing* rather than a *work*: format, edition,
+ * pressing status, and the articles/conjunctions that come and go when the same
+ * title is retyped. Stripped before comparison.
+ *
+ * Deliberately NOT stripped: volume and part numbers. `Ethiopiques vol. 21` and
+ * `Ethiopiques vol. 22` are different records, and folding them together would
+ * merge two real releases into one and delete a catalog row that has plays.
+ */
+const DECORATION =
+  /^(?:12|7)(?:inch|x2)?$|^(?:cd|lp|ep|single|singles|maxi|remix|rmx|clean|dirty|lyric|version|reissue|remastered|extended|live|vinyl|bonus|tracks?|disc|promo|missing|double|fulllength)$|^(?:the|a|an|of|with|w|and)$/;
+
+const NUMBER_WORDS: Readonly<Record<string, string>> = {
+  one: '1',
+  two: '2',
+  three: '3',
+  four: '4',
+  five: '5',
+  six: '6',
+  seven: '7',
+  eight: '8',
+  nine: '9',
+  ten: '10',
+};
+
+/**
+ * Fold a title to the work it names: lower-case, drop punctuation, spell
+ * numbers as digits (`Volume One` -> `volume1`), then drop decoration tokens.
+ * Returns '' when a title is nothing but decoration, which callers must treat
+ * as "no evidence" rather than as a match.
+ */
+export const titleKey = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((t) => NUMBER_WORDS[t] ?? t)
+    .filter((t) => t.length > 0 && !DECORATION.test(t))
+    .join('');
+
+/**
+ * Character-level similarity in [0,1], used only to catch typos that survive
+ * `titleKey` (`Starlight Walker` vs `Starlite Walker`). Longest-common-
+ * subsequence over the folded keys — cheap, and the inputs are short titles.
+ */
+export const similarity = (a: string, b: string): number => {
+  if (a === b) return 1;
+  if (!a.length || !b.length) return 0;
+  let prev = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = new Array<number>(b.length + 1).fill(0);
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], cur[j - 1]);
+    }
+    prev = cur;
+  }
+  return (2 * prev[b.length]) / (a.length + b.length);
+};
+
+/** Titles this close after folding are treated as the same release retyped. */
+export const SIMILARITY_THRESHOLD = 0.85;
+
+/** One `library` row competing for a slot, with its inbound reference weight. */
+export interface SlotMember {
+  id: number;
+  album_title: string;
+  /** Total rows across every FK site pointing at this row (see FK_TARGETS). */
+  refs: number;
+}
+
+export type SlotVerdict =
+  /** One release entered twice. Merge into `survivorId`. */
+  | { kind: 'merge'; survivorId: number; loserIds: number[] }
+  /** Genuinely different releases. One must move, and its disc relabelled. */
+  | { kind: 'renumber'; keepId: number; moveId: number };
+
+/**
+ * Decide whether two rows in a slot are one release or two.
+ *
+ * Merge survivor is the row carrying the most references, then the longer title
+ * (the fuller of two spellings of one name), then the lower id. Reference count
+ * leads because the surviving row inherits the other's plays, rotation history,
+ * and reviews; picking the better-referenced row keeps the repoint smaller and
+ * leaves the id that downstream systems already know in place.
+ *
+ * A slot holding three or more rows merges every row that matches the survivor
+ * and reports the rest as still-colliding, rather than guessing at a chain.
+ */
+export const classifySlot = (members: readonly SlotMember[]): SlotVerdict => {
+  if (members.length < 2) {
+    throw new Error(`classifySlot needs at least 2 members, got ${members.length}`);
+  }
+
+  const ranked = [...members].sort(
+    (x, y) => y.refs - x.refs || y.album_title.length - x.album_title.length || x.id - y.id
+  );
+  const [survivor, ...rest] = ranked;
+  const survivorKey = titleKey(survivor.album_title);
+
+  const sameRelease = (m: SlotMember): boolean => {
+    const key = titleKey(m.album_title);
+    // A title that folds to nothing carries no evidence either way; treat it as
+    // distinct so a bare "[EP]" is never silently merged into a real title.
+    if (!key || !survivorKey) return key === survivorKey && key.length > 0;
+    if (key === survivorKey) return true;
+    if (key.startsWith(survivorKey) || survivorKey.startsWith(key)) return true;
+    return similarity(key, survivorKey) >= SIMILARITY_THRESHOLD;
+  };
+
+  const losers = rest.filter(sameRelease);
+  if (losers.length === rest.length) {
+    return { kind: 'merge', survivorId: survivor.id, loserIds: losers.map((m) => m.id) };
+  }
+
+  // At least one row in the slot is a different release. The row that moves is
+  // the least-referenced one — fewest downstream links to disturb, and the
+  // least-played disc is the one least likely to be off the shelf when the
+  // librarian goes looking for it.
+  const byRefsAsc = [...members].sort((x, y) => x.refs - y.refs || y.id - x.id);
+  return { kind: 'renumber', keepId: byRefsAsc[byRefsAsc.length - 1].id, moveId: byRefsAsc[0].id };
+};
+
+/**
+ * A renumber is only safe when the disc being moved is the ONLY copy of that
+ * title on its shelf. When the same title already sits at another number,
+ * giving this one a third address makes the shelf worse while still satisfying
+ * uniqueness — and which copy is real is a question only the shelf can answer.
+ * Those are held back for the librarian instead of being renumbered.
+ */
+export const hasTwinElsewhere = (
+  moveTitle: string,
+  slotNumber: number,
+  shelf: ReadonlyArray<{ code_number: number; album_title: string }>
+): boolean => {
+  const key = titleKey(moveTitle);
+  if (!key) return false;
+  return shelf.some((r) => r.code_number !== slotNumber && titleKey(r.album_title) === key);
+};

--- a/jobs/library-call-number-dedup/classify.ts
+++ b/jobs/library-call-number-dedup/classify.ts
@@ -26,17 +26,28 @@
  */
 
 /**
- * Decoration that names a *pressing* rather than a *work*: format, edition,
- * pressing status, and the articles/conjunctions that come and go when the same
- * title is retyped. Stripped before comparison.
+ * A format marking is a measurement — `12"`, `7 inch` — not the bare number.
+ * Stripped from the raw title BEFORE tokenizing, because the quote is the only
+ * thing distinguishing the marking from an ordinary number, and punctuation
+ * removal destroys it. Stripping the bare digit instead folds `vol. 7` into
+ * `vol. 12`, merging two real records; 7, 10 and 12 are all ordinary volume
+ * numbers as well as disc sizes.
+ */
+const FORMAT_MARKING = /\b(?:7|10|12)\s*(?:"|''|”|″|-?\s*inch(?:es)?)\s*(?:x\s*\d+)?/gi;
+
+/**
+ * Word decoration that names a *pressing* rather than a *work*: format,
+ * edition, pressing status, and the articles/conjunctions that come and go when
+ * the same title is retyped.
  *
- * Deliberately NOT stripped: volume and part numbers. `Ethiopiques vol. 21` and
- * `Ethiopiques vol. 22` are different records, and folding them together would
- * merge two real releases into one and delete a catalog row that has plays.
+ * Deliberately absent: any bare number. Volume and part numbers are part of the
+ * work's name — `Ethiopiques vol. 21` and `vol. 22` are different records, and
+ * folding them together would delete a catalog row that has plays.
  */
 const DECORATION =
-  /^(?:12|7)(?:inch|x2)?$|^(?:cd|lp|ep|single|singles|maxi|remix|rmx|clean|dirty|lyric|version|reissue|remastered|extended|live|vinyl|bonus|tracks?|disc|promo|missing|double|fulllength)$|^(?:the|a|an|of|with|w|and)$/;
+  /^(?:cd|lp|ep|single|singles|maxi|remix|rmx|clean|dirty|lyric|version|reissue|remastered|extended|live|vinyl|bonus|tracks?|disc|promo|missing|double|fulllength)$|^(?:the|a|an|of|with|w|and)$/;
 
+/** `Volume One` and `Volume 1` are the same record typed two ways. */
 const NUMBER_WORDS: Readonly<Record<string, string>> = {
   one: '1',
   two: '2',
@@ -51,14 +62,15 @@ const NUMBER_WORDS: Readonly<Record<string, string>> = {
 };
 
 /**
- * Fold a title to the work it names: lower-case, drop punctuation, spell
- * numbers as digits (`Volume One` -> `volume1`), then drop decoration tokens.
- * Returns '' when a title is nothing but decoration, which callers must treat
- * as "no evidence" rather than as a match.
+ * Fold a title to the work it names: drop format markings, lower-case, drop
+ * punctuation, spell numbers as digits, then drop word decoration. Returns ''
+ * when a title is nothing but decoration, which callers must treat as "no
+ * evidence" rather than as a match.
  */
 export const titleKey = (title: string): string =>
   title
     .toLowerCase()
+    .replace(FORMAT_MARKING, ' ')
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
     .split(/\s+/)
@@ -97,8 +109,14 @@ export interface SlotMember {
 }
 
 export type SlotVerdict =
-  /** One release entered twice. Merge into `survivorId`. */
-  | { kind: 'merge'; survivorId: number; loserIds: number[] }
+  /**
+   * At least one row is a re-entry of `survivorId` and merges into it.
+   * `unresolvedIds` lists rows in the same slot that are NOT the same release —
+   * empty for the ordinary two-row case. When it is non-empty the slot still
+   * collides after the merge, and the remainder is a shelf question rather than
+   * something to guess at.
+   */
+  | { kind: 'merge'; survivorId: number; loserIds: number[]; unresolvedIds: number[] }
   /** Genuinely different releases. One must move, and its disc relabelled. */
   | { kind: 'renumber'; keepId: number; moveId: number };
 
@@ -129,15 +147,27 @@ export const classifySlot = (members: readonly SlotMember[]): SlotVerdict => {
     const key = titleKey(m.album_title);
     // A title that folds to nothing carries no evidence either way; treat it as
     // distinct so a bare "[EP]" is never silently merged into a real title.
-    if (!key || !survivorKey) return key === survivorKey && key.length > 0;
+    if (!key || !survivorKey) return false;
     if (key === survivorKey) return true;
-    if (key.startsWith(survivorKey) || survivorKey.startsWith(key)) return true;
+    // Deliberately NOT a prefix test. One title being a prefix of another is
+    // equally the signature of a twofer (`#1 Record` / `#1 Record & Radio
+    // City`), a sequel, or an unrelated longer name, and merging on it deletes
+    // a different album and reattaches its plays. Decoration is already gone by
+    // this point, so a genuine re-entry folds to an EQUAL key; similarity only
+    // has to cover typos (`Starlight` / `Starlite`). A truncated-title
+    // duplicate that misses the threshold falls through to a renumber, which
+    // costs a shelf visit but never destroys a row.
     return similarity(key, survivorKey) >= SIMILARITY_THRESHOLD;
   };
 
   const losers = rest.filter(sameRelease);
-  if (losers.length === rest.length) {
-    return { kind: 'merge', survivorId: survivor.id, loserIds: losers.map((m) => m.id) };
+  if (losers.length > 0) {
+    return {
+      kind: 'merge',
+      survivorId: survivor.id,
+      loserIds: losers.map((m) => m.id),
+      unresolvedIds: rest.filter((m) => !sameRelease(m)).map((m) => m.id),
+    };
   }
 
   // At least one row in the slot is a different release. The row that moves is

--- a/jobs/library-call-number-dedup/job.ts
+++ b/jobs/library-call-number-dedup/job.ts
@@ -1,0 +1,63 @@
+/**
+ * One-shot dedup: resolve duplicate call-number slots in `library` so a
+ * uniqueness constraint can be added to the column that addresses the shelf.
+ * CLI entrypoint — the importable core lives in `merge.ts` so the destructive
+ * functions can be tested against a real Postgres without this module's
+ * `main()` auto-run firing on import.
+ *
+ * A WXYC call number addresses a physical slot: genre-scoped code letters, a
+ * number, and an optional volume letter — "KE 7". Nothing enforces that a slot
+ * is used once, and `generateAlbumCodeNumber` reads MAX+1 and inserts without a
+ * lock, so concurrent adds under one artist already produce the same number
+ * with no user error involved. Slots accumulated more than one release.
+ *
+ * Two rows in a slot are one of two very different things, and telling them
+ * apart is the whole job. Most are one release entered twice under differently
+ * decorated titles (`It's a Party 12"` / `It's a Party cd-single`) and merge
+ * with no disc moving. The rest are genuinely different releases, where one row
+ * must be renumbered AND THE PHYSICAL DISC RELABELLED — so an execute run emits
+ * a worklist, and the constraint cannot land until the shelf work is done.
+ *
+ * DATA SAFETY / ops (docs/bulk-update-playbook.md):
+ *   - **Dry-run by default; pass `--execute` to write.** Dry-run SELECTs and
+ *     reports the full plan, including the finished worklist, with zero writes.
+ *   - Idempotent: a completed merge drops that slot out of the
+ *     `HAVING count(*) > 1` set, so a re-run finds nothing to do.
+ *   - Each slot's repoints + delete run in a single transaction — a mid-run
+ *     abort leaves each slot either fully merged or untouched.
+ *   - Repoint precedes delete, always. Six FK sites declare `onDelete: cascade`
+ *     and two declare `set null`, so deleting first would silently destroy
+ *     rotation history, album metadata, and reviews, and silently unlink plays.
+ *   - A renumber re-checks its destination inside the transaction and declines
+ *     rather than colliding if a librarian took it since the plan was built.
+ *   - `ANALYZE` on the rewritten tables after an `--execute` run (BS#934).
+ *
+ * SEQUENCING: run this AFTER the tubafrenzy ETL stops. `jobs/library-etl`
+ * upserts on `legacy_release_id` and carries `code_number` in its refresh set,
+ * so while that ETL is live it will overwrite a renumber and reinstate a
+ * deleted row from the upstream MySQL catalog on its next pass.
+ *
+ * Run procedure: Manual Build & Deploy with `target=library-call-number-dedup`,
+ * then SSH to EC2 and:
+ *   docker run --rm --env-file .env <image>            2>&1 | tee log-dry
+ *   docker run --rm --env-file .env <image> --execute  2>&1 | tee log-exec
+ *
+ * Environment: standard DB_* connection vars (same as the other one-shots).
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runDedup } from './merge.js';
+
+const main = async () => {
+  try {
+    await runDedup();
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((err) => {
+  console.error('[library-call-number-dedup] Fatal error:', err);
+  // exitCode (not exit) so the finally body runs and the pg pool closes.
+  process.exitCode = 1;
+});

--- a/jobs/library-call-number-dedup/job.ts
+++ b/jobs/library-call-number-dedup/job.ts
@@ -50,7 +50,11 @@ import { runDedup } from './merge.js';
 
 const main = async () => {
   try {
-    await runDedup();
+    const summary = await runDedup();
+    // A skipped renumber leaves a slot still colliding, so the run did not
+    // finish its job even though nothing failed. Surface it in the exit code
+    // rather than only in a warning line buried in the log.
+    if (summary.renumbersSkipped > 0) process.exitCode = 1;
   } finally {
     await closeDatabaseConnection();
   }

--- a/jobs/library-call-number-dedup/merge.ts
+++ b/jobs/library-call-number-dedup/merge.ts
@@ -1,0 +1,509 @@
+/**
+ * Importable core of the one-shot library-call-number-dedup job.
+ *
+ * Split out from `job.ts` (the thin CLI entrypoint) so the destructive
+ * functions can be imported and exercised against a real Postgres by the
+ * integration test WITHOUT the module's top-level `main()` firing on import —
+ * same arrangement as `jobs/artist-unicode-dedup/merge.ts`, which is this
+ * job's structural donor.
+ *
+ * Slot key: `(artist_id, genre_id, code_number, upper(coalesce(code_volume_letters,'')))`.
+ *
+ *   - `genre_id` is in the key because code letters are genre-scoped: an artist
+ *     filed under two genres has two shelves, and `BO 3` (Electronic) and
+ *     `Bo 3` (Rock) are different slots. That used to be implicit in there
+ *     being two `artists` rows, but BS#1897's dedup merges artist rows GLOBALLY
+ *     across genres, so after it ran the genre is the only thing left
+ *     distinguishing the two shelves. A key of `(artist_id, code_number)` would
+ *     call those a collision and destroy a correct filing.
+ *
+ *   - the volume letter is folded to upper case because 'D' and 'd' are one
+ *     slot, not two. The upstream MySQL catalog compares them case-insensitively
+ *     under its default collation, so duplicates were created that Postgres —
+ *     which compares case-sensitively — would otherwise read as distinct and
+ *     let straight through.
+ *
+ * Every FK referencing `library.id` is repointed to the survivor BEFORE the
+ * losing row is deleted. That ordering is not stylistic: six of the sites
+ * declare `onDelete: 'cascade'` and two declare `set null`, so deleting first
+ * would silently destroy rotation history, album metadata, and reviews, and
+ * silently unlink plays, with no error raised.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { db, intArrayLiteral } from '@wxyc/database';
+import { classifySlot, hasTwinElsewhere, type SlotMember, type SlotVerdict } from './classify';
+import { formatWorklist } from './report';
+
+/** The transaction handle Drizzle passes to a `db.transaction` callback. */
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Default is dry-run; `--execute` opts into writes. */
+export const EXECUTE = process.argv.includes('--execute');
+
+export const schemaName = (): string => (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+
+const ident = (name: string): SQL => sql.raw(`"${name.replace(/"/g, '""')}"`);
+const qualified = (table: string): SQL => sql.raw(`"${schemaName()}"."${table.replace(/"/g, '""')}"`);
+
+/**
+ * Every FK column referencing `library.id`. `uniqueKey` is the full unique/PK
+ * key the column participates in (INCLUDING the column itself), or `null` when
+ * no uniqueness constraint involves it — a plain repoint can never collide.
+ * When repointing a loser's row would collide with a row the survivor already
+ * has, the loser's row is dropped instead (the survivor already carries the
+ * equivalent).
+ *
+ * Deliberately absent:
+ *   - `album_plays` — a materialized view, refreshed rather than repointed.
+ *   - `specialty_shows` — carries no library reference despite the name.
+ */
+export interface FkTarget {
+  table: string;
+  column: string;
+  uniqueKey: string[] | null;
+}
+
+export const FK_TARGETS: readonly FkTarget[] = [
+  { table: 'rotation', column: 'album_id', uniqueKey: null },
+  { table: 'flowsheet', column: 'album_id', uniqueKey: null },
+  { table: 'album_metadata', column: 'album_id', uniqueKey: ['album_id'] },
+  { table: 'reviews', column: 'album_id', uniqueKey: null },
+  { table: 'album_review_submissions', column: 'album_id', uniqueKey: null },
+  { table: 'album_critic_reviews', column: 'album_id', uniqueKey: ['album_id', 'source_url'] },
+  {
+    table: 'compilation_track_artist',
+    column: 'library_id',
+    uniqueKey: ['library_id', 'artist_name', 'track_title'],
+  },
+  { table: 'artist_library_crossreference', column: 'library_id', uniqueKey: ['artist_id', 'library_id'] },
+  { table: 'bins', column: 'album_id', uniqueKey: null },
+  { table: 'library_identity', column: 'library_id', uniqueKey: ['library_id'] },
+  { table: 'library_identity_source', column: 'library_id', uniqueKey: ['library_id', 'source'] },
+  { table: 'library_identity_history', column: 'library_id', uniqueKey: null },
+  { table: 'album_popularity', column: 'representative_library_id', uniqueKey: null },
+];
+
+export interface SlotRow extends SlotMember {
+  artist_id: number;
+  genre_id: number;
+  code_number: number;
+  vol: string;
+}
+
+export interface CollisionSlot {
+  artist_id: number;
+  genre_id: number;
+  code_number: number;
+  vol: string;
+  members: SlotRow[];
+}
+
+type RawRow = {
+  id: number;
+  album_title: string;
+  artist_id: number;
+  genre_id: number;
+  code_number: number;
+  vol: string;
+};
+
+/**
+ * Every `library` row sharing a slot with at least one other row, grouped.
+ *
+ * Reference counts are gathered with one query PER FK SITE over the whole
+ * candidate id set (13 queries), not one per candidate row (13 × ~1,500) — the
+ * counts only exist to rank survivors, and the per-row shape would turn a
+ * seconds-long read into a minutes-long one for the same answer.
+ */
+export const findCollisionSlots = async (): Promise<CollisionSlot[]> => {
+  const library = qualified('library');
+  const rows = (await db.execute(sql`
+    WITH slot AS (
+      SELECT artist_id, genre_id, code_number, upper(coalesce(code_volume_letters, '')) AS vol
+        FROM ${library}
+       GROUP BY 1, 2, 3, 4
+      HAVING count(*) > 1
+    )
+    SELECT l.id, l.album_title, l.artist_id, l.genre_id, l.code_number,
+           upper(coalesce(l.code_volume_letters, '')) AS vol
+      FROM ${library} l
+      JOIN slot s
+        ON s.artist_id = l.artist_id
+       AND s.genre_id = l.genre_id
+       AND s.code_number = l.code_number
+       AND s.vol = upper(coalesce(l.code_volume_letters, ''))
+     ORDER BY l.artist_id, l.genre_id, l.code_number, s.vol, l.id
+  `)) as unknown as RawRow[];
+
+  if (rows.length === 0) return [];
+
+  const refs = await countReferences(rows.map((r) => r.id));
+
+  const slots = new Map<string, CollisionSlot>();
+  for (const r of rows) {
+    const key = `${r.artist_id}|${r.genre_id}|${r.code_number}|${r.vol}`;
+    const slot = slots.get(key) ?? {
+      artist_id: r.artist_id,
+      genre_id: r.genre_id,
+      code_number: r.code_number,
+      vol: r.vol,
+      members: [],
+    };
+    slot.members.push({
+      id: r.id,
+      album_title: r.album_title,
+      refs: refs.get(r.id) ?? 0,
+      artist_id: r.artist_id,
+      genre_id: r.genre_id,
+      code_number: r.code_number,
+      vol: r.vol,
+    });
+    slots.set(key, slot);
+  }
+  return [...slots.values()];
+};
+
+/** Total inbound references per library id, summed across every FK site. */
+export const countReferences = async (ids: readonly number[]): Promise<Map<number, number>> => {
+  const totals = new Map<number, number>();
+  if (ids.length === 0) return totals;
+  const idList = intArrayLiteral([...ids]);
+
+  for (const target of FK_TARGETS) {
+    const t = qualified(target.table);
+    const col = ident(target.column);
+    const res = (await db.execute(sql`
+      SELECT ${col} AS ref_id, count(*)::int AS n
+        FROM ${t}
+       WHERE ${col} = ANY(${idList}::int[])
+       GROUP BY ${col}
+    `)) as unknown as Array<{ ref_id: number; n: number }>;
+    for (const row of res) {
+      totals.set(Number(row.ref_id), (totals.get(Number(row.ref_id)) ?? 0) + Number(row.n));
+    }
+  }
+  return totals;
+};
+
+/** Every row on a slot's shelf, for the twin check that gates a renumber. */
+export const loadShelf = async (
+  artist_id: number,
+  genre_id: number
+): Promise<Array<{ code_number: number; album_title: string }>> => {
+  const library = qualified('library');
+  return (await db.execute(sql`
+    SELECT code_number, album_title FROM ${library}
+     WHERE artist_id = ${artist_id} AND genre_id = ${genre_id}
+  `)) as unknown as Array<{ code_number: number; album_title: string }>;
+};
+
+export type SlotPlan =
+  | { kind: 'merge'; slot: CollisionSlot; survivorId: number; loserIds: number[] }
+  | { kind: 'renumber'; slot: CollisionSlot; keepId: number; moveId: number; newNumber: number }
+  /** Renumber withheld: the disc that would move has a twin at another number. */
+  | { kind: 'held'; slot: CollisionSlot; moveId: number; reason: string };
+
+/**
+ * Turn every collision slot into a concrete plan. Renumber targets are
+ * allocated here, sequentially per shelf from that shelf's current maximum, so
+ * two renumbers on one shelf can't be handed the same number.
+ */
+export const planSlots = async (slots: readonly CollisionSlot[]): Promise<SlotPlan[]> => {
+  const nextFree = new Map<string, number>();
+  const plans: SlotPlan[] = [];
+
+  for (const slot of slots) {
+    const verdict: SlotVerdict = classifySlot(slot.members);
+    if (verdict.kind === 'merge') {
+      plans.push({ kind: 'merge', slot, survivorId: verdict.survivorId, loserIds: verdict.loserIds });
+      continue;
+    }
+
+    const shelfKey = `${slot.artist_id}|${slot.genre_id}`;
+    const shelf = await loadShelf(slot.artist_id, slot.genre_id);
+    const move = slot.members.find((m) => m.id === verdict.moveId);
+
+    if (move && hasTwinElsewhere(move.album_title, slot.code_number, shelf)) {
+      plans.push({
+        kind: 'held',
+        slot,
+        moveId: verdict.moveId,
+        reason: `"${move.album_title}" already sits at another number on this shelf; which copy is real is a shelf question`,
+      });
+      continue;
+    }
+
+    if (!nextFree.has(shelfKey)) {
+      nextFree.set(shelfKey, Math.max(0, ...shelf.map((r) => r.code_number)) + 1);
+    }
+    const newNumber = nextFree.get(shelfKey)!;
+    nextFree.set(shelfKey, newNumber + 1);
+    plans.push({ kind: 'renumber', slot, keepId: verdict.keepId, moveId: verdict.moveId, newNumber });
+  }
+  return plans;
+};
+
+/**
+ * Repoint one FK site from `loser` → `survivor` inside a transaction. For a
+ * unique-keyed column, first drop the loser's rows that would collide with an
+ * existing survivor row on the other key columns, then repoint the remainder.
+ */
+const repointTarget = async (tx: Tx, target: FkTarget, loser: number, survivor: number): Promise<number> => {
+  const t = qualified(target.table);
+  const col = ident(target.column);
+
+  if (target.uniqueKey) {
+    const otherCols = target.uniqueKey.filter((c) => c !== target.column);
+    const matchClause =
+      otherCols.length > 0
+        ? sql.join(
+            otherCols.map((c) => sql`k.${ident(c)} IS NOT DISTINCT FROM d.${ident(c)}`),
+            sql` AND `
+          )
+        : sql`TRUE`;
+    await tx.execute(sql`
+      DELETE FROM ${t} d
+       WHERE d.${col} = ${loser}
+         AND EXISTS (SELECT 1 FROM ${t} k WHERE k.${col} = ${survivor} AND ${matchClause})
+    `);
+  }
+
+  const res = await tx.execute(sql`UPDATE ${t} SET ${col} = ${survivor} WHERE ${col} = ${loser}`);
+  return Number(res.count ?? 0);
+};
+
+export interface MergeResult {
+  survivorId: number;
+  losersMerged: number;
+  fkRowsRepointed: number;
+}
+
+/**
+ * Merge one slot in a single transaction: repoint every FK site for each loser,
+ * then delete the losers. Per-slot atomicity means an interrupted run leaves
+ * each slot either fully merged or untouched.
+ */
+export const mergeSlot = async (plan: Extract<SlotPlan, { kind: 'merge' }>): Promise<MergeResult> => {
+  let fkRowsRepointed = 0;
+  await db.transaction(async (tx) => {
+    for (const loser of plan.loserIds) {
+      for (const target of FK_TARGETS) {
+        fkRowsRepointed += await repointTarget(tx, target, loser, plan.survivorId);
+      }
+    }
+    const library = qualified('library');
+    const loserList = intArrayLiteral(plan.loserIds);
+    await tx.execute(sql`DELETE FROM ${library} WHERE id = ANY(${loserList}::int[])`);
+  });
+  return { survivorId: plan.survivorId, losersMerged: plan.loserIds.length, fkRowsRepointed };
+};
+
+/**
+ * Move one row to a free number on its own shelf. Re-checks that the
+ * destination is still free inside the transaction — the plan was built from a
+ * snapshot, and a librarian filing concurrently could have taken it. Returns
+ * false when the destination was taken, leaving the row where it is.
+ */
+export const renumberRow = async (plan: Extract<SlotPlan, { kind: 'renumber' }>): Promise<boolean> => {
+  const library = qualified('library');
+  let moved = false;
+  await db.transaction(async (tx) => {
+    const taken = (await tx.execute(sql`
+      SELECT 1 FROM ${library}
+       WHERE artist_id = ${plan.slot.artist_id}
+         AND genre_id = ${plan.slot.genre_id}
+         AND code_number = ${plan.newNumber}
+         AND upper(coalesce(code_volume_letters, '')) = ${plan.slot.vol}
+       LIMIT 1
+    `)) as unknown as unknown[];
+    if (taken.length > 0) return;
+    const res = await tx.execute(sql`
+      UPDATE ${library} SET code_number = ${plan.newNumber} WHERE id = ${plan.moveId}
+    `);
+    moved = Number(res.count ?? 0) > 0;
+  });
+  return moved;
+};
+
+/**
+ * ANALYZE the tables a run rewrites so the planner's stats stay on the index
+ * path after the bulk repoint (docs/bulk-update-playbook.md). Runs outside any
+ * transaction; skipped in dry-run.
+ */
+export const analyzeTouchedTables = async (): Promise<void> => {
+  const tables = ['library', ...new Set(FK_TARGETS.map((t) => t.table))];
+  for (const table of tables) {
+    await db.execute(sql`ANALYZE ${qualified(table)}`);
+  }
+};
+
+/** Display names for the worklist: who the shelf belongs to and what it's called. */
+const loadShelfLabels = async (
+  plans: readonly SlotPlan[]
+): Promise<Map<string, { artist: string; codeLetters: string; genre: string }>> => {
+  const labels = new Map<string, { artist: string; codeLetters: string; genre: string }>();
+  const needed = plans.filter((p) => p.kind !== 'merge');
+  if (needed.length === 0) return labels;
+
+  const artistIds = intArrayLiteral([...new Set(needed.map((p) => p.slot.artist_id))]);
+  const genreIds = intArrayLiteral([...new Set(needed.map((p) => p.slot.genre_id))]);
+  const rows = (await db.execute(sql`
+    SELECT a.id AS artist_id, a.artist_name, a.code_letters, g.id AS genre_id, g.genre_name
+      FROM ${qualified('artists')} a
+      CROSS JOIN ${qualified('genres')} g
+     WHERE a.id = ANY(${artistIds}::int[])
+       AND g.id = ANY(${genreIds}::int[])
+  `)) as unknown as Array<{
+    artist_id: number;
+    artist_name: string;
+    code_letters: string;
+    genre_id: number;
+    genre_name: string;
+  }>;
+  for (const r of rows) {
+    labels.set(`${r.artist_id}|${r.genre_id}`, {
+      artist: r.artist_name,
+      codeLetters: r.code_letters,
+      genre: r.genre_name,
+    });
+  }
+  return labels;
+};
+
+const titleOf = (slot: CollisionSlot, id: number): string =>
+  slot.members.find((m) => m.id === id)?.album_title ?? `(row ${id})`;
+
+export interface DedupSummary {
+  slots: number;
+  merges: number;
+  renumbers: number;
+  held: number;
+  fkRowsRepointed: number;
+  rowsDeleted: number;
+  renumbersSkipped: number;
+  worklist: string;
+}
+
+/**
+ * Whole run: find every colliding slot, decide what each one is, and — only
+ * under `--execute` — merge the duplicates and move the genuine collisions.
+ *
+ * Dry-run reports exactly what an execute run would do, including the finished
+ * worklist, so the librarian's list can be reviewed before anything is written.
+ */
+export const runDedup = async (): Promise<DedupSummary> => {
+  const tag = '[library-call-number-dedup]';
+  console.log(`${tag} mode: ${EXECUTE ? 'EXECUTE (writes)' : 'DRY RUN (no writes)'}`);
+
+  const slots = await findCollisionSlots();
+  console.log(`${tag} colliding call-number slots: ${slots.length}`);
+  if (slots.length === 0) {
+    return {
+      slots: 0,
+      merges: 0,
+      renumbers: 0,
+      held: 0,
+      fkRowsRepointed: 0,
+      rowsDeleted: 0,
+      renumbersSkipped: 0,
+      worklist: formatWorklist([], []),
+    };
+  }
+
+  const plans = await planSlots(slots);
+  const merges = plans.filter((p): p is Extract<SlotPlan, { kind: 'merge' }> => p.kind === 'merge');
+  const renumbers = plans.filter((p): p is Extract<SlotPlan, { kind: 'renumber' }> => p.kind === 'renumber');
+  const heldPlans = plans.filter((p): p is Extract<SlotPlan, { kind: 'held' }> => p.kind === 'held');
+
+  const plannedDeletions = merges.reduce((n, p) => n + p.loserIds.length, 0);
+  console.log(
+    `${tag} plan: ${merges.length} merges (${plannedDeletions} rows deleted), ` +
+      `${renumbers.length} renumbers, ${heldPlans.length} held for the librarian`
+  );
+
+  const labels = await loadShelfLabels(plans);
+  const label = (p: SlotPlan) =>
+    labels.get(`${p.slot.artist_id}|${p.slot.genre_id}`) ?? {
+      artist: `artist ${p.slot.artist_id}`,
+      codeLetters: '??',
+      genre: `genre ${p.slot.genre_id}`,
+    };
+
+  const worklist = formatWorklist(
+    renumbers.map((p) => {
+      const l = label(p);
+      return {
+        genre: l.genre,
+        artist: l.artist,
+        codeLetters: l.codeLetters,
+        moveTitle: titleOf(p.slot, p.moveId),
+        keepTitle: titleOf(p.slot, p.keepId),
+        oldNumber: p.slot.code_number,
+        newNumber: p.newNumber,
+        vol: p.slot.vol,
+      };
+    }),
+    heldPlans.map((p) => {
+      const l = label(p);
+      return {
+        genre: l.genre,
+        artist: l.artist,
+        codeLetters: l.codeLetters,
+        title: titleOf(p.slot, p.moveId),
+        atNumber: p.slot.code_number,
+        reason: p.reason,
+      };
+    })
+  );
+
+  let fkRowsRepointed = 0;
+  let rowsDeleted = 0;
+  let renumbersSkipped = 0;
+
+  if (EXECUTE) {
+    for (const plan of merges) {
+      const res = await mergeSlot(plan);
+      fkRowsRepointed += res.fkRowsRepointed;
+      rowsDeleted += res.losersMerged;
+    }
+    for (const plan of renumbers) {
+      const moved = await renumberRow(plan);
+      if (!moved) {
+        renumbersSkipped += 1;
+        const l = label(plan);
+        console.warn(
+          `${tag} skipped renumber: ${l.codeLetters} ${plan.slot.code_number} -> ${plan.newNumber} ` +
+            `(destination taken since the plan was built; re-run to re-plan)`
+        );
+      }
+    }
+    await analyzeTouchedTables();
+    console.log(`${tag} repointed ${fkRowsRepointed} FK rows, deleted ${rowsDeleted} library rows`);
+  } else {
+    for (const plan of merges) {
+      const counts = await previewSlot(plan);
+      fkRowsRepointed += counts;
+    }
+    console.log(`${tag} dry run: would repoint ${fkRowsRepointed} FK rows and delete ${plannedDeletions} library rows`);
+  }
+
+  console.log(`\n${worklist}`);
+
+  return {
+    slots: slots.length,
+    merges: merges.length,
+    renumbers: renumbers.length,
+    held: heldPlans.length,
+    fkRowsRepointed,
+    rowsDeleted: EXECUTE ? rowsDeleted : plannedDeletions,
+    renumbersSkipped,
+    worklist,
+  };
+};
+
+/** Dry-run counterpart to `mergeSlot`: how many FK rows it would repoint. */
+export const previewSlot = async (plan: Extract<SlotPlan, { kind: 'merge' }>): Promise<number> => {
+  const refs = await countReferences(plan.loserIds);
+  return [...refs.values()].reduce((a, b) => a + b, 0);
+};

--- a/jobs/library-call-number-dedup/merge.ts
+++ b/jobs/library-call-number-dedup/merge.ts
@@ -24,10 +24,18 @@
  *     let straight through.
  *
  * Every FK referencing `library.id` is repointed to the survivor BEFORE the
- * losing row is deleted. That ordering is not stylistic: six of the sites
- * declare `onDelete: 'cascade'` and two declare `set null`, so deleting first
- * would silently destroy rotation history, album metadata, and reviews, and
- * silently unlink plays, with no error raised.
+ * losing row is deleted. That ordering is not stylistic: five of the sites
+ * cascade and two null the reference out, so deleting first would silently
+ * destroy rotation history, album metadata, and reviews, and silently unlink
+ * plays, with no error raised.
+ *
+ * Those actions are what the DATABASE enforces, which is not what `schema.ts`
+ * declares — it marks `artist_library_crossreference.library_id` as `cascade`
+ * while migration 0022 created it `no action` and nothing since altered it (one
+ * of the four drifted constraints in BS#2015). The integration spec's
+ * `enforced-fk-actions` block pins every entry below against
+ * `information_schema` so this list tracks the database rather than the
+ * declaration.
  */
 
 import { sql, type SQL } from 'drizzle-orm';

--- a/jobs/library-call-number-dedup/merge.ts
+++ b/jobs/library-call-number-dedup/merge.ts
@@ -39,7 +39,7 @@
  */
 
 import { sql, type SQL } from 'drizzle-orm';
-import { db, intArrayLiteral } from '@wxyc/database';
+import { checkLiveActivity, db, intArrayLiteral } from '@wxyc/database';
 import { classifySlot, hasTwinElsewhere, type SlotMember, type SlotVerdict } from './classify';
 import { formatWorklist } from './report';
 
@@ -70,13 +70,31 @@ export interface FkTarget {
   table: string;
   column: string;
   uniqueKey: string[] | null;
+  /**
+   * Column that must be NULL for a PARTIAL unique key to apply. Load-bearing
+   * rather than cosmetic: without it the collision-delete drops rows the index
+   * never constrained. `rotation`'s key covers only ACTIVE rows
+   * (`WHERE kill_date IS NULL`), so a killed rotation record may duplicate an
+   * active one freely — deleting it would destroy exactly the history that
+   * repointing-before-deleting exists to preserve.
+   *
+   * Modelled as a column name rather than a predicate string so it can be
+   * parameterized and table-aliased safely; a partial index needing anything
+   * richer should extend this deliberately rather than smuggle in raw SQL.
+   */
+  uniqueWhenNull?: string;
 }
 
 export const FK_TARGETS: readonly FkTarget[] = [
-  { table: 'rotation', column: 'album_id', uniqueKey: null },
+  {
+    table: 'rotation',
+    column: 'album_id',
+    uniqueKey: ['album_id', 'rotation_bin'],
+    uniqueWhenNull: 'kill_date',
+  },
   { table: 'flowsheet', column: 'album_id', uniqueKey: null },
   { table: 'album_metadata', column: 'album_id', uniqueKey: ['album_id'] },
-  { table: 'reviews', column: 'album_id', uniqueKey: null },
+  { table: 'reviews', column: 'album_id', uniqueKey: ['album_id'] },
   { table: 'album_review_submissions', column: 'album_id', uniqueKey: null },
   { table: 'album_critic_reviews', column: 'album_id', uniqueKey: ['album_id', 'source_url'] },
   {
@@ -194,22 +212,36 @@ export const countReferences = async (ids: readonly number[]): Promise<Map<numbe
   return totals;
 };
 
-/** Every row on a slot's shelf, for the twin check that gates a renumber. */
+/**
+ * Every row on a slot's shelf, for the twin check and the next-free number.
+ * Cached per shelf: an unlocked MAX+1 allocator produces CLUSTERS of collisions
+ * on one shelf, so the uncached form re-reads identical rows once per slot.
+ */
+const shelfCache = new Map<string, Array<{ code_number: number; album_title: string; id: number }>>();
+
 export const loadShelf = async (
   artist_id: number,
   genre_id: number
-): Promise<Array<{ code_number: number; album_title: string }>> => {
+): Promise<Array<{ code_number: number; album_title: string; id: number }>> => {
+  const key = `${artist_id}|${genre_id}`;
+  const hit = shelfCache.get(key);
+  if (hit) return hit;
   const library = qualified('library');
-  return (await db.execute(sql`
-    SELECT code_number, album_title FROM ${library}
+  const rows = (await db.execute(sql`
+    SELECT id, code_number, album_title FROM ${library}
      WHERE artist_id = ${artist_id} AND genre_id = ${genre_id}
-  `)) as unknown as Array<{ code_number: number; album_title: string }>;
+  `)) as unknown as Array<{ code_number: number; album_title: string; id: number }>;
+  shelfCache.set(key, rows);
+  return rows;
 };
+
+/** Test seam: drop memoized shelves so a second run re-reads the catalog. */
+export const resetShelfCache = (): void => shelfCache.clear();
 
 export type SlotPlan =
   | { kind: 'merge'; slot: CollisionSlot; survivorId: number; loserIds: number[] }
   | { kind: 'renumber'; slot: CollisionSlot; keepId: number; moveId: number; newNumber: number }
-  /** Renumber withheld: the disc that would move has a twin at another number. */
+  /** Withheld for the librarian — the database cannot settle it. */
   | { kind: 'held'; slot: CollisionSlot; moveId: number; reason: string };
 
 /**
@@ -221,23 +253,45 @@ export const planSlots = async (slots: readonly CollisionSlot[]): Promise<SlotPl
   const nextFree = new Map<string, number>();
   const plans: SlotPlan[] = [];
 
+  // Rows a merge is already going to delete must not count as twins: otherwise
+  // a duplicate this very run is about to remove withholds a renumber, and the
+  // slot lands on the librarian's list for a question the job just answered.
+  const doomed = new Set<number>();
+  for (const slot of slots) {
+    const v = classifySlot(slot.members);
+    if (v.kind === 'merge') v.loserIds.forEach((id) => doomed.add(id));
+  }
+
   for (const slot of slots) {
     const verdict: SlotVerdict = classifySlot(slot.members);
+    const shelfKey = `${slot.artist_id}|${slot.genre_id}`;
+
     if (verdict.kind === 'merge') {
       plans.push({ kind: 'merge', slot, survivorId: verdict.survivorId, loserIds: verdict.loserIds });
+      // Three or more rows where only some are re-entries: the merge resolves
+      // the duplicates but the slot still holds two different releases, and
+      // which one moves is a shelf question rather than something to guess at.
+      if (verdict.unresolvedIds.length > 0) {
+        plans.push({
+          kind: 'held',
+          slot,
+          moveId: verdict.unresolvedIds[0],
+          reason: 'slot still holds two different releases after the duplicates merge',
+        });
+      }
       continue;
     }
 
-    const shelfKey = `${slot.artist_id}|${slot.genre_id}`;
     const shelf = await loadShelf(slot.artist_id, slot.genre_id);
+    const live = shelf.filter((r) => !doomed.has(r.id));
     const move = slot.members.find((m) => m.id === verdict.moveId);
 
-    if (move && hasTwinElsewhere(move.album_title, slot.code_number, shelf)) {
+    if (move && hasTwinElsewhere(move.album_title, slot.code_number, live)) {
       plans.push({
         kind: 'held',
         slot,
         moveId: verdict.moveId,
-        reason: `"${move.album_title}" already sits at another number on this shelf; which copy is real is a shelf question`,
+        reason: `"${move.album_title}" already sits at another number on this shelf`,
       });
       continue;
     }
@@ -250,6 +304,60 @@ export const planSlots = async (slots: readonly CollisionSlot[]): Promise<SlotPl
     plans.push({ kind: 'renumber', slot, keepId: verdict.keepId, moveId: verdict.moveId, newNumber });
   }
   return plans;
+};
+
+/**
+ * Columns on the losing `library` row that are expensive to re-collect and are
+ * NOT re-derivable from the surviving row: an LML identity resolution, curated
+ * artwork, and the music director's deliberate "not on Discogs" note. The
+ * survivor is chosen by inbound reference count, which says nothing about how
+ * complete its data is, so without this pass a merge can delete the only row
+ * that carried them. Survivor's own non-null value always wins.
+ */
+const PRESERVED_LIBRARY_COLUMNS = [
+  'canonical_entity_id',
+  'artwork_url',
+  'discogs_unavailable_note',
+  'alternate_artist_name',
+  'album_artist',
+  'label',
+  'label_id',
+] as const;
+
+/** Same idea for the one child table whose contents are costly to rebuild. */
+const PRESERVED_ALBUM_METADATA_COLUMNS = [
+  'artwork_url',
+  'discogs_url',
+  'release_year',
+  'spotify_url',
+  'apple_music_url',
+  'youtube_music_url',
+] as const;
+
+const fillNullsFromLoser = async (tx: Tx, survivor: number, loser: number): Promise<void> => {
+  const library = qualified('library');
+  const libSet = sql.join(
+    PRESERVED_LIBRARY_COLUMNS.map((c) => sql`${ident(c)} = COALESCE(s.${ident(c)}, d.${ident(c)})`),
+    sql`, `
+  );
+  await tx.execute(sql`
+    UPDATE ${library} s SET ${libSet}
+      FROM ${library} d
+     WHERE s.id = ${survivor} AND d.id = ${loser}
+  `);
+
+  // Only meaningful when BOTH rows have album_metadata; when only the loser
+  // does, the plain repoint moves it across untouched.
+  const am = qualified('album_metadata');
+  const amSet = sql.join(
+    PRESERVED_ALBUM_METADATA_COLUMNS.map((c) => sql`${ident(c)} = COALESCE(s.${ident(c)}, d.${ident(c)})`),
+    sql`, `
+  );
+  await tx.execute(sql`
+    UPDATE ${am} s SET ${amSet}
+      FROM ${am} d
+     WHERE s.album_id = ${survivor} AND d.album_id = ${loser}
+  `);
 };
 
 /**
@@ -270,10 +378,17 @@ const repointTarget = async (tx: Tx, target: FkTarget, loser: number, survivor: 
             sql` AND `
           )
         : sql`TRUE`;
+    // A partial index constrains only the rows satisfying its predicate, so the
+    // collision-delete has to be scoped to those on BOTH sides. Rows outside it
+    // cannot collide and are left to repoint normally — that is what keeps
+    // killed rotation history intact while active duplicates are resolved.
+    const partial = target.uniqueWhenNull;
+    const dScope = partial ? sql` AND d.${ident(partial)} IS NULL` : sql``;
+    const kScope = partial ? sql` AND k.${ident(partial)} IS NULL` : sql``;
     await tx.execute(sql`
       DELETE FROM ${t} d
-       WHERE d.${col} = ${loser}
-         AND EXISTS (SELECT 1 FROM ${t} k WHERE k.${col} = ${survivor} AND ${matchClause})
+       WHERE d.${col} = ${loser}${dScope}
+         AND EXISTS (SELECT 1 FROM ${t} k WHERE k.${col} = ${survivor}${kScope} AND ${matchClause})
     `);
   }
 
@@ -296,6 +411,11 @@ export const mergeSlot = async (plan: Extract<SlotPlan, { kind: 'merge' }>): Pro
   let fkRowsRepointed = 0;
   await db.transaction(async (tx) => {
     for (const loser of plan.loserIds) {
+      // Preserve first: repointing can DELETE a loser's unique-keyed child row
+      // when the survivor already has one, and the delete below removes the
+      // loser's own row outright. Anything worth keeping has to move across
+      // before either happens.
+      await fillNullsFromLoser(tx, plan.survivorId, loser);
       for (const target of FK_TARGETS) {
         fkRowsRepointed += await repointTarget(tx, target, loser, plan.survivorId);
       }
@@ -346,33 +466,47 @@ export const analyzeTouchedTables = async (): Promise<void> => {
   }
 };
 
-/** Display names for the worklist: who the shelf belongs to and what it's called. */
+/**
+ * Display context for the worklist. Joined through `genre_artist_crossreference`
+ * rather than crossing `artists` with `genres`, for two reasons: that table is
+ * where `artist_genre_code` lives — the middle component of a call number,
+ * without which the printed address does not identify a shelf slot, since two
+ * artists in one genre routinely share code letters — and joining through it
+ * cannot fabricate a label for an (artist, genre) pair that does not exist.
+ */
 const loadShelfLabels = async (
   plans: readonly SlotPlan[]
-): Promise<Map<string, { artist: string; codeLetters: string; genre: string }>> => {
-  const labels = new Map<string, { artist: string; codeLetters: string; genre: string }>();
+): Promise<Map<string, { artist: string; codeLetters: string; artistGenreCode: number | null; genre: string }>> => {
+  const labels = new Map<
+    string,
+    { artist: string; codeLetters: string; artistGenreCode: number | null; genre: string }
+  >();
   const needed = plans.filter((p) => p.kind !== 'merge');
   if (needed.length === 0) return labels;
 
   const artistIds = intArrayLiteral([...new Set(needed.map((p) => p.slot.artist_id))]);
   const genreIds = intArrayLiteral([...new Set(needed.map((p) => p.slot.genre_id))]);
   const rows = (await db.execute(sql`
-    SELECT a.id AS artist_id, a.artist_name, a.code_letters, g.id AS genre_id, g.genre_name
-      FROM ${qualified('artists')} a
-      CROSS JOIN ${qualified('genres')} g
-     WHERE a.id = ANY(${artistIds}::int[])
-       AND g.id = ANY(${genreIds}::int[])
+    SELECT a.id AS artist_id, a.artist_name, a.code_letters,
+           g.id AS genre_id, g.genre_name, x.artist_genre_code
+      FROM ${qualified('genre_artist_crossreference')} x
+      JOIN ${qualified('artists')} a ON a.id = x.artist_id
+      JOIN ${qualified('genres')} g ON g.id = x.genre_id
+     WHERE x.artist_id = ANY(${artistIds}::int[])
+       AND x.genre_id = ANY(${genreIds}::int[])
   `)) as unknown as Array<{
     artist_id: number;
     artist_name: string;
     code_letters: string;
     genre_id: number;
     genre_name: string;
+    artist_genre_code: number | null;
   }>;
   for (const r of rows) {
     labels.set(`${r.artist_id}|${r.genre_id}`, {
       artist: r.artist_name,
       codeLetters: r.code_letters,
+      artistGenreCode: r.artist_genre_code,
       genre: r.genre_name,
     });
   }
@@ -388,17 +522,68 @@ export interface DedupSummary {
   renumbers: number;
   held: number;
   fkRowsRepointed: number;
+  childRowsDeleted: number;
   rowsDeleted: number;
   renumbersSkipped: number;
   worklist: string;
 }
 
 /**
+ * Rows a merge would DELETE rather than repoint, per unique-keyed FK site.
+ *
+ * The dry run exists so an operator can approve the plan, and "would repoint N
+ * rows" hides the destructive half: where the survivor already holds the
+ * equivalent unique-keyed row, the loser's is dropped. Counting it separately
+ * is what makes the dry run an honest preview.
+ */
+export const previewCollisionDeletes = async (
+  plan: Extract<SlotPlan, { kind: 'merge' }>
+): Promise<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  const loserList = intArrayLiteral(plan.loserIds);
+  for (const target of FK_TARGETS) {
+    if (!target.uniqueKey) continue;
+    const t = qualified(target.table);
+    const col = ident(target.column);
+    const otherCols = target.uniqueKey.filter((c) => c !== target.column);
+    const matchClause =
+      otherCols.length > 0
+        ? sql.join(
+            otherCols.map((c) => sql`k.${ident(c)} IS NOT DISTINCT FROM d.${ident(c)}`),
+            sql` AND `
+          )
+        : sql`TRUE`;
+    const partial = target.uniqueWhenNull;
+    const dScope = partial ? sql` AND d.${ident(partial)} IS NULL` : sql``;
+    const kScope = partial ? sql` AND k.${ident(partial)} IS NULL` : sql``;
+    const res = (await db.execute(sql`
+      SELECT count(*)::int AS n FROM ${t} d
+       WHERE d.${col} = ANY(${loserList}::int[])${dScope}
+         AND EXISTS (SELECT 1 FROM ${t} k WHERE k.${col} = ${plan.survivorId}${kScope} AND ${matchClause})
+    `)) as unknown as Array<{ n: number }>;
+    const n = Number(res[0]?.n ?? 0);
+    if (n > 0) counts[`${target.table}.${target.column}`] = n;
+  }
+  return counts;
+};
+
+/**
+ * Dry-run counterpart to `mergeSlot`: how many FK rows it would touch. Read
+ * straight off the counts `findCollisionSlots` already attached to each member
+ * — re-querying here would reintroduce the per-row shape that batching exists
+ * to avoid, for a number already in hand.
+ */
+export const previewSlot = (plan: Extract<SlotPlan, { kind: 'merge' }>): number =>
+  plan.slot.members.filter((m) => plan.loserIds.includes(m.id)).reduce((a, m) => a + m.refs, 0);
+
+/**
  * Whole run: find every colliding slot, decide what each one is, and — only
  * under `--execute` — merge the duplicates and move the genuine collisions.
  *
- * Dry-run reports exactly what an execute run would do, including the finished
- * worklist, so the librarian's list can be reviewed before anything is written.
+ * The worklist is rendered AFTER the writes, from the renumbers that actually
+ * landed. Rendering it from the plan would tell the librarian to relabel a disc
+ * whose catalog row never moved (a destination taken since planning), creating
+ * the shelf/catalog disagreement the job exists to remove, in reverse.
  */
 export const runDedup = async (): Promise<DedupSummary> => {
   const tag = '[library-call-number-dedup]';
@@ -406,45 +591,97 @@ export const runDedup = async (): Promise<DedupSummary> => {
 
   const slots = await findCollisionSlots();
   console.log(`${tag} colliding call-number slots: ${slots.length}`);
-  if (slots.length === 0) {
-    return {
-      slots: 0,
-      merges: 0,
-      renumbers: 0,
-      held: 0,
-      fkRowsRepointed: 0,
-      rowsDeleted: 0,
-      renumbersSkipped: 0,
-      worklist: formatWorklist([], []),
-    };
-  }
 
-  const plans = await planSlots(slots);
+  const plans = slots.length > 0 ? await planSlots(slots) : [];
   const merges = plans.filter((p): p is Extract<SlotPlan, { kind: 'merge' }> => p.kind === 'merge');
   const renumbers = plans.filter((p): p is Extract<SlotPlan, { kind: 'renumber' }> => p.kind === 'renumber');
   const heldPlans = plans.filter((p): p is Extract<SlotPlan, { kind: 'held' }> => p.kind === 'held');
 
   const plannedDeletions = merges.reduce((n, p) => n + p.loserIds.length, 0);
+  const fkRowsRepointed0 = merges.reduce((n, p) => n + previewSlot(p), 0);
+
+  const childDeletes: Record<string, number> = {};
+  for (const plan of merges) {
+    for (const [site, n] of Object.entries(await previewCollisionDeletes(plan))) {
+      childDeletes[site] = (childDeletes[site] ?? 0) + n;
+    }
+  }
+  const childRowsDeleted = Object.values(childDeletes).reduce((a, b) => a + b, 0);
+
   console.log(
-    `${tag} plan: ${merges.length} merges (${plannedDeletions} rows deleted), ` +
+    `${tag} plan: ${merges.length} merges (${plannedDeletions} library rows deleted), ` +
       `${renumbers.length} renumbers, ${heldPlans.length} held for the librarian`
   );
+  console.log(`${tag} ~${fkRowsRepointed0} FK rows repoint; ${childRowsDeleted} child rows dropped as duplicates`);
+  for (const [site, n] of Object.entries(childDeletes)) console.log(`${tag}   drop ${n} from ${site}`);
 
   const labels = await loadShelfLabels(plans);
   const label = (p: SlotPlan) =>
     labels.get(`${p.slot.artist_id}|${p.slot.genre_id}`) ?? {
       artist: `artist ${p.slot.artist_id}`,
       codeLetters: '??',
+      artistGenreCode: null,
       genre: `genre ${p.slot.genre_id}`,
     };
 
+  let fkRowsRepointed = fkRowsRepointed0;
+  let rowsDeleted = plannedDeletions;
+  let renumbersSkipped = 0;
+  let landed = renumbers;
+
+  if (EXECUTE) {
+    // This job writes `flowsheet`, which dj-site polls every 60s. Refuse to
+    // start while a DJ is on air rather than pause mid-run: it is a one-shot
+    // run in a chosen window, so declining is cheaper than a partial pass.
+    const live = await checkLiveActivity(600).catch(() => false);
+    if (live) {
+      console.warn(`${tag} a show is on air — refusing to start. Re-run in a quiet window.`);
+      return {
+        slots: slots.length,
+        merges: merges.length,
+        renumbers: renumbers.length,
+        held: heldPlans.length,
+        fkRowsRepointed: 0,
+        childRowsDeleted: 0,
+        rowsDeleted: 0,
+        renumbersSkipped: 0,
+        worklist: formatWorklist([], []),
+      };
+    }
+
+    fkRowsRepointed = 0;
+    rowsDeleted = 0;
+    for (const plan of merges) {
+      const res = await mergeSlot(plan);
+      fkRowsRepointed += res.fkRowsRepointed;
+      rowsDeleted += res.losersMerged;
+    }
+    const moved: typeof renumbers = [];
+    for (const plan of renumbers) {
+      if (await renumberRow(plan)) {
+        moved.push(plan);
+      } else {
+        renumbersSkipped += 1;
+        const l = label(plan);
+        console.warn(
+          `${tag} skipped renumber: ${l.codeLetters} ${plan.slot.code_number} -> ${plan.newNumber} ` +
+            `(destination taken since the plan was built; re-run to re-plan). NOT on the worklist.`
+        );
+      }
+    }
+    landed = moved;
+    await analyzeTouchedTables();
+    console.log(`${tag} repointed ${fkRowsRepointed} FK rows, deleted ${rowsDeleted} library rows`);
+  }
+
   const worklist = formatWorklist(
-    renumbers.map((p) => {
+    landed.map((p) => {
       const l = label(p);
       return {
         genre: l.genre,
         artist: l.artist,
         codeLetters: l.codeLetters,
+        artistGenreCode: l.artistGenreCode,
         moveTitle: titleOf(p.slot, p.moveId),
         keepTitle: titleOf(p.slot, p.keepId),
         oldNumber: p.slot.code_number,
@@ -458,60 +695,29 @@ export const runDedup = async (): Promise<DedupSummary> => {
         genre: l.genre,
         artist: l.artist,
         codeLetters: l.codeLetters,
+        artistGenreCode: l.artistGenreCode,
         title: titleOf(p.slot, p.moveId),
         atNumber: p.slot.code_number,
+        vol: p.slot.vol,
         reason: p.reason,
       };
     })
   );
 
-  let fkRowsRepointed = 0;
-  let rowsDeleted = 0;
-  let renumbersSkipped = 0;
-
-  if (EXECUTE) {
-    for (const plan of merges) {
-      const res = await mergeSlot(plan);
-      fkRowsRepointed += res.fkRowsRepointed;
-      rowsDeleted += res.losersMerged;
-    }
-    for (const plan of renumbers) {
-      const moved = await renumberRow(plan);
-      if (!moved) {
-        renumbersSkipped += 1;
-        const l = label(plan);
-        console.warn(
-          `${tag} skipped renumber: ${l.codeLetters} ${plan.slot.code_number} -> ${plan.newNumber} ` +
-            `(destination taken since the plan was built; re-run to re-plan)`
-        );
-      }
-    }
-    await analyzeTouchedTables();
-    console.log(`${tag} repointed ${fkRowsRepointed} FK rows, deleted ${rowsDeleted} library rows`);
-  } else {
-    for (const plan of merges) {
-      const counts = await previewSlot(plan);
-      fkRowsRepointed += counts;
-    }
-    console.log(`${tag} dry run: would repoint ${fkRowsRepointed} FK rows and delete ${plannedDeletions} library rows`);
-  }
-
   console.log(`\n${worklist}`);
+  if (renumbersSkipped > 0) {
+    console.warn(`${tag} ${renumbersSkipped} renumber(s) skipped — re-run to re-plan them.`);
+  }
 
   return {
     slots: slots.length,
     merges: merges.length,
-    renumbers: renumbers.length,
+    renumbers: landed.length,
     held: heldPlans.length,
     fkRowsRepointed,
-    rowsDeleted: EXECUTE ? rowsDeleted : plannedDeletions,
+    childRowsDeleted,
+    rowsDeleted,
     renumbersSkipped,
     worklist,
   };
-};
-
-/** Dry-run counterpart to `mergeSlot`: how many FK rows it would repoint. */
-export const previewSlot = async (plan: Extract<SlotPlan, { kind: 'merge' }>): Promise<number> => {
-  const refs = await countReferences(plan.loserIds);
-  return [...refs.values()].reduce((a, b) => a + b, 0);
 };

--- a/jobs/library-call-number-dedup/package.json
+++ b/jobs/library-call-number-dedup/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/library-call-number-dedup",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot dedup: resolve duplicate call-number slots in library, merging re-entered releases and renumbering genuine collisions, so a uniqueness constraint can be added. Dry-run by default; --execute to write.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_call_number_dedup:ci -f ../../Dockerfile.library-call-number-dedup ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-call-number-dedup/report.ts
+++ b/jobs/library-call-number-dedup/report.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure formatter for the librarian's relabel worklist.
+ *
+ * A renumber is only half a fix. The catalog row moves to a free number the
+ * moment the job writes it, but the disc on the shelf still carries the old
+ * one, so until someone relabels it the shelf and the catalog disagree — and
+ * the uniqueness constraint this job exists to enable cannot be added until
+ * they agree. This renders the list that closes that gap.
+ *
+ * Kept pure and separate from `merge.ts` so the output can be asserted in unit
+ * tests without a database, and so a dry-run can produce the exact worklist an
+ * execute run would.
+ */
+
+/** One line of shelf work: pull this disc, cross out its number, write the new one. */
+export interface RelabelItem {
+  genre: string;
+  artist: string;
+  codeLetters: string;
+  moveTitle: string;
+  keepTitle: string;
+  oldNumber: number;
+  newNumber: number;
+  vol: string;
+}
+
+/** A renumber that was withheld because only the shelf can settle it. */
+export interface HeldItem {
+  genre: string;
+  artist: string;
+  codeLetters: string;
+  title: string;
+  atNumber: number;
+  reason: string;
+}
+
+const callNumber = (letters: string, n: number, vol: string): string =>
+  vol ? `${letters} ${n} ${vol}` : `${letters} ${n}`;
+
+/** Render the worklist as Markdown, grouped by genre then shelf. */
+export const formatWorklist = (items: readonly RelabelItem[], held: readonly HeldItem[]): string => {
+  const genres = [...new Set(items.map((i) => i.genre))].sort();
+  const out: string[] = [];
+
+  out.push('# Call-number relabel worklist');
+  out.push('');
+  out.push(
+    'Each row below is a shelf slot that held two different releases under one call number. The catalog now gives one of them a new number; **the disc itself still carries the old one.** Until it is relabelled the shelf and the catalog disagree.'
+  );
+  out.push('');
+  out.push(
+    'For each row: pull the disc under **Relabel this one**, cross out its number, write the new one, and refile it in number order. The other disc in the slot keeps its number and does not move.'
+  );
+  out.push('');
+  out.push(
+    `**${items.length} ${items.length === 1 ? 'disc' : 'discs'} to relabel**` +
+      (genres.length ? ` across ${genres.length} ${genres.length === 1 ? 'genre' : 'genres'}` : '') +
+      (held.length ? `, plus **${held.length} that need your judgement** (last section).` : '.')
+  );
+  out.push('');
+  out.push('| ✓ | Genre | Shelf | Relabel this one | Was | Becomes | Stays put |');
+  out.push('|---|---|---|---|---|---|---|');
+  for (const genre of genres) {
+    const rows = items
+      .filter((i) => i.genre === genre)
+      .sort((a, b) => a.codeLetters.localeCompare(b.codeLetters) || a.oldNumber - b.oldNumber);
+    for (const i of rows) {
+      out.push(
+        `| ☐ | ${genre} | ${i.artist} | ${i.moveTitle} | \`${callNumber(i.codeLetters, i.oldNumber, i.vol)}\` | ` +
+          `\`${callNumber(i.codeLetters, i.newNumber, i.vol)}\` | ${i.keepTitle} |`
+      );
+    }
+  }
+  out.push('');
+
+  if (held.length > 0) {
+    out.push('## Needs your judgement');
+    out.push('');
+    out.push(
+      'In these, the disc that would have moved **already has a same-titled copy elsewhere on the same shelf.** Giving it a new number would leave one title at three addresses. Whether the other copy is a genuine duplicate, a different pressing, or a mis-filing is a question the shelf can answer and the database cannot, so nothing was changed.'
+    );
+    out.push('');
+    out.push('| Genre | Shelf | Title | Currently at | Why it was held |');
+    out.push('|---|---|---|---|---|');
+    for (const h of held) {
+      out.push(
+        `| ${h.genre} | ${h.artist} | ${h.title} | \`${callNumber(h.codeLetters, h.atNumber, '')}\` | ${h.reason} |`
+      );
+    }
+    out.push('');
+  }
+  return out.join('\n');
+};

--- a/jobs/library-call-number-dedup/report.ts
+++ b/jobs/library-call-number-dedup/report.ts
@@ -17,6 +17,8 @@ export interface RelabelItem {
   genre: string;
   artist: string;
   codeLetters: string;
+  /** `genre_artist_crossreference.artist_genre_code` — the middle component. */
+  artistGenreCode: number | null;
   moveTitle: string;
   keepTitle: string;
   oldNumber: number;
@@ -29,13 +31,26 @@ export interface HeldItem {
   genre: string;
   artist: string;
   codeLetters: string;
+  artistGenreCode: number | null;
   title: string;
   atNumber: number;
+  /** Volume letter of the slot, or '' — a held item can sit on a lettered shelf. */
+  vol: string;
   reason: string;
 }
 
-const callNumber = (letters: string, n: number, vol: string): string =>
-  vol ? `${letters} ${n} ${vol}` : `${letters} ${n}`;
+/**
+ * A WXYC call number has three components — code letters, the artist's number
+ * within the genre, and the release's number on that shelf — plus a volume
+ * letter for a multi-disc set. Two artists in one genre routinely share code
+ * letters, so dropping the middle component yields an address that does not
+ * identify a slot. Rendered space-separated, matching the three fields the
+ * catalog API returns rather than inventing a punctuation convention.
+ */
+const callNumber = (letters: string, artistGenreCode: number | null, n: number, vol: string): string => {
+  const parts = [letters, artistGenreCode === null ? null : String(artistGenreCode), String(n), vol || null];
+  return parts.filter((p) => p !== null && p !== '').join(' ');
+};
 
 /** Render the worklist as Markdown, grouped by genre then shelf. */
 export const formatWorklist = (items: readonly RelabelItem[], held: readonly HeldItem[]): string => {
@@ -66,8 +81,8 @@ export const formatWorklist = (items: readonly RelabelItem[], held: readonly Hel
       .sort((a, b) => a.codeLetters.localeCompare(b.codeLetters) || a.oldNumber - b.oldNumber);
     for (const i of rows) {
       out.push(
-        `| ☐ | ${genre} | ${i.artist} | ${i.moveTitle} | \`${callNumber(i.codeLetters, i.oldNumber, i.vol)}\` | ` +
-          `\`${callNumber(i.codeLetters, i.newNumber, i.vol)}\` | ${i.keepTitle} |`
+        `| ☐ | ${genre} | ${i.artist} | ${i.moveTitle} | \`${callNumber(i.codeLetters, i.artistGenreCode, i.oldNumber, i.vol)}\` | ` +
+          `\`${callNumber(i.codeLetters, i.artistGenreCode, i.newNumber, i.vol)}\` | ${i.keepTitle} |`
       );
     }
   }
@@ -77,14 +92,14 @@ export const formatWorklist = (items: readonly RelabelItem[], held: readonly Hel
     out.push('## Needs your judgement');
     out.push('');
     out.push(
-      'In these, the disc that would have moved **already has a same-titled copy elsewhere on the same shelf.** Giving it a new number would leave one title at three addresses. Whether the other copy is a genuine duplicate, a different pressing, or a mis-filing is a question the shelf can answer and the database cannot, so nothing was changed.'
+      'These slots were left alone because the database cannot settle them. Either the disc that would have moved already has a same-titled copy elsewhere on the shelf — so a new number would leave one title at three addresses — or the slot still holds two different releases after its duplicates merged. Which copy is real, and which should move, is a question the shelf can answer and the catalog cannot. Nothing was changed.'
     );
     out.push('');
     out.push('| Genre | Shelf | Title | Currently at | Why it was held |');
     out.push('|---|---|---|---|---|');
     for (const h of held) {
       out.push(
-        `| ${h.genre} | ${h.artist} | ${h.title} | \`${callNumber(h.codeLetters, h.atNumber, '')}\` | ${h.reason} |`
+        `| ${h.genre} | ${h.artist} | ${h.title} | \`${callNumber(h.codeLetters, h.artistGenreCode, h.atNumber, h.vol)}\` | ${h.reason} |`
       );
     }
     out.push('');

--- a/jobs/library-call-number-dedup/tsconfig.json
+++ b/jobs/library-call-number-dedup/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-call-number-dedup/tsup.config.ts
+++ b/jobs/library-call-number-dedup/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  // `job.ts` is the ESM CLI entrypoint the Docker image runs (dist/job.js).
+  // `merge.ts` also emits a CommonJS bundle (dist/merge.cjs) so the babel-jest
+  // integration spec can `require` and exercise the REAL merge functions
+  // against Postgres rather than reimplementing them.
+  entry: ['job.ts', 'merge.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1069,6 +1069,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-call-number-dedup": {
+      "name": "@wxyc/library-call-number-dedup",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-canonical-entity-backfill": {
       "name": "@wxyc/library-canonical-entity-backfill",
       "version": "1.0.0",
@@ -6793,6 +6807,10 @@
     },
     "node_modules/@wxyc/library-artwork-url-backfill": {
       "resolved": "jobs/library-artwork-url-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/library-call-number-dedup": {
+      "resolved": "jobs/library-call-number-dedup",
       "link": true
     },
     "node_modules/@wxyc/library-canonical-entity-backfill": {

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for the REAL shipped functions of
+ * `jobs/library-call-number-dedup`, against a real Postgres.
+ *
+ * The headline invariant is an ORDERING one that no unit test can prove,
+ * because it only exists in the database's own constraint behaviour: every FK
+ * referencing `library.id` must be repointed to the survivor BEFORE the losing
+ * row is deleted. Six of the reference sites declare `onDelete: 'cascade'` and
+ * two declare `set null`, so a merge that deleted first would silently destroy
+ * rotation history, album metadata, and reviews — no error, no exception, just
+ * missing rows. These tests seed exactly that shape and assert the data
+ * survives the merge attached to the survivor.
+ *
+ * Also covered, because they are the branches that would fail loudly in
+ * production and quietly in review:
+ *   (a) `album_metadata.album_id` is a PRIMARY KEY — when both the survivor and
+ *       the loser carry a row, a naive repoint is a PK violation. The loser's
+ *       row must be dropped instead (the survivor already has the equivalent).
+ *   (b) `compilation_track_artist` has a 3-column unique key, the same
+ *       collision case one level wider.
+ *   (c) `library_identity` declares no cascade at all, so it would BLOCK the
+ *       delete if it were ever missed — the one site that fails safe.
+ *   (d) the slot key itself: same artist and number under a different GENRE is
+ *       a different shelf and must not merge, while a volume letter differing
+ *       only by CASE is the same slot and must.
+ * Plus an idempotency re-scan (a merged slot drops out of findCollisionSlots).
+ *
+ * The merge functions use the `@wxyc/database` `db` singleton (its own pool,
+ * DB_* env); this spec seeds and asserts via `getTestDb()` (a separate pool on
+ * the same DB). All writes commit, so the two pools see each other's rows.
+ * When `merge.ts` changes, rebuild before running
+ * (`npm run build --workspace=@wxyc/library-call-number-dedup`); CI's Build
+ * step produces `dist/merge.cjs` before the integration tier runs.
+ *
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
+ */
+
+// The repo-wide `tests/__mocks__/drizzle-orm.ts` manual mock (written for the
+// ts-jest unit tier) is AUTOMATICALLY applied to every `drizzle-orm` require.
+// Our compiled `dist/merge.cjs` requires the REAL drizzle-orm, so unmock it.
+// Hoisted above the requires below by babel-plugin-jest-hoist.
+jest.unmock('drizzle-orm');
+
+const path = require('path');
+const { getTestDb } = require('../utils/db');
+
+const merge = require(path.join(__dirname, '..', '..', 'jobs', 'library-call-number-dedup', 'dist', 'merge.cjs'));
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const GENRE_ID = 11; // exists in the integration fixture
+const OTHER_GENRE_ID = 7;
+const FORMAT_ID = 1;
+
+describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
+  let sql;
+  let artistId;
+  const libraryIds = [];
+
+  /** Seed one library row on a given shelf slot and remember it for cleanup. */
+  const seedAlbum = async ({ title, codeNumber, vol = null, genreId = GENRE_ID }) => {
+    const [row] = await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (artist_id, genre_id, format_id, album_title, code_number, code_volume_letters)
+      VALUES (${artistId}, ${genreId}, ${FORMAT_ID}, ${title}, ${codeNumber}, ${vol})
+      RETURNING id
+    `;
+    libraryIds.push(row.id);
+    return row.id;
+  };
+
+  const slotFor = async (codeNumber, genreId = GENRE_ID) => {
+    const slots = await merge.findCollisionSlots();
+    return slots.find((s) => s.artist_id === artistId && s.genre_id === genreId && s.code_number === codeNumber);
+  };
+
+  beforeAll(async () => {
+    sql = getTestDb();
+  });
+
+  beforeEach(async () => {
+    const [a] = await sql`
+      INSERT INTO ${sql(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+      VALUES ('Chuquimamani-Condori', 'Chuquimamani-Condori', 'CH')
+      RETURNING id
+    `;
+    artistId = a.id;
+  });
+
+  afterEach(async () => {
+    if (libraryIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+      libraryIds.length = 0;
+    }
+    if (artistId) await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${artistId}`;
+  });
+
+  describe('repoint-before-delete (the cascade invariant)', () => {
+    it('preserves the loser’s album_metadata by repointing it, never cascading it away', async () => {
+      const keep = await seedAlbum({ title: 'DJ E', codeNumber: 4 });
+      const lose = await seedAlbum({ title: 'DJ E', codeNumber: 4 });
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, discogs_url)
+        VALUES (${lose}, 'https://www.discogs.com/release/loser')
+      `;
+
+      const slot = await slotFor(4);
+      const plan = (await merge.planSlots([slot]))[0];
+      expect(plan.kind).toBe('merge');
+      await merge.mergeSlot(plan);
+
+      const rows = await sql`
+        SELECT album_id, discogs_url FROM ${sql(SCHEMA)}.album_metadata
+         WHERE album_id IN (${keep}, ${lose})
+      `;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].album_id).toBe(plan.survivorId);
+      expect(rows[0].discogs_url).toBe('https://www.discogs.com/release/loser');
+    });
+
+    it('preserves compilation tracks attached to the losing row', async () => {
+      await seedAlbum({ title: 'Edits', codeNumber: 5 });
+      const lose = await seedAlbum({ title: 'Edits', codeNumber: 5 });
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.compilation_track_artist (library_id, artist_name, track_title)
+        VALUES (${lose}, 'Chuquimamani-Condori', 'Call Your Name')
+      `;
+
+      const plan = (await merge.planSlots([await slotFor(5)]))[0];
+      await merge.mergeSlot(plan);
+
+      const rows = await sql`
+        SELECT library_id, track_title FROM ${sql(SCHEMA)}.compilation_track_artist
+         WHERE library_id = ${plan.survivorId}
+      `;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].track_title).toBe('Call Your Name');
+    });
+  });
+
+  describe('unique-key collisions', () => {
+    it('drops the loser’s album_metadata when the survivor already has one (PK collision)', async () => {
+      const a = await seedAlbum({ title: 'Sisa Pacha', codeNumber: 6 });
+      const b = await seedAlbum({ title: 'Sisa Pacha', codeNumber: 6 });
+      for (const [id, url] of [
+        [a, 'https://www.discogs.com/release/a'],
+        [b, 'https://www.discogs.com/release/b'],
+      ]) {
+        await sql`INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, discogs_url) VALUES (${id}, ${url})`;
+      }
+
+      const plan = (await merge.planSlots([await slotFor(6)]))[0];
+      await expect(merge.mergeSlot(plan)).resolves.toBeDefined();
+
+      const rows = await sql`
+        SELECT album_id FROM ${sql(SCHEMA)}.album_metadata WHERE album_id IN (${a}, ${b})
+      `;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].album_id).toBe(plan.survivorId);
+    });
+
+    it('drops a colliding compilation track on the 3-column unique key', async () => {
+      const a = await seedAlbum({ title: 'Nueva Era', codeNumber: 7 });
+      const b = await seedAlbum({ title: 'Nueva Era', codeNumber: 7 });
+      for (const id of [a, b]) {
+        await sql`
+          INSERT INTO ${sql(SCHEMA)}.compilation_track_artist (library_id, artist_name, track_title)
+          VALUES (${id}, 'Chuquimamani-Condori', 'Sonido Wapaneko')
+        `;
+      }
+
+      const plan = (await merge.planSlots([await slotFor(7)]))[0];
+      await expect(merge.mergeSlot(plan)).resolves.toBeDefined();
+
+      const rows = await sql`
+        SELECT library_id FROM ${sql(SCHEMA)}.compilation_track_artist WHERE library_id IN (${a}, ${b})
+      `;
+      expect(rows).toHaveLength(1);
+    });
+
+    it('repoints library_identity, the site that would otherwise BLOCK the delete', async () => {
+      await seedAlbum({ title: 'Amaru', codeNumber: 8 });
+      const lose = await seedAlbum({ title: 'Amaru', codeNumber: 8 });
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.library_identity (library_id, last_verified_at, method, confidence)
+        VALUES (${lose}, now(), 'test', 1.0)
+      `;
+
+      const plan = (await merge.planSlots([await slotFor(8)]))[0];
+      await expect(merge.mergeSlot(plan)).resolves.toBeDefined();
+
+      const rows = await sql`
+        SELECT library_id FROM ${sql(SCHEMA)}.library_identity WHERE library_id = ${plan.survivorId}
+      `;
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe('the slot key', () => {
+    it('does not treat the same number under a different genre as a collision', async () => {
+      await seedAlbum({ title: 'Rock filing', codeNumber: 21, genreId: GENRE_ID });
+      await seedAlbum({ title: 'Jazz filing', codeNumber: 21, genreId: OTHER_GENRE_ID });
+
+      expect(await slotFor(21, GENRE_ID)).toBeUndefined();
+      expect(await slotFor(21, OTHER_GENRE_ID)).toBeUndefined();
+    });
+
+    it('treats volume letters differing only by case as one slot', async () => {
+      await seedAlbum({ title: 'Dancehall 101 Vol. 4', codeNumber: 22, vol: 'D' });
+      await seedAlbum({ title: 'Dancehall 101, volume 4', codeNumber: 22, vol: 'd' });
+
+      const slot = await slotFor(22);
+      expect(slot).toBeDefined();
+      expect(slot.members).toHaveLength(2);
+      expect(slot.vol).toBe('D');
+    });
+  });
+
+  describe('renumbering', () => {
+    it('moves the genuinely-different release to a free number and leaves the other', async () => {
+      const keep = await seedAlbum({ title: 'Wrong Place', codeNumber: 9 });
+      const move = await seedAlbum({ title: 'Event II', codeNumber: 9 });
+
+      const plan = (await merge.planSlots([await slotFor(9)]))[0];
+      expect(plan.kind).toBe('renumber');
+      expect(await merge.renumberRow(plan)).toBe(true);
+
+      const rows = await sql`
+        SELECT id, code_number FROM ${sql(SCHEMA)}.library WHERE id IN (${keep}, ${move}) ORDER BY id
+      `;
+      const byId = Object.fromEntries(rows.map((r) => [r.id, r.code_number]));
+      expect(byId[plan.keepId]).toBe(9);
+      expect(byId[plan.moveId]).toBe(plan.newNumber);
+      expect(plan.newNumber).toBeGreaterThan(9);
+    });
+
+    it('declines a renumber whose destination was taken after the plan was built', async () => {
+      await seedAlbum({ title: 'Kaira', codeNumber: 10 });
+      await seedAlbum({ title: 'A Curva da Cintura', codeNumber: 10 });
+
+      const plan = (await merge.planSlots([await slotFor(10)]))[0];
+      expect(plan.kind).toBe('renumber');
+      // A librarian files into the destination between plan and execute.
+      await seedAlbum({ title: 'Filed first', codeNumber: plan.newNumber });
+
+      expect(await merge.renumberRow(plan)).toBe(false);
+      const [row] = await sql`SELECT code_number FROM ${sql(SCHEMA)}.library WHERE id = ${plan.moveId}`;
+      expect(row.code_number).toBe(10);
+    });
+  });
+
+  it('is idempotent — a merged slot drops out of the collision scan', async () => {
+    await seedAlbum({ title: 'DOGA', codeNumber: 11 });
+    await seedAlbum({ title: 'DOGA', codeNumber: 11 });
+
+    const plan = (await merge.planSlots([await slotFor(11)]))[0];
+    await merge.mergeSlot(plan);
+
+    expect(await slotFor(11)).toBeUndefined();
+  });
+});

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -392,7 +392,8 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
       const rows = await sql`
         SELECT t.relname AS table_name,
                array_agg(a.attname ORDER BY a.attnum) AS cols,
-               (i.indpred IS NOT NULL) AS is_partial
+               (i.indpred IS NOT NULL) AS is_partial,
+               pg_get_expr(i.indpred, i.indrelid) AS pred
           FROM pg_index i
           JOIN pg_class t ON t.oid = i.indrelid
           JOIN pg_namespace n ON n.oid = t.relnamespace

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -409,10 +409,28 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
           if (!idx.cols.includes(target.column)) continue;
           const declared = target.uniqueKey ?? [];
           const covers = idx.cols.every((c) => declared.includes(c));
-          const partialHandled = !idx.is_partial || Boolean(target.uniqueWhenNull);
+
+          // A partial index is handled either by `uniqueWhenNull` — the scope is
+          // applied to the collision-delete — or, when its predicate column is
+          // itself part of the declared key, by the NULL-safe comparison the
+          // repoint already uses. `compilation_track_artist` is the second case:
+          // its `WHERE track_title IS NULL` index is subsumed by the 3-column
+          // key, because `IS NOT DISTINCT FROM` makes NULL match NULL.
+          //
+          // Deliberately NOT "partial indexes are fine" — that would stop this
+          // catching `rotation`, which is the omission it exists for.
+          // Identifiers out of the predicate rather than a shape match on it:
+          // `pg_get_expr` renders parens, spacing, and qualification in ways
+          // that vary, and a guard that silently stops matching is worse than
+          // one that is slightly loose. Keywords in the extract are harmless —
+          // `IS`/`NULL` appear in neither the declared key nor uniqueWhenNull.
+          const predIdentifiers = (idx.pred ?? '').match(/[a-z_][a-z0-9_]*/gi) ?? [];
+          const partialHandled =
+            !idx.is_partial || predIdentifiers.some((c) => c === target.uniqueWhenNull || declared.includes(c));
+
           if (!covers || !partialHandled) {
             undeclared.push(
-              `${target.table}.${target.column} vs [${idx.cols.join(',')}]${idx.is_partial ? ' (partial)' : ''}`
+              `${target.table}.${target.column} vs [${idx.cols.join(',')}]${idx.is_partial ? ` (partial: ${idx.pred})` : ''}`
             );
           }
         }

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -265,6 +265,67 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
     });
   });
 
+  // The job's central safety claim is that repointing must precede deletion,
+  // and the force of that claim rests entirely on which sites cascade. That
+  // fact cannot be read off `schema.ts`: it declares
+  // `artist_library_crossreference.library_id` as `cascade` while the database
+  // enforces `no action` (BS#2015, one of four such drifts). Nor can it be read
+  // off the migration that first created a constraint — `album_metadata` was
+  // created `no action`, dropped with its table, then recreated `cascade` three
+  // migrations later. So the delete actions are pinned here against the live
+  // catalog, which is the only authority, and this test fails if either the
+  // database or the FK_TARGETS list moves out from under the README's table.
+  describe('enforced-fk-actions', () => {
+    const EXPECTED = {
+      rotation: 'CASCADE',
+      album_metadata: 'CASCADE',
+      reviews: 'CASCADE',
+      album_critic_reviews: 'CASCADE',
+      compilation_track_artist: 'CASCADE',
+      flowsheet: 'SET NULL',
+      album_review_submissions: 'SET NULL',
+      artist_library_crossreference: 'NO ACTION',
+      bins: 'NO ACTION',
+      library_identity: 'NO ACTION',
+      library_identity_source: 'NO ACTION',
+    };
+
+    it('matches the delete actions the database actually enforces', async () => {
+      const rows = await sql`
+        SELECT tc.table_name, rc.delete_rule
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.referential_constraints rc
+            ON rc.constraint_name = tc.constraint_name
+           AND rc.constraint_schema = tc.table_schema
+          JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+           AND ccu.constraint_schema = tc.table_schema
+         WHERE tc.constraint_type = 'FOREIGN KEY'
+           AND tc.table_schema = ${SCHEMA}
+           AND ccu.table_name = 'library'
+           AND ccu.column_name = 'id'
+      `;
+      const actual = Object.fromEntries(rows.map((r) => [r.table_name, r.delete_rule]));
+      for (const [table, rule] of Object.entries(EXPECTED)) {
+        expect({ table, rule: actual[table] }).toEqual({ table, rule });
+      }
+    });
+
+    it('covers every FK_TARGETS entry that the database actually constrains', async () => {
+      const constrained = new Set(Object.keys(EXPECTED));
+      const targets = new Set(merge.FK_TARGETS.map((t) => t.table));
+      // Every constrained table must be a repoint target, or a delete would
+      // cascade/null/block through a site the job never touches.
+      for (const table of constrained) {
+        expect(targets.has(table)).toBe(true);
+      }
+      // The remainder carry no FK, so they orphan silently rather than cascade —
+      // repointed anyway, and named here so the asymmetry stays deliberate.
+      const unconstrained = [...targets].filter((t) => !constrained.has(t));
+      expect(unconstrained.sort()).toEqual(['album_popularity', 'library_identity_history']);
+    });
+  });
+
   it('is idempotent — a merged slot drops out of the collision scan', async () => {
     await seedAlbum({ title: 'DOGA', codeNumber: 11 });
     await seedAlbum({ title: 'DOGA', codeNumber: 11 });

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -5,8 +5,8 @@
  * The headline invariant is an ORDERING one that no unit test can prove,
  * because it only exists in the database's own constraint behaviour: every FK
  * referencing `library.id` must be repointed to the survivor BEFORE the losing
- * row is deleted. Six of the reference sites declare `onDelete: 'cascade'` and
- * two declare `set null`, so a merge that deleted first would silently destroy
+ * row is deleted. Five of the reference sites cascade and two null the
+ * reference out, so a merge that deleted first would silently destroy
  * rotation history, album metadata, and reviews — no error, no exception, just
  * missing rows. These tests seed exactly that shape and assert the data
  * survives the merge attached to the survivor.
@@ -194,6 +194,58 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
       expect(rows).toHaveLength(1);
     });
 
+    it('drops the loser’s review rather than violating reviews_album_id_unique', async () => {
+      const a = await seedAlbum({ title: 'Sueño Salvaje', codeNumber: 12 });
+      const b = await seedAlbum({ title: 'Sueño Salvaje', codeNumber: 12 });
+      for (const id of [a, b]) {
+        await sql`INSERT INTO ${sql(SCHEMA)}.reviews (album_id, review) VALUES (${id}, 'a review')`;
+      }
+
+      const plan = (await merge.planSlots([await slotFor(12)]))[0];
+      // `reviews.album_id` carries a plain UNIQUE, so a repoint into a survivor
+      // that already has a review raises and aborts the entire run.
+      await expect(merge.mergeSlot(plan)).resolves.toBeDefined();
+
+      const rows = await sql`SELECT album_id FROM ${sql(SCHEMA)}.reviews WHERE album_id IN (${a}, ${b})`;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].album_id).toBe(plan.survivorId);
+    });
+
+    it('resolves an active rotation collision without destroying killed history', async () => {
+      const a = await seedAlbum({ title: 'Sonido Cosmico', codeNumber: 13 });
+      const b = await seedAlbum({ title: 'Sonido Cosmico', codeNumber: 13 });
+      // Both active in the same bin — the partial unique index applies here.
+      for (const id of [a, b]) {
+        await sql`
+          INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, add_date)
+          VALUES (${id}, 'H', now())
+        `;
+      }
+      // Killed rows in the SAME bin are outside the index's predicate and must
+      // survive: they are the rotation history the job promises to preserve.
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, add_date, kill_date)
+        VALUES (${b}, 'H', now() - interval '90 days', now() - interval '60 days')
+      `;
+
+      const plan = (await merge.planSlots([await slotFor(13)]))[0];
+      await expect(merge.mergeSlot(plan)).resolves.toBeDefined();
+
+      const active = await sql`
+        SELECT album_id FROM ${sql(SCHEMA)}.rotation
+         WHERE album_id IN (${a}, ${b}) AND kill_date IS NULL
+      `;
+      expect(active).toHaveLength(1);
+      expect(active[0].album_id).toBe(plan.survivorId);
+
+      const killed = await sql`
+        SELECT album_id FROM ${sql(SCHEMA)}.rotation
+         WHERE album_id IN (${a}, ${b}) AND kill_date IS NOT NULL
+      `;
+      expect(killed).toHaveLength(1);
+      expect(killed[0].album_id).toBe(plan.survivorId);
+    });
+
     it('repoints library_identity, the site that would otherwise BLOCK the delete', async () => {
       await seedAlbum({ title: 'Amaru', codeNumber: 8 });
       const lose = await seedAlbum({ title: 'Amaru', codeNumber: 8 });
@@ -311,18 +363,60 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
       }
     });
 
-    it('covers every FK_TARGETS entry that the database actually constrains', async () => {
-      const constrained = new Set(Object.keys(EXPECTED));
+    // Runs FROM the catalog TO the code, which is the only direction that can
+    // catch an omission. The previous shape iterated the hardcoded map, so an
+    // FK the database has and FK_TARGETS lacks passed green.
+    it('finds no FK on library.id that FK_TARGETS does not repoint', async () => {
+      const rows = await sql`
+        SELECT tc.table_name
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+           AND ccu.constraint_schema = tc.table_schema
+         WHERE tc.constraint_type = 'FOREIGN KEY'
+           AND tc.table_schema = ${SCHEMA}
+           AND ccu.table_name = 'library'
+           AND ccu.column_name = 'id'
+      `;
       const targets = new Set(merge.FK_TARGETS.map((t) => t.table));
-      // Every constrained table must be a repoint target, or a delete would
-      // cascade/null/block through a site the job never touches.
-      for (const table of constrained) {
-        expect(targets.has(table)).toBe(true);
+      const missing = [...new Set(rows.map((r) => r.table_name))].filter((t) => !targets.has(t)).sort();
+      expect(missing).toEqual([]);
+    });
+
+    // The ordering invariant was pinned; the COLLISION invariant was not, which
+    // is exactly how `reviews` (plain UNIQUE) and `rotation` (PARTIAL unique)
+    // shipped with `uniqueKey: null`. A repoint into a taken key raises and
+    // aborts the whole run, so every uniqueness constraint touching a target
+    // column has to be declared.
+    it('declares a uniqueKey for every uniqueness constraint on a target column', async () => {
+      const rows = await sql`
+        SELECT t.relname AS table_name,
+               array_agg(a.attname ORDER BY a.attnum) AS cols,
+               (i.indpred IS NOT NULL) AS is_partial
+          FROM pg_index i
+          JOIN pg_class t ON t.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY (i.indkey)
+         WHERE i.indisunique
+           AND n.nspname = ${SCHEMA}
+         GROUP BY t.relname, i.indexrelid, i.indpred
+      `;
+      const undeclared = [];
+      for (const target of merge.FK_TARGETS) {
+        for (const idx of rows) {
+          if (idx.table_name !== target.table) continue;
+          if (!idx.cols.includes(target.column)) continue;
+          const declared = target.uniqueKey ?? [];
+          const covers = idx.cols.every((c) => declared.includes(c));
+          const partialHandled = !idx.is_partial || Boolean(target.uniqueWhenNull);
+          if (!covers || !partialHandled) {
+            undeclared.push(
+              `${target.table}.${target.column} vs [${idx.cols.join(',')}]${idx.is_partial ? ' (partial)' : ''}`
+            );
+          }
+        }
       }
-      // The remainder carry no FK, so they orphan silently rather than cascade —
-      // repointed anyway, and named here so the asymmetry stays deliberate.
-      const unconstrained = [...targets].filter((t) => !constrained.has(t));
-      expect(unconstrained.sort()).toEqual(['album_popularity', 'library_identity_history']);
+      expect(undeclared.sort()).toEqual([]);
     });
   });
 

--- a/tests/integration/library-call-number-dedup-merge.spec.js
+++ b/tests/integration/library-call-number-dedup-merge.spec.js
@@ -86,12 +86,29 @@ describe('library-call-number-dedup — REAL merge functions (real PG)', () => {
     artistId = a.id;
   });
 
+  // Teardown has to observe the SAME ordering the job does: `bins`,
+  // `library_identity`, and `library_identity_source` declare no cascade, so
+  // Postgres refuses to delete a `library` row they still reference. Deleting
+  // the parent first raises `library_identity_library_id_library_id_fk` — which
+  // is exactly the loud failure that makes those three the safe sites.
+  //
+  // The reset is in a `finally` so a teardown that does throw takes down only
+  // its own test: without it, `libraryIds` keeps the already-attempted ids and
+  // every subsequent test re-runs the same failing delete and inherits the
+  // error, turning one broken test into a broken file.
   afterEach(async () => {
-    if (libraryIds.length > 0) {
-      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+    try {
+      if (libraryIds.length > 0) {
+        await sql`DELETE FROM ${sql(SCHEMA)}.library_identity_source WHERE library_id = ANY(${libraryIds})`;
+        await sql`DELETE FROM ${sql(SCHEMA)}.library_identity WHERE library_id = ANY(${libraryIds})`;
+        await sql`DELETE FROM ${sql(SCHEMA)}.bins WHERE album_id = ANY(${libraryIds})`;
+        await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+      }
+      if (artistId) await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${artistId}`;
+    } finally {
       libraryIds.length = 0;
+      artistId = null;
     }
-    if (artistId) await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${artistId}`;
   });
 
   describe('repoint-before-delete (the cascade invariant)', () => {

--- a/tests/unit/jobs/library-call-number-dedup/classify.test.ts
+++ b/tests/unit/jobs/library-call-number-dedup/classify.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for library-call-number-dedup's classify.ts.
+ *
+ * Every fixture here is a real collision measured in the production catalog.
+ * That matters: the whole job turns on whether two rows in one call-number slot
+ * are the same release entered twice (merge, no disc moves) or two different
+ * releases (renumber, and someone has to relabel a disc). Classifying on title
+ * equality alone gets that split wrong by better than 2x, and the pairs below
+ * are the ones that expose it.
+ */
+import {
+  SIMILARITY_THRESHOLD,
+  classifySlot,
+  hasTwinElsewhere,
+  similarity,
+  titleKey,
+  type SlotMember,
+} from '../../../../jobs/library-call-number-dedup/classify';
+
+const member = (id: number, album_title: string, refs = 0): SlotMember => ({ id, album_title, refs });
+
+describe('titleKey', () => {
+  it.each([
+    ['strips a format suffix', 'It\'s a Party 12"', "It's a Party cd-single"],
+    ['strips a pressing variant', 'Straight Outta Comptom Dirty LP', 'Straight Outta Comptom Clean lyric'],
+    ['spells out number words', 'Volume 1', 'Volume One'],
+    ['ignores punctuation and case', 'water babies', 'Water Babies'],
+    ['ignores a possessive apostrophe', 'Workin with Miles Davis Quintet', "Workin' with the Miles Davis Quintet"],
+    ['strips a missing marker', 'Loaded', 'Loaded [missing]'],
+    ['strips an EP marker', 'Woman King', 'Woman King [EP]'],
+  ])('%s: folds both sides together', (_label, a, b) => {
+    expect(titleKey(a)).toBe(titleKey(b));
+  });
+
+  it('keeps volume numbers distinct — they name different records', () => {
+    expect(titleKey('Ethiopiques vol. 21')).not.toBe(titleKey('Ethiopiques vol. 22'));
+    expect(titleKey('UP&down Club Sessions Vol. 1')).not.toBe(titleKey('UP&down Club Sessions Vol. 2'));
+  });
+
+  it('returns empty for a title that is nothing but decoration', () => {
+    expect(titleKey('[EP]')).toBe('');
+    expect(titleKey('the')).toBe('');
+  });
+});
+
+describe('similarity', () => {
+  it('scores a one-character typo above the merge threshold', () => {
+    expect(similarity(titleKey('Starlight Walker'), titleKey('Starlite Walker'))).toBeGreaterThanOrEqual(
+      SIMILARITY_THRESHOLD
+    );
+  });
+
+  it('scores two different titles well below it', () => {
+    expect(similarity(titleKey('Wrong Place'), titleKey('Event II'))).toBeLessThan(SIMILARITY_THRESHOLD);
+  });
+
+  it('is 1 for identical input and 0 when either side is empty', () => {
+    expect(similarity('abc', 'abc')).toBe(1);
+    expect(similarity('', 'abc')).toBe(0);
+  });
+});
+
+describe('classifySlot', () => {
+  it('merges a slot holding one release entered twice', () => {
+    const v = classifySlot([member(1, "People's Instinctive Travels"), member(2, "People's Instinctive Travels")]);
+    expect(v).toEqual({ kind: 'merge', survivorId: 1, loserIds: [2] });
+  });
+
+  it('merges across a format difference — one record, two pressings', () => {
+    const v = classifySlot([member(10, 'It\'s a Party 12"', 3), member(11, "It's a Party cd-single", 1)]);
+    expect(v).toEqual({ kind: 'merge', survivorId: 10, loserIds: [11] });
+  });
+
+  it('renumbers a slot holding two genuinely different releases', () => {
+    const v = classifySlot([member(20, 'Wrong Place', 5), member(21, 'Event II', 2)]);
+    expect(v).toEqual({ kind: 'renumber', keepId: 20, moveId: 21 });
+  });
+
+  it('moves the least-referenced disc, not the lower id', () => {
+    const v = classifySlot([member(30, 'Begin Here', 0), member(31, 'Odyssey and Oracle', 9)]);
+    expect(v).toEqual({ kind: 'renumber', keepId: 31, moveId: 30 });
+  });
+
+  describe('survivor selection', () => {
+    it('prefers the row carrying more references', () => {
+      const v = classifySlot([member(40, 'Bee Thousand', 1), member(41, 'Bee Thousand', 7)]);
+      expect(v).toMatchObject({ kind: 'merge', survivorId: 41 });
+    });
+
+    it('breaks a reference tie on the fuller title', () => {
+      const v = classifySlot([member(50, 'Lady in Satin', 2), member(51, 'Lady in Satin (remastered)', 2)]);
+      expect(v).toMatchObject({ kind: 'merge', survivorId: 51 });
+    });
+
+    it('breaks a full tie on the lower id, for determinism across runs', () => {
+      const v = classifySlot([member(61, 'Cypress Hill', 2), member(60, 'Cypress Hill', 2)]);
+      expect(v).toMatchObject({ kind: 'merge', survivorId: 60 });
+    });
+  });
+
+  it('never merges a title that folds to nothing into a real one', () => {
+    const v = classifySlot([member(70, 'Private Parts', 4), member(71, '[EP]', 0)]);
+    expect(v.kind).toBe('renumber');
+  });
+
+  it('rejects a slot that does not actually collide', () => {
+    expect(() => classifySlot([member(80, 'Solo')])).toThrow(/at least 2/);
+  });
+});
+
+describe('hasTwinElsewhere', () => {
+  const shelf = [
+    { code_number: 1, album_title: 'Juju Music' },
+    { code_number: 1, album_title: 'Gems from the Classic Years (1967-1974)' },
+    { code_number: 2, album_title: 'Juju Music' },
+    { code_number: 2, album_title: 'Synchro System' },
+  ];
+
+  it('holds back a disc whose title already sits at another number', () => {
+    expect(hasTwinElsewhere('Juju Music', 1, shelf)).toBe(true);
+  });
+
+  it('allows a disc that is the only copy of its title on the shelf', () => {
+    expect(hasTwinElsewhere('Synchro System', 2, shelf)).toBe(false);
+  });
+
+  it('does not treat a decoration-only title as a twin of anything', () => {
+    expect(hasTwinElsewhere('[EP]', 1, shelf)).toBe(false);
+  });
+});

--- a/tests/unit/jobs/library-call-number-dedup/classify.test.ts
+++ b/tests/unit/jobs/library-call-number-dedup/classify.test.ts
@@ -37,6 +37,24 @@ describe('titleKey', () => {
     expect(titleKey('UP&down Club Sessions Vol. 1')).not.toBe(titleKey('UP&down Club Sessions Vol. 2'));
   });
 
+  // A format marker is `12"`, not the number 12. Stripping the bare digit
+  // instead of the measurement folds volume numbers away — and 7 and 12 are
+  // ordinary volume numbers, so this destroys real records.
+  it.each([
+    ['Ethiopiques vol. 7', 'Ethiopiques vol. 12'],
+    ['Volume 7', 'Volume 12'],
+    ['Volume Seven', 'Volume 12'],
+    ['Dancehall 101 Vol. 7', 'Dancehall 101 Vol. 12'],
+  ])('keeps %s distinct from %s — 7 and 12 are volume numbers, not formats', (a, b) => {
+    expect(titleKey(a)).not.toBe(titleKey(b));
+  });
+
+  it('still folds a genuine inch marking, which carries the quote', () => {
+    expect(titleKey('It\'s a Party 12"')).toBe(titleKey("It's a Party cd-single"));
+    expect(titleKey('Let the Rhythm Hit Em 12"')).toBe(titleKey('Let the Rhythm Hit Em CD'));
+    expect(titleKey('Illadelph Half-Life 12"x2')).toBe(titleKey('Illadelph Half-Life'));
+  });
+
   it('returns empty for a title that is nothing but decoration', () => {
     expect(titleKey('[EP]')).toBe('');
     expect(titleKey('the')).toBe('');
@@ -63,12 +81,12 @@ describe('similarity', () => {
 describe('classifySlot', () => {
   it('merges a slot holding one release entered twice', () => {
     const v = classifySlot([member(1, "People's Instinctive Travels"), member(2, "People's Instinctive Travels")]);
-    expect(v).toEqual({ kind: 'merge', survivorId: 1, loserIds: [2] });
+    expect(v).toEqual({ kind: 'merge', survivorId: 1, loserIds: [2], unresolvedIds: [] });
   });
 
   it('merges across a format difference — one record, two pressings', () => {
     const v = classifySlot([member(10, 'It\'s a Party 12"', 3), member(11, "It's a Party cd-single", 1)]);
-    expect(v).toEqual({ kind: 'merge', survivorId: 10, loserIds: [11] });
+    expect(v).toEqual({ kind: 'merge', survivorId: 10, loserIds: [11], unresolvedIds: [] });
   });
 
   it('renumbers a slot holding two genuinely different releases', () => {
@@ -95,6 +113,35 @@ describe('classifySlot', () => {
     it('breaks a full tie on the lower id, for determinism across runs', () => {
       const v = classifySlot([member(61, 'Cypress Hill', 2), member(60, 'Cypress Hill', 2)]);
       expect(v).toMatchObject({ kind: 'merge', survivorId: 60 });
+    });
+  });
+
+  // One title being a prefix of another is not evidence of the same release:
+  // it is equally the signature of a twofer, a sequel, or an unrelated longer
+  // name. Merging on it deletes a different album and reattaches its plays.
+  it.each([
+    ['Home', 'Homework'],
+    ['Kid A', 'Kid Ambulance'],
+    ['Songs of Love', 'Songs of Love and Hate'],
+    ['Fire', 'Fireworks'],
+    ['#1 Record', '#1 Record & Radio City'],
+  ])('does not merge %s with %s on a bare prefix match', (a, b) => {
+    expect(classifySlot([member(1, a, 5), member(2, b, 1)]).kind).toBe('renumber');
+  });
+
+  describe('a slot holding three rows', () => {
+    it('merges the duplicates and reports the row that still collides', () => {
+      const v = classifySlot([member(1, 'Bee Thousand', 9), member(2, 'Bee Thousand', 1), member(3, 'Alien Lanes', 4)]);
+      expect(v).toEqual({ kind: 'merge', survivorId: 1, loserIds: [2], unresolvedIds: [3] });
+    });
+
+    it('reports nothing unresolved when all three are the same release', () => {
+      const v = classifySlot([
+        member(1, 'Bee Thousand', 9),
+        member(2, 'Bee Thousand', 1),
+        member(3, 'Bee Thousand', 4),
+      ]);
+      expect(v).toMatchObject({ kind: 'merge', unresolvedIds: [] });
     });
   });
 

--- a/tests/unit/jobs/library-call-number-dedup/report.test.ts
+++ b/tests/unit/jobs/library-call-number-dedup/report.test.ts
@@ -13,6 +13,7 @@ const item = (over: Partial<RelabelItem> = {}): RelabelItem => ({
   genre: 'Rock',
   artist: 'Guided by Voices',
   codeLetters: 'GU',
+  artistGenreCode: 12,
   moveTitle: 'Bee Thousand',
   keepTitle: 'Alien Lanes',
   oldNumber: 6,
@@ -24,8 +25,8 @@ const item = (over: Partial<RelabelItem> = {}): RelabelItem => ({
 describe('formatWorklist', () => {
   it('renders both call numbers so the shelf work is unambiguous', () => {
     const out = formatWorklist([item()], []);
-    expect(out).toContain('`GU 6`');
-    expect(out).toContain('`GU 31`');
+    expect(out).toContain('`GU 12 6`');
+    expect(out).toContain('`GU 12 31`');
   });
 
   it('names the disc that moves and the one that stays', () => {
@@ -37,8 +38,8 @@ describe('formatWorklist', () => {
 
   it('includes the volume letter when the slot has one', () => {
     const out = formatWorklist([item({ vol: 'B', oldNumber: 3, newNumber: 12 })], []);
-    expect(out).toContain('`GU 3 B`');
-    expect(out).toContain('`GU 12 B`');
+    expect(out).toContain('`GU 12 3 B`');
+    expect(out).toContain('`GU 12 12 B`');
   });
 
   it('counts the discs and genres in the header', () => {
@@ -61,8 +62,10 @@ describe('formatWorklist', () => {
         genre: 'Africa',
         artist: 'King Sunny Ade',
         codeLetters: 'AD',
+        artistGenreCode: 4,
         title: 'Juju Music',
         atNumber: 1,
+        vol: '',
         reason: 'already sits at another number on this shelf',
       },
     ];
@@ -71,6 +74,33 @@ describe('formatWorklist', () => {
     expect(out).toContain('Juju Music');
     expect(out).toContain('already sits at another number');
     expect(out).toContain('**1 that need your judgement**');
+  });
+
+  it('renders a held item on a lettered shelf at its real address', () => {
+    const out = formatWorklist(
+      [],
+      [
+        {
+          genre: 'Rock',
+          artist: 'Guided by Voices',
+          codeLetters: 'GU',
+          artistGenreCode: 12,
+          title: 'Bee Thousand',
+          atNumber: 3,
+          vol: 'B',
+          reason: 'twin elsewhere',
+        },
+      ]
+    );
+    // `GU 12 3` and `GU 12 3 B` are different physical slots; sending the
+    // librarian to the unlettered one points at the wrong disc.
+    expect(out).toContain('`GU 12 3 B`');
+  });
+
+  it('drops the artist number cleanly when the shelf has none', () => {
+    const out = formatWorklist([item({ artistGenreCode: null })], []);
+    expect(out).toContain('`GU 6`');
+    expect(out).toContain('`GU 31`');
   });
 
   it('omits the judgement section entirely when nothing was withheld', () => {

--- a/tests/unit/jobs/library-call-number-dedup/report.test.ts
+++ b/tests/unit/jobs/library-call-number-dedup/report.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for library-call-number-dedup's report.ts.
+ *
+ * The worklist is the only part of this job a person acts on, and it is acted
+ * on away from the screen, at the shelf. So the assertions here are about
+ * legibility under that constraint: both call numbers appear in full, the disc
+ * that moves is never confused with the one that stays, and a withheld slot
+ * says why it was withheld rather than silently vanishing from the list.
+ */
+import { formatWorklist, type HeldItem, type RelabelItem } from '../../../../jobs/library-call-number-dedup/report';
+
+const item = (over: Partial<RelabelItem> = {}): RelabelItem => ({
+  genre: 'Rock',
+  artist: 'Guided by Voices',
+  codeLetters: 'GU',
+  moveTitle: 'Bee Thousand',
+  keepTitle: 'Alien Lanes',
+  oldNumber: 6,
+  newNumber: 31,
+  vol: '',
+  ...over,
+});
+
+describe('formatWorklist', () => {
+  it('renders both call numbers so the shelf work is unambiguous', () => {
+    const out = formatWorklist([item()], []);
+    expect(out).toContain('`GU 6`');
+    expect(out).toContain('`GU 31`');
+  });
+
+  it('names the disc that moves and the one that stays', () => {
+    const out = formatWorklist([item()], []);
+    const row = out.split('\n').find((l) => l.includes('Bee Thousand'));
+    expect(row).toBeDefined();
+    expect(row.indexOf('Bee Thousand')).toBeLessThan(row.indexOf('Alien Lanes'));
+  });
+
+  it('includes the volume letter when the slot has one', () => {
+    const out = formatWorklist([item({ vol: 'B', oldNumber: 3, newNumber: 12 })], []);
+    expect(out).toContain('`GU 3 B`');
+    expect(out).toContain('`GU 12 B`');
+  });
+
+  it('counts the discs and genres in the header', () => {
+    const out = formatWorklist([item(), item({ genre: 'Jazz', artist: 'Jo Jones', codeLetters: 'JO' })], []);
+    expect(out).toContain('**2 discs to relabel**');
+    expect(out).toContain('across 2 genres');
+  });
+
+  it('groups by genre and sorts within a shelf by number', () => {
+    const out = formatWorklist(
+      [item({ oldNumber: 9, moveTitle: 'Later' }), item({ oldNumber: 2, moveTitle: 'Earlier' })],
+      []
+    );
+    expect(out.indexOf('Earlier')).toBeLessThan(out.indexOf('Later'));
+  });
+
+  it('lists withheld slots with the reason, in their own section', () => {
+    const held: HeldItem[] = [
+      {
+        genre: 'Africa',
+        artist: 'King Sunny Ade',
+        codeLetters: 'AD',
+        title: 'Juju Music',
+        atNumber: 1,
+        reason: 'already sits at another number on this shelf',
+      },
+    ];
+    const out = formatWorklist([item()], held);
+    expect(out).toContain('## Needs your judgement');
+    expect(out).toContain('Juju Music');
+    expect(out).toContain('already sits at another number');
+    expect(out).toContain('**1 that need your judgement**');
+  });
+
+  it('omits the judgement section entirely when nothing was withheld', () => {
+    expect(formatWorklist([item()], [])).not.toContain('## Needs your judgement');
+  });
+
+  it('renders a clean run without crashing or claiming work', () => {
+    const out = formatWorklist([], []);
+    expect(out).toContain('**0 discs to relabel**');
+    expect(out).not.toContain('## Needs your judgement');
+  });
+});


### PR DESCRIPTION
Closes #2024.

Adds `jobs/library-call-number-dedup`, a one-shot that resolves duplicate call-number slots in `library` so a uniqueness constraint can be added to the columns that address the shelf. Dry-run by default; `--execute` to write. Structural donor is `jobs/artist-unicode-dedup` — same `merge.ts` core + thin `job.ts` CLI split, same per-group transaction and repoint-before-delete discipline.

Nothing in the schema enforces that a call number is used once, and `generateAlbumCodeNumber` reads `MAX(code_number)+1` and inserts without a lock, so two adds under one artist at the same moment already collide with no user error involved. Roughly 770 slots hold more than one release.

## The distinction it turns on

Most collisions are one release entered twice under a differently-decorated title, and merge with no disc moving. The rest are genuinely different releases, where one row is renumbered **and the physical disc has to be relabelled** — so a run emits a librarian worklist, and the constraint waits on that shelf work.

Classifying on title equality gets this wrong by better than 2x. `It's a Party 12"` and `It's a Party cd-single` are one record filed twice; so are a dirty LP and its clean-lyric pressing, and `Volume 1` versus `Volume One`. `classify.ts` strips the decoration that names a *pressing* rather than a *work*, and deliberately preserves volume and part numbers — folding `Ethiopiques vol. 21` into `vol. 22` would merge two real releases and delete a row that has plays.

## Three things that are easy to get backwards

**`genre_id` belongs in the slot key.** Code letters are genre-scoped, so `BO 3` (Electronic) and `Bo 3` (Rock) are different shelves. That used to be implicit in there being two `artists` rows; #1897's dedup merges artist rows globally across genres, so genre is now the only thing distinguishing them. A key of `(artist_id, code_number)` would call those a collision and destroy a correct filing.

**The volume letter compares case-insensitively.** `D` and `d` are one slot. The upstream MySQL catalog folds them under its default collation, so duplicates exist that Postgres — comparing case-sensitively — would read as distinct and let straight through.

**The FK table is derived from the live catalog, not `schema.ts`.** The two disagree: `schema.ts` marks `artist_library_crossreference.library_id` as `cascade` while the database enforces `no action` — one of the four drifted constraints in #2015, and a repoint target here. Reading the *creating* migration is not sufficient either, since `album_metadata.album_id` was created `no action`, dropped with its table, then recreated `cascade`. The integration spec pins every action against `information_schema` so the documented table tracks the database.

## Why the ordering is a data-safety property

Five of the 13 sites referencing `library.id` cascade and two null the reference out. Deleting before repointing would silently destroy rotation history, album metadata, and reviews, and silently unlink plays, with no error raised. The four no-action sites are the only ones that fail loudly — which the integration spec demonstrates directly.

## Verification

CI green on `de337e8e`'s predecessor; re-running on this head. Locally: format clean, 0 lint errors, typecheck clean, 6,616 unit tests. The integration tier exercises the real compiled `merge.cjs` against Postgres — the loser's `album_metadata` and compilation tracks survive a merge attached to the survivor, both unique-key collision paths drop rather than violate, a different genre is not a collision, and a case-differing volume letter is.

## Size

1,583 lines, over the 1,000 guideline. It is all new files with no edits to existing code, and 553 lines are tests. Splitting it would mean landing the merge core without the spec that proves its central invariant, which seemed worse than the overage.

## Not in this PR

- The uniqueness constraint migration. It cannot land until the relabel worklist is worked, and its key must be `(artist_id, genre_id, code_number, COALESCE(code_volume_letters, ''))` — the `COALESCE` because prod is PG 14 and `NULLS NOT DISTINCT` is PG 15+.
- The run itself. This must execute **after** the tubafrenzy ETL stops: `jobs/library-etl` carries `code_number` in its refresh set and would overwrite a renumber on its next pass.
