### PR TITLE
chore(deps): cover dev_env/mock-api-server with dependabot and patch body-parser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,23 @@ updates:
       # compatibility and we are on it as of #2043, so the pin has nothing left to
       # hold back -- dependabot only ever proposes forward, never down to 1.6.25.
 
+  # The CI mock API server carries its own package-lock.json, and the root `/`
+  # entry above does NOT cover it -- dependabot scopes an npm entry to the
+  # directory's own manifest tree, and this one is outside the root workspaces
+  # globs (apps/*, jobs/*, shared/*). Without this entry GitHub still *files*
+  # alerts against dev_env/mock-api-server/package-lock.json but no PR is ever
+  # raised to clear them, so they accrue silently regardless of severity. That
+  # is how the body-parser alert sat open (BS#2043).
+  - package-ecosystem: 'npm'
+    directory: '/dev_env/mock-api-server'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    groups:
+      mock-api-server:
+        patterns:
+          - '*'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/dev_env/mock-api-server/package-lock.json
+++ b/dev_env/mock-api-server/package-lock.json
@@ -128,21 +128,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -888,17 +901,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {


### PR DESCRIPTION
Clears the **last** open Dependabot alert — #119, GHSA-v422-hmwv-36x6 (body-parser DoS when an invalid `limit` value silently disables size enforcement) — and closes the config gap that let it sit open. Part of #2043 (PR 3 of 3, closes the epic).

## The gap matters more than the alert

The severity here is `low` and the code is a CI-only mock that is never deployed. But the gap behind it isn't severity-scoped.

`dependabot.yml` registered the npm ecosystem only for directory `/`, and dependabot scopes an npm entry to that directory's own manifest tree. `dev_env/mock-api-server` has its **own** `package-lock.json` and sits outside the root workspaces globs (`apps/*`, `jobs/*`, `shared/*`) — so it was covered by nothing. GitHub still *files* alerts against it; no PR was ever raised to clear them.

Any future advisory landing there, at any severity, would have accrued exactly the same way — visible on the alert board, permanently unactioned.

## Changes

- **`dependabot.yml`**: adds a second npm entry for `/dev_env/mock-api-server` on the same weekly Monday cadence, with a catch-all group so the handful of deps there arrive as one PR rather than several. The comment records *why* the root entry doesn't reach it, so the next person doesn't have to re-derive it.
- **`body-parser` 2.2.2 → 2.3.0**, which `express@5.2.1`'s `^2.2.1` range already permitted. Pulls `type-is` 2.1.0 and two nested `content-type` 2.0.0 copies with it.

## Verification

The mock server sits directly in the integration path, so a request-parsing regression there surfaces as integration failures:

- mock server builds (`tsc` + fixtures copy)
- `npm run format:check` — clean (covers the YAML)
- `npm run test:unit` — 6724 tests / 416 suites passing
- `npm run ci:testmock` (Docker CI mirror) — **93 suites / 872 integration tests passing**

## After this merges

The Dependabot board goes to **0 open**, from 17 at the start of #2043.
