### PR TITLE
Mark the library-call-number-dedup dry-run worklist as a preview in places that survive forwarding

### DIFF
--- a/jobs/library-call-number-dedup/README.md
+++ b/jobs/library-call-number-dedup/README.md
@@ -63,6 +63,7 @@ Two tables are deliberately **not** targets: `album_plays` is a materialized vie
 - **Refuses to start while a show is on air.** The job writes `flowsheet`, which dj-site polls every 60s. It is a one-shot run in a chosen window, so declining outright is cheaper than pausing mid-pass.
 - **A skipped renumber sets a non-zero exit code** and is kept off the worklist. The catalog row never moved, so telling the librarian to relabel that disc would create the shelf/catalog disagreement this job exists to remove, in reverse.
 - **A slot holding three rows** merges its duplicates and reports the remainder for the librarian, rather than guessing which of two different releases should move.
+- **A dry-run worklist must never reach the librarian.** It describes physical relabelling against a catalog that has not moved, so acting on it produces the shelf/catalog disagreement this job exists to remove, in reverse — and because `--execute` is gated open-endedly on Phase 3.5 (below), a preview can sit around for months before a real worklist exists to displace it. A dry run therefore titles its worklist `PREVIEW, DO NOT DISTRIBUTE`, banners it above and below the table, and stamps `PREVIEW` in place of the check-off box on every row, so the warning survives being forwarded, pasted without its first paragraph, or printed. Only the `--execute` worklist carries the clean title.
 - `ANALYZE` on the rewritten tables after an `--execute` run, per `docs/bulk-update-playbook.md`.
 
 ## Sequencing
@@ -79,9 +80,9 @@ Running before the ETL stops is therefore not catastrophic but decays, and the d
 
 Then, in order:
 
