### PR TITLE
docs(library-call-number-dedup): correct the ETL sequencing gate and record the constraint's own gate

### DIFF
--- a/jobs/library-call-number-dedup/README.md
+++ b/jobs/library-call-number-dedup/README.md
@@ -67,7 +67,11 @@ Two tables are deliberately **not** targets: `album_plays` is a materialized vie
 
 ## Sequencing
 
-**Run this after the tubafrenzy ETL stops.** `jobs/library-etl` upserts on `legacy_release_id` and carries `code_number` in its refresh set, so while that ETL is live it will overwrite a renumber and reinstate a deleted row from the upstream MySQL catalog on its next pass.
+**Run this after the tubafrenzy ETL stops** — that is, after Phase 5 of the turndown ([#1543](https://github.com/WXYC/Backend-Service/issues/1543), org Project #36). `jobs/library-etl` upserts on `legacy_release_id` and carries both `code_number` and `code_volume_letters` in its refresh set, so while that ETL is live it will overwrite a renumber and reinstate a deleted row from the upstream MySQL catalog.
+
+**The revert is triggered by an upstream edit, not by the clock, and pausing the ETL is not a workaround.** `library-etl` is incremental — `buildReleaseQuery` filters `WHERE lr.TIME_LAST_MODIFIED > <last run>` — so it fetches only releases whose _upstream_ timestamp advanced. This job writes Postgres and leaves MySQL untouched, so a deduped release is absent from the next fetch and the next pass does not revert it. What reverts it is a librarian editing that release in tubafrenzy, at any point afterward: the re-fetch refreshes `code_number` from `excluded.*`, and a merged-away row whose `legacy_release_id` no longer resolves is INSERTed fresh, resurrecting the slot. A pause window covers a ~20-second run that was never at risk and restores the open-ended exposure the moment it lifts.
+
+Running before the ETL stops is therefore not catastrophic but decays, and the decay is worse than it looks: the relabelling in step 3 is _physical_, so a later revert leaves a disc mislabelled in the opposite direction — the shelf/catalog disagreement this job exists to remove.
 
 Then, in order:
 
@@ -75,6 +79,8 @@ Then, in order:
 2. `--execute`.
 3. Give the worklist to the librarian. Until the discs are relabelled, the shelf and the catalog disagree.
 4. Add the uniqueness constraint, keyed as above.
+
+**Step 4 has its own hard gate on the same event, for a different reason** ([#2033](https://github.com/WXYC/Backend-Service/issues/2033)). Upstream MySQL enforces no uniqueness on the call-number tuple and hosts the unlocked `MAX+1` allocator, so it can mint a new duplicate at any time. Once the constraint exists, that release's INSERT violates it — and `ON CONFLICT (legacy_release_id)` does not absorb a violation of a different index. The release loop is one transaction, so it aborts the entire ETL run, exactly as `job.ts` documents for `library_legacy_release_id_idx` and #752. Do not merge the constraint migration while `library-etl` is live.
 
 ## Running
 

--- a/jobs/library-call-number-dedup/job.ts
+++ b/jobs/library-call-number-dedup/job.ts
@@ -32,10 +32,27 @@
  *     rather than colliding if a librarian took it since the plan was built.
  *   - `ANALYZE` on the rewritten tables after an `--execute` run (BS#934).
  *
- * SEQUENCING: run this AFTER the tubafrenzy ETL stops. `jobs/library-etl`
- * upserts on `legacy_release_id` and carries `code_number` in its refresh set,
- * so while that ETL is live it will overwrite a renumber and reinstate a
- * deleted row from the upstream MySQL catalog on its next pass.
+ * SEQUENCING: run this AFTER the tubafrenzy ETL stops (turndown Phase 5,
+ * BS#1543). `jobs/library-etl` upserts on `legacy_release_id` and carries
+ * `code_number` + `code_volume_letters` in its refresh set, so while that ETL
+ * is live it will overwrite a renumber and reinstate a deleted row from the
+ * upstream MySQL catalog.
+ *
+ * The revert is triggered by an UPSTREAM EDIT, not by the clock — and pausing
+ * the ETL is therefore not a workaround. `library-etl` is incremental
+ * (`WHERE lr.TIME_LAST_MODIFIED > <last run>`), so it fetches only releases
+ * whose MySQL timestamp advanced. This job writes Postgres only, so a deduped
+ * release is absent from the next fetch and the next pass does NOT revert it.
+ * What reverts it is a librarian editing that release in tubafrenzy, at any
+ * point afterward. A pause window covers a ~20s run that was never at risk.
+ *
+ * The uniqueness constraint this job exists to enable has its own hard gate on
+ * the same event, for a different reason (BS#2033): upstream MySQL enforces no
+ * uniqueness and hosts the unlocked MAX+1 allocator, so it can mint a new
+ * duplicate at any time. That INSERT would violate the constraint, and
+ * ON CONFLICT (legacy_release_id) does not absorb a violation of a different
+ * index — the release loop is one transaction, so it aborts the WHOLE ETL run
+ * (same failure library-etl documents for library_legacy_release_id_idx, #752).
  *
  * Run procedure: Manual Build & Deploy with `target=library-call-number-dedup`,
  * then SSH to EC2 and:


### PR DESCRIPTION
Refs #2033. Docs and comments only; no behavior change.

## What was wrong

`jobs/library-call-number-dedup/README.md` and the `job.ts` header both said that while `library-etl` is live it will revert a renumber and reinstate a deleted row **"on its next pass."**

That overstates the immediacy, and the imprecision is load-bearing — it makes pausing the ETL around the run look like a viable workaround, which is exactly the conclusion someone reading the sequencing note would reach.

`library-etl` is **incremental**, not full-snapshot (`jobs/library-etl/job.ts:279`):

```sql
WHERE lr.TIME_LAST_MODIFIED > ${lastRunMs}
```

It fetches only releases whose *upstream* timestamp advanced. This job writes Postgres and leaves MySQL untouched, so a deduped release is absent from the next fetch and the next pass does not revert it.

What does revert it is a librarian editing that release in tubafrenzy, at any point afterward: the re-fetch refreshes `code_number` / `code_volume_letters` from `excluded.*`, and a merged-away row whose `legacy_release_id` no longer resolves is INSERTed fresh, resurrecting the slot.

So the exposure is **per-row and open-ended**, not clock-driven. A pause window covers a ~20-second run that was never at risk, and restores the exposure the moment it lifts.

## What's added

The separate and harder gate on step 4, filed as #2033: the uniqueness constraint cannot be added while the ETL is live **at all**. Upstream MySQL enforces no uniqueness on the call-number tuple and hosts the unlocked `MAX+1` allocator, so it can mint a new duplicate at any time. That INSERT violates the new index; `ON CONFLICT (legacy_release_id)` does not absorb a violation of a *different* index; and the release loop is one transaction — so it takes down the whole ETL run, the same failure `library-etl` already documents for `library_legacy_release_id_idx` and #752.

Both gates now point at turndown Phase 5 (#1543). Also notes that `code_volume_letters` sits in the refresh set alongside `code_number`, which the original text omitted.

## Verification

Prod dry run from `library-call-number-dedup:v0.1.0`, 2026-08-07 15:34 PDT — read-only, 19 seconds, exit 0:

```
colliding call-number slots: 270
plan: 149 merges (149 library rows deleted), 116 renumbers, 6 held for the librarian
~531 FK rows repoint; 372 child rows dropped as duplicates
```

Recorded on #2024. `prettier --check` passes on both files; no other checks apply (a comment-only `.ts` edit under `jobs/**`, which `npm run typecheck` does not cover).