### PR TITLE
test-infra: canonical renderSql utility + mock-queue leakage hardening

### DIFF
--- a/tests/unit/jobs/library-identity-consumer/writer.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/writer.test.ts
@@ -31,58 +31,7 @@ import {
   stampUnresolvedAttemptedAt,
   writeCompilationTracks,
 } from '../../../../jobs/library-identity-consumer/writer';
-
-type SqlChunk = { value?: string | string[]; queryChunks?: SqlChunk[]; raw?: string };
-type SqlLike = {
-  sql?: string | string[];
-  values?: unknown[];
-  queryChunks?: Array<string | SqlChunk>;
-  raw?: string;
-  // The manual drizzle mock's `sql.join` shape (tests/__mocks__/drizzle-orm.ts)
-  // — same handling as flowsheet-ghost-row-sweep's renderer.
-  join?: unknown[];
-  sep?: unknown;
-};
-const renderValue = (v: unknown): string => {
-  if (v == null) return '';
-  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
-  if (typeof v === 'object') {
-    const o = v as SqlChunk & SqlLike;
-    if (typeof o.raw === 'string') return o.raw;
-    if (Array.isArray(o.queryChunks) || Array.isArray(o.sql) || Array.isArray(o.join)) return renderSql(o);
-    if (Array.isArray(o.value)) return o.value.join('');
-    if (typeof o.value === 'string') return o.value;
-  }
-  return '';
-};
-const renderSql = (value: unknown): string => {
-  const obj = value as SqlLike | null | undefined;
-  if (!obj) return '';
-  if (Array.isArray(obj.sql)) {
-    let out = '';
-    const fragments = obj.sql;
-    const values = obj.values ?? [];
-    for (let i = 0; i < fragments.length; i++) {
-      out += fragments[i];
-      if (i < values.length) out += renderValue(values[i]);
-    }
-    return out;
-  }
-  if (typeof obj.sql === 'string') return obj.sql;
-  if (Array.isArray(obj.join)) return obj.join.map(renderSql).join(renderSql(obj.sep));
-  if (obj.queryChunks) {
-    return obj.queryChunks
-      .map((chunk) => {
-        if (typeof chunk === 'string') return chunk;
-        if (Array.isArray(chunk.queryChunks)) return renderSql(chunk);
-        if (Array.isArray(chunk.value)) return chunk.value.join('');
-        if (typeof chunk.value === 'string') return chunk.value;
-        return '';
-      })
-      .join('');
-  }
-  return '';
-};
+import { renderSql } from '../../../utils/render-sql';
 
 const findCallMatching = (pattern: RegExp): unknown[] | undefined => {
   const calls = (db.execute as jest.Mock).mock.calls;
@@ -270,7 +219,13 @@ describe('writeCompilationTracks (BS#1991 / #801 S2)', () => {
   });
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    // clearMocks (jest.unit.config.ts) clears call history automatically
+    // before every test, but it does NOT drain unconsumed
+    // mockResolvedValueOnce queues (BS#2051) — a surplus Once left over from
+    // one test would otherwise be consumed by the next test's first
+    // db.execute call. mockReset() drains the queue (and any lingering
+    // default resolved value) along with the call history.
+    (db.execute as jest.Mock).mockReset();
   });
 
   it('is a no-op (no query) for an empty results array', async () => {
@@ -554,7 +509,10 @@ describe('writeCompilationTracks — review-gate fixes (BS#1991 bounce 1)', () =
   const foldCalls = () => (db.execute as jest.Mock).mock.calls.filter((c) => /fold_artist_name/i.test(renderSql(c[0])));
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    // See the matching comment in the "writeCompilationTracks (BS#1991 /
+    // #801 S2)" describe above (BS#2051): mockReset() drains unconsumed
+    // mockResolvedValueOnce queues, not just call history.
+    (db.execute as jest.Mock).mockReset();
   });
 
   it('issues NO UPDATE statement when every matched row is already unchanged — the watermark trigger is FOR EACH STATEMENT and fires even on UPDATE 0', async () => {

--- a/tests/unit/jobs/library-identity-consumer/writer.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/writer.test.ts
@@ -225,6 +225,12 @@ describe('writeCompilationTracks (BS#1991 / #801 S2)', () => {
     // one test would otherwise be consumed by the next test's first
     // db.execute call. mockReset() drains the queue (and any lingering
     // default resolved value) along with the call history.
+    // This also permanently strips the module-load default
+    // `.mockResolvedValue([])` set at tests/mocks/database.mock.ts:51 — it
+    // never comes back for the rest of this file. Harmless today because
+    // every writer.ts call site coalesces (`rows ?? []` etc.), but a
+    // describe block added later that calls db.execute without queuing its
+    // own value would silently get `undefined` instead of `[]`.
     (db.execute as jest.Mock).mockReset();
   });
 
@@ -472,6 +478,38 @@ describe('writeCompilationTracks (BS#1991 / #801 S2)', () => {
     );
     expect(renderSql(updateCall?.[0])).not.toContain('B9');
   });
+
+  // Regression pair for the beforeEach's mockReset() above (BS#2051). These
+  // two tests must run in this exact declared order — Jest's default
+  // sequencer preserves declaration order (this repo's test scripts and CI
+  // never pass --randomize), so that's a safe assumption here even though
+  // it wouldn't be for tests that assert independent behavior. If the
+  // beforeEach is ever reverted to clearAllMocks() (which clears call
+  // history but leaves queued mockResolvedValueOnce values in place — see
+  // that comment for the full mechanism), the second test below starts
+  // receiving the first test's undrained surplus instead of a clean mock,
+  // and fails loudly.
+  it('leaves a deliberate surplus mockResolvedValueOnce queued and unconsumed — paired with the next test (BS#2051)', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([]) // CTA fetch: no rows, so writeCompilationTracks issues no further query
+      .mockResolvedValueOnce('BS#2051-UNDRAINED-SURPLUS'); // deliberately left unconsumed
+
+    const outcome = await writeCompilationTracks([compilation()]);
+
+    expect(outcome.rows_skipped_no_cta_match).toBe(1);
+  });
+
+  it("does not receive the previous test's undrained surplus — pins the beforeEach's mockReset() (BS#2051)", async () => {
+    // No mockResolvedValueOnce queued in this test at all. A correctly
+    // mockReset() mock has no queued value and no leftover implementation
+    // (mockReset() also drops the database.mock.ts:51 module-load default —
+    // see the beforeEach comment), so a raw call resolves to undefined. If
+    // the previous test's surplus had leaked through instead (the
+    // clearAllMocks() regression this pair guards against), this would
+    // resolve to 'BS#2051-UNDRAINED-SURPLUS' instead.
+    const result = await (db.execute as jest.Mock)();
+    expect(result).toBeUndefined();
+  });
 });
 
 describe('writeCompilationTracks — review-gate fixes (BS#1991 bounce 1)', () => {
@@ -511,7 +549,10 @@ describe('writeCompilationTracks — review-gate fixes (BS#1991 bounce 1)', () =
   beforeEach(() => {
     // See the matching comment in the "writeCompilationTracks (BS#1991 /
     // #801 S2)" describe above (BS#2051): mockReset() drains unconsumed
-    // mockResolvedValueOnce queues, not just call history.
+    // mockResolvedValueOnce queues, not just call history — and, same as
+    // that block, permanently strips the module-load default
+    // `.mockResolvedValue([])` at tests/mocks/database.mock.ts:51 for the
+    // rest of this file.
     (db.execute as jest.Mock).mockReset();
   });
 

--- a/tests/unit/utils/render-sql.test.ts
+++ b/tests/unit/utils/render-sql.test.ts
@@ -111,15 +111,15 @@ describe('renderSql — unrecognized shapes throw loudly instead of rendering em
   });
 
   it('throws for a null top-level chunk rather than returning an empty string', () => {
-    expect(() => renderSql(null)).toThrow();
+    expect(() => renderSql(null)).toThrow(/unrecognized SQL mock shape/);
   });
 
   it('throws for an undefined top-level chunk rather than returning an empty string', () => {
-    expect(() => renderSql(undefined)).toThrow();
+    expect(() => renderSql(undefined)).toThrow(/unrecognized SQL mock shape/);
   });
 
   it('throws for a bare primitive where a SQL chunk object was expected', () => {
-    expect(() => renderSql(42)).toThrow();
+    expect(() => renderSql(42)).toThrow(/unrecognized SQL mock shape/);
   });
 
   it('throws for an unrecognized separator shape nested inside an otherwise-valid {join, sep} chunk', () => {

--- a/tests/unit/utils/render-sql.test.ts
+++ b/tests/unit/utils/render-sql.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the canonical SQL renderer (tests/utils/render-sql.ts,
+ * BS#2051), which renders the four chunk shapes the manual drizzle-orm mock
+ * (tests/__mocks__/drizzle-orm.ts) can hand to `db.execute(...)`:
+ * `{ sql, values }`, `{ raw }`, `{ join, sep }`, and `{ queryChunks }`.
+ *
+ * The `{ join, sep }` coverage below is a direct regression test for the
+ * PR #2041 failure mode: a local renderer with no case for that shape
+ * silently rendered an empty string instead of throwing, and the resulting
+ * assertion failure (`FROM (VALUES )`) pointed nowhere near the real bug.
+ */
+import { renderSql, renderValue } from '../../utils/render-sql';
+import { sql } from '../../__mocks__/drizzle-orm';
+
+describe('renderSql — {sql, values} tagged-template chunks', () => {
+  it('renders fragments with interpolated primitive values', () => {
+    const chunk = { sql: ['SELECT * FROM t WHERE id = ', ' AND name = ', ''], values: [42, 'Stereolab'] };
+    expect(renderSql(chunk)).toBe('SELECT * FROM t WHERE id = 42 AND name = Stereolab');
+  });
+
+  it('renders a chunk with no interpolated values', () => {
+    expect(renderSql({ sql: ['SELECT 1'], values: [] })).toBe('SELECT 1');
+  });
+
+  it('renders null-valued interpolations as an empty string (a bound SQL NULL)', () => {
+    expect(renderSql({ sql: ['x = ', ''], values: [null] })).toBe('x = ');
+  });
+
+  it('recurses into a nested {sql, values} chunk used as an interpolated value', () => {
+    const inner = { sql: ['a = ', ''], values: [1] };
+    const outer = { sql: ['WHERE ', ' AND b = 2'], values: [inner] };
+    expect(renderSql(outer)).toBe('WHERE a = 1 AND b = 2');
+  });
+});
+
+describe('renderSql — {raw} chunks (sql.raw)', () => {
+  it('renders the raw string verbatim', () => {
+    expect(renderSql({ raw: '"wxyc_schema"."library_identity"' })).toBe('"wxyc_schema"."library_identity"');
+  });
+
+  it('renders a {raw} chunk used as an interpolated value inside a {sql, values} chunk', () => {
+    const table = { raw: '"wxyc_schema"."library"' };
+    const chunk = { sql: ['UPDATE ', ' SET x = 1'], values: [table] };
+    expect(renderSql(chunk)).toBe('UPDATE "wxyc_schema"."library" SET x = 1');
+  });
+});
+
+describe('renderSql — {join, sep} chunks (sql.join) — PR #2041 regression coverage', () => {
+  it('joins rendered {sql, values} fragments with a rendered {sql, values} separator', () => {
+    const fragments = [
+      { sql: ['(', ', ', ')'], values: [1, 'a'] },
+      { sql: ['(', ', ', ')'], values: [2, 'b'] },
+    ];
+    const sep = { sql: [', '], values: [] };
+    expect(renderSql({ join: fragments, sep })).toBe('(1, a), (2, b)');
+  });
+
+  it('joins fragments with a {raw} separator', () => {
+    const fragments = [{ raw: 'a = 1' }, { raw: 'b = 2' }];
+    expect(renderSql({ join: fragments, sep: { raw: ' OR ' } })).toBe('a = 1 OR b = 2');
+  });
+
+  it('never renders an empty body: a {join, sep} chunk with non-empty fragments must not collapse to the empty string', () => {
+    // This is the exact shape of the PR #2041 bug: a renderer with no
+    // {join, sep} case fell through its default branch and produced ''
+    // here, which surfaced downstream as `FROM (VALUES )`.
+    const fragments = [{ raw: "'A'" }, { raw: "'B'" }];
+    const rendered = renderSql({ join: fragments, sep: { sql: [', '], values: [] } });
+    expect(rendered).not.toBe('');
+    expect(rendered).toBe("'A', 'B'");
+  });
+
+  it('treats an undefined separator as no separator at all (matches sql.join called without one)', () => {
+    expect(renderSql({ join: [{ raw: 'a' }, { raw: 'b' }], sep: undefined })).toBe('ab');
+  });
+
+  it('renders a {join, sep} chunk used as an interpolated value inside a {sql, values} chunk (the FROM (VALUES ...) shape)', () => {
+    const rows = [
+      { sql: ['(', ', ', ')'], values: [1, 'a'] },
+      { sql: ['(', ', ', ')'], values: [2, 'b'] },
+    ];
+    const joined = { join: rows, sep: { sql: [', '], values: [] } };
+    const query = { sql: ['SELECT * FROM (VALUES ', ') AS v(id, name)'], values: [joined] };
+    expect(renderSql(query)).toBe('SELECT * FROM (VALUES (1, a), (2, b)) AS v(id, name)');
+  });
+});
+
+describe('renderSql — {queryChunks} fragments (real drizzle-orm leaking through)', () => {
+  it('joins string chunks and {value} chunks', () => {
+    const chunk = { queryChunks: ['SELECT ', { value: ['1'] }, ' AS one'] };
+    expect(renderSql(chunk)).toBe('SELECT 1 AS one');
+  });
+
+  it('renders a {value} chunk whose value is a plain string', () => {
+    const chunk = { queryChunks: ['x = ', { value: 'y' }] };
+    expect(renderSql(chunk)).toBe('x = y');
+  });
+
+  it('recurses into a nested queryChunks fragment', () => {
+    const inner = { queryChunks: ['a = ', { value: ['1'] }] };
+    const outer = { queryChunks: ['WHERE ', inner] };
+    expect(renderSql(outer)).toBe('WHERE a = 1');
+  });
+});
+
+describe('renderSql — unrecognized shapes throw loudly instead of rendering empty', () => {
+  it('throws for an object matching none of the four known shapes, serializing the offending value', () => {
+    const bogus = { totallyUnknownField: 'mystery-value' };
+    expect(() => renderSql(bogus)).toThrow(/totallyUnknownField/);
+    expect(() => renderSql(bogus)).toThrow(/mystery-value/);
+  });
+
+  it('throws for a null top-level chunk rather than returning an empty string', () => {
+    expect(() => renderSql(null)).toThrow();
+  });
+
+  it('throws for an undefined top-level chunk rather than returning an empty string', () => {
+    expect(() => renderSql(undefined)).toThrow();
+  });
+
+  it('throws for a bare primitive where a SQL chunk object was expected', () => {
+    expect(() => renderSql(42)).toThrow();
+  });
+
+  it('throws for an unrecognized separator shape nested inside an otherwise-valid {join, sep} chunk', () => {
+    const fragments = [{ raw: 'a' }, { raw: 'b' }];
+    expect(() => renderSql({ join: fragments, sep: { mystery: true } })).toThrow(/mystery/);
+  });
+});
+
+describe('renderValue — bound SQL parameter values', () => {
+  it('renders null and undefined as an empty string (a bound SQL NULL)', () => {
+    expect(renderValue(null)).toBe('');
+    expect(renderValue(undefined)).toBe('');
+  });
+
+  it('stringifies primitive values', () => {
+    expect(renderValue(42)).toBe('42');
+    expect(renderValue('Stereolab')).toBe('Stereolab');
+    expect(renderValue(true)).toBe('true');
+    expect(renderValue(false)).toBe('false');
+  });
+
+  it('delegates a nested SQL-chunk-shaped value to renderSql', () => {
+    expect(renderValue({ raw: 'NOW()' })).toBe('NOW()');
+    expect(renderValue({ sql: ['x'], values: [] })).toBe('x');
+    expect(renderValue({ join: [{ raw: 'a' }], sep: undefined })).toBe('a');
+  });
+
+  it('throws with the offending value serialized for an unrecognized shape', () => {
+    const bogus = { mystery: true };
+    expect(() => renderValue(bogus)).toThrow(/mystery/);
+  });
+});
+
+describe('renderSql — against the shared drizzle-orm mock (tests/__mocks__/drizzle-orm.ts)', () => {
+  it('renders sql`...` tagged-template output produced by the real mock function', () => {
+    const id = 42;
+    expect(renderSql(sql`SELECT * FROM t WHERE id = ${id}`)).toBe('SELECT * FROM t WHERE id = 42');
+  });
+
+  it('renders sql.raw(...) output produced by the real mock function', () => {
+    expect(renderSql(sql.raw('"wxyc_schema"."library_identity"'))).toBe('"wxyc_schema"."library_identity"');
+  });
+
+  it('renders sql.join(...) output produced by the real mock function — the exact shape PR #2041 broke on', () => {
+    const rows = [sql`(${1}, ${'a'})`, sql`(${2}, ${'b'})`];
+    const joined = sql.join(rows, sql`, `);
+    expect(renderSql(joined)).toBe('(1, a), (2, b)');
+  });
+});

--- a/tests/utils/render-sql.ts
+++ b/tests/utils/render-sql.ts
@@ -1,0 +1,143 @@
+/**
+ * Canonical SQL renderer for unit tests driving the manual drizzle-orm mock
+ * at `tests/__mocks__/drizzle-orm.ts` (BS#2051).
+ *
+ * The mock can hand `db.execute(...)` (and its own sub-fragments) one of
+ * four distinct "chunk" shapes:
+ *
+ *   - `{ sql: string[], values: unknown[] }` — the `` sql`...` `` tagged
+ *     template (mock lines 5-9)
+ *   - `{ raw: string }`                      — `sql.raw(...)` (mock line 11)
+ *   - `{ join: unknown[], sep: unknown }`     — `sql.join(...)` (mock line 12)
+ *   - `{ queryChunks: unknown[] }`            — a REAL drizzle-orm `SQL`
+ *     fragment that slipped through the mock (e.g. built by code this suite
+ *     doesn't mock, or produced by `sql.raw`'s real counterpart upstream)
+ *
+ * Forty-plus unit-test files each hand-rolled their own subset of this
+ * rendering logic, and every one of them fell back to an empty string on a
+ * shape it didn't recognize. During PR #2041, one such local renderer had no
+ * case for `{ join, sep }`: instead of throwing, it silently rendered
+ * nothing, the assertion saw `FROM (VALUES )` with an empty body, and the
+ * resulting failure message pointed nowhere near the actual bug. `renderSql`
+ * and `renderValue` below throw instead — loudly, with the offending value
+ * serialized — the moment they meet something that isn't one of the four
+ * shapes above. An unhandled shape is a bug in the renderer (or a fifth mock
+ * shape nobody has taught it yet), never a silently empty string.
+ *
+ * Do not "fix" this by changing the shared mock's `sql.join` to compose a
+ * `{ sql, values }` fragment instead of `{ join, sep }` — several suites
+ * define their own local drizzle-orm mocks that pin the `{ join, sep }`
+ * shape, and changing the shared mock's output shape would break them for
+ * reasons unrelated to what they're testing. Normalize here, at the
+ * renderer, not at the mock.
+ */
+
+interface SqlLikeShape {
+  sql?: unknown;
+  values?: readonly unknown[];
+  raw?: unknown;
+  join?: readonly unknown[];
+  sep?: unknown;
+  queryChunks?: readonly unknown[];
+  value?: unknown;
+}
+
+/** Best-effort serialization of an offending value for an error message. */
+function describeUnknownShape(value: unknown): string {
+  try {
+    const json = JSON.stringify(value, null, 2);
+    if (json !== undefined) return json;
+  } catch {
+    // circular structure or similar — fall through to util.inspect, which
+    // (unlike JSON.stringify/String) is built to handle arbitrary values.
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { inspect } = require('node:util') as typeof import('node:util');
+  return inspect(value, { depth: 6 });
+}
+
+function unrecognizedShapeError(fnName: string, value: unknown): Error {
+  return new Error(
+    `${fnName}: unrecognized SQL mock shape — expected one of {sql, values}, {raw}, {join, sep}, or ` +
+      `{queryChunks}. Received: ${describeUnknownShape(value)}`
+  );
+}
+
+/**
+ * Renders a single bound value (an entry of a `{ sql, values }` chunk's
+ * `values` array, or a `queryChunks` entry that isn't a raw string).
+ *
+ * `null`/`undefined` are legitimate bound-SQL-NULL values, not an
+ * unrecognized shape, and render as `''`. Anything else that isn't a
+ * primitive or one of the four recognized chunk shapes throws.
+ */
+export function renderValue(value: unknown): string {
+  if (value === null || typeof value === 'undefined') return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (typeof value === 'object') {
+    const obj = value as SqlLikeShape;
+    if (
+      Array.isArray(obj.sql) ||
+      typeof obj.sql === 'string' ||
+      typeof obj.raw === 'string' ||
+      Array.isArray(obj.join) ||
+      Array.isArray(obj.queryChunks)
+    ) {
+      return renderSql(obj);
+    }
+    // A real drizzle-orm `Param`-like chunk, which carries its bound value
+    // (or array of value fragments) under `.value` rather than one of the
+    // four shapes above.
+    if (Array.isArray(obj.value)) return obj.value.join('');
+    if (typeof obj.value === 'string') return obj.value;
+  }
+  throw unrecognizedShapeError('renderValue', value);
+}
+
+/**
+ * Renders a SQL "chunk" — anything the manual drizzle-orm mock could hand to
+ * `db.execute(...)` — to a flat string, recursing into nested fragments.
+ *
+ * Throws (never returns `''`) when `value` is `null`/`undefined` or doesn't
+ * match one of the four recognized shapes. A SQL chunk, unlike a bound
+ * value, should never legitimately be absent — `db.execute` is always
+ * called with a real `sql`-tag result.
+ */
+export function renderSql(value: unknown): string {
+  if (value !== null && typeof value === 'object') {
+    const obj = value as SqlLikeShape;
+
+    // `` sql`...` `` tagged template: { sql: string[], values: unknown[] }
+    if (Array.isArray(obj.sql)) {
+      const fragments = obj.sql as readonly string[];
+      const values = obj.values ?? [];
+      let out = '';
+      for (let i = 0; i < fragments.length; i++) {
+        out += fragments[i];
+        if (i < values.length) out += renderValue(values[i]);
+      }
+      return out;
+    }
+    if (typeof obj.sql === 'string') return obj.sql;
+
+    // sql.raw(...): { raw: string }
+    if (typeof obj.raw === 'string') return obj.raw;
+
+    // sql.join([...], sep): { join: unknown[], sep: unknown }. `sep` is
+    // `undefined` only when the caller passed no separator to `sql.join`
+    // (real drizzle-orm treats that as no separator, not an error).
+    if (Array.isArray(obj.join)) {
+      const sepText = obj.sep === null || typeof obj.sep === 'undefined' ? '' : renderSql(obj.sep);
+      return obj.join.map((fragment) => renderSql(fragment)).join(sepText);
+    }
+
+    // A real drizzle-orm SQL fragment leaking through: { queryChunks: [...] }
+    if (Array.isArray(obj.queryChunks)) {
+      return obj.queryChunks.map((chunk) => (typeof chunk === 'string' ? chunk : renderValue(chunk))).join('');
+    }
+  }
+
+  throw unrecognizedShapeError('renderSql', value);
+}


### PR DESCRIPTION
Closes #2051.

## What this does

Adds a canonical SQL renderer for unit tests and hardens mock-queue reset semantics in the `library-identity-consumer` suite. Test infrastructure only — no production code is touched.

### 1. Canonical renderer — `tests/utils/render-sql.ts`

44 unit-test files defined their own local `renderSql`/`renderValue` (47 definitions), each covering a different subset of the shapes the manual drizzle mock at `tests/__mocks__/drizzle-orm.ts` produces. This adds one implementation handling all four: `{sql, values}` (tagged template), `{join, sep}` (`sql.join`), `{raw}` (`sql.raw`), and `queryChunks` (real drizzle fragments leaking through), recursing into nested chunks.

The important property is not the deduplication — it is that **an unrecognized shape now throws** with the offending value serialized, instead of silently rendering an empty string. That silent-empty behavior is the actual defect: during #2041 a local renderer with no `{join, sep}` case rendered `FROM (VALUES )` and sent debugging in the wrong direction, because the assertion failure pointed nowhere near the cause.

The mock's `sql.join` output shape is deliberately **not** changed. Composing it into a `{sql, values}` fragment looks tidier and is riskier: several suites define their own local drizzle mocks that pin the `{join, sep}` shape, so changing the shared mock breaks them for reasons unrelated to what they test. Normalizing at the renderer keeps the blast radius at the assertion layer.

### 2. Mock-queue hardening

`jest.unit.config.ts` sets `clearMocks: true`, which clears call history but does **not** drain unconsumed `mockResolvedValueOnce` queues. A test that queues three Onces and consumes two leaves the third armed for whichever test runs next, which then receives a response meant for a different query — a cascade of this made #2041's fix rounds considerably more expensive than they needed to be.

The two `writeCompilationTracks` describe blocks (the positional-Once risk surface) now call `(db.execute as jest.Mock).mockReset()` in `beforeEach`, which drains the queue. It is scoped to `db.execute` alone so it does not clobber `db.transaction`'s factory implementation.

## Scope

Migration is **opportunistic by design**. Only `tests/unit/jobs/library-identity-consumer/writer.test.ts` is converted — the suite that was actually burned by this bug and the one #1992/S3 will touch next. The other ~43 files keep their local renderers and should be migrated on contact. Converting all 44 in one pass would be a large mechanical diff across suites nobody is working in.

No test's assertions changed. The only edits to the migrated file are the renderer import, the removal of its 51-line local implementation, and the two `beforeEach` bodies.

## Verification

Review confirmed old-vs-new renderer equivalence empirically rather than by inspection: the previous local implementation was re-appended and instrumented to throw on any divergence — **32/32 pass, zero divergences**, with a negative control proving ~114 render calls were genuinely compared. The new renderer is a superset-or-throw of the old one, never rendering *less*, which is what keeps the suite's two `.not.toContain(...)` pins from going vacuous.

Five mutations against `writer.ts` confirmed the pins still fail on broken code. The decisive one: replacing `sql.join` with an unknown chunk shape — the exact #2041 failure mode — now produces 7 pointed `unrecognized SQL mock shape` errors rather than a silent empty render.

Following review, the mock-queue half gained its own regression test. It was previously unprotected: reverting `mockReset()` to `clearAllMocks()` left the suite green, so nothing would have stopped a future editor from undoing it. The new ordered pair queues an unconsumed `Once` in one test and asserts the next receives no leaked value; it was verified to go **RED** when `mockReset()` is reverted. That pair depends on declaration order — Jest's `--randomize` can shuffle siblings within a describe block, and this repo's scripts and CI never pass it — so the dependency is documented in a comment above the pair, and it was confirmed green under 8 randomized seeds.

Also from review: the three `.toThrow()` assertions in the renderer's own tests now pin the error message, since a bare `.toThrow()` would pass on an incidental `TypeError` rather than the intended error — and that message *is* the loudness property this change exists to establish. Both `mockReset()` sites carry a note that they permanently strip `tests/mocks/database.mock.ts`'s module-load `.mockResolvedValue([])` default for the rest of the file (inert today only because `writer.ts` coalesces at all three consumption sites).

Local CI green: `lint` (0 errors), `format:check`, `typecheck`, `test:unit` (417 suites / 6752 tests).

## Note for the reviewer

This branch and #2050 both touch `tests/unit/jobs/library-identity-consumer/writer.test.ts`. `git merge-tree` reports exactly one conflict, in the import block; resolution is "keep both import lines, keep the deletion." #2050's 194-line append does not conflict, and its new tests make no `db.execute` calls, so the `mockReset()` change cannot perturb them.