-1. Dry run. Review the plan and the worklist. (The plan drifts — re-derive it rather than trusting an earlier run's numbers.)
+1. Dry run. Review the plan and the worklist yourself; it is a preview, and it goes to nobody. (The plan drifts — re-derive it rather than trusting an earlier run's numbers.)
 2. `--execute`.
-3. Give the worklist to the librarian. Until the discs are relabelled, the shelf and the catalog disagree.
+3. Give **that run's** worklist to the librarian. Until the discs are relabelled, the shelf and the catalog disagree.
 4. Add the uniqueness constraint, keyed as above.
 
 **Step 4 has its own hard gate on the same event, for a different reason** ([#2033](https://github.com/WXYC/Backend-Service/issues/2033)). Upstream MySQL enforces no uniqueness on the call-number tuple and hosts the unlocked `MAX+1` allocator, so it can mint a new duplicate at any time. Once the constraint exists, that release's INSERT violates it — and `ON CONFLICT (legacy_release_id)` does not absorb a violation of a different index. The release loop is one transaction, so it aborts the entire ETL run, exactly as `job.ts` documents for `library_legacy_release_id_idx` and #752. Do not merge the constraint migration while `library-etl` is live.
@@ -96,6 +97,8 @@ docker run --rm --env-file .env <image> --execute  2>&1 | tee log-exec
 ```
 
 Environment: standard `DB_*` connection vars, same as the other one-shots.
+
+The job writes no files — the worklist is Markdown on stdout, so it is lifted out of the log by hand. If you save one, let the filename repeat what the title already says: a dry run's copy is `call-number-worklist-PREVIEW-DO-NOT-DISTRIBUTE.md`, and only the `--execute` run's copy gets the plain `call-number-worklist.md` that a librarian may be sent.
 
 ## Tests
 

--- a/jobs/library-call-number-dedup/job.ts
+++ b/jobs/library-call-number-dedup/job.ts
@@ -21,6 +21,9 @@
  * DATA SAFETY / ops (docs/bulk-update-playbook.md):
  *   - **Dry-run by default; pass `--execute` to write.** Dry-run SELECTs and
  *     reports the full plan, including the finished worklist, with zero writes.
+ *     That worklist is marked PREVIEW throughout — title, banners above and
+ *     below the table, and every row — and must not go to the librarian: it
+ *     describes relabelling against a catalog no run has moved.
  *   - Idempotent: a completed merge drops that slot out of the
  *     `HAVING count(*) > 1` set, so a re-run finds nothing to do.
  *   - Each slot's repoints + delete run in a single transaction — a mid-run

--- a/jobs/library-call-number-dedup/merge.ts
+++ b/jobs/library-call-number-dedup/merge.ts
@@ -583,7 +583,9 @@ export const previewSlot = (plan: Extract<SlotPlan, { kind: 'merge' }>): number 
  * The worklist is rendered AFTER the writes, from the renumbers that actually
  * landed. Rendering it from the plan would tell the librarian to relabel a disc
  * whose catalog row never moved (a destination taken since planning), creating
- * the shelf/catalog disagreement the job exists to remove, in reverse.
+ * the shelf/catalog disagreement the job exists to remove, in reverse. A dry run
+ * renders the whole plan for review, and is marked PREVIEW throughout for the
+ * same reason: there, no catalog row moved at all.
  */
 export const runDedup = async (): Promise<DedupSummary> => {
   const tag = '[library-call-number-dedup]';
@@ -645,7 +647,9 @@ export const runDedup = async (): Promise<DedupSummary> => {
         childRowsDeleted: 0,
         rowsDeleted: 0,
         renumbersSkipped: 0,
-        worklist: formatWorklist([], []),
+        // 'dry-run' even though `--execute` was passed: the run declined before
+        // writing anything, so nothing on a worklist from here could be acted on.
+        worklist: formatWorklist([], [], 'dry-run'),
       };
     }
 
@@ -701,7 +705,8 @@ export const runDedup = async (): Promise<DedupSummary> => {
         vol: p.slot.vol,
         reason: p.reason,
       };
-    })
+    }),
+    EXECUTE ? 'execute' : 'dry-run'
   );
 
   console.log(`\n${worklist}`);

--- a/jobs/library-call-number-dedup/report.ts
+++ b/jobs/library-call-number-dedup/report.ts
@@ -9,7 +9,17 @@
  *
  * Kept pure and separate from `merge.ts` so the output can be asserted in unit
  * tests without a database, and so a dry-run can produce the exact worklist an
- * execute run would.
+ * execute run would — same rows, same numbers, so the plan can be reviewed
+ * before it is approved.
+ *
+ * That property is also the hazard, which is why `mode` is a required argument
+ * rather than an optional one. A dry-run worklist describes physical shelf work
+ * against a catalog that has not moved: act on it and every relabelled disc
+ * disagrees with its catalog row, which is the disagreement this job exists to
+ * remove, in reverse. The document therefore has to say which run produced it,
+ * and it has to say so in places that survive being forwarded, pasted without
+ * its first paragraph, or printed — so the marking is in the title, a header
+ * banner, every row of the table, and a footer, not in a single banner on top.
  */
 
 /** One line of shelf work: pull this disc, cross out its number, write the new one. */
@@ -52,36 +62,82 @@ const callNumber = (letters: string, artistGenreCode: number | null, n: number, 
   return parts.filter((p) => p !== null && p !== '').join(' ');
 };
 
+/**
+ * Which run produced this document, and therefore whether it may be acted on.
+ * Required, not defaulted: the unmarked document is the dangerous one, so there
+ * is no value a future call site can forget its way into.
+ */
+export type WorklistMode = 'dry-run' | 'execute';
+
+/**
+ * Header banner. States the hazard rather than just the mode, because "dry run"
+ * is jargon to the person holding the discs.
+ */
+const PREVIEW_HEADER =
+  '> **PREVIEW OF A RUN THAT HAS NOT HAPPENED — DO NOT SEND THIS TO THE LIBRARIAN.** This came from a dry run. The job made no writes, so every catalog row still holds the call number it had before. Relabelling a disc from this list would put the shelf out of step with a catalog that never moved — the shelf/catalog disagreement this job exists to remove, in reverse. Only an `--execute` run produces a worklist that may be acted on.';
+
+/**
+ * Footer banner. Deliberately repeats the header rather than referring back to
+ * it: the table is the part that gets forwarded on its own, and whoever receives
+ * it that way has the footer and not the header.
+ */
+const PREVIEW_FOOTER =
+  '> **End of PREVIEW — nothing above has happened.** Every call number in the "Would become" column is planned, not assigned, and is re-planned from scratch on each run. No catalog row has moved. Do not relabel any disc from this document, and do not forward it.';
+
 /** Render the worklist as Markdown, grouped by genre then shelf. */
-export const formatWorklist = (items: readonly RelabelItem[], held: readonly HeldItem[]): string => {
+export const formatWorklist = (
+  items: readonly RelabelItem[],
+  held: readonly HeldItem[],
+  mode: WorklistMode
+): string => {
+  const preview = mode === 'dry-run';
   const genres = [...new Set(items.map((i) => i.genre))].sort();
   const out: string[] = [];
 
-  out.push('# Call-number relabel worklist');
+  // The title is the closest thing this document has to a filename: it is what
+  // a paste into a doc, an email subject, or a print header inherits.
+  out.push(preview ? '# Call-number relabel worklist — PREVIEW, DO NOT DISTRIBUTE' : '# Call-number relabel worklist');
   out.push('');
+  if (preview) {
+    out.push(PREVIEW_HEADER);
+    out.push('');
+  }
   out.push(
-    'Each row below is a shelf slot that held two different releases under one call number. The catalog now gives one of them a new number; **the disc itself still carries the old one.** Until it is relabelled the shelf and the catalog disagree.'
+    preview
+      ? 'Each row below is a shelf slot that holds two different releases under one call number. An `--execute` run would give one of them a new number, after which **the disc itself would still carry the old one** and would need relabelling. That run has not been made.'
+      : 'Each row below is a shelf slot that held two different releases under one call number. The catalog now gives one of them a new number; **the disc itself still carries the old one.** Until it is relabelled the shelf and the catalog disagree.'
   );
   out.push('');
   out.push(
-    'For each row: pull the disc under **Relabel this one**, cross out its number, write the new one, and refile it in number order. The other disc in the slot keeps its number and does not move.'
+    preview
+      ? 'Nothing here is an instruction. It is the shelf work an `--execute` run would create if it ran now, shown so the plan can be reviewed before it is approved.'
+      : 'For each row: pull the disc under **Relabel this one**, cross out its number, write the new one, and refile it in number order. The other disc in the slot keeps its number and does not move.'
   );
   out.push('');
   out.push(
-    `**${items.length} ${items.length === 1 ? 'disc' : 'discs'} to relabel**` +
+    `**${items.length} ${items.length === 1 ? 'disc' : 'discs'} ${preview ? 'would need relabelling' : 'to relabel'}**` +
       (genres.length ? ` across ${genres.length} ${genres.length === 1 ? 'genre' : 'genres'}` : '') +
-      (held.length ? `, plus **${held.length} that need your judgement** (last section).` : '.')
+      (held.length
+        ? `, plus **${held.length} that ${preview ? 'would need' : 'need'} your judgement** (last section).`
+        : '.')
   );
   out.push('');
-  out.push('| ✓ | Genre | Shelf | Relabel this one | Was | Becomes | Stays put |');
+  out.push(
+    preview
+      ? '| ⚠ | Genre | Shelf | Would relabel this one | Was | Would become | Stays put |'
+      : '| ✓ | Genre | Shelf | Relabel this one | Was | Becomes | Stays put |'
+  );
   out.push('|---|---|---|---|---|---|---|');
   for (const genre of genres) {
     const rows = items
       .filter((i) => i.genre === genre)
       .sort((a, b) => a.codeLetters.localeCompare(b.codeLetters) || a.oldNumber - b.oldNumber);
     for (const i of rows) {
+      // The check-off box becomes the word PREVIEW: a single row lifted out of
+      // the table still carries the warning, and there is nothing to check off
+      // on a run that has not happened.
       out.push(
-        `| ☐ | ${genre} | ${i.artist} | ${i.moveTitle} | \`${callNumber(i.codeLetters, i.artistGenreCode, i.oldNumber, i.vol)}\` | ` +
+        `| ${preview ? 'PREVIEW' : '☐'} | ${genre} | ${i.artist} | ${i.moveTitle} | \`${callNumber(i.codeLetters, i.artistGenreCode, i.oldNumber, i.vol)}\` | ` +
           `\`${callNumber(i.codeLetters, i.artistGenreCode, i.newNumber, i.vol)}\` | ${i.keepTitle} |`
       );
     }
@@ -102,6 +158,11 @@ export const formatWorklist = (items: readonly RelabelItem[], held: readonly Hel
         `| ${h.genre} | ${h.artist} | ${h.title} | \`${callNumber(h.codeLetters, h.artistGenreCode, h.atNumber, h.vol)}\` | ${h.reason} |`
       );
     }
+    out.push('');
+  }
+
+  if (preview) {
+    out.push(PREVIEW_FOOTER);
     out.push('');
   }
   return out.join('\n');

