### PR TITLE
chore(deps): bump better-auth to 1.6.26 and dedupe the orphaned root copy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,16 +40,12 @@ updates:
       # upgrade TypeScript as a tracked change once the toolchain supports TS7.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
-      # Hold better-auth 1.6.25: it tightened the client-plugin option-inference
-      # types so jwtClient() no longer satisfies BetterAuthClientPlugin, and
-      # `npm run typecheck` fails in shared/authentication/src/auth.client.ts
-      # (TS2322). 1.6.25 is the current latest, so there is no fixed release to
-      # move to. Lift this once an upstream version restores client-plugin type
-      # compatibility. See PR #1834 (closed).
-      - dependency-name: 'better-auth'
-        versions: ['1.6.25']
-      - dependency-name: '@better-auth/*'
-        versions: ['1.6.25']
+      # The better-auth 1.6.25 hold is gone: 1.6.25 tightened client-plugin
+      # option inference so jwtClient() no longer satisfied BetterAuthClientPlugin
+      # and `npm run typecheck` failed in shared/authentication/src/auth.client.ts
+      # (TS2322, upstream better-auth#10515, see closed PR #1834). 1.6.26 restores
+      # compatibility and we are on it as of #2043, so the pin has nothing left to
+      # hold back -- dependabot only ever proposes forward, never down to 1.6.25.
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -20,7 +20,7 @@
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
     "@wxyc/shared": "^3.3.0",
-    "better-auth": "^1.6.23",
+    "better-auth": "^1.6.26",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -28,7 +28,7 @@
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.19.0",
-    "better-auth": "^1.6.23",
+    "better-auth": "^1.6.26",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
         "@wxyc/shared": "^3.3.0",
-        "better-auth": "^1.6.23",
+        "better-auth": "^1.6.26",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -83,124 +83,6 @@
         "drizzle-orm": "^0.45.0"
       }
     },
-    "apps/auth/node_modules/@better-auth/core": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
-      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@standard-schema/spec": "^1.1.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@cloudflare/workers-types": ">=4",
-        "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.7",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5 || ^0.29.0",
-        "nanostores": "^1.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
-      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2"
-      },
-      "peerDependenciesMeta": {
-        "drizzle-orm": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
-      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "kysely": "^0.28.17 || ^0.29.0"
-      },
-      "peerDependenciesMeta": {
-        "kysely": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
-      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2"
-      }
-    },
-    "apps/auth/node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
-      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "mongodb": "^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "mongodb": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
-      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@prisma/client": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/@better-auth/telemetry": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
-      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1"
-      }
-    },
     "apps/auth/node_modules/@types/express-serve-static-core": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
@@ -212,131 +94,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "apps/auth/node_modules/better-auth": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
-      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/core": "1.6.23",
-        "@better-auth/drizzle-adapter": "1.6.23",
-        "@better-auth/kysely-adapter": "1.6.23",
-        "@better-auth/memory-adapter": "1.6.23",
-        "@better-auth/mongo-adapter": "1.6.23",
-        "@better-auth/prisma-adapter": "1.6.23",
-        "@better-auth/telemetry": "1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.7",
-        "defu": "^6.1.4",
-        "jose": "^6.1.3",
-        "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.1.1",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@lynx-js/react": "*",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "@sveltejs/kit": "^2.0.0",
-        "@tanstack/react-start": "^1.0.0",
-        "@tanstack/solid-start": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
-        "mongodb": "^6.0.0 || ^7.0.0",
-        "mysql2": "^3.0.0",
-        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "solid-js": "^1.0.0",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@lynx-js/react": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "@tanstack/react-start": {
-          "optional": true
-        },
-        "@tanstack/solid-start": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "drizzle-kit": {
-          "optional": true
-        },
-        "drizzle-orm": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "solid-js": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "apps/auth/node_modules/better-call": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
-      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "apps/backend": {
@@ -356,7 +113,7 @@
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.19.0",
-        "better-auth": "^1.6.23",
+        "better-auth": "^1.6.26",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -380,124 +137,6 @@
         "drizzle-orm": "^0.45.0"
       }
     },
-    "apps/backend/node_modules/@better-auth/core": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
-      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@standard-schema/spec": "^1.1.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@cloudflare/workers-types": ">=4",
-        "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.7",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5 || ^0.29.0",
-        "nanostores": "^1.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
-      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2"
-      },
-      "peerDependenciesMeta": {
-        "drizzle-orm": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
-      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "kysely": "^0.28.17 || ^0.29.0"
-      },
-      "peerDependenciesMeta": {
-        "kysely": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
-      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2"
-      }
-    },
-    "apps/backend/node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
-      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "mongodb": "^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "mongodb": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
-      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@prisma/client": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/@better-auth/telemetry": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
-      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1"
-      }
-    },
     "apps/backend/node_modules/axios": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
@@ -508,131 +147,6 @@
         "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "apps/backend/node_modules/better-auth": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
