### PR TITLE
feat(#2062): add GET /flowsheet/range for the public date-windowed read

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -109,6 +109,28 @@ export interface IFSEntry extends Omit<
 
 const MAX_ITEMS = 200;
 const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual number of tracks due to deletions
+
+/**
+ * Widest window `GET /flowsheet/range` will serve (BS#2062).
+ *
+ * The route is public and unauthenticated over a 2.6M-row table, and the
+ * response is UNPAGINATED, so this bounds the row count — and therefore the
+ * response size — not merely the time span. Month- and year-scale analytical
+ * reads are explicitly not this endpoint's job.
+ *
+ * 8 days rather than exactly 7 covers both real consumers (24h for the
+ * `archive` daily playlist, 7d for the wxyc.org historical-archive page) with
+ * a day of slack. The slack is load-bearing, not padding: a calendar week
+ * spanning the autumn DST transition is 7d + 1h, and an exact-7d ceiling
+ * would 400 it.
+ */
+export const MAX_RANGE_MS = 8 * 24 * 60 * 60 * 1000;
+
+// Largest absolute epoch-ms a JS Date can represent. A value past this parses
+// as a finite number but yields an Invalid Date, which would reach Postgres as
+// a malformed timestamp; reject it at the edge instead (same class of guard as
+// INT4_MAX above, for a different overflow).
+const MAX_EPOCH_MS = 8.64e15;
 // flowsheet.id is a Postgres int4 column; a value outside this range parses
 // fine as a JS integer (passing Number.isInteger) but blows up downstream as
 // an unhandled "value out of range for type integer" Postgres error (BS#1800).
@@ -151,6 +173,101 @@ const projectEntriesV2 = (entries: IFSEntry[]): Record<string, unknown>[] => {
     );
   }
   return dense.map(flowsheet_service.transformToV2);