--- a/tests/unit/jobs/library-call-number-dedup/report.test.ts
+++ b/tests/unit/jobs/library-call-number-dedup/report.test.ts
@@ -6,6 +6,12 @@
  * legibility under that constraint: both call numbers appear in full, the disc
  * that moves is never confused with the one that stays, and a withheld slot
  * says why it was withheld rather than silently vanishing from the list.
+ *
+ * The second block covers the other half of legibility: whether the document
+ * admits it is a preview. A dry-run worklist describes shelf work against a
+ * catalog that has not moved, so the assertions there are about the warning
+ * surviving the ways a markdown table actually travels — forwarded, pasted
+ * without its opening paragraph, or printed.
  */
 import { formatWorklist, type HeldItem, type RelabelItem } from '../../../../jobs/library-call-number-dedup/report';
 
@@ -24,26 +30,26 @@ const item = (over: Partial<RelabelItem> = {}): RelabelItem => ({
 
 describe('formatWorklist', () => {
   it('renders both call numbers so the shelf work is unambiguous', () => {
-    const out = formatWorklist([item()], []);
+    const out = formatWorklist([item()], [], 'execute');
     expect(out).toContain('`GU 12 6`');
     expect(out).toContain('`GU 12 31`');
   });
 
   it('names the disc that moves and the one that stays', () => {
-    const out = formatWorklist([item()], []);
+    const out = formatWorklist([item()], [], 'execute');
     const row = out.split('\n').find((l) => l.includes('Bee Thousand'));
     expect(row).toBeDefined();
     expect(row.indexOf('Bee Thousand')).toBeLessThan(row.indexOf('Alien Lanes'));
   });
 
   it('includes the volume letter when the slot has one', () => {
-    const out = formatWorklist([item({ vol: 'B', oldNumber: 3, newNumber: 12 })], []);
+    const out = formatWorklist([item({ vol: 'B', oldNumber: 3, newNumber: 12 })], [], 'execute');
     expect(out).toContain('`GU 12 3 B`');
     expect(out).toContain('`GU 12 12 B`');
   });
 
   it('counts the discs and genres in the header', () => {
-    const out = formatWorklist([item(), item({ genre: 'Jazz', artist: 'Jo Jones', codeLetters: 'JO' })], []);
+    const out = formatWorklist([item(), item({ genre: 'Jazz', artist: 'Jo Jones', codeLetters: 'JO' })], [], 'execute');
     expect(out).toContain('**2 discs to relabel**');
     expect(out).toContain('across 2 genres');
   });
@@ -51,7 +57,8 @@ describe('formatWorklist', () => {
   it('groups by genre and sorts within a shelf by number', () => {
     const out = formatWorklist(
       [item({ oldNumber: 9, moveTitle: 'Later' }), item({ oldNumber: 2, moveTitle: 'Earlier' })],
-      []
+      [],
+      'execute'
     );
     expect(out.indexOf('Earlier')).toBeLessThan(out.indexOf('Later'));
   });
@@ -69,7 +76,7 @@ describe('formatWorklist', () => {
         reason: 'already sits at another number on this shelf',
       },
     ];
-    const out = formatWorklist([item()], held);
+    const out = formatWorklist([item()], held, 'execute');
     expect(out).toContain('## Needs your judgement');
     expect(out).toContain('Juju Music');
     expect(out).toContain('already sits at another number');
@@ -90,7 +97,8 @@ describe('formatWorklist', () => {
           vol: 'B',
           reason: 'twin elsewhere',
         },
-      ]
+      ],
+      'execute'
     );
     // `GU 12 3` and `GU 12 3 B` are different physical slots; sending the
     // librarian to the unlettered one points at the wrong disc.
@@ -98,18 +106,91 @@ describe('formatWorklist', () => {
   });
 
   it('drops the artist number cleanly when the shelf has none', () => {
-    const out = formatWorklist([item({ artistGenreCode: null })], []);
+    const out = formatWorklist([item({ artistGenreCode: null })], [], 'execute');
     expect(out).toContain('`GU 6`');
     expect(out).toContain('`GU 31`');
   });
 
   it('omits the judgement section entirely when nothing was withheld', () => {
-    expect(formatWorklist([item()], [])).not.toContain('## Needs your judgement');
+    expect(formatWorklist([item()], [], 'execute')).not.toContain('## Needs your judgement');
   });
 
   it('renders a clean run without crashing or claiming work', () => {
-    const out = formatWorklist([], []);
+    const out = formatWorklist([], [], 'execute');
     expect(out).toContain('**0 discs to relabel**');
     expect(out).not.toContain('## Needs your judgement');
+  });
+
+  it('gives the executed worklist a clean title and no preview marking anywhere', () => {
+    const out = formatWorklist([item()], [], 'execute');
+    expect(out.split('\n')[0]).toBe('# Call-number relabel worklist');
+    expect(out).not.toMatch(/PREVIEW|DO NOT/);
+  });
+});
+
+describe('formatWorklist, dry run', () => {
+  const held: HeldItem[] = [
+    {
+      genre: 'Africa',
+      artist: 'King Sunny Ade',
+      codeLetters: 'AD',
+      artistGenreCode: 4,
+      title: 'Juju Music',
+      atNumber: 1,
+      vol: '',
+      reason: 'already sits at another number on this shelf',
+    },
+  ];
+
+  it('puts the warning in the title, which is what a paste or a print header inherits', () => {
+    const out = formatWorklist([item()], [], 'dry-run');
+    expect(out.split('\n')[0]).toBe('# Call-number relabel worklist — PREVIEW, DO NOT DISTRIBUTE');
+  });
+
+  it('warns above the table and again below it, so a forwarded tail still carries it', () => {
+    const out = formatWorklist([item()], held, 'dry-run');
+    const table = out.indexOf('| PREVIEW |');
+    expect(out.slice(0, table)).toContain('DO NOT SEND THIS TO THE LIBRARIAN');
+    expect(out.slice(table)).toContain('End of PREVIEW');
+  });
+
+  it('keeps the footer after the judgement section rather than stranding it mid-document', () => {
+    const out = formatWorklist([item()], held, 'dry-run');
+    expect(out.indexOf('## Needs your judgement')).toBeLessThan(out.indexOf('End of PREVIEW'));
+  });
+
+  it('marks every row, so a single row lifted out of the table is still legible as a preview', () => {
+    const out = formatWorklist([item(), item({ genre: 'Jazz', artist: 'Jo Jones', codeLetters: 'JO' })], [], 'dry-run');
+    const rows = out.split('\n').filter((l) => l.includes('Bee Thousand'));
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(row.startsWith('| PREVIEW |')).toBe(true);
+    expect(out).not.toContain('| ☐ |');
+  });
+
+  it('states the numbers as planned rather than as assigned', () => {
+    const out = formatWorklist([item()], held, 'dry-run');
+    expect(out).toContain('Would become');
+    expect(out).toContain('**1 disc would need relabelling**');
+    expect(out).toContain('**1 that would need your judgement**');
+    expect(out).not.toContain('to relabel**');
+  });
+
+  it('gives no relabelling instruction, since there is nothing to act on yet', () => {
+    const out = formatWorklist([item()], [], 'dry-run');
+    expect(out).not.toContain('cross out its number');
+    expect(out).toContain('Nothing here is an instruction');
+  });
+
+  it('still shows the same rows and numbers, so the plan can be reviewed before approval', () => {
+    const out = formatWorklist([item()], [], 'dry-run');
+    expect(out).toContain('`GU 12 6`');
+    expect(out).toContain('`GU 12 31`');
+    expect(out).toContain('Bee Thousand');
+  });
+
+  it('warns even on an empty plan, which is the run most likely to be mistaken for the real one', () => {
+    const out = formatWorklist([], [], 'dry-run');
+    expect(out).toContain('PREVIEW, DO NOT DISTRIBUTE');
+    expect(out).toContain('End of PREVIEW');
   });
 });


### PR DESCRIPTION
## The hazard

`jobs/library-call-number-dedup` renders a librarian worklist: a table of discs to pull off the shelf, cross out the call number on, and relabel. A prod dry run today produced 116 relabel rows plus 6 held slots.

**A dry-run worklist and an `--execute` worklist were byte-identical given the same plan.** `formatWorklist` took no mode argument. The only signal that no writes had happened was this line, printed at the very top of the run log:

```
[library-call-number-dedup] mode: DRY RUN (no writes)
```

— ahead of the plan counts and 116 table rows. The job writes no file, so the way this document travels is: copy the Markdown out of the log and send it. Nothing that comes along with it says which run produced it. Forward the table alone, paste it without its first paragraph, or print it, and the distinction is gone entirely.

That distinction is the whole safety property. A dry-run worklist describes **physical relabelling against a catalog that has not moved** — no row was renumbered, every `library` row still holds its old call number. Relabel a disc from it and the disc disagrees with its own catalog row: precisely the shelf/catalog disagreement this job exists to remove, arrived at from the other direction. The README already treats the inverse case as serious enough to warrant a non-zero exit code — a renumber that was *planned but skipped* is deliberately kept off the worklist for exactly this reason. A whole worklist from a run that wrote nothing is that same failure at 116x.

And the window is open-ended rather than momentary. `--execute` is gated on turndown Phase 3.5 (#2033), which has no calendar date and is itself gated on the MD catalog-edit UI rebuild (WXYC/dj-site#1071). A preview can sit in someone's inbox for months before a real worklist exists to displace it.

## The change

`formatWorklist` now takes a required `mode: 'dry-run' | 'execute'`. Required rather than defaulted, because the unmarked document is the dangerous one — there is no value a future call site can forget its way into.

A dry run marks the document in four places, chosen so the marking survives how a Markdown table actually travels:

| Where | Why there |
|---|---|
| Title — `# Call-number relabel worklist — PREVIEW, DO NOT DISTRIBUTE` | What a paste into a doc, an email subject, or a print header inherits. Stands in for the filename this job never writes. |
| Banner above the table | The reader who starts at the top. |
| `PREVIEW` in place of the check-off box, on **every row** | A single row lifted out of the table still carries it. There is also nothing to check off on a run that has not happened. |
| Banner below the table | Repeats the header rather than referring back to it: the table is what gets forwarded on its own, and whoever receives it that way has the footer, not the header. |

Tense follows through — `**116 discs would need relabelling**`, a `Would become` column — and the relabelling instruction ("pull the disc, cross out its number, write the new one") is replaced with a note that nothing here is an instruction. The rows and numbers are unchanged, so a dry run is still an honest preview of the plan it is there to let you review.

Rendered dry-run head:

```
# Call-number relabel worklist — PREVIEW, DO NOT DISTRIBUTE

> **PREVIEW OF A RUN THAT HAS NOT HAPPENED — DO NOT SEND THIS TO THE LIBRARIAN.** This came from a dry
> run. The job made no writes, so every catalog row still holds the call number it had before. …

| ⚠ | Genre | Shelf | Would relabel this one | Was | Would become | Stays put |
|---|---|---|---|---|---|---|
| PREVIEW | Rock | Jessica Pratt | On Your Own Love Again | `PR 8 3` | `PR 8 41` | Quiet Signs |
```

Also: a README `## Safety` bullet stating plainly that a dry-run worklist must never reach the librarian, a naming convention for a saved copy (`call-number-worklist-PREVIEW-DO-NOT-DISTRIBUTE.md`; only the `--execute` copy gets the plain name), and sequencing steps 1 and 3 tightened to say *whose* worklist goes to the librarian.

## What is deliberately not changed

- No plan logic. No change to what `--execute` does to data. No migration.
- **The `--execute` output is byte-identical.** Every pre-existing test kept its exact expectations and simply passes the new argument; a new test asserts the executed document's first line is the clean title and that the string `PREVIEW` appears nowhere in it.
- The on-air refusal path renders `'dry-run'` even though `--execute` was passed, since it declines before writing anything.

## Verification

- `npm run test:unit` — 415 suites / 6646 tests pass. `tests/unit/jobs/library-call-number-dedup/` is 55 pass, including 8 new preview assertions (title, header-before-table, footer-after-judgement-section, per-row marking, planned-not-assigned tense, no instruction, plan rows still present, empty plan still warned).
- `npx tsc --noEmit -p jobs/library-call-number-dedup/tsconfig.json --types node` — clean. (`npm run typecheck` does not cover `jobs/**`, so this was run directly.)
- `npm run typecheck`, `npm run format:check`, `eslint` on the touched files — clean (the two `security/detect-object-injection` warnings on `merge.ts:608` are pre-existing and on an untouched line).

Related: #2033 (the sequencing ticket that defers `--execute` indefinitely, and the reason a preview outlives its run), #2024 (parent).