-      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/core": "1.6.23",
-        "@better-auth/drizzle-adapter": "1.6.23",
-        "@better-auth/kysely-adapter": "1.6.23",
-        "@better-auth/memory-adapter": "1.6.23",
-        "@better-auth/mongo-adapter": "1.6.23",
-        "@better-auth/prisma-adapter": "1.6.23",
-        "@better-auth/telemetry": "1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.7",
-        "defu": "^6.1.4",
-        "jose": "^6.1.3",
-        "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.1.1",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@lynx-js/react": "*",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "@sveltejs/kit": "^2.0.0",
-        "@tanstack/react-start": "^1.0.0",
-        "@tanstack/solid-start": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
-        "mongodb": "^6.0.0 || ^7.0.0",
-        "mysql2": "^3.0.0",
-        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "solid-js": "^1.0.0",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@lynx-js/react": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "@tanstack/react-start": {
-          "optional": true
-        },
-        "@tanstack/solid-start": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "drizzle-kit": {
-          "optional": true
-        },
-        "drizzle-orm": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "solid-js": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "apps/backend/node_modules/better-call": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
-      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "apps/backend/node_modules/lru-cache": {
@@ -2197,11 +1711,10 @@
       "license": "MIT"
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.20.tgz",
-      "integrity": "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.26.tgz",
+      "integrity": "sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
@@ -2212,7 +1725,7 @@
         "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.6",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
         "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
@@ -2227,13 +1740,12 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.20.tgz",
-      "integrity": "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.26.tgz",
+      "integrity": "sha512-SMvAeeUqEsz0BLtWVVp+HdStAVOwcxs4vPkL/AVmFJ0e9dDKItXl881xWeB/Ze4NgBW6NYmUId9qI4LrdQu3hA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2",
         "drizzle-orm": "^0.45.2"
       },
@@ -2244,13 +1756,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.20.tgz",
-      "integrity": "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.26.tgz",
+      "integrity": "sha512-Y0Kdqn8JQMR8dHMtUnbBNqq7Mk8mDf18DwTves2uhjtRfcOWByVTGxsFMDVUbedMuoM+Ab+v04bwCk94sAo8NA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -2261,24 +1772,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.20.tgz",
-      "integrity": "sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.26.tgz",
+      "integrity": "sha512-kb5ahphEp9jyMleXU4T8I/xgWPa8gjOLFKKsnaVqR/BU+h7xqTOsjJwTY3evY+PFYHvjNFUlrjZ1Km8A/w1p/w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.20.tgz",
-      "integrity": "sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.26.tgz",
+      "integrity": "sha512-jYGhuIQqj48h69ROLPYdc8jgqDaMmRRLLFiRViZFYarNyBuYUV07DywJXvRuw8l9ADx+M1TB+BJZGnLE2nnmwQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -2289,13 +1798,12 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.20.tgz",
-      "integrity": "sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.26.tgz",
+      "integrity": "sha512-ILQoYmnoYyghDP4iN1h/Gkd9Jt7Xs/vxoNAt4AuuJJbqs73u27LlQM4P1YiP7nJ+bM1iVTBI1dDF73myIAtjzQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -2310,13 +1818,12 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.20.tgz",
-      "integrity": "sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.26.tgz",
+      "integrity": "sha512-pBs69RORUSJHRF9r5PdeY7pzLRga09YSWew8igFYrBvT2tLt7DktrbD5WjryLZpAZOuKAMZ+Xo0DlJbnvLWGpQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@better-auth/core": "^1.6.20",
+        "@better-auth/core": "^1.6.26",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -7355,24 +6862,23 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.20.tgz",
-      "integrity": "sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==",
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.26.tgz",
+      "integrity": "sha512-nhXWrDDj+EnZsHq1j0z1c6DowOMFZWZHe6LCaXbBfLIgHHZm6dyazBQcbRspM4spUIcUt250Mc1BFOSuP7eniQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@better-auth/core": "1.6.20",
-        "@better-auth/drizzle-adapter": "1.6.20",
-        "@better-auth/kysely-adapter": "1.6.20",
-        "@better-auth/memory-adapter": "1.6.20",
-        "@better-auth/mongo-adapter": "1.6.20",
-        "@better-auth/prisma-adapter": "1.6.20",
-        "@better-auth/telemetry": "1.6.20",
+        "@better-auth/core": "1.6.26",
+        "@better-auth/drizzle-adapter": "1.6.26",
+        "@better-auth/kysely-adapter": "1.6.26",
+        "@better-auth/memory-adapter": "1.6.26",
+        "@better-auth/mongo-adapter": "1.6.26",
+        "@better-auth/prisma-adapter": "1.6.26",
+        "@better-auth/telemetry": "1.6.26",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.6",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
         "kysely": "^0.28.17 || ^0.29.0",
@@ -7461,11 +6967,10 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.6.tgz",
-      "integrity": "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -13363,9 +12868,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -15134,7 +14639,7 @@
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
         "@wxyc/shared": "^3.3.0",
-        "better-auth": "^1.6.23",
+        "better-auth": "^1.6.26",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
       },
