### PR TITLE
chore(deps): refresh transitive brace-expansion, js-yaml, and ip-address to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7547,16 +7547,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9682,9 +9682,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10014,9 +10014,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -11623,9 +11623,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13971,9 +13971,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears **15 of the 17** open Dependabot alerts. Part of #2043 (PR 1 of 3).

Lockfile-only. Every declaring range already permitted the patched version, so no `package.json` changed and the diff is exactly five version bumps — no additions, no removals:

| Package | From | To | Alerts |
|---|---|---|---|
| `brace-expansion` (root) | 5.0.6 | 5.0.9 | #114 #122 #127 |
| `brace-expansion` (under `glob`) | 2.1.1 | 2.1.4 | #116 #123 #129 |
| `brace-expansion` (under `test-exclude`) | 1.1.15 | 1.1.18 | #115 #124 #128 |
| `js-yaml` | 3.14.2 | 3.15.1 | #113 #117 #131 |
| `ip-address` | 10.2.0 | 10.4.0 | #125 #126 #130 |

## Reachability

None of these was exploitable, which is why this is a plain refresh rather than a hardening change:

- **brace-expansion** and **js-yaml** are dev-only. The first is reached through `minimatch` under `glob`/`test-exclude`/jest and its DoS needs a hostile glob pattern; ours are hardcoded in jest and eslint config. The second comes via `@istanbuljs/load-nyc-config`, which parses our own nyc config.
- **ip-address** is runtime, via `express-rate-limit`'s `ipKeyGenerator`. Three of our four limiters (`rateLimiting.ts` ×2, `apps/auth/app.ts` ×2) pass a custom `keyGenerator` from `rate-limit-key.ts` that keys on the raw `x-real-ip` string and never constructs an `Address4`/`Address6`, so they never reach the vulnerable parser. `internal-bans.route.ts` sets no `keyGenerator` and does fall through to the library default — but the advisories' SSRF framing still doesn't apply, because we never gate an outbound request on a parsed address. The real exposure there was rate-limit bucket misattribution (two textual forms of one IP landing in different buckets, so ~2× the intended limit) on a `ROM_INTERNAL_KEY`-authenticated route.

## Remaining two alerts

Tracked in #2043 and handled in the follow-up PRs, because each needs more than a lockfile refresh:

- **better-auth** (#120) — the vulnerable 1.6.20 is an orphaned hoisted copy kept alive by `@wxyc/shared`'s *optional* peer; all three workspaces already run a patched 1.6.23. Needs a dedupe plus the 1.6.26 bump, and 1.6.25 is a known typecheck breaker, so it gets its own PR.
- **body-parser** (#119) — in `dev_env/mock-api-server`, which `dependabot.yml` doesn't cover at all.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (845 pre-existing warnings)
- `npm run format:check` — clean
- `npm run test:unit` — 6668 tests / 416 suites passing
- `npm install` after the update produced no further lockfile drift, confirming the lock is coherent with every manifest