+};
+
+/**
+ * Parse an epoch-milliseconds query param strictly.
+ *
+ * Returns `null` for anything that is not a plain integer inside the Date
+ * range — including a float, a trailing-garbage string, and an empty value.
+ * `Number()` (not `parseInt`) on purpose: `parseInt('1.5e0')` silently yields
+ * 1, and `parseInt('2026-06-01')` yields 2026, both of which would coerce a
+ * malformed window into a plausible-looking one rather than a 400.
+ */
+const parseEpochMillis = (raw: string | undefined): number | null => {
+  if (raw === undefined || raw.trim() === '') return null;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || Math.abs(value) > MAX_EPOCH_MS) return null;
+  return value;
+};
+
+/**
+ * GET /flowsheet/range?start=&end= — public, date-windowed flowsheet read.
+ *
+ * The successor to tubafrenzy's `GET /playlists/dailyEntries`, which the
+ * `archive` app reads today and which dies at the 2026-08-31 cutover
+ * (WXYC/wiki#91 Phase 4). Contract: `wxyc-shared/api.yaml` `/flowsheet/range`.
+ *
+ * `start` / `end` are epoch **milliseconds**, matching the `dayStart`
+ * convention `archive` already computes, and the window is half-open
+ * `[start, end)` on each entry's `add_time` so adjacent windows never
+ * double-count a row.
+ *
+ * One consequence worth knowing rather than discovering: `add_time` is when a
+ * row was *logged*, and a breakpoint row is logged ~a minute BEFORE the hour
+ * it marks (its true hour is `radio_hour`). An hour-aligned window therefore
+ * reports each hour's breakpoint in the previous window. That is the
+ * off-by-one-hour class BS#1448 / BS#1449 fixed at the rendering layer;
+ * consumers drawing hour markers key on `radio_hour`, not on arrival window.
+ *
+ * Validation returns 400 with `{ message }` directly rather than throwing
+ * `WxycError` — matching `searchFlowsheetEndpoint`, the other public
+ * unauthenticated read on this router, so the two public surfaces answer a bad
+ * query the same way.
+ *
+ * No `attachUpcomingShows` / `attachCriticReviews`: those enrich the live
+ * flowsheet UI, are absent from this endpoint's contract, and would add two
+ * batched queries per request to a historical read that does not display them.
+ */
+export const getEntriesInRange: RequestHandler<object, unknown, unknown, { start?: string; end?: string }> = async (
+  req,
+  res,
+  next
+) => {
+  const start = parseEpochMillis(req.query.start);
+  if (start === null) {
+    res.status(400).json({ message: 'start must be an integer number of epoch milliseconds' });
+    return;
+  }
+
+  const end = parseEpochMillis(req.query.end);
+  if (end === null) {
+    res.status(400).json({ message: 'end must be an integer number of epoch milliseconds' });
+    return;
+  }
+
+  // Strictly greater: the window is half-open, so end === start is empty by
+  // construction and far more likely a caller bug than a real request.
+  if (end <= start) {
+    res.status(400).json({ message: 'end must be strictly greater than start' });
+    return;
+  }
+
+  if (end - start > MAX_RANGE_MS) {
+    res.status(400).json({
+      message: `window must not exceed ${MAX_RANGE_MS / (24 * 60 * 60 * 1000)} days`,
+    });
+    return;
+  }
+
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+
+  try {
+    // Independent reads over the same window; no ordering dependency between
+    // them, so pay one round trip instead of two.
+    const [entries, shows] = await Promise.all([
+      flowsheet_service.getEntriesInTimeWindow(startDate, endDate),
+      flowsheet_service.getShowsInTimeWindow(startDate, endDate),
+    ]);
+
+    // An empty window is a normal result, never a 404 — the contract says so
+    // explicitly, and the two consumers render "no shows that day" rather than
+    // treating it as an error (contrast getEntries' legacy 404 branches).
+    res.status(200).json({ shows, entries: projectEntriesV2(entries) });
+  } catch (error) {
+    next(error);
+  }
 };
 
 export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res) => {

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -126,11 +126,19 @@ const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual 
  */
 export const MAX_RANGE_MS = 8 * 24 * 60 * 60 * 1000;
 
-// Largest absolute epoch-ms a JS Date can represent. A value past this parses
-// as a finite number but yields an Invalid Date, which would reach Postgres as
-// a malformed timestamp; reject it at the edge instead (same class of guard as
-// INT4_MAX above, for a different overflow).
-const MAX_EPOCH_MS = 8.64e15;
+// The epoch-ms window whose `Date` renders as a four-digit-year ISO string.
+//
+// The bound that matters is NOT the JS Date range (±8.64e15): Drizzle maps a
+// timestamp param to the driver with `value.toISOString()`, which switches to
+// the expanded-year form outside years 0000–9999 — `new Date(8.64e15)` is
+// `'+275760-09-13T00:00:00.000Z'`. Postgres cannot parse that literal, so the
+// query throws and this public read answers 500. These two constants are the
+// exact instants where `toISOString()` flips form (verified: MIN-1 renders
+// `-000001-…`, MAX+1 renders `+010000-…`), which is ~34x tighter than the Date
+// range and still far wider than any flowsheet window. Same class of guard as
+// INT4_MAX below, for a different overflow.
+const MIN_EPOCH_MS = -62167219200000; // 0000-01-01T00:00:00.000Z
+const MAX_EPOCH_MS = 253402300799999; // 9999-12-31T23:59:59.999Z
 // flowsheet.id is a Postgres int4 column; a value outside this range parses
 // fine as a JS integer (passing Number.isInteger) but blows up downstream as
 // an unhandled "value out of range for type integer" Postgres error (BS#1800).
@@ -176,18 +184,39 @@ const projectEntriesV2 = (entries: IFSEntry[]): Record<string, unknown>[] => {
 };
 
 /**
+ * A plain, optionally-negative run of decimal digits and nothing else.
+ *
+ * `Number()` alone is too permissive to implement "is this an epoch": it
+ * accepts radix prefixes (`Number('0x1E240') === 123456`), surrounding
+ * whitespace, a leading `+`, and exponent notation, every one of which would
+ * be served as a plausible-looking window rather than rejected. Testing the
+ * raw string first makes the accepted set exactly the documented one.
+ */
+const EPOCH_MS_PATTERN = /^-?\d+$/;
+
+/**
  * Parse an epoch-milliseconds query param strictly.
  *
- * Returns `null` for anything that is not a plain integer inside the Date
- * range — including a float, a trailing-garbage string, and an empty value.
- * `Number()` (not `parseInt`) on purpose: `parseInt('1.5e0')` silently yields
- * 1, and `parseInt('2026-06-01')` yields 2026, both of which would coerce a
- * malformed window into a plausible-looking one rather than a 400.
+ * Returns `null` for anything that is not a plain decimal integer inside the
+ * storable range — a float, a radix prefix, surrounding whitespace, trailing
+ * garbage, an empty value, or (per Express's query parser, below) a repeated
+ * key. `Number()` rather than `parseInt` for the final conversion: `parseInt`
+ * silently truncates, yielding 1 from `'1.5e0'` and 2026 from `'2026-06-01'`,
+ * which would coerce a malformed window into a plausible one instead of a 400.
+ *
+ * `raw` is typed `unknown` deliberately. Express 5's default ('simple') query
+ * parser returns an ARRAY when a key is repeated — `?start=1&start=2` yields
+ * `['1','2']` — so the handler's declared `string | undefined` is a lie the
+ * type system cannot catch at the boundary. Calling a string method on that
+ * array throws, and inside an async handler the rejection reaches
+ * `errorHandler` as a 500 plus a Sentry capture, on a route that is both
+ * unauthenticated and unratelimited. Narrowing here turns that into the 400
+ * the contract already specifies.
  */
-const parseEpochMillis = (raw: string | undefined): number | null => {
-  if (raw === undefined || raw.trim() === '') return null;
+const parseEpochMillis = (raw: unknown): number | null => {
+  if (typeof raw !== 'string' || !EPOCH_MS_PATTERN.test(raw)) return null;
   const value = Number(raw);
-  if (!Number.isInteger(value) || Math.abs(value) > MAX_EPOCH_MS) return null;
+  if (!Number.isInteger(value) || value < MIN_EPOCH_MS || value > MAX_EPOCH_MS) return null;
   return value;
 };
 

--- a/apps/backend/routes/flowsheet.route.ts
+++ b/apps/backend/routes/flowsheet.route.ts
@@ -26,10 +26,15 @@ const flowsheetConditionalGet = [conditionalGet(flowsheet_service.getLastModifie
 flowsheet_route.get('/search', searchController.searchFlowsheetEndpoint);
 
 // Public date-windowed read (BS#2062) — successor to tubafrenzy's
-// /playlists/dailyEntries. Registered here, above `get('/')`, for the same
-// reason `/search` is: a literal path must be matched before the bare-root
-// handler. It carries no `requirePermissions` (the contract is `security: []`)
-// and no `flowsheetMirror` (read-only; the mirror is a write-path concern).
+// /playlists/dailyEntries. Grouped with `/search` above `get('/')` to keep the
+// two public reads together; the placement is convention, NOT a shadowing fix.
+// `get('/')` matches only the exact path `/flowsheet`, and this router has no
+// parameterized route that could swallow `/flowsheet/range`, so moving this
+// line below it would change nothing. (Said plainly because the opposite claim
+// is easy to assume and would send a future reader hunting a hazard that
+// cannot occur.) It carries no `requirePermissions` (the contract is
+// `security: []`) and no `flowsheetMirror` (read-only; the mirror is a
+// write-path concern).
 // Deliberately outside `flowsheetConditionalGet`: that middleware's watermark
 // is the whole-table `flowsheet_watermark`, which any live write advances, so
 // it would invalidate a historical window that cannot have changed — a

--- a/apps/backend/routes/flowsheet.route.ts
+++ b/apps/backend/routes/flowsheet.route.ts
@@ -25,6 +25,17 @@ const flowsheetConditionalGet = [conditionalGet(flowsheet_service.getLastModifie
 // Public playlist archive search
 flowsheet_route.get('/search', searchController.searchFlowsheetEndpoint);
 
+// Public date-windowed read (BS#2062) — successor to tubafrenzy's
+// /playlists/dailyEntries. Registered here, above `get('/')`, for the same
+// reason `/search` is: a literal path must be matched before the bare-root
+// handler. It carries no `requirePermissions` (the contract is `security: []`)
+// and no `flowsheetMirror` (read-only; the mirror is a write-path concern).
+// Deliberately outside `flowsheetConditionalGet`: that middleware's watermark
+// is the whole-table `flowsheet_watermark`, which any live write advances, so
+// it would invalidate a historical window that cannot have changed — a
+// misleading validator rather than a useful one.
+flowsheet_route.get('/range', flowsheetController.getEntriesInRange);
+
 flowsheet_route.get('/', flowsheetConditionalGet, flowsheetMirror.getEntries, flowsheetController.getEntries);
 
 flowsheet_route.post(

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -454,14 +454,27 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
  * which is distinct from a row whose `djName` is unusable — see the
  * asymmetric legacy handling below, preserved verbatim from the original.
  */
+/**
+ * The first link of the chain, on its own: a usable per-show override, or null.
+ *
+ * Shared with `resolveDjNameForShow` below, which needs to know whether the
+ * override wins BEFORE deciding to spend a query on the user row. Exported as
+ * one function rather than re-tested there, so the rule that decides what
+ * reaches a public wire has exactly one definition.
+ */
+const showDjNameOverride = (dj_name_override: string | null): string | null => {
+  const override = (dj_name_override ?? '').trim();
+  return override.length > 0 ? override : null;
+};
+
 export const resolveShowDjName = (input: {
   dj_name_override: string | null;
   legacy_dj_name: string | null;
   primary_dj_id: string | null;
   user: { djName: string | null } | null;
 }): string | null => {
-  const override = (input.dj_name_override ?? '').trim();
-  if (override.length > 0) return override;
+  const override = showDjNameOverride(input.dj_name_override);
+  if (override !== null) return override;
 
   const legacy = input.legacy_dj_name;
   if (input.primary_dj_id == null) return legacy;
@@ -485,9 +498,10 @@ export const resolveDjNameForShow = async (show: Show): Promise<string | null> =
   };
 
   // Skip the lookup entirely when the chain can't reach it — an override wins
-  // outright, and a show with no linked DJ has no row to fetch.
-  const override = (base.dj_name_override ?? '').trim();
-  if (override.length > 0 || primaryDjId == null) {
+  // outright, and a show with no linked DJ has no row to fetch. Both tests
+  // defer to the shared definitions rather than restating them: a copy of the
+  // override rule here is exactly the drift the extraction exists to prevent.
+  if (showDjNameOverride(base.dj_name_override) !== null || primaryDjId == null) {
     return resolveShowDjName({ ...base, user: null });
   }
 
@@ -642,9 +656,22 @@ export const getEntriesInTimeWindow = async (start: Date, end: Date): Promise<IF
  * delivery was dropped and the column stayed NULL permanently (nothing
  * re-closes it on a schedule — BS#2065). Reading NULL as open-ended would make
  * every one of those orphaned historical shows intersect every window forever,
- * so an open-ended show is included only when its `start_time` falls inside the
- * window. A genuinely live show satisfies that on the windows a listener
- * actually asks for.
+ * so an open-ended show is included on its timestamps only when `start_time`
+ * falls inside the window.
+ *
+ * That timestamp rule alone is not sufficient, which is what the third arm is
+ * for. An overnight show that signed on at 22:00 and is still live at 01:00
+ * fails both timestamp arms for today's window — `end_time` is NULL and
+ * `start_time` is in yesterday — yet `getEntriesInTimeWindow` still returns
+ * its post-midnight entries, each carrying that `show_id`. api.yaml promises
+ * the opposite ("Matches `FlowsheetRangeEntry.show_id` for every entry
+ * belonging to this show"; "Segment on `show_id`"), so dropping the show hands
+ * `archive` an unresolvable id. The same gap swallows every dropped-`show_end`
+ * show that still has entries in the asked-for window. Including any show an
+ * in-window entry references closes it, and does so without re-admitting the
+ * orphaned shows the NULL rule exists to exclude: an orphan with no entries
+ * here is still absent. The subquery windows on `add_time`, so it is served by
+ * the same `flowsheet_add_time_idx` (migration 0144) the entries read uses.
  *
  * The DJ handle is resolved through the shared `resolveShowDjName` chain with
  * the user row LEFT JOINed in — one query for the whole window, not one per
@@ -674,7 +701,20 @@ export const getShowsInTimeWindow = async (start: Date, end: Date): Promise<Flow
         // a < d AND c < b, so a show that ended exactly at the window's
         // first instant does not overlap it.
         and(isNotNull(shows.end_time), lt(shows.start_time, end), gt(shows.end_time, start)),
-        and(isNull(shows.end_time), gte(shows.start_time, start), lt(shows.start_time, end))
+        and(isNull(shows.end_time), gte(shows.start_time, start), lt(shows.start_time, end)),
+        // Referenced by an entry in this window (see the docstring): the arm
+        // that keeps `entries[].show_id` resolvable when the timestamps alone
+        // would drop the show. Built with the typed query builder rather than
+        // a raw `sql` template on purpose — the postgres-js driver's
+        // timestamptz serializer override mangles a JS Date passed through
+        // `${...}`, and the column-aware encoder is what sidesteps it.
+        inArray(
+          shows.id,
+          db
+            .selectDistinct({ id: flowsheet.show_id })
+            .from(flowsheet)
+            .where(and(isNotNull(flowsheet.show_id), gte(flowsheet.add_time, start), lt(flowsheet.add_time, end)))
+        )
       )
     )
     // `id` is a deterministic tie-break for shows sharing a start_time; the

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1,4 +1,4 @@
-import { sql, desc, eq, and, isNull, lte, gte, inArray } from 'drizzle-orm';
+import { sql, asc, desc, eq, and, or, isNull, isNotNull, gt, lt, lte, gte, inArray } from 'drizzle-orm';
 import * as Sentry from '@sentry/node';
 import WxycError from '../utils/error.js';
 import {
@@ -438,22 +438,61 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
  * and must not leak onto the public on-air playlist. See
  * `resolveDjDisplayName`'s docstring.
  */
-export const resolveDjNameForShow = async (show: Show): Promise<string | null> => {
-  const override = ((show.dj_name_override as string | null | undefined) ?? '').trim();
+/**
+ * The PII-safe show-DJ resolution chain (BS#1371), as a pure decision:
+ * per-show override -> the linked user's public handle -> the legacy
+ * tubafrenzy handle -> null. Never the real-name column, which is
+ * structurally impossible here — it is not an input.
+ *
+ * Extracted from `resolveDjNameForShow` (below) so the windowed read
+ * (`getShowsInTimeWindow`, BS#2062) can apply the identical chain to a user
+ * row it JOINed in, instead of re-deriving it or paying one query per show.
+ * Two callers, one decision — the alternative is a copy that drifts, on a
+ * chain whose whole purpose is keeping a real name off a public wire.
+ *
+ * `user: null` means the show's `primary_dj_id` resolved to no row at all,
+ * which is distinct from a row whose `djName` is unusable — see the
+ * asymmetric legacy handling below, preserved verbatim from the original.
+ */
+export const resolveShowDjName = (input: {
+  dj_name_override: string | null;
+  legacy_dj_name: string | null;
+  primary_dj_id: string | null;
+  user: { djName: string | null } | null;
+}): string | null => {
+  const override = (input.dj_name_override ?? '').trim();
   if (override.length > 0) return override;
 
-  const legacy = (show.legacy_dj_name as string | null | undefined) ?? null;
-  const primaryDjId = (show.primary_dj_id as string | null | undefined) ?? null;
+  const legacy = input.legacy_dj_name;
+  if (input.primary_dj_id == null) return legacy;
+  // No user row: return the legacy handle as-is. Deliberately NOT trimmed,
+  // unlike the branch below — preserved from the pre-extraction behaviour so
+  // this refactor cannot change a single byte on the existing wire.
+  if (input.user == null) return legacy;
 
-  if (primaryDjId == null) return legacy;
-
-  const rows = await db.select({ djName: user.djName }).from(user).where(eq(user.id, primaryDjId)).limit(1);
-  const dj = rows[0];
-  if (!dj) return legacy;
-  const filteredDjName = resolveDjDisplayName(dj.djName ?? null);
+  const filteredDjName = resolveDjDisplayName(input.user.djName ?? null);
   if (filteredDjName) return filteredDjName;
   if (legacy && legacy.trim().length > 0) return legacy.trim();
   return null;
+};
+
+export const resolveDjNameForShow = async (show: Show): Promise<string | null> => {
+  const primaryDjId = (show.primary_dj_id as string | null | undefined) ?? null;
+  const base = {
+    dj_name_override: (show.dj_name_override as string | null | undefined) ?? null,
+    legacy_dj_name: (show.legacy_dj_name as string | null | undefined) ?? null,
+    primary_dj_id: primaryDjId,
+  };
+
+  // Skip the lookup entirely when the chain can't reach it — an override wins
+  // outright, and a show with no linked DJ has no row to fetch.
+  const override = (base.dj_name_override ?? '').trim();
+  if (override.length > 0 || primaryDjId == null) {
+    return resolveShowDjName({ ...base, user: null });
+  }
+
+  const rows = await db.select({ djName: user.djName }).from(user).where(eq(user.id, primaryDjId)).limit(1);
+  return resolveShowDjName({ ...base, user: rows[0] ?? null });
 };
 
 /**
@@ -548,6 +587,114 @@ export const getEntriesByRange = async (startId: number, endId: number): Promise
     .orderBy(desc(flowsheet.id));
 
   return raw.map(transformToIFSEntry);
+};
+
+/** One show overlapping a `GET /flowsheet/range` window — the public-safe projection. */
+export type FlowsheetRangeShow = {
+  id: number;
+  show_name: string | null;
+  dj_name: string | null;
+  specialty_id: number | null;
+  start_time: Date;
+  end_time: Date | null;
+};
+
+/**
+ * Every flowsheet entry logged in the half-open window `[start, end)` (BS#2062).
+ *
+ * Distinct from `getEntriesByRange` above, which windows on `flowsheet.id`.
+ * This one windows on `add_time` and returns EVERY entry type — the
+ * show_start / show_end markers and breakpoints are exactly what let a
+ * consumer segment a day into shows, so the `entry_type = 'track'` partial
+ * index cannot serve it. Migration 0144 adds the unpartitioned
+ * `flowsheet_add_time_idx` this relies on; without it the planner falls back
+ * to a full scan of the ~1.7 GB heap.
+ *
+ * Ordered by `add_time` ASC, tie-broken on `id` ASC — NOT `play_order`, which
+ * is assigned per-show by two independent writers and therefore repeats
+ * across the many shows a window spans (ordering by it interleaves them).
+ * `id` is globally monotonic, the same reason `getEntriesByShow` ties on it
+ * after the 2026-05-01 reordering incident.
+ */
+export const getEntriesInTimeWindow = async (start: Date, end: Date): Promise<IFSEntry[]> => {
+  const raw = await db
+    .select(FSEntryFieldsRaw)
+    .from(flowsheet)
+    .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .leftJoin(library, eq(library.id, flowsheet.album_id))
+    .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+    .where(and(gte(flowsheet.add_time, start), lt(flowsheet.add_time, end)))
+    .orderBy(asc(flowsheet.add_time), asc(flowsheet.id));
+
+  return raw.map(transformToIFSEntry);
+};
+
+/**
+ * Every show overlapping the window `[start, end)` (BS#2062), ordered by
+ * `start_time` ASC.
+ *
+ * Overlap, not containment: a show that spans midnight belongs to both days.
+ * A closed show `[start_time, end_time)` intersects when it starts before the
+ * window ends and ends after the window starts.
+ *
+ * **A NULL `end_time` is not "still on the air."** It has two causes that this
+ * column cannot distinguish: the show is genuinely live, or its `show_end`
+ * delivery was dropped and the column stayed NULL permanently (nothing
+ * re-closes it on a schedule — BS#2065). Reading NULL as open-ended would make
+ * every one of those orphaned historical shows intersect every window forever,
+ * so an open-ended show is included only when its `start_time` falls inside the
+ * window. A genuinely live show satisfies that on the windows a listener
+ * actually asks for.
+ *
+ * The DJ handle is resolved through the shared `resolveShowDjName` chain with
+ * the user row LEFT JOINed in — one query for the whole window, not one per
+ * show. `user.id` is selected alongside `djName` specifically to tell "no user
+ * row" from "user row with an unusable djName"; the chain treats them
+ * differently.
+ */
+export const getShowsInTimeWindow = async (start: Date, end: Date): Promise<FlowsheetRangeShow[]> => {
+  const rows = await db
+    .select({
+      id: shows.id,
+      show_name: shows.show_name,
+      specialty_id: shows.specialty_id,
+      start_time: shows.start_time,
+      end_time: shows.end_time,
+      dj_name_override: shows.dj_name_override,
+      legacy_dj_name: shows.legacy_dj_name,
+      primary_dj_id: shows.primary_dj_id,
+      user_id: user.id,
+      user_dj_name: user.djName,
+    })
+    .from(shows)
+    .leftJoin(user, eq(user.id, shows.primary_dj_id))
+    .where(
+      or(
+        // Strict `>`: two half-open intervals [a,b) and [c,d) intersect iff
+        // a < d AND c < b, so a show that ended exactly at the window's
+        // first instant does not overlap it.
+        and(isNotNull(shows.end_time), lt(shows.start_time, end), gt(shows.end_time, start)),
+        and(isNull(shows.end_time), gte(shows.start_time, start), lt(shows.start_time, end))
+      )
+    )
+    // `id` is a deterministic tie-break for shows sharing a start_time; the
+    // contract only specifies start_time ordering, and an unstable secondary
+    // order would reshuffle between identical requests.
+    .orderBy(asc(shows.start_time), asc(shows.id));
+
+  return rows.map((row) => ({
+    id: row.id,
+    show_name: row.show_name ?? null,
+    dj_name: resolveShowDjName({
+      dj_name_override: row.dj_name_override ?? null,
+      legacy_dj_name: row.legacy_dj_name ?? null,
+      primary_dj_id: row.primary_dj_id ?? null,
+      user: row.user_id == null ? null : { djName: row.user_dj_name ?? null },
+    }),
+    specialty_id: row.specialty_id ?? null,
+    start_time: row.start_time,
+    end_time: row.end_time ?? null,
+  }));
 };
 
 export const getEntriesByShow = async (...show_ids: number[]): Promise<IFSEntry[]> => {

--- a/tests/integration/flowsheet-range.spec.js
+++ b/tests/integration/flowsheet-range.spec.js
@@ -63,15 +63,21 @@ describe('GET /flowsheet/range (BS#2062)', () => {
     // endsAtStart: ends exactly at the window's first instant — [a,b) does NOT
     //              contain b, so this must be EXCLUDED
     // openInside:  NULL end_time, starts inside  — included
-    // openBefore:  NULL end_time, starts before  — EXCLUDED (a dropped show_end
-    //              leaves end_time NULL forever; treating NULL as open-ended
-    //              would make every such show intersect every window)
+    // openBefore:  NULL end_time, starts before, NO entries in window —
+    //              EXCLUDED (a dropped show_end leaves end_time NULL forever;
+    //              treating NULL as open-ended alone would make every such
+    //              orphaned show intersect every window from then on)
+    // openOvernight: NULL end_time, starts before, HAS entries in window —
+    //              INCLUDED. The overnight show still on the air past midnight.
+    //              Neither end_time nor start_time can tell it apart from
+    //              openBefore; the entries it owns in this window can.
     // after:       starts after the window ends  — excluded
     await insertShow('spansStart', -2 * 60 * 60 * 1000, 2 * 60 * 60 * 1000, `${MARKER} spansStart`);
     await insertShow('inside', 5 * 60 * 60 * 1000, 8 * 60 * 60 * 1000, `${MARKER} inside`);
     await insertShow('endsAtStart', -3 * 60 * 60 * 1000, 0, `${MARKER} endsAtStart`);
     await insertShow('openInside', 10 * 60 * 60 * 1000, null, `${MARKER} openInside`);
     await insertShow('openBefore', -5 * 60 * 60 * 1000, null, `${MARKER} openBefore`);
+    await insertShow('openOvernight', -2 * 60 * 60 * 1000, null, `${MARKER} openOvernight`);
     await insertShow('after', DAY_MS + 60 * 60 * 1000, DAY_MS + 2 * 60 * 60 * 1000, `${MARKER} after`);
 
     const insertEntry = async (key, offsetMs, entryType, showKey, extra = {}) => {
@@ -116,6 +122,16 @@ describe('GET /flowsheet/range (BS#2062)', () => {
     // Two rows sharing an add_time, to pin the `id` ASC tie-break.
     await insertEntry('tieA', 6 * 60 * 60 * 1000, 'track', 'inside', { artist_name: 'Tie A' });
     await insertEntry('tieB', 6 * 60 * 60 * 1000, 'track', 'inside', { artist_name: 'Tie B' });
+
+    // The overnight show's post-midnight track. This row is what makes
+    // `openOvernight` distinguishable from `openBefore`, and it is why the
+    // shows query cannot be a pure start_time/end_time predicate: the entry is
+    // in the window regardless, so dropping its show breaks `show_id`.
+    await insertEntry('overnight', 30 * 60 * 1000, 'track', 'openOvernight', {
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      track_title: 'Back, Baby',
+    });
   });
 
   afterAll(async () => {
@@ -190,8 +206,46 @@ describe('GET /flowsheet/range (BS#2062)', () => {
     expect(ids).toContain(showIds.inside);
     expect(ids).toContain(showIds.openInside); // NULL end_time, starts inside
     expect(ids).not.toContain(showIds.endsAtStart); // ends exactly at window start
-    expect(ids).not.toContain(showIds.openBefore); // NULL end_time, starts before
+    expect(ids).not.toContain(showIds.openBefore); // NULL end_time, starts before, no entries here
     expect(ids).not.toContain(showIds.after);
+  });
+
+  it('includes an open-ended show that started before the window but has entries inside it', async () => {
+    // The overnight show, live past midnight. `start_time` places it in
+    // yesterday's window and `end_time` is NULL, so neither arm of the
+    // start/end overlap predicate reaches it — but its post-midnight entries
+    // ARE in this window and carry its show_id.
+    const res = await fetchWindow();
+    expect(res.body.shows.map((s) => s.id)).toContain(showIds.openOvernight);
+    expect(res.body.entries.map((e) => e.id)).toContain(entryIds.overnight);
+  });
+
+  it('never returns an entry whose show_id is absent from shows', async () => {
+    // The contract api.yaml states outright: FlowsheetRangeShow.id "matches
+    // FlowsheetRangeEntry.show_id for every entry belonging to this show", and
+    // consumers are told to "segment on show_id". An entry pointing at a show
+    // that isn't in the payload is an unresolvable id in `archive`'s grouping.
+    // Asserted over the WHOLE window, not just this spec's fixtures, so any
+    // seeded row that violates it fails here too.
+    const res = await fetchWindow();
+    const present = new Set(res.body.shows.map((s) => s.id));
+    const dangling = res.body.entries
+      .map((e) => e.show_id)
+      .filter((id) => id !== null && id !== undefined && !present.has(id));
+
+    expect([...new Set(dangling)]).toEqual([]);
+  });
+
+  it('holds the no-dangling-show_id invariant across a week-wide window too', async () => {
+    // A wider window sweeps in more shows and more dropped-show_end rows
+    // (BS#2065), which is where a start/end-only predicate fails most often.
+    const res = await fetchWindow(WINDOW_START - 3 * DAY_MS, WINDOW_START + 4 * DAY_MS);
+    const present = new Set(res.body.shows.map((s) => s.id));
+    const dangling = res.body.entries
+      .map((e) => e.show_id)
+      .filter((id) => id !== null && id !== undefined && !present.has(id));
+
+    expect([...new Set(dangling)]).toEqual([]);
   });
 
   it('orders shows by start_time ascending', async () => {
@@ -244,12 +298,15 @@ describe('GET /flowsheet/range (BS#2062)', () => {
     }
   });
 
-  it('is not shadowed by the templated routes on this router', async () => {
-    // `/range` is registered above `get('/')`; a regression that moved it
-    // below would send this to the paginated handler and 200 with the wrong
-    // shape rather than fail loudly.
+  it('answers with the range shape, not the paginated GET /flowsheet shape', async () => {
+    // NOT a shadowing test: `get('/')` matches only the exact path, so no
+    // ordering change on this router could route /range to the paginated
+    // handler. What this does pin is that the route is registered and its own
+    // handler answered — a deleted or renamed registration 404s here.
     const res = await fetchWindow();
+    expect(res.status).toBe(200);
     expect(Array.isArray(res.body.entries)).toBe(true);
+    expect(Array.isArray(res.body.shows)).toBe(true);
     expect(res.body).not.toHaveProperty('totalPages');
   });
 });

--- a/tests/integration/flowsheet-range.spec.js
+++ b/tests/integration/flowsheet-range.spec.js
@@ -1,0 +1,255 @@
+/**
+ * BS#2062 — `GET /flowsheet/range?start=&end=`, against a real database.
+ *
+ * The unit specs cover parameter validation and the pure DJ-name chain with
+ * the service mocked out. What can only be proven here is the SQL: the
+ * half-open `[start, end)` window on `add_time`, the `add_time`/`id` ordering,
+ * the show-overlap predicate (including the deliberately asymmetric treatment
+ * of a NULL `end_time`), and that an unattributed row survives the read.
+ *
+ * The window is placed in 1998 — comfortably outside anything the shared
+ * dev/CI schema seeds, and outside the fixture flowsheet rows — so the
+ * assertions can be exact ("these ids, in this order") rather than
+ * "contains". Everything this spec writes is torn down in afterAll.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+// Midnight ET on 1998-04-02 (EDT, UTC-4) and the following midnight.
+const WINDOW_START = Date.UTC(1998, 3, 2, 4, 0, 0);
+const WINDOW_END = Date.UTC(1998, 3, 3, 4, 0, 0);
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MARKER = 'BS2062 Range Probe';
+
+const at = (offsetMs) => new Date(WINDOW_START + offsetMs).toISOString();
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('GET /flowsheet/range (BS#2062)', () => {
+  let sql;
+  const showIds = {};
+  const entryIds = {};
+
+  beforeAll(async () => {
+    sql = makeSql();
+
+    const insertShow = async (key, startOffset, endOffset, legacyDjName) => {
+      const rows = await sql`
+        INSERT INTO ${sql(SCHEMA)}.shows (start_time, end_time, legacy_dj_name)
+        VALUES (
+          ${at(startOffset)}::timestamptz,
+          ${endOffset === null ? null : at(endOffset)}::timestamptz,
+          ${legacyDjName}
+        )
+        RETURNING id`;
+      showIds[key] = rows[0].id;
+    };
+
+    // inside:      wholly within the window
+    // spansStart:  begins the previous day, ends inside — overlap, not containment
+    // endsAtStart: ends exactly at the window's first instant — [a,b) does NOT
+    //              contain b, so this must be EXCLUDED
+    // openInside:  NULL end_time, starts inside  — included
+    // openBefore:  NULL end_time, starts before  — EXCLUDED (a dropped show_end
+    //              leaves end_time NULL forever; treating NULL as open-ended
+    //              would make every such show intersect every window)
+    // after:       starts after the window ends  — excluded
+    await insertShow('spansStart', -2 * 60 * 60 * 1000, 2 * 60 * 60 * 1000, `${MARKER} spansStart`);
+    await insertShow('inside', 5 * 60 * 60 * 1000, 8 * 60 * 60 * 1000, `${MARKER} inside`);
+    await insertShow('endsAtStart', -3 * 60 * 60 * 1000, 0, `${MARKER} endsAtStart`);
+    await insertShow('openInside', 10 * 60 * 60 * 1000, null, `${MARKER} openInside`);
+    await insertShow('openBefore', -5 * 60 * 60 * 1000, null, `${MARKER} openBefore`);
+    await insertShow('after', DAY_MS + 60 * 60 * 1000, DAY_MS + 2 * 60 * 60 * 1000, `${MARKER} after`);
+
+    const insertEntry = async (key, offsetMs, entryType, showKey, extra = {}) => {
+      const rows = await sql`
+        INSERT INTO ${sql(SCHEMA)}.flowsheet
+          (show_id, add_time, entry_type, artist_name, album_title, track_title, message, play_order)
+        VALUES (
+          ${showKey === null ? null : showIds[showKey]},
+          ${at(offsetMs)}::timestamptz,
+          ${entryType},
+          ${extra.artist_name ?? null},
+          ${extra.album_title ?? null},
+          ${extra.track_title ?? null},
+          ${extra.message ?? null},
+          ${extra.play_order ?? 1}
+        )
+        RETURNING id`;
+      entryIds[key] = rows[0].id;
+    };
+
+    // Boundary rows: exactly at start (INCLUDED) and exactly at end (EXCLUDED).
+    await insertEntry('atStart', 0, 'track', 'spansStart', {
+      artist_name: 'Stereolab',
+      album_title: 'Aluminum Tunes',
+      track_title: 'Pop Quiz',
+    });
+    await insertEntry('beforeStart', -1, 'track', 'spansStart', { artist_name: 'Excluded Before' });
+    await insertEntry('atEnd', DAY_MS, 'track', 'after', { artist_name: 'Excluded At End' });
+
+    // A show_start marker — the entry types the partial `entry_type='track'`
+    // index cannot serve, and the reason this endpoint needed its own index.
+    await insertEntry('marker', 60 * 1000, 'show_start', 'spansStart', { message: `${MARKER} start` });
+
+    // Unattributed row: 20 of 2.6M rows have a NULL show_id and Phase 0 decided
+    // against a backfill, so the read must return it rather than drop or crash.
+    await insertEntry('orphan', 3 * 60 * 60 * 1000, 'track', null, {
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+    });
+
+    // Two rows sharing an add_time, to pin the `id` ASC tie-break.
+    await insertEntry('tieA', 6 * 60 * 60 * 1000, 'track', 'inside', { artist_name: 'Tie A' });
+    await insertEntry('tieB', 6 * 60 * 60 * 1000, 'track', 'inside', { artist_name: 'Tie B' });
+  });
+
+  afterAll(async () => {
+    if (!sql) return;
+    // `sql.unsafe` with an explicit `$1::int[]`, matching
+    // flowsheet-deep-pagination.spec.js. A tagged-template `ANY(${ids})` does
+    // NOT reliably bind a JS array here, and a teardown that throws strands
+    // fixture rows in the shared CI schema for every later run.
+    // Flowsheet first — it FKs to shows.
+    const ids = Object.values(entryIds);
+    if (ids.length) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE id = ANY($1::int[])`, [ids]);
+    }
+    const sIds = Object.values(showIds);
+    if (sIds.length) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".shows WHERE id = ANY($1::int[])`, [sIds]);
+    }
+    await sql.end({ timeout: 5 });
+  });
+
+  const fetchWindow = (start = WINDOW_START, end = WINDOW_END) =>
+    request.get(`/flowsheet/range?start=${start}&end=${end}`);
+
+  it('is public — no Authorization header required', async () => {
+    const res = await fetchWindow();
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('shows');
+    expect(res.body).toHaveProperty('entries');
+  });
+
+  it('applies a half-open [start, end) window on add_time', async () => {
+    const res = await fetchWindow();
+    const ids = res.body.entries.map((e) => e.id);
+
+    expect(ids).toContain(entryIds.atStart); // exactly at start: included
+    expect(ids).not.toContain(entryIds.atEnd); // exactly at end: excluded
+    expect(ids).not.toContain(entryIds.beforeStart);
+  });
+
+  it('orders entries by add_time ASC, tie-broken on id ASC', async () => {
+    const res = await fetchWindow();
+    const mine = res.body.entries.filter((e) => Object.values(entryIds).includes(e.id));
+
+    const times = mine.map((e) => new Date(e.add_time).getTime());
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+
+    const tieA = mine.findIndex((e) => e.id === entryIds.tieA);
+    const tieB = mine.findIndex((e) => e.id === entryIds.tieB);
+    expect(tieA).toBeGreaterThanOrEqual(0);
+    expect(tieB).toBe(tieA + 1); // lower id first, at an identical add_time
+  });
+
+  it('returns every entry type, not just tracks', async () => {
+    const res = await fetchWindow();
+    const marker = res.body.entries.find((e) => e.id === entryIds.marker);
+    expect(marker).toBeDefined();
+    expect(marker.entry_type).toBe('show_start');
+  });
+
+  it('returns an unattributed entry with show_id null', async () => {
+    const res = await fetchWindow();
+    const orphan = res.body.entries.find((e) => e.id === entryIds.orphan);
+    expect(orphan).toBeDefined();
+    expect(orphan.show_id).toBeNull();
+  });
+
+  it('includes overlapping shows and excludes non-overlapping ones', async () => {
+    const res = await fetchWindow();
+    const ids = res.body.shows.map((s) => s.id);
+
+    expect(ids).toContain(showIds.spansStart); // starts before, ends inside
+    expect(ids).toContain(showIds.inside);
+    expect(ids).toContain(showIds.openInside); // NULL end_time, starts inside
+    expect(ids).not.toContain(showIds.endsAtStart); // ends exactly at window start
+    expect(ids).not.toContain(showIds.openBefore); // NULL end_time, starts before
+    expect(ids).not.toContain(showIds.after);
+  });
+
+  it('orders shows by start_time ascending', async () => {
+    const res = await fetchWindow();
+    const mine = res.body.shows.filter((s) => Object.values(showIds).includes(s.id));
+    const times = mine.map((s) => new Date(s.start_time).getTime());
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  it('projects shows PII-safely — public handle only, no user id or real name', async () => {
+    const res = await fetchWindow();
+    const show = res.body.shows.find((s) => s.id === showIds.inside);
+
+    expect(Object.keys(show).sort()).toEqual(['dj_name', 'end_time', 'id', 'show_name', 'specialty_id', 'start_time']);
+    expect(show.dj_name).toBe(`${MARKER} inside`); // legacy handle, the last chain link
+  });
+
+  it('returns a show spanning midnight in BOTH adjacent days', async () => {
+    const prevDay = await fetchWindow(WINDOW_START - DAY_MS, WINDOW_START);
+    const thisDay = await fetchWindow();
+
+    expect(prevDay.body.shows.map((s) => s.id)).toContain(showIds.spansStart);
+    expect(thisDay.body.shows.map((s) => s.id)).toContain(showIds.spansStart);
+  });
+
+  it('answers an empty window with 200 and empty arrays, never 404', async () => {
+    // 1996, well clear of this spec's fixtures and anything else seeded.
+    const start = Date.UTC(1996, 0, 1);
+    const res = await fetchWindow(start, start + DAY_MS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ shows: [], entries: [] });
+  });
+
+  it('400s on a malformed, inverted, or oversize window', async () => {
+    const eightDaysAndOne = 8 * DAY_MS + 1;
+    const cases = [
+      `/flowsheet/range?end=${WINDOW_END}`,
+      `/flowsheet/range?start=${WINDOW_START}`,
+      `/flowsheet/range?start=nope&end=${WINDOW_END}`,
+      `/flowsheet/range?start=${WINDOW_END}&end=${WINDOW_START}`,
+      `/flowsheet/range?start=${WINDOW_START}&end=${WINDOW_START}`,
+      `/flowsheet/range?start=${WINDOW_START}&end=${WINDOW_START + eightDaysAndOne}`,
+    ];
+
+    for (const path of cases) {
+      const res = await request.get(path);
+      expect([path, res.status]).toEqual([path, 400]);
+      expect(typeof res.body.message).toBe('string');
+    }
+  });
+
+  it('is not shadowed by the templated routes on this router', async () => {
+    // `/range` is registered above `get('/')`; a regression that moved it
+    // below would send this to the paginated handler and 200 with the wrong
+    // shape rather than fail loudly.
+    const res = await fetchWindow();
+    expect(Array.isArray(res.body.entries)).toBe(true);
+    expect(res.body).not.toHaveProperty('totalPages');
+  });
+});

--- a/tests/unit/controllers/flowsheet.range.test.ts
+++ b/tests/unit/controllers/flowsheet.range.test.ts
@@ -48,7 +48,7 @@ const makeRes = () => {
   return res;
 };
 
-const invoke = async (query: Record<string, string | undefined>) => {
+const invoke = async (query: Record<string, string | string[] | undefined>) => {
   const req = { query } as unknown as Request;
   const res = makeRes();
   const next = jest.fn();
@@ -115,6 +115,70 @@ describe('getEntriesInRange — parameter validation', () => {
   it('every 400 carries a message body', async () => {
     const { res } = await invoke({ start: 'nope', end: 'nope' });
     expect(res._body).toEqual(expect.objectContaining({ message: expect.any(String) }));
+  });
+
+  // Express 5's default ('simple') query parser yields an ARRAY for a repeated
+  // key, so `req.query.start` is not always a string despite the handler's
+  // declared type. Calling a string method on it throws synchronously, and an
+  // async handler's throw becomes a rejected promise that Express forwards to
+  // `errorHandler` — a 500 plus one Sentry capture, on an unauthenticated and
+  // unratelimited route. `searchFlowsheetEndpoint`, the sibling public read,
+  // escapes this only because `parseInt` coerces an array instead of throwing.
+  it.each([
+    ['a repeated start', { start: ['1', '2'], end: String(MIDNIGHT_ET + DAY_MS) }],
+    ['a repeated end', { start: String(MIDNIGHT_ET), end: ['1', '2'] }],
+    ['both repeated', { start: ['1', '2'], end: ['3', '4'] }],
+  ])('400s rather than throwing on %s', async (_label, query) => {
+    const { res, next } = await invoke(query);
+    expect(res._status).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  // The guard has to bound the POSTGRES timestamptz range, not the JS Date
+  // range: `new Date(8.64e15).toISOString()` is '+275760-09-13T00:00:00.000Z',
+  // an expanded-year form Postgres cannot parse. Drizzle's timestamp mapper is
+  // `value.toISOString()`, so such a value reaches the driver verbatim and the
+  // query throws — another 500 on a public route. Year 9999 ends at 2.53e14.
+  it.each([
+    ['just past the far future', 253402300800000],
+    ['the JS Date maximum', 8640000000000000],
+    ['the JS Date minimum', -8640000000000000],
+    ['before year 1', -62167219200000 - 86400000],
+  ])('400s on an epoch outside the storable range (%s)', async (_label, start) => {
+    const { res, next } = await invoke({ start: String(start), end: String(start + 1000) });
+    expect(res._status).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  it('accepts an epoch at the edges of the storable range', async () => {
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+    expect(res._status).toBe(200);
+  });
+
+  // `Number()` is deliberately used over `parseInt` (the docstring explains
+  // why), but it accepts more than the docstring's "plain integer": radix
+  // prefixes and surrounding whitespace both parse to a finite integer and
+  // would be served as a plausible-looking window instead of rejected.
+  it.each([
+    ['hex', '0x1E240'],
+    ['binary', '0b101'],
+    ['octal', '0o17'],
+    ['leading/trailing whitespace', '  1780000000000  '],
+    ['a positive sign', '+1780000000000'],
+    ['integral scientific notation', '1e12'],
+    ['Infinity', 'Infinity'],
+  ])('400s on a %s start', async (_label, start) => {
+    const { res } = await invoke({ start, end: String(MIDNIGHT_ET + DAY_MS) });
+    expect(res._status).toBe(400);
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  it('still accepts a negative epoch (pre-1970 flowsheet history is in range)', async () => {
+    const start = Date.UTC(1969, 0, 1);
+    const { res } = await invoke({ start: String(start), end: String(start + DAY_MS) });
+    expect(res._status).toBe(200);
   });
 });
 

--- a/tests/unit/controllers/flowsheet.range.test.ts
+++ b/tests/unit/controllers/flowsheet.range.test.ts
@@ -1,0 +1,215 @@
+import { Request, Response } from 'express';
+
+/**
+ * BS#2062 — `GET /flowsheet/range?start=&end=`.
+ *
+ * The public, date-windowed flowsheet read that replaces tubafrenzy's
+ * `GET /playlists/dailyEntries` at the turndown. Contract lives in
+ * `wxyc-shared/api.yaml` (`/flowsheet/range`, merged in wxyc-shared#331); the
+ * cases below are its stated 400 conditions plus the window/ordering
+ * semantics it pins.
+ */
+
+const getEntriesInTimeWindow = jest.fn();
+const getShowsInTimeWindow = jest.fn();
+const transformToV2 = jest.fn();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getEntriesInTimeWindow: (...args: unknown[]) => getEntriesInTimeWindow(...args),
+  getShowsInTimeWindow: (...args: unknown[]) => getShowsInTimeWindow(...args),
+  transformToV2: (...args: unknown[]) => transformToV2(...args),
+}));
+
+import { getEntriesInRange, MAX_RANGE_MS } from '../../../apps/backend/controllers/flowsheet.controller';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// 2026-06-01T04:00:00Z — midnight ET on a summer (EDT) date.
+const MIDNIGHT_ET = Date.UTC(2026, 5, 1, 4, 0, 0);
+
+beforeEach(() => {
+  getEntriesInTimeWindow.mockReset();
+  getShowsInTimeWindow.mockReset();
+  transformToV2.mockReset();
+  getEntriesInTimeWindow.mockResolvedValue([]);
+  getShowsInTimeWindow.mockResolvedValue([]);
+  transformToV2.mockImplementation((entry: { id: number }) => ({ id: entry.id, projected: true }));
+});
+
+const makeRes = () => {
+  const res = {} as Response & { _status: number; _body: unknown };
+  res.status = jest.fn(function (this: typeof res, code: number) {
+    this._status = code;
+    return this;
+  });
+  res.json = jest.fn(function (this: typeof res, body: unknown) {
+    this._body = body;
+    return this;
+  });
+  return res;
+};
+
+const invoke = async (query: Record<string, string | undefined>) => {
+  const req = { query } as unknown as Request;
+  const res = makeRes();
+  const next = jest.fn();
+  await getEntriesInRange(req, res, next);
+  return { res, next };
+};
+
+describe('getEntriesInRange — parameter validation', () => {
+  it.each([
+    ['both missing', {}],
+    ['start missing', { end: String(MIDNIGHT_ET + DAY_MS) }],
+    ['end missing', { start: String(MIDNIGHT_ET) }],
+  ])('400s when %s', async (_label, query) => {
+    const { res } = await invoke(query);
+    expect(res._status).toBe(400);
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['non-numeric', 'yesterday'],
+    ['empty string', ''],
+    ['a float', '1780000000000.5'],
+    ['scientific notation with a fractional value', '1.5e0'],
+    ['beyond the representable Date range', '9000000000000000'],
+  ])('400s on a %s start', async (_label, start) => {
+    const { res } = await invoke({ start, end: String(MIDNIGHT_ET + DAY_MS) });
+    expect(res._status).toBe(400);
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  it('400s when end equals start (the window is half-open, so this is empty by construction)', async () => {
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET) });
+    expect(res._status).toBe(400);
+  });
+
+  it('400s when end precedes start', async () => {
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET - 1) });
+    expect(res._status).toBe(400);
+  });
+
+  it('400s on a window wider than the 8-day ceiling', async () => {
+    const { res } = await invoke({
+      start: String(MIDNIGHT_ET),
+      end: String(MIDNIGHT_ET + MAX_RANGE_MS + 1),
+    });
+    expect(res._status).toBe(400);
+    expect(getEntriesInTimeWindow).not.toHaveBeenCalled();
+  });
+
+  it('accepts a window exactly at the ceiling', async () => {
+    const { res } = await invoke({
+      start: String(MIDNIGHT_ET),
+      end: String(MIDNIGHT_ET + MAX_RANGE_MS),
+    });
+    expect(res._status).toBe(200);
+  });
+
+  it('sets the ceiling above a DST-spanning week', () => {
+    // A 7-day window across the autumn transition is 7d + 1h. The ceiling is
+    // deliberately 8d rather than exactly 7d so that request does not 400.
+    expect(MAX_RANGE_MS).toBeGreaterThan(7 * DAY_MS + 60 * 60 * 1000);
+  });
+
+  it('every 400 carries a message body', async () => {
+    const { res } = await invoke({ start: 'nope', end: 'nope' });
+    expect(res._body).toEqual(expect.objectContaining({ message: expect.any(String) }));
+  });
+});
+
+describe('getEntriesInRange — window semantics', () => {
+  it('passes a half-open [start, end) window as Dates to the service', async () => {
+    const end = MIDNIGHT_ET + DAY_MS;
+    await invoke({ start: String(MIDNIGHT_ET), end: String(end) });
+
+    expect(getEntriesInTimeWindow).toHaveBeenCalledWith(new Date(MIDNIGHT_ET), new Date(end));
+    expect(getShowsInTimeWindow).toHaveBeenCalledWith(new Date(MIDNIGHT_ET), new Date(end));
+  });
+
+  it('serves a midnight-ET day boundary', async () => {
+    await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+    const [start, end] = getEntriesInTimeWindow.mock.calls[0];
+    expect(start.toISOString()).toBe('2026-06-01T04:00:00.000Z');
+    expect(end.toISOString()).toBe('2026-06-02T04:00:00.000Z');
+  });
+
+  it('serves a Sunday→Saturday week boundary', async () => {
+    // 2026-05-31 is a Sunday; midnight ET that day through the next Sunday.
+    const weekStart = Date.UTC(2026, 4, 31, 4, 0, 0);
+    const { res } = await invoke({ start: String(weekStart), end: String(weekStart + 7 * DAY_MS) });
+    expect(res._status).toBe(200);
+    const [start, end] = getEntriesInTimeWindow.mock.calls[0];
+    expect(new Date(start).getUTCDay()).toBe(0);
+    expect(end.getTime() - start.getTime()).toBe(7 * DAY_MS);
+  });
+});
+
+describe('getEntriesInRange — response shape', () => {
+  it('returns 200 with empty arrays for an empty window, never 404', async () => {
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ shows: [], entries: [] });
+  });
+
+  it('projects entries through the same transform GET /flowsheet uses', async () => {
+    // Field parity with GET /flowsheet is a contract requirement, not a
+    // coincidence: iOS V2 decodes both with a single decoder (api.yaml
+    // FlowsheetRangeEntry).
+    getEntriesInTimeWindow.mockResolvedValue([{ id: 11 }, { id: 12 }]);
+
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+
+    expect(transformToV2).toHaveBeenCalledTimes(2);
+    expect(res._body).toEqual({
+      shows: [],
+      entries: [
+        { id: 11, projected: true },
+        { id: 12, projected: true },
+      ],
+    });
+  });
+
+  it('returns an entry whose show_id is null rather than dropping or crashing on it', async () => {
+    // 20 of 2.6M rows are unattributed; Phase 0 decided against a backfill.
+    transformToV2.mockImplementation((e: { id: number; show_id: number | null }) => ({
+      id: e.id,
+      show_id: e.show_id,
+    }));
+    getEntriesInTimeWindow.mockResolvedValue([{ id: 7, show_id: null }]);
+
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ shows: [], entries: [{ id: 7, show_id: null }] });
+  });
+
+  it('passes shows through verbatim', async () => {
+    const show = {
+      id: 900,
+      show_name: null,
+      dj_name: 'DJ Chuquimamani',
+      specialty_id: null,
+      start_time: new Date(MIDNIGHT_ET),
+      end_time: null,
+    };
+    getShowsInTimeWindow.mockResolvedValue([show]);
+
+    const { res } = await invoke({ start: String(MIDNIGHT_ET), end: String(MIDNIGHT_ET + DAY_MS) });
+
+    expect((res._body as { shows: unknown[] }).shows).toEqual([show]);
+  });
+
+  it('forwards a service failure to next() rather than answering 200', async () => {
+    getEntriesInTimeWindow.mockRejectedValue(new Error('statement timeout'));
+
+    const { res, next } = await invoke({
+      start: String(MIDNIGHT_ET),
+      end: String(MIDNIGHT_ET + DAY_MS),
+    });
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res._status).not.toBe(200);
+  });
+});

--- a/tests/unit/services/flowsheet.range.service.test.ts
+++ b/tests/unit/services/flowsheet.range.service.test.ts
@@ -1,0 +1,84 @@
+/**
+ * BS#2062 — the pure show-projection half of `GET /flowsheet/range`.
+ *
+ * `resolveShowDjName` is the PII-safe resolution chain (BS#1371) shared by the
+ * per-show `resolveDjNameForShow` (which fetches the user row itself) and the
+ * windowed read (which joins it in, one query for the whole window rather than
+ * one per show). Extracting the decision keeps the two from drifting; these
+ * tests pin the decision, and a sibling assertion pins the delegation.
+ */
+
+import { resolveShowDjName, resolveDjDisplayName } from '../../../apps/backend/services/flowsheet.service';
+
+const chain = (over: Partial<Parameters<typeof resolveShowDjName>[0]> = {}) =>
+  resolveShowDjName({
+    dj_name_override: null,
+    legacy_dj_name: null,
+    primary_dj_id: null,
+    user: null,
+    ...over,
+  });
+
+describe('resolveShowDjName', () => {
+  it('prefers a per-show override over everything else', () => {
+    expect(
+      chain({
+        dj_name_override: 'DJ Nilüfer',
+        primary_dj_id: 'u1',
+        user: { djName: 'DJ Other' },
+        legacy_dj_name: 'legacy',
+      })
+    ).toBe('DJ Nilüfer');
+  });
+
+  it('trims the override and ignores a whitespace-only one', () => {
+    expect(chain({ dj_name_override: '  DJ Juana  ' })).toBe('DJ Juana');
+    expect(chain({ dj_name_override: '   ', legacy_dj_name: 'legacy' })).toBe('legacy');
+  });
+
+  it('falls back to the legacy handle when the show has no linked user', () => {
+    expect(chain({ primary_dj_id: null, legacy_dj_name: 'Legacy Handle' })).toBe('Legacy Handle');
+  });
+
+  it("uses the linked user's public handle", () => {
+    expect(chain({ primary_dj_id: 'u1', user: { djName: 'DJ Stereolab' } })).toBe('DJ Stereolab');
+  });
+
+  it('falls through "anonymous" to the legacy handle', () => {
+    // resolveDjDisplayName treats the literal "anonymous" as unresolvable.
+    expect(chain({ primary_dj_id: 'u1', user: { djName: 'Anonymous' }, legacy_dj_name: 'Legacy Handle' })).toBe(
+      'Legacy Handle'
+    );
+    expect(resolveDjDisplayName('Anonymous')).toBeNull();
+  });
+
+  it('returns the legacy handle UNTRIMMED when the user row is missing entirely', () => {
+    // Deliberate asymmetry carried over from resolveDjNameForShow: the
+    // missing-user branch returns `legacy` as-is, while the resolved-but-
+    // unusable-djName branch below returns `legacy.trim()`. Pinned so the
+    // batched path cannot quietly "clean it up" and change the wire.
+    expect(chain({ primary_dj_id: 'u1', user: null, legacy_dj_name: '  spacey  ' })).toBe('  spacey  ');
+  });
+
+  it('returns the legacy handle TRIMMED when the user resolves to no usable name', () => {
+    expect(chain({ primary_dj_id: 'u1', user: { djName: null }, legacy_dj_name: '  spacey  ' })).toBe('spacey');
+  });
+
+  it('returns null when nothing in the chain resolves', () => {
+    expect(chain({ primary_dj_id: 'u1', user: { djName: '  ' }, legacy_dj_name: '   ' })).toBeNull();
+    expect(chain()).toBeNull();
+  });
+
+  it('never returns a real-name column — it is not an input at all', () => {
+    // The PII guard is structural: the function's input has no real-name field,
+    // so no ordering of the chain can leak one.
+    expect(Object.keys(chain.length ? { a: 1 } : {})).toBeDefined();
+    const input = {
+      dj_name_override: null,
+      legacy_dj_name: null,
+      primary_dj_id: null,
+      user: null,
+    };
+    expect(Object.keys(input).sort()).toEqual(['dj_name_override', 'legacy_dj_name', 'primary_dj_id', 'user']);
+  });
+});


### PR DESCRIPTION
Closes #2062.

**Chained on [#2077](https://github.com/WXYC/Backend-Service/pull/2077)** (the `flowsheet.add_time` index). Based on `main` so CI runs — `test.yml` triggers only on PRs whose base is `main` — so this shows both commits until #2077 merges, then shrinks to one. **Merge #2077 first**, and run its out-of-band `CREATE INDEX CONCURRENTLY` before that: without the index this endpoint full-scans a ~1.7 GB heap per request on a public route.

## What

Backend had no date-windowed flowsheet read. `GET /flowsheet` pages by offset and `GET /flowsheet/search` is full-text with no date filter, so neither can answer "give me this day" — which is what `archive` gets from tubafrenzy's `/playlists/dailyEntries` today, and what the wxyc.org historical-archive page needs once that dies.

Implements the contract merged in [wxyc-shared#331](https://github.com/WXYC/wxyc-shared/pull/331): half-open `[start, end)` on `add_time` in epoch **milliseconds**, `{shows, entries}`, public and unauthenticated, an 8-day ceiling, and an empty window as a `200` with empty arrays rather than a `404`.

## Decisions worth reviewing

**Entries reuse `projectEntriesV2`, the same projection `GET /flowsheet` uses.** Field parity there is a contract requirement, not a coincidence — iOS V2 decodes both with a single decoder — so sharing the function buys it by construction rather than by copy.

**No `attachUpcomingShows` / `attachCriticReviews`.** They enrich the live UI, are absent from this contract, and would add two batched queries per request to a historical read that doesn't display them.

**`shows` overlaps rather than contains**, so a show spanning midnight belongs to both days. **A NULL `end_time` is not treated as open-ended**: it has two indistinguishable causes — genuinely live, or a dropped `show_end` that left the column NULL permanently ([#2065](https://github.com/WXYC/Backend-Service/issues/2065)) — and reading it as open-ended would make every orphaned historical show intersect every window forever. An open-ended show is included only when its `start_time` falls inside the window, which a genuinely live show satisfies on the windows a listener actually asks for.

**The DJ chain is extracted, not duplicated.** `resolveShowDjName` is the pure BS#1371 decision lifted out of `resolveDjNameForShow`, so the windowed read can apply it to a LEFT JOINed user row — one query for the whole window instead of one per show. Two callers, one decision, on a chain whose entire purpose is keeping a real name off a public wire. The extraction preserves the original's asymmetric legacy handling verbatim (untrimmed when the user row is missing, trimmed when the row resolves to no usable name); a test pins that so a later tidy-up can't quietly change the wire.

**Ordering is `add_time` ASC, tie-broken on `id` ASC** — never `play_order`, which two independent writers assign per-show and which therefore repeats across the many shows a window spans.

**Route registration is above `get('/')`**, alongside `/search`, and carries no `requirePermissions` (contract is `security: []`) and no `flowsheetMirror` (read-only). Deliberately outside `flowsheetConditionalGet`: that middleware's watermark is the whole-table `flowsheet_watermark`, which any live write advances, so it would invalidate a historical window that cannot have changed.

## Verification

- `npm run test:unit` — **6,944 passed**, 424 suites (31 new)
- `npm run lint` 0 errors · `npm run typecheck` pass · `npm run format:check` clean
- New: `tests/unit/controllers/flowsheet.range.test.ts` (validation, window semantics, response shape, `next()` on service failure), `tests/unit/services/flowsheet.range.service.test.ts` (the DJ chain incl. the trim asymmetry), `tests/integration/flowsheet-range.spec.js` (the AC matrix end-to-end)
- **Exercised against real Postgres, not only mocks.** A throwaway probe ran both service queries against a live database and confirmed all 11 SQL behaviours: boundary inclusion/exclusion at both ends, the `id` tie-break at an identical `add_time`, non-track entry types returned, a NULL `show_id` surviving the read, every arm of the overlap predicate (`spansStart`/`inside`/`openInside` in; `endsAtStart`/`openBefore`/`after` out), the show projection's exact key set, midnight-spanning double membership, and the empty window.

That probe earned its keep by catching two binding traps the mocked tests structurally could not: a JS `Date` in a raw `sql` template throws under this repo's overridden date serializer, and Drizzle expands a JS array in a template into a record — so neither `ANY($1)` nor `ANY($1::int[])` binds there. The second one matters beyond the probe: the integration spec's teardown now uses `sql.unsafe(..., '$1::int[]')` like `flowsheet-deep-pagination.spec.js`, because a teardown that throws strands fixture rows in the shared CI schema for every later run.

## Acceptance criteria

- [x] Live, public, `{shows, entries}` matching the merged spec
- [x] Midnight-ET day boundary; Sunday→Saturday week boundary; NULL `show_id` returned; oversize → 400; malformed/missing → 400; `start > end` → 400
- [x] Empty window → `200 {shows: [], entries: []}`, not 404
- [x] lint / typecheck / test:unit green
- [x] No migration in this PR — it ships as #2077, first

Response-shape compatibility with `archive`'s `mapTubafrenzyDailyEntry` / `groupEntriesIntoShows` is deliberately left for the repoint ticket ([archive#105](https://github.com/WXYC/archive/issues/105)) to absorb: the envelope is the `{shows, entries}` shape it already consumes, but the per-entry shape is Backend's V2 projection, not tubafrenzy's, so the mapper is where that delta belongs.

## Related

- Parent: [wiki#91](https://github.com/WXYC/wiki/issues/91) (Phase 4). Milestone: [wiki#93](https://github.com/WXYC/wiki/issues/93), deadline 2026-08-31.
- Blocks [archive#105](https://github.com/WXYC/archive/issues/105) and [website#213](https://github.com/WXYC/website/issues/213).