@@ -15142,249 +14647,6 @@
         "@types/express": "^5.0.6",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3"
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/core": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
-      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@standard-schema/spec": "^1.1.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@cloudflare/workers-types": ">=4",
-        "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.7",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5 || ^0.29.0",
-        "nanostores": "^1.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
-      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2"
-      },
-      "peerDependenciesMeta": {
-        "drizzle-orm": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
-      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "kysely": "^0.28.17 || ^0.29.0"
-      },
-      "peerDependenciesMeta": {
-        "kysely": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
-      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2"
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
-      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "mongodb": "^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "mongodb": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
-      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@prisma/client": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/@better-auth/telemetry": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
-      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1"
-      }
-    },
-    "shared/authentication/node_modules/better-auth": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
-      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/core": "1.6.23",
-        "@better-auth/drizzle-adapter": "1.6.23",
-        "@better-auth/kysely-adapter": "1.6.23",
-        "@better-auth/memory-adapter": "1.6.23",
-        "@better-auth/mongo-adapter": "1.6.23",
-        "@better-auth/prisma-adapter": "1.6.23",
-        "@better-auth/telemetry": "1.6.23",
-        "@better-auth/utils": "0.4.2",
-        "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.7",
-        "defu": "^6.1.4",
-        "jose": "^6.1.3",
-        "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.1.1",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@lynx-js/react": "*",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "@sveltejs/kit": "^2.0.0",
-        "@tanstack/react-start": "^1.0.0",
-        "@tanstack/solid-start": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
-        "mongodb": "^6.0.0 || ^7.0.0",
-        "mysql2": "^3.0.0",
-        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "solid-js": "^1.0.0",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@lynx-js/react": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "@tanstack/react-start": {
-          "optional": true
-        },
-        "@tanstack/solid-start": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "drizzle-kit": {
-          "optional": true
-        },
-        "drizzle-orm": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "solid-js": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "shared/authentication/node_modules/better-call": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
-      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "shared/database": {

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -23,7 +23,7 @@
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",
     "@wxyc/shared": "^3.3.0",
-    "better-auth": "^1.6.23",
+    "better-auth": "^1.6.26",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"
   },


### PR DESCRIPTION
Clears the last **runtime** Dependabot alert — #120, GHSA-qq9h-g4jm-xgf3 (account takeover via pre-account hijacking on magic-link and email-OTP sign-in). Part of #2043 (PR 2 of 3).

## Why the alert existed, and why dependabot couldn't clear it

It was never a live exposure, but it was also never going to clear on its own.

`apps/auth`, `apps/backend`, and `shared/authentication` each declared `^1.6.23` and each carried its own nested **1.6.23** — patched, since the fix landed in 1.6.22. The vulnerable **1.6.20 was a stale hoisted copy at the tree root**, kept alive only to satisfy `@wxyc/shared`'s *optional* peer `better-auth: ^1.5.0`.

Nothing in this repo loads it. The only better-auth importer in `@wxyc/shared` is `dist/auth-client/index.js`; we import solely the `/auth-client/auth` subpath, and that module has no imports at all. `emailOTP` is additionally configured `disableSignUp: true`, which closes the account-creation vector the advisory turns on.

Because the orphan is a **resolution artifact rather than a version-range problem**, dependabot was structurally blind to it: its `better-auth` group targets the direct dependency, which was already on a patched range. It would have stayed open indefinitely.

## The fix

Bumping the three manifests to `^1.6.26` and running `npm update better-auth` collapses all four copies into a single hoisted 1.6.26 and removes **27 duplicated nested lock entries** (hence the −826 line lockfile diff). `npm audit` now reports **0 vulnerabilities**.

## Why 1.6.26 specifically

1.6.24 was safe, but **1.6.25 tightened client-plugin option inference** so `jwtClient()` no longer satisfied `BetterAuthClientPlugin`, breaking `npm run typecheck` in `shared/authentication/src/auth.client.ts` (TS2322, upstream better-auth#10515 — see closed PR #1834). That is why `dependabot.yml` held 1.6.25.

1.6.26 restores compatibility, verified here. The hold therefore has nothing left to hold back and is removed — dependabot only ever proposes forward, so it cannot walk us back onto 1.6.25. The comment is replaced with a note recording why the pin existed and why it's gone, rather than deleted silently.

## Verification

This is the only change in the set with real regression risk, so it got the full treatment:

- `npm run typecheck` — clean (this is the check 1.6.25 broke)
- `npm run lint` — 0 errors (845 pre-existing warnings)
- `npm run format:check` — clean
- `npm run test:unit` — 6668 tests / 416 suites passing
- `npm run ci:testmock` (Docker CI mirror) — **92 suites / 871 integration tests passing** against real Postgres, exercising the auth flows this bump actually touches

## Follow-up noted, not fixed here

The same stale-hoisted-copy pathology still exists benignly for `axios` (root 1.18.1 vs `apps/backend`'s 1.19.0). It carries no advisory today, so it's left alone rather than widening this PR — but it's the same shape, and the next advisory that lands on a hoisted transitive will be invisible to dependabot in exactly the same way.
