### PR TITLE
docs(schema): describe the post-0137 legacy_release_id shape

### DIFF
--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -491,10 +491,12 @@ export type Album = InferSelectModel<typeof library>;
 // 1,000,000 so Backend-authored catalog adds (POST /library → insertAlbum)
 // never collide with the tubafrenzy legacy id space (legacy max ~72,276 <
 // this floor). This lets the Backend-sourced library.db producer emit a
-// stored `legacy_release_id AS id`. The column default below draws from this
-// sequence, so the mint fires ONLY on the addAlbum path — the ETL insert
-// (jobs/library-etl/job.ts) and every seed/fixture set legacy_release_id
-// explicitly, so the default is inert there.
+// stored `legacy_release_id AS id`. The floor is a convention, not a
+// constraint — nothing rejects an upstream id at or above it. The column
+// default below draws from this sequence and fires wherever the column is
+// omitted: `jobs/library-etl` sets it explicitly and so bypasses the default,
+// but `dev_env/seed_db.sql` does not, so every dev library row mints from
+// this sequence. See the `legacy_release_id` column comment for the full shape.
 export const libraryLegacyReleaseIdSeq = wxyc_schema.sequence('library_legacy_release_id_seq', {
   startWith: 1000000,
   minValue: 1000000,
@@ -515,9 +517,13 @@ export const libraryLegacyReleaseIdSeq = wxyc_schema.sequence('library_legacy_re
  *     and an LP issue of the same album are distinct rows.
  *   - NULL `canonical_entity_id` / `canonical_entity_confidence` /
  *     `canonical_entity_resolved_at` until LML resolves them (Epic B-1).
- *   - `legacy_release_id` is unique per row when present, but a small
- *     residual of rows have NULL `legacy_release_id` (orphaned from the
- *     ETL's link pass).
+ *   - `legacy_release_id` is no longer nullable: migration 0137 (BS#1963)
+ *     backfilled the NULL rows and set the column NOT NULL. It is not,
+ *     however, always the upstream `LIBRARY_RELEASE.ID` — a Backend-authored
+ *     add carries a sequence mint instead, and the ETL does not restamp one
+ *     when a matching upstream release later arrives (BS#2073). Nothing
+ *     bounds upstream ids below the 1,000,000 mint floor, so a constraint
+ *     here must not assume the two id ranges stay disjoint.
  *
  * Constraints added here must accept the full upstream shape, or they will
  * block the next library-etl pass. See WXYC/Backend-Service#702.
@@ -550,11 +556,21 @@ export const library = wxyc_schema.table(
     disc_quantity: smallint('disc_quantity').default(1).notNull(),
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     plays: integer('plays').default(0).notNull(),
-    // BS#1963: Backend-minted surrogate key. NOT NULL + a nextval default off
-    // `library_legacy_release_id_seq` (floor 1,000,000) mints an id on catalog
-    // adds that omit the column (insertAlbum), while the ETL/seeds/fixtures set
-    // it explicitly and so bypass the default. Backend mints are authoritative
-    // for the rows they create, so the source-tagged constraint is confirmed.
+    // Canonical description of this column — the sequence, SOURCE-block, and
+    // unique-index comments all defer here.
+    //
+    // A surrogate key present on every row, from one of two sources kept apart
+    // by convention rather than by constraint: the upstream `LIBRARY_RELEASE.ID`
+    // (set explicitly by `jobs/library-etl`; observed legacy max ~72,276) and a
+    // mint from `library_legacy_release_id_seq` (floor 1,000,000) for
+    // Backend-authored adds. The nextval default fires wherever the column is
+    // omitted — `insertAlbum`, and also the dev_env seeds, which do not set it.
+    // Unique since migration 0034; NOT NULL since 0137 (BS#1963), which
+    // backfilled the rows still NULL at that point. A row that starts as a
+    // Backend mint keeps that id even if the same release is later filed
+    // upstream — the ETL's restamp branch has been unreachable since 0137
+    // (BS#2073). Backend mints are authoritative for the rows they create, so
+    // the source-tagged constraint is confirmed.
     legacy_release_id: integer('legacy_release_id')
       .default(sql`nextval('"wxyc_schema"."library_legacy_release_id_seq"'::regclass)`)
       .notNull(), // eslint-disable-line wxyc/source-tagged-constraint-confirmed
@@ -615,9 +631,11 @@ export const library = wxyc_schema.table(
       genreIdIdx: index('genre_id_idx').on(table.genre_id),
       formatIdIdx: index('format_id_idx').on(table.format_id),
       artistIdIdx: index('artist_id_idx').on(table.artist_id),
-      // legacy_release_id is the surrogate key the legacy MySQL library
-      // assigns each release; one row per legacy_release_id by the upstream
-      // invariant (NULLs allowed for never-imported rows).
+      // Created in migration 0034. This index is what actually enforces one
+      // row per legacy_release_id across both id sources; the 1,000,000 mint
+      // floor is only a convention keeping them from meeting. Non-partial from
+      // the start — Postgres treats NULLs as distinct, so the rows that were
+      // NULL before 0137 needed no carve-out. See the column comment above.
       // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
       legacyReleaseIdIdx: uniqueIndex('library_legacy_release_id_idx').on(table.legacy_release_id),
       albumArtistTrgmIdx: index('album_artist_trgm_idx').using(`gin`, sql`${table.album_artist} gin_trgm_ops`),

--- a/tests/unit/database/schema.legacy-ids.test.ts
+++ b/tests/unit/database/schema.legacy-ids.test.ts
@@ -17,6 +17,26 @@ describe('schema: legacy ID columns for ETL deduplication', () => {
     expect(def).toContain('legacy_release_id');
   });
 
+  // Slice one column's declaration out of a table body, so an assertion about
+  // this column can't be satisfied by a chained call on a later one.
+  const extractColumnDef = (tableDef: string, columnName: string): string => {
+    const start = tableDef.indexOf(`${columnName}: `);
+    if (start === -1) throw new Error(`Column ${columnName} not found in table definition`);
+    const rest = tableDef.slice(start);
+    // A declaration runs until the next one at the same (4-space) indentation.
+    const next = rest.slice(1).search(/\n {4}\w+: /);
+    return next === -1 ? rest : rest.slice(0, next + 1);
+  };
+
+  // Pins the two facts the surrounding comments assert (BS#1963 / migration
+  // 0137). Without this, relaxing the column leaves the prose stale and CI
+  // green — the drift #2028 was filed to repair.
+  it('library.legacy_release_id should be NOT NULL with a nextval default off the mint sequence', () => {
+    const col = extractColumnDef(extractTableDef('library'), 'legacy_release_id');
+    expect(col).toContain('.notNull()');
+    expect(col).toContain(`nextval('"wxyc_schema"."library_legacy_release_id_seq"'::regclass)`);
+  });
+
   it('flowsheet table should have legacy_entry_id column', () => {
     const def = extractTableDef('flowsheet');
     expect(def).toContain('legacy_entry_id');


### PR DESCRIPTION
Closes #2028

## What

Four comment blocks on `wxyc_schema.library` described `legacy_release_id` inconsistently; two of them still described the pre-BS#1963 world in which the column had a NULL residual. All four are rewritten, with the column declaration made canonical and the other three deferring to it. Adds one unit assertion binding the prose to the schema.

## Why the old text was wrong

Verified against `shared/database/src/migrations/0137_mint-legacy-release-id.sql` (commit `81fed2b8`, on `main` since 2026-08-03) and `0034_legacy_id_columns.sql`:

- 0137 creates `library_legacy_release_id_seq` (`MINVALUE`/`START WITH` 1,000,000), runs an unbounded `UPDATE ... WHERE legacy_release_id IS NULL` backfill, guards on no survivors (#705), then `SET DEFAULT nextval(...)` and `SET NOT NULL`.
- **0034**, not 0137, created `library_legacy_release_id_idx`. 0137 never touches the index — it references it as pre-existing.

This was not cosmetic. The stale prose seeded a factual error into a cross-repo contract: the wxyc-shared PR adding `BulkResolveInput.legacy_release_id` (api.yaml 1.33.0, WXYC/wxyc-shared#315) initially documented the nonexistent NULL residual as a routine wire state. Review caught it there; this removes the source text.

## What changed beyond the two blocks #2028 named

Review of the first draft found the replacement prose introducing its own inaccuracies, and a sibling block that was already wrong. All are corrected here:

- **Uniqueness is attributed to 0034**, not 0137. A reader auditing when the guarantee took effect was being sent 100+ migrations too late.
- **The "no NULL carve-out" claim is dropped.** Postgres treats NULLs as distinct in a unique index, so the non-partial 0034 index tolerated the NULL rows for its whole life. `NOT NULL` did not remove a need for a carve-out; there was never one. Applying the inverted reasoning to the still-nullable `flowsheet_legacy_entry_id_idx` / `shows_legacy_show_id_idx` siblings would have invented a requirement they don't have.
- **The seed claim is corrected.** The sequence comment asserted "every seed/fixture set `legacy_release_id` explicitly, so the default is inert there." `dev_env/seed_db.sql` never sets the column — every dev library row mints from the sequence and lands at 1,000,000+. Pre-existing (BS#1963), but it is 22 lines from the edit and about the same column.
- **The keyspace split is described as a convention, not an invariant.** Nothing bounds upstream ids below the mint floor; the unique index is what actually enforces one row per id across both sources. The SOURCE block states this as a shape a constraint must tolerate, which is what that list is for.
- **The "ETL carries the upstream id verbatim" claim is gone.** It is true only on the insert path. 0137 made the restamp branch at `jobs/library-etl/job.ts:1034` unreachable (`if (existing.legacyReleaseId == null)` can no longer hold), so a Backend-authored row keeps its mint even after the same release is filed upstream, and the upstream id lands nowhere. Filed as #2073; referenced from the comments rather than described as intended behavior.
- **Four near-duplicate blocks collapse to one canonical description** at the column declaration, where `.notNull()` and `.default(nextval)` actually live. The drift above is what having four copies 60 lines apart produced.

## The regression this surfaced

#2073 is the substantive find. Since 2026-08-03, an MD-added album that the librarian later files in tubafrenzy never receives its upstream `LIBRARY_RELEASE.ID`, so tubafrenzy flowsheet rows for it fail the `legacy_release_id` join permanently. That matters more since WXYC/wiki#88 Phase 3, because `jobs/legacy-linkage-resolve` — which joins on exactly that column — is now the only thing repairing `flowsheet.album_id`. The symptom is indistinguishable from a benign filing lag.

## The prose is now pinned

`tests/unit/database/schema.legacy-ids.test.ts` asserted only that the column exists. It now also pins `.notNull()` and the default's sequence name, sliced to this column's own declaration so a chained call on a later column can't satisfy it. Verified by mutation: removing `.notNull()` fails it, and renaming the sequence fails it. The first draft of this assertion passed both mutations — it was matching a later column's `.notNull()`.

## The eslint disable is kept

`// eslint-disable-next-line wxyc/source-tagged-constraint-confirmed` above `legacyReleaseIdIdx` stays. The rule (`eslint-rules/source-tagged-constraint.cjs`) keys on the `SOURCE:` marker attached to the table declaration's ancestors and on the constraint call itself — never the comment above it, so this edit cannot change whether it fires. `eslint --no-cache shared/database/src/schema.ts` reports an identical 7-warning set before and after, with no `Unused eslint-disable directive` at the index (that check is live — four such warnings appear elsewhere in the file).

## Checks run locally

| Check | Result |
|---|---|
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run lint` | pass — 0 errors, 859 warnings (unchanged baseline) |
| `npm run test:unit` | pass — 421 suites, 6873 tests |
| `npm run check:auth-tables-doc` | pass |

`npm run ci:testmock` could not run: the Docker image build fails at `npm install --omit=dev` with `401 Unauthorized` fetching `@wxyc/shared@3.3.0` from GitHub Packages. The local `NPM_TOKEN` returns 401 for that tarball directly, so it is a stale workstation credential, not something this diff touches.
