### PR TITLE
library-identity-consumer retrospective refactorings (behavior-preserving)

### DIFF
--- a/jobs/library-identity-consumer/select.ts
+++ b/jobs/library-identity-consumer/select.ts
@@ -260,6 +260,35 @@ export const resolveRecheck = (raw: string | undefined = process.env.RECHECK): b
 };
 
 /**
+ * BS#1800 freshness guard: "canonicalized, and no `library_identity` row has
+ * been verified within the last `staleDays` days." This is the entire
+ * flag-off, non-recheck eligibility test for the non-`va` cohort, and the
+ * shared prefix for the `va` cohort below — see `markerTtlClause` for the
+ * one clause that distinguishes them.
+ */
+const freshnessGuard = (staleDays: number): SQL => sql`
+      AND "canonical_entity_id" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
+        WHERE li."library_id" = ${LIBRARY_TABLE}."id"
+          AND li."last_verified_at" >= NOW() - (interval '1 day' * ${staleDays})
+      )`;
+
+/**
+ * BS#1991 bounce-1: the no-match marker TTL clause, ANDed onto
+ * `freshnessGuard` for the `va` cohort only. A resolved compilation writes no
+ * `library_identity` row, so without this clause the flag-off `va` predicate
+ * would re-select it on every run forever — the re-ask pathology bounce-1
+ * closed. This clause, present for `va` and absent for non-`va`, is the
+ * entire delta between the two flag-off eligibility arms.
+ */
+const markerTtlClause = (unresolvedRetryDays: number): SQL => sql`
+      AND (
+        "unresolved_attempted_at" IS NULL
+        OR "unresolved_attempted_at" < NOW() - (interval '1 day' * ${unresolvedRetryDays})
+      )`;
+
+/**
  * Load the next batch of libraries needing identity refresh.
  *
  * The predicate is the canonicalized-and-fresh gate described above. Rows are skipped when
@@ -314,7 +343,9 @@ export const loadBatch = async (
   // TTL. A resolved compilation writes no `library_identity` row, so without
   // this clause the flag-off predicate re-selects it on every run forever —
   // the exact re-ask pathology this issue closes. Scoped to the va cohort:
-  // the non-va arm stays byte-identical to the pre-BS#1991 predicate.
+  // the non-va arm stays byte-identical to the pre-BS#1991 predicate. The two
+  // arms below share `freshnessGuard` verbatim; `markerTtlClause` is the
+  // entire va-vs-non-va delta (#2050).
   // BS#1991: `recheck` mode replaces the normal freshness/no-match-marker
   // eligibility entirely — it deliberately IGNORES `unresolvedRetryDays` and
   // re-drives every va-cohort row this job has previously visited
@@ -344,24 +375,8 @@ export const loadBatch = async (
         )
       )`
       : cohort === 'va'
-        ? sql`
-      AND "canonical_entity_id" IS NOT NULL
-      AND NOT EXISTS (
-        SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
-        WHERE li."library_id" = ${LIBRARY_TABLE}."id"
-          AND li."last_verified_at" >= NOW() - (interval '1 day' * ${staleDays})
-      )
-      AND (
-        "unresolved_attempted_at" IS NULL
-        OR "unresolved_attempted_at" < NOW() - (interval '1 day' * ${unresolvedRetryDays})
-      )`
-        : sql`
-      AND "canonical_entity_id" IS NOT NULL
-      AND NOT EXISTS (
-        SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
-        WHERE li."library_id" = ${LIBRARY_TABLE}."id"
-          AND li."last_verified_at" >= NOW() - (interval '1 day' * ${staleDays})
-      )`;
+        ? sql`${freshnessGuard(staleDays)}${markerTtlClause(unresolvedRetryDays)}`
+        : freshnessGuard(staleDays);
 
   const rows = (await db.execute(sql`
     SELECT

--- a/jobs/library-identity-consumer/writer.ts
+++ b/jobs/library-identity-consumer/writer.ts
@@ -215,8 +215,20 @@ export const writeSingleArtist = async (
  *
  * Binds the ids as a single Postgres array literal (`= ANY('{...}'::int[])`)
  * rather than an `IN (...)` splat, per BS#1071/#1072. Empty input is a no-op
- * (no query). The `id` values are numbers (LibraryRow.id), so the literal is
- * injection-safe.
+ * (no query). The literal is built via `@wxyc/database`'s `intArrayLiteral`,
+ * which round-trips every id through `Number(...)` and a real
+ * `Number.isSafeInteger` check rather than trusting the `number[]` parameter
+ * type — see that helper's docblock for why "the caller's type says so" isn't
+ * a runtime guarantee.
+ *
+ * One harmless behavior delta from the hand-rolled join this replaced: a
+ * malformed id now throws inside `intArrayLiteral` instead of being spliced
+ * into a bad literal for Postgres to reject. Both outcomes land in the same
+ * `try`/`catch` at `orchestrate.ts` (around the `stampUnresolvedAttemptedAt`
+ * call site) and produce the same `stamp_error` warn-and-continue, so the
+ * drain behaves identically either way — and the path is unreachable in
+ * practice absent an unchecked cast upstream, since this parameter is typed
+ * `number[]`.
  */
 export const stampUnresolvedAttemptedAt = async (libraryIds: number[]): Promise<void> => {
   if (libraryIds.length === 0) return;
@@ -445,6 +457,16 @@ const float4 = (x: number | null): number | null => (x === null ? null : Math.fr
  * SQL-level `IS DISTINCT FROM` guard this prefilter backstops (and cannot
  * be replaced by, since that guard alone doesn't prevent the statement from
  * being issued in the first place).
+ *
+ * **Preconditions (unchecked — caller's responsibility):** `entries` must be
+ * non-empty (`entries[entries.length - 1]` is read unconditionally) and
+ * every entry's `resolved_artist_name` must be non-null (it's looked up
+ * directly in `artistIdByName`). Both hold structurally for `writeCompilationTracks`'s
+ * `survivors` list — entries with a null `resolved_artist_name` are filtered
+ * out before grouping, and a key only reaches `entriesByKey` via a `push`, so
+ * the bucket is never empty — but neither is enforced here, since this
+ * function was extracted from an inline loop where both were already
+ * guaranteed by the caller; see #2050.
  */
 export const buildWriteRow = (
   ctaRow: CtaRow,

--- a/jobs/library-identity-consumer/writer.ts
+++ b/jobs/library-identity-consumer/writer.ts
@@ -220,11 +220,10 @@ export const writeSingleArtist = async (
  */
 export const stampUnresolvedAttemptedAt = async (libraryIds: number[]): Promise<void> => {
   if (libraryIds.length === 0) return;
-  const idArrayLiteral = `{${libraryIds.join(',')}}`;
   await db.execute(sql`
     UPDATE ${LIBRARY_TABLE}
     SET "unresolved_attempted_at" = NOW()
-    WHERE "id" = ANY(${idArrayLiteral}::int[])
+    WHERE "id" = ANY(${intArrayLiteral(libraryIds)}::int[])
   `);
 };
 
@@ -418,6 +417,118 @@ export const analyzeCompilationTrackArtist = async (): Promise<void> => {
   await db.execute(sql`ANALYZE ${COMPILATION_TRACK_ARTIST_TABLE}`);
 };
 
+/**
+ * `compilation_track_artist.track_artist_link_confidence` is `float4`
+ * (Postgres `real`). A value round-tripped through that column and read back
+ * through postgres-js's float8 lens differs in the digits float4 cannot
+ * represent, so `buildWriteRow`'s unchanged-row prefilter must compare both
+ * sides through the same float32 quantization or a genuinely-unchanged row
+ * reads as changed.
+ */
+const float4 = (x: number | null): number | null => (x === null ? null : Math.fround(x));
+
+/**
+ * Per-row decision logic for a single CTA-matched, librarian-cleared
+ * survivor (#2050, extracted from `writeCompilationTracks`): the last-entry
+ * pick, the confidence range guard, the track-position rider, and the
+ * app-side unchanged-row prefilter. Mutates `outcome`'s skip/ambiguous
+ * counters for whichever disposition it reaches along the way.
+ *
+ * Returns the row to queue for the batched UPDATE, or `null` when the row is
+ * unchanged from what `compilation_track_artist` already carries.
+ *
+ * **Load-bearing:** the `null` return is not an optimization. The `0138`
+ * watermark trigger on `compilation_track_artist` is `FOR EACH STATEMENT`
+ * and fires even on `UPDATE 0`, so an unchanged row must never reach the
+ * batched UPDATE at all — that's what stops a no-op re-drain from advancing
+ * `library_watermark`. See `applyCompilationWrites`'s docstring for the
+ * SQL-level `IS DISTINCT FROM` guard this prefilter backstops (and cannot
+ * be replaced by, since that guard alone doesn't prevent the statement from
+ * being issued in the first place).
+ */
+export const buildWriteRow = (
+  ctaRow: CtaRow,
+  entries: BulkResolveTrackEntry[],
+  artistIdByName: Map<string, number | null>,
+  outcome: CompilationWriteOutcome
+): CompilationWriteRow | null => {
+  // Multiple entries at the same key: identity write uses the last one
+  // (an LML echo duplicate at this key is a data-quality edge case, not
+  // something this job can fully disambiguate) — the position write is
+  // what's genuinely ambiguous, and is handled separately below.
+  const entry = entries[entries.length - 1];
+  const trackArtistId = artistIdByName.get(entry.resolved_artist_name as string) ?? null;
+  if (trackArtistId === null) outcome.rows_skipped_no_catalog_artist += 1;
+
+  // `track_artist_link_confidence` carries `CHECK (BETWEEN 0 AND 1)`
+  // (migration 0140). A single out-of-range value from LML must not abort
+  // the whole page's batched UPDATE — null it out (a legal value; the
+  // constraint is nullable) and log, mirroring `writeSingleArtist`'s own
+  // defense against its sibling `library_identity_source` constraint.
+  let confidence = entry.confidence;
+  if (confidence !== null && (confidence < 0 || confidence > 1)) {
+    log(
+      'warn',
+      'compilation_confidence_out_of_range',
+      `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) got an out-of-range confidence ${confidence} from LML; writing NULL instead`,
+      { cta_id: ctaRow.id, library_id: ctaRow.library_id, confidence }
+    );
+    confidence = null;
+  }
+
+  let newPosition: string | null = null;
+  if (ctaRow.track_position === null) {
+    const distinctPositions = [...new Set(entries.map((e) => e.track_position).filter((p) => p !== null))];
+    if (distinctPositions.length === 1) {
+      const offered = distinctPositions[0];
+      // `track_position` is varchar(20) (schema.ts) but the wire field is
+      // an unbounded string (LML's store is TEXT) — an over-long value
+      // sent verbatim raises 22001 and aborts the whole chunk, turning
+      // the page into a permanent retry loop. Same defense as the
+      // confidence guard above: null it and log; the identity write is
+      // unaffected.
+      if (offered.length > CTA_TRACK_POSITION_MAX_LENGTH) {
+        log(
+          'warn',
+          'compilation_position_too_long',
+          `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) got a ${offered.length}-char track_position from LML (varchar(${CTA_TRACK_POSITION_MAX_LENGTH}) column); position left unset`,
+          { cta_id: ctaRow.id, library_id: ctaRow.library_id, position_length: offered.length }
+        );
+      } else {
+        newPosition = offered;
+      }
+    } else if (distinctPositions.length > 1) {
+      outcome.position_rows_skipped_ambiguous += 1;
+      log(
+        'warn',
+        'compilation_position_ambiguous',
+        `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) has ${distinctPositions.length} distinct track_position values offered at the same (artist_name, track_title) key; position left unset`,
+        { cta_id: ctaRow.id, library_id: ctaRow.library_id, distinct_positions: distinctPositions.length }
+      );
+    }
+  }
+
+  // App-side unchanged check (belt) ahead of the SQL `IS DISTINCT FROM`
+  // (braces): the 0138 watermark trigger is FOR EACH STATEMENT and fires
+  // even on `UPDATE 0`, so an unchanged row must not even be queued — a
+  // fully-unchanged page then issues no UPDATE statement at all and a
+  // no-op re-drain genuinely never advances `library_watermark`.
+  // Confidence compares through Math.fround because the column is float4:
+  // the stored value read back through a float8 lens differs from the wire
+  // float8 in digits float4 cannot represent.
+  const unchanged =
+    (ctaRow.track_artist_id ?? null) === trackArtistId &&
+    float4(ctaRow.track_artist_link_confidence ?? null) === float4(confidence) &&
+    (ctaRow.track_artist_link_method ?? null) === 'lml_backfill' &&
+    newPosition === null;
+  if (unchanged) {
+    outcome.rows_skipped_unchanged += 1;
+    return null;
+  }
+
+  return { ctaId: ctaRow.id, trackArtistId, confidence, position: newPosition };
+};
+
 export const writeCompilationTracks = async (
   results: Extract<BulkResolveResult, { kind: 'compilation' }>[]
 ): Promise<CompilationWriteOutcome> => {
@@ -494,82 +605,8 @@ export const writeCompilationTracks = async (
   const writeRows: CompilationWriteRow[] = [];
 
   for (const { ctaRow, entries } of survivors) {
-    // Multiple entries at the same key: identity write uses the last one
-    // (an LML echo duplicate at this key is a data-quality edge case, not
-    // something this job can fully disambiguate) — the position write is
-    // what's genuinely ambiguous, and is handled separately below.
-    const entry = entries[entries.length - 1];
-    const trackArtistId = artistIdByName.get(entry.resolved_artist_name as string) ?? null;
-    if (trackArtistId === null) outcome.rows_skipped_no_catalog_artist += 1;
-
-    // `track_artist_link_confidence` carries `CHECK (BETWEEN 0 AND 1)`
-    // (migration 0140). A single out-of-range value from LML must not abort
-    // the whole page's batched UPDATE — null it out (a legal value; the
-    // constraint is nullable) and log, mirroring `writeSingleArtist`'s own
-    // defense against its sibling `library_identity_source` constraint.
-    let confidence = entry.confidence;
-    if (confidence !== null && (confidence < 0 || confidence > 1)) {
-      log(
-        'warn',
-        'compilation_confidence_out_of_range',
-        `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) got an out-of-range confidence ${confidence} from LML; writing NULL instead`,
-        { cta_id: ctaRow.id, library_id: ctaRow.library_id, confidence }
-      );
-      confidence = null;
-    }
-
-    let newPosition: string | null = null;
-    if (ctaRow.track_position === null) {
-      const distinctPositions = [...new Set(entries.map((e) => e.track_position).filter((p) => p !== null))];
-      if (distinctPositions.length === 1) {
-        const offered = distinctPositions[0];
-        // `track_position` is varchar(20) (schema.ts) but the wire field is
-        // an unbounded string (LML's store is TEXT) — an over-long value
-        // sent verbatim raises 22001 and aborts the whole chunk, turning
-        // the page into a permanent retry loop. Same defense as the
-        // confidence guard above: null it and log; the identity write is
-        // unaffected.
-        if (offered.length > CTA_TRACK_POSITION_MAX_LENGTH) {
-          log(
-            'warn',
-            'compilation_position_too_long',
-            `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) got a ${offered.length}-char track_position from LML (varchar(${CTA_TRACK_POSITION_MAX_LENGTH}) column); position left unset`,
-            { cta_id: ctaRow.id, library_id: ctaRow.library_id, position_length: offered.length }
-          );
-        } else {
-          newPosition = offered;
-        }
-      } else if (distinctPositions.length > 1) {
-        outcome.position_rows_skipped_ambiguous += 1;
-        log(
-          'warn',
-          'compilation_position_ambiguous',
-          `CTA row ${ctaRow.id} (library_id=${ctaRow.library_id}) has ${distinctPositions.length} distinct track_position values offered at the same (artist_name, track_title) key; position left unset`,
-          { cta_id: ctaRow.id, library_id: ctaRow.library_id, distinct_positions: distinctPositions.length }
-        );
-      }
-    }
-
-    // App-side unchanged check (belt) ahead of the SQL `IS DISTINCT FROM`
-    // (braces): the 0138 watermark trigger is FOR EACH STATEMENT and fires
-    // even on `UPDATE 0`, so an unchanged row must not even be queued — a
-    // fully-unchanged page then issues no UPDATE statement at all and a
-    // no-op re-drain genuinely never advances `library_watermark`.
-    // Confidence compares through Math.fround because the column is float4:
-    // the stored value read back through a float8 lens differs from the wire
-    // float8 in digits float4 cannot represent.
-    const float4 = (x: number | null): number | null => (x === null ? null : Math.fround(x));
-    const unchanged =
-      (ctaRow.track_artist_id ?? null) === trackArtistId &&
-      float4(ctaRow.track_artist_link_confidence ?? null) === float4(confidence) &&
-      (ctaRow.track_artist_link_method ?? null) === 'lml_backfill' &&
-      newPosition === null;
-    if (unchanged) {
-      outcome.rows_skipped_unchanged += 1;
-      continue;
-    }
-
-    writeRows.push({ ctaId: ctaRow.id, trackArtistId, confidence, position: newPosition });
+    const writeRow = buildWriteRow(ctaRow, entries, artistIdByName, outcome);
+    if (writeRow) writeRows.push(writeRow);
   }
 
   const { written, returnedIds } = await applyCompilationWrites(writeRows);

--- a/tests/unit/jobs/library-identity-consumer/writer.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/writer.test.ts
@@ -916,4 +916,26 @@ describe('buildWriteRow (#2050 per-row decision logic, extracted from writeCompi
     expect(row).toEqual({ ctaId: 42, trackArtistId: 7, confidence: 0.9, position: null });
     expect(outcome.rows_skipped_unchanged).toBe(0);
   });
+
+  it('non-disjoint counters: a row with no catalog artist match can ALSO be unchanged, incrementing both', () => {
+    // Pins the ordering documented on CompilationWriteOutcome.rows_skipped_no_catalog_artist:
+    // the no_catalog_artist increment must happen before the unchanged early
+    // return, or a row that is simultaneously "no match" and "already NULL in
+    // the CTA row" would only ever count once.
+    const outcome = makeOutcome();
+    const row = buildWriteRow(
+      ctaRow({
+        track_artist_id: null,
+        track_artist_link_confidence: null,
+        track_artist_link_method: 'lml_backfill',
+      }),
+      [track({ confidence: null })],
+      new Map([['Juana Molina', null]]),
+      outcome
+    );
+
+    expect(row).toBeNull();
+    expect(outcome.rows_skipped_no_catalog_artist).toBe(1);
+    expect(outcome.rows_skipped_unchanged).toBe(1);
+  });
 });

--- a/tests/unit/jobs/library-identity-consumer/writer.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/writer.test.ts
@@ -30,8 +30,10 @@ import {
   writeSingleArtist,
   stampUnresolvedAttemptedAt,
   writeCompilationTracks,
+  buildWriteRow,
 } from '../../../../jobs/library-identity-consumer/writer';
 import { renderSql } from '../../../utils/render-sql';
+import type { CompilationWriteOutcome } from '../../../../jobs/library-identity-consumer/writer';
 
 const findCallMatching = (pattern: RegExp): unknown[] | undefined => {
   const calls = (db.execute as jest.Mock).mock.calls;
@@ -719,5 +721,199 @@ describe('writeCompilationTracks — review-gate fixes (BS#1991 bounce 1)', () =
 
     const gapWarns = (log as jest.Mock).mock.calls.filter((c) => c[1] === 'compilation_cta_match_gap');
     expect(gapWarns.length).toBe(0);
+  });
+});
+
+describe('buildWriteRow (#2050 per-row decision logic, extracted from writeCompilationTracks)', () => {
+  const track = (overrides: Partial<BulkResolveTrackEntry> = {}): BulkResolveTrackEntry => ({
+    artist_name: 'Juana Molina',
+    track_title: 'la paradoja',
+    track_position: null,
+    resolved_artist_name: 'Juana Molina',
+    confidence: 0.9,
+    ...overrides,
+  });
+  const ctaRow = (overrides: Record<string, unknown> = {}) => ({
+    id: 42,
+    library_id: 200,
+    artist_name: 'Juana Molina',
+    track_title: 'la paradoja',
+    track_position: null,
+    track_artist_link_method: null,
+    track_artist_id: null,
+    track_artist_link_confidence: null,
+    ...overrides,
+  });
+  const makeOutcome = (): CompilationWriteOutcome => ({
+    rows_written: 0,
+    rows_skipped_unchanged: 0,
+    rows_skipped_librarian: 0,
+    rows_skipped_no_cta_match: 0,
+    rows_skipped_no_catalog_artist: 0,
+    position_rows_written: 0,
+    position_rows_skipped_ambiguous: 0,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('last-entry pick: the identity write uses the LAST entry at a shared key, not the first', () => {
+    const outcome = makeOutcome();
+    const entries = [
+      track({ resolved_artist_name: 'First Artist', confidence: 0.1 }),
+      track({ resolved_artist_name: 'Second Artist', confidence: 0.9 }),
+    ];
+    const artistIdByName = new Map<string, number | null>([
+      ['First Artist', 1],
+      ['Second Artist', 2],
+    ]);
+
+    const row = buildWriteRow(ctaRow(), entries, artistIdByName, outcome);
+
+    expect(row?.trackArtistId).toBe(2);
+    expect(row?.confidence).toBe(0.9);
+  });
+
+  it('confidence guard: nulls an out-of-range (>1) confidence and logs it', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(ctaRow(), [track({ confidence: 1.5 })], new Map([['Juana Molina', 7]]), outcome);
+
+    expect(row?.confidence).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      'warn',
+      'compilation_confidence_out_of_range',
+      expect.any(String),
+      expect.objectContaining({ cta_id: 42, confidence: 1.5 })
+    );
+  });
+
+  it('confidence guard: nulls an out-of-range (<0) confidence too', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(ctaRow(), [track({ confidence: -0.1 })], new Map([['Juana Molina', 7]]), outcome);
+
+    expect(row?.confidence).toBeNull();
+  });
+
+  it('confidence guard: a null confidence passes through untouched (not "out of range")', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(ctaRow(), [track({ confidence: null })], new Map([['Juana Molina', 7]]), outcome);
+
+    expect(row?.confidence).toBeNull();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('position rider: writes the offered position when the CTA row has none and exactly one is offered', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(ctaRow(), [track({ track_position: 'A1' })], new Map([['Juana Molina', 7]]), outcome);
+
+    expect(row?.position).toBe('A1');
+  });
+
+  it('position rider: leaves the position unset (and counts ambiguous) when entries disagree', () => {
+    const outcome = makeOutcome();
+    const entries = [track({ track_position: 'A1' }), track({ track_position: 'B3' })];
+
+    const row = buildWriteRow(ctaRow(), entries, new Map([['Juana Molina', 7]]), outcome);
+
+    expect(row?.position).toBeNull();
+    expect(outcome.position_rows_skipped_ambiguous).toBe(1);
+    expect(log).toHaveBeenCalledWith(
+      'warn',
+      'compilation_position_ambiguous',
+      expect.any(String),
+      expect.objectContaining({ cta_id: 42, distinct_positions: 2 })
+    );
+  });
+
+  it('position rider: nulls (and warns on) a position longer than varchar(20) instead of aborting', () => {
+    const outcome = makeOutcome();
+    const longPosition = 'A'.repeat(25);
+
+    const row = buildWriteRow(
+      ctaRow(),
+      [track({ track_position: longPosition })],
+      new Map([['Juana Molina', 7]]),
+      outcome
+    );
+
+    expect(row?.position).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      'warn',
+      'compilation_position_too_long',
+      expect.any(String),
+      expect.objectContaining({ cta_id: 42, position_length: 25 })
+    );
+  });
+
+  it('position rider: does not fire when the CTA row already carries a position', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(
+      ctaRow({ track_position: 'A1' }),
+      [track({ track_position: 'B9' })],
+      new Map([['Juana Molina', 7]]),
+      outcome
+    );
+
+    expect(row?.position).toBeNull();
+  });
+
+  it('counts rows_skipped_no_catalog_artist when the resolved name has no (or an ambiguous) artists match', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(ctaRow(), [track()], new Map([['Juana Molina', null]]), outcome);
+
+    expect(row?.trackArtistId).toBeNull();
+    expect(outcome.rows_skipped_no_catalog_artist).toBe(1);
+  });
+
+  it('unchanged-row prefilter: returns null and counts rows_skipped_unchanged when nothing would change', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(
+      ctaRow({
+        track_position: 'A1',
+        track_artist_link_method: 'lml_backfill',
+        track_artist_id: 7,
+        track_artist_link_confidence: 0.9,
+      }),
+      [track({ track_position: 'A1', confidence: 0.9 })],
+      new Map([['Juana Molina', 7]]),
+      outcome
+    );
+
+    expect(row).toBeNull();
+    expect(outcome.rows_skipped_unchanged).toBe(1);
+  });
+
+  it('unchanged-row prefilter: quantizes confidence through Math.fround (float4 column) before comparing', () => {
+    const outcome = makeOutcome();
+    // 0.2 stored as Postgres `real` (float4) surfaces as 0.20000000298023224
+    // through a float8 lens; Math.fround must map both to the same float32
+    // or a genuinely-unchanged row would read as changed.
+    const row = buildWriteRow(
+      ctaRow({
+        track_artist_link_method: 'lml_backfill',
+        track_artist_id: 7,
+        track_artist_link_confidence: 0.20000000298023224,
+      }),
+      [track({ confidence: 0.2 })],
+      new Map([['Juana Molina', 7]]),
+      outcome
+    );
+
+    expect(row).toBeNull();
+    expect(outcome.rows_skipped_unchanged).toBe(1);
+  });
+
+  it('returns a write row (not null) when the verdict genuinely changed', () => {
+    const outcome = makeOutcome();
+    const row = buildWriteRow(
+      ctaRow({ track_artist_link_method: 'lml_backfill', track_artist_id: 7, track_artist_link_confidence: 0.5 }),
+      [track({ confidence: 0.9 })],
+      new Map([['Juana Molina', 7]]),
+      outcome
+    );
+
+    expect(row).toEqual({ ctaId: 42, trackArtistId: 7, confidence: 0.9, position: null });
+    expect(outcome.rows_skipped_unchanged).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Retrospective cleanup on #1990/#1991 (PR #2037, PR #2041) in `jobs/library-identity-consumer/`, ahead of the next change in this job (S3 replace-tracklist, #1992). Three behavior-preserving refactorings, all verified to change nothing at runtime:

- **Shared array literal.** `stampUnresolvedAttemptedAt` in `writer.ts` now builds its Postgres array literal via the shared `intArrayLiteral` helper from `@wxyc/database` instead of hand-rolling it a second way in the same file.
- **Named eligibility fragments.** `select.ts`'s `eligibilityCore` extracts the `freshnessGuard` and `markerTtlClause` SQL fragments, so the `va`-vs-non-`va` delta in the flag-off predicate is a single visible line (`markerTtlClause` present or absent) instead of two near-identical inline blocks a reader has to diff by eye.
- **Per-row write decision extracted.** `writeCompilationTracks`'s per-row decision logic (last-entry pick, confidence range guard, track-position rider, and the load-bearing app-side unchanged-row prefilter that keeps a no-op re-drain from tripping the `FOR EACH STATEMENT` watermark trigger) is extracted into `buildWriteRow`, leaving `writeCompilationTracks` to handle fetch, grouping, resolution, and batched dispatch.

`buildWriteRow` takes the page-level `outcome` accumulator by reference and mutates it (and logs) rather than returning a single disposition value — it extracts "decision + bookkeeping" together, not a pure decision function. That's deliberate: `rows_skipped_no_catalog_artist` and `rows_skipped_unchanged` are non-disjoint by design (a row can be both "no catalog match" and "already this way in the CTA row"), so a single-disposition return type would have to re-encode that overlap — a bigger and riskier change than this cleanup authorized.

## Verification

- The `select.ts` extraction was checked beyond the existing regex-based unit pins by diffing the full rendered SQL text (via the same mock-drizzle renderer the unit tests use) across eight flag/cohort/recheck combinations before and after the refactor — byte-identical in every case, including parameter binding order.
- `buildWriteRow` was built test-first: unit tests exercising the extracted function in isolation (including the float4-quantization edge case for the float4 confidence column, and a dedicated pin for the non-disjoint counter ordering above) were written and confirmed red before the extraction, then green after.
- All pre-existing pins in this job's unit suite pass unmodified, including the review-gate fixes describe block.

Closes #2050
