### PR TITLE
perf(#2080): make the rotation_bin fallback indexable

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -152,7 +152,7 @@ const FSEntryFieldsRaw = {
   rotation_id: flowsheet.rotation_id,
   // Primary source is the FK join (`leftJoin(rotation, rotation.id = flowsheet.rotation_id)`).
   // Fallback fires only when that join misses (rotation.rotation_bin IS NULL) and the entry
-  // looks like a real track with non-blank artist+album. Three match cohorts:
+  // looks like a real track with non-empty artist+album. Three match cohorts:
   //   (a) flowsheet.album_id matches an active rotation.album_id (library-linked rotation rows);
   //   (b) (artist, album) snapshot matches active rotation row's denormalized fields
   //       (library-unlinked rotation rows hold the snapshot directly);
@@ -198,21 +198,42 @@ const FSEntryFieldsRaw = {
   // result. A row matching two arms appears twice in the union, which the
   // LIMIT 1 makes harmless.
   //
-  // GUARD: `trim(coalesce(...)) <> ''`, tightened from `coalesce(...) <> ''`.
-  // This is the one deliberate behaviour change. Under the old guard an entry
-  // whose artist AND album were whitespace-only ('   ') passed, then trimmed to
-  // '' inside the subquery and matched the LEFT-JOINed NULL side of every
-  // active rotation row without a library link — returning the lowest-id one as
-  // a badge. That is a garbage badge on a garbage entry, and it is the only
-  // case where arm 3's original LEFT JOIN differed from the inner JOIN used
-  // here. Zero such rows exist in a 7-day prod sample; the tightened guard both
-  // fixes the bug and makes the inner join exactly equivalent.
+  // GUARD: unchanged — still `coalesce(col, '') <> ''`, NOT a trimmed variant.
+  //
+  // An earlier revision of BS#2080 tightened it to `trim(coalesce(col, ''))
+  // <> ''` to make arm 3's inner JOIN provably equivalent to the LEFT JOIN it
+  // replaced. That was wrong, and the way it was wrong is worth recording: the
+  // guard gates ALL THREE arms, but the whitespace argument only ever applied
+  // to arm 3. An entry with a real artist, a blank-but-non-empty album title
+  // ('   ') and a populated `album_id` matches arm 1 on `album_id` alone —
+  // arm 1 never looks at the text — so tightening a TEXT guard silently
+  // dropped a legitimate badge. Verified against the clone: album_id 36962
+  // returned 'M' under the original guard and nothing under the tightened one.
+  //
+  // Two further reasons to leave it alone. `shared/legacy-mirror`'s
+  // `isActiveRotationMatch` — the write-path twin, kept in sync at the
+  // cohort/predicate level — guards on the raw value specifically so neither
+  // side normalizes more aggressively than the other; trimming here forks that
+  // key. And PG's `trim()` strips only ASCII space, so it would not have
+  // caught the NBSP/tab cases the word "whitespace" implies anyway.
+  //
+  // What remains is one narrow difference, and it is very hard to observe. For
+  // an entry whose artist AND album both trim to '', arm 3's original LEFT JOIN
+  // matched the NULL side of every active rotation row lacking a library link;
+  // the inner JOIN below does not. But arm 2 usually reaches the same rows
+  // first: a library-LINKED rotation row carries NULL denormalized names, which
+  // `coalesce(..., '')` turns into '', so arm 2 already matches any blank entry
+  // whenever such a row is active — the common case. The divergence therefore
+  // needs a window containing a library-LESS active row with non-blank names
+  // and NO blank-named row at all. Zero such cases in a 7-day prod diff over
+  // 1,030 rows; the integration spec pins the shadowing rather than the
+  // divergence, because its fixtures cannot produce the latter either.
   rotation_bin: sql<string | null>`
     COALESCE(
       ${rotation.rotation_bin},
       CASE WHEN ${flowsheet.rotation_id} IS NULL
-        AND trim(coalesce(${flowsheet.artist_name}, '')) <> ''
-        AND trim(coalesce(${flowsheet.album_title}, '')) <> ''
+        AND coalesce(${flowsheet.artist_name}, '') <> ''
+        AND coalesce(${flowsheet.album_title}, '') <> ''
       THEN (
         SELECT t.rotation_bin FROM (
           -- (a) library-linked rotation rows, matched on album_id (album_id_idx)

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -236,10 +236,17 @@ const FSEntryFieldsRaw = {
         AND coalesce(${flowsheet.album_title}, '') <> ''
       THEN (
         SELECT t.rotation_bin FROM (
-          -- (a) library-linked rotation rows, matched on album_id (album_id_idx)
+          -- (a) library-linked rotation rows, matched on album_id (album_id_idx).
+          --     There is deliberately no "album_id IS NOT NULL" guard here:
+          --     SQL equality against NULL is NULL, never true, so a free-form
+          --     entry already matches nothing. That guard was inherited from
+          --     the OR form, where it was equally redundant. Removing it was
+          --     verified equivalent over 1,030 real rows plus a synthetic
+          --     NULL-album_id row: 0 disagreements, identical buffers.
+          --     (No backticks in this template -- they close the sql tag.)
           SELECT r2.id, r2.rotation_bin
           FROM ${rotation} r2
-          WHERE ${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id}
+          WHERE r2.album_id = ${flowsheet.album_id}
             AND r2.add_date <= ${flowsheet.add_time}::date
             AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
           UNION ALL

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -152,7 +152,7 @@ const FSEntryFieldsRaw = {
   rotation_id: flowsheet.rotation_id,
   // Primary source is the FK join (`leftJoin(rotation, rotation.id = flowsheet.rotation_id)`).
   // Fallback fires only when that join misses (rotation.rotation_bin IS NULL) and the entry
-  // looks like a real track with non-empty artist+album. Three match cohorts:
+  // looks like a real track with non-blank artist+album. Three match cohorts:
   //   (a) flowsheet.album_id matches an active rotation.album_id (library-linked rotation rows);
   //   (b) (artist, album) snapshot matches active rotation row's denormalized fields
   //       (library-unlinked rotation rows hold the snapshot directly);
@@ -166,38 +166,84 @@ const FSEntryFieldsRaw = {
   // Subquery only fires per-row on a missed FK join; on rows with a populated rotation_id
   // COALESCE short-circuits and the subquery is not evaluated.
   //
-  // Tie-break (`ORDER BY r2.id`): the schema source comment at `rotation` explicitly
+  // Tie-break (`ORDER BY t.id` over the union): the schema source comment at `rotation` explicitly
   // permits multiple active rows per (album_id, rotation_bin) over an album's lifecycle
   // (re-bins, re-adds, label-driven re-promotes). Picking the lowest `id` (oldest active
   // row) is a deliberate, stable choice for the badge UX — when an album has been re-binned
   // L → M, the badge reports its original cohort rather than flipping retroactively. This
   // matches the historical-correctness story above (add_date/kill_date window filtered against add_time).
   // The primary FK join via flowsheet.rotation_id remains canonical when present.
+  //
+  // SHAPE (BS#2080): the three match cohorts are a UNION ALL of three
+  // separately-indexable probes, NOT an OR over one joined set. They were an
+  // OR until the range read (BS#2062) made the per-row cost visible. Because
+  // the OR spanned three tables, no index on any one of them could serve it —
+  // the planner had to materialize the whole rotation-library-artists join and
+  // filter afterwards, at 239 buffers and ~11.7ms cold per row. Prod response
+  // time on `GET /flowsheet/range` fit `1.125s + 19.0ms * n_fallback`
+  // (R^2=0.957) and the 7-day window (1,030 fallbacks, ~20.7s predicted) blew
+  // the 5s statement timeout outright. Over those same 1,030 rows:
+  // 224,554 buffers / 1,317.8ms -> 12,509 buffers / 4.6ms. Every arm is now an
+  // index scan. Verified equivalent, not assumed: both forms run over all
+  // 1,030 rows produced zero disagreements.
+  //
+  // Do not fold these arms back into an OR for readability. The three indexes
+  // (migration 0145) only apply per-arm, and the OR form cannot use them.
+  // Likewise, keep each arm's expression character-for-character identical to
+  // its index — `lower(trim(coalesce(col, '')))` — or the planner silently
+  // reverts to the seq scan this shape exists to avoid.
+  //
+  // ORDER BY over the union is `t.id`, preserving the original's `ORDER BY
+  // r2.id LIMIT 1`: lowest matching rotation id wins, same tie-break, same
+  // result. A row matching two arms appears twice in the union, which the
+  // LIMIT 1 makes harmless.
+  //
+  // GUARD: `trim(coalesce(...)) <> ''`, tightened from `coalesce(...) <> ''`.
+  // This is the one deliberate behaviour change. Under the old guard an entry
+  // whose artist AND album were whitespace-only ('   ') passed, then trimmed to
+  // '' inside the subquery and matched the LEFT-JOINed NULL side of every
+  // active rotation row without a library link — returning the lowest-id one as
+  // a badge. That is a garbage badge on a garbage entry, and it is the only
+  // case where arm 3's original LEFT JOIN differed from the inner JOIN used
+  // here. Zero such rows exist in a 7-day prod sample; the tightened guard both
+  // fixes the bug and makes the inner join exactly equivalent.
   rotation_bin: sql<string | null>`
     COALESCE(
       ${rotation.rotation_bin},
       CASE WHEN ${flowsheet.rotation_id} IS NULL
-        AND coalesce(${flowsheet.artist_name}, '') <> ''
-        AND coalesce(${flowsheet.album_title}, '') <> ''
+        AND trim(coalesce(${flowsheet.artist_name}, '')) <> ''
+        AND trim(coalesce(${flowsheet.album_title}, '')) <> ''
       THEN (
-        SELECT r2.rotation_bin
-        FROM ${rotation} r2
-        LEFT JOIN ${library} l2 ON l2.id = r2.album_id
-        LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
-        WHERE r2.add_date <= ${flowsheet.add_time}::date
-          AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
-          AND (
-            (${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id})
-            OR (
-              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
-              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
-            )
-            OR (
-              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
-              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
-            )
-          )
-        ORDER BY r2.id
+        SELECT t.rotation_bin FROM (
+          -- (a) library-linked rotation rows, matched on album_id (album_id_idx)
+          SELECT r2.id, r2.rotation_bin
+          FROM ${rotation} r2
+          WHERE ${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id}
+            AND r2.add_date <= ${flowsheet.add_time}::date
+            AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
+          UNION ALL
+          -- (b) library-unlinked rotation rows holding the (artist, album)
+          --     snapshot directly (rotation_norm_artist_album_idx)
+          SELECT r2.id, r2.rotation_bin
+          FROM ${rotation} r2
+          WHERE lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
+            AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
+            AND r2.add_date <= ${flowsheet.add_time}::date
+            AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
+          UNION ALL
+          -- (c) library-linked rotation rows whose denorm fields are NULL, so
+          --     the names come from the library+artists join
+          --     (library_norm_album_title_idx -> album_id_idx -> artists_norm_name_idx)
+          SELECT r2.id, r2.rotation_bin
+          FROM ${rotation} r2
+          JOIN ${library} l2 ON l2.id = r2.album_id
+          JOIN ${artists} a2 ON a2.id = l2.artist_id
+          WHERE lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
+            AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
+            AND r2.add_date <= ${flowsheet.add_time}::date
+            AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
+        ) t
+        ORDER BY t.id
         LIMIT 1
       )
       END

--- a/shared/database/src/migrations/0145_rotation-bin-fallback-indexes.sql
+++ b/shared/database/src/migrations/0145_rotation-bin-fallback-indexes.sql
@@ -1,0 +1,86 @@
+-- BS#2080. Three expression indexes that make the `rotation_bin` fallback
+-- subquery in `FSEntryFieldsRaw` (apps/backend/services/flowsheet.service.ts)
+-- indexable. Ships together with the rewrite of that subquery from a
+-- three-armed `OR` into a `UNION ALL` of three separately-indexable probes —
+-- the indexes are useless without the rewrite, and the rewrite is pointless
+-- without the indexes.
+--
+-- The problem. That fallback fires once per flowsheet row whose `rotation_id`
+-- is NULL and whose artist+album are non-empty, and its predicate ORs three
+-- arms together across THREE tables (`rotation`, `library`, `artists`). Because
+-- the OR spans tables, no index on any one of them can serve it: the planner
+-- has to materialize the whole rotation-library-artists join and filter it
+-- afterwards. Measured against the prod-shaped clone fixture (rotation=21,563,
+-- library=64,193, artists=24,078) that is 239 buffers and ~11.7 ms cold PER
+-- ROW, with a 21,563-row seq scan of `rotation` inside it.
+--
+-- What it cost. `GET /flowsheet/range` (BS#2062) reads a whole window rather
+-- than a page, so the per-row cost multiplies. Measured on prod across seven
+-- consecutive 24h windows, response time is almost perfectly linear in the
+-- number of rows that take the fallback and only loosely related to the number
+-- of entries returned:
+--
+--     time = 1.125s + 19.0ms * n_fallback     (R^2 = 0.957)
+--     (fit against total entry count instead: R^2 = 0.877)
+--
+-- A 24h window runs 91-191 fallbacks (3.0-4.8 s observed). The 7-day window
+-- that wxyc.org's historical-archive page needs runs 1,030 — a predicted
+-- ~20.7 s against a 5 s `DB_STATEMENT_TIMEOUT_MS`, which is exactly the HTTP
+-- 500 that endpoint answers today. Seven separate daily calls covering the same
+-- span summed to 27.5 s of real work, corroborating the fit.
+--
+-- The yield of all that work is small: over those seven days, 1,030 fallback
+-- executions produced 19 badges.
+--
+-- Measured over all 1,030 real prod fallback rows against the clone fixture:
+--
+--   three-armed OR, no indexes:   224,554 buffers,  1,317.8 ms
+--   UNION ALL + these indexes:     12,509 buffers,      4.6 ms
+--
+-- Every arm becomes an index scan and the `rotation` seq scan disappears. The
+-- buffer count is the durable part — prod is a `db.t3.micro` with 1 GiB of RAM,
+-- so 224,554 buffers (~1.75 GB of touches) cannot stay resident and pays close
+-- to the cold cost on every row, which is why prod's 19.0 ms/row tracks the
+-- measured cold 11.7 ms rather than the warm 0.79 ms.
+--
+-- Equivalence was verified, not assumed: both forms were run over all 1,030
+-- rows and the results diffed. Zero disagreements, and identical badge
+-- distributions (1,011 null / 7 H / 6 M / 3 L / 3 S). See the subquery's own
+-- comment for the one deliberate behaviour change that accompanies this (the
+-- whitespace-only artist/album guard).
+--
+-- Why single-column rather than composite. This is the shape that was
+-- benchmarked: the planner drives arm 3 from `library_norm_album_title_idx`
+-- (~1.75 rows per probe) into the existing `album_id_idx` on `rotation`, and
+-- applies `artists_norm_name_idx` last as a filter on the few survivors. All
+-- three tables are small (21k-64k rows) so each index is a couple of MB, and
+-- none of them takes meaningful write traffic — `rotation` changes when the MD
+-- re-bins, `library` when the librarian files a release.
+--
+-- Production ops:
+--   - These are NOT the CONCURRENTLY form, because Drizzle wraps each migration
+--     file in a transaction and `CREATE INDEX CONCURRENTLY cannot run inside a
+--     transaction block` — same constraint as 0144, 0139, 0080, 0078, 0074,
+--     0070, 0068, 0057.
+--   - Run out-of-band on prod FIRST. These are the generated statements below,
+--     verbatim, with CONCURRENTLY added — the index expression must match the
+--     query character-for-character, so do not reformat them:
+--       CREATE INDEX CONCURRENTLY IF NOT EXISTS "artists_norm_name_idx" ON "wxyc_schema"."artists" USING btree (lower(trim(coalesce("artist_name", ''))));
+--       CREATE INDEX CONCURRENTLY IF NOT EXISTS "library_norm_album_title_idx" ON "wxyc_schema"."library" USING btree (lower(trim(coalesce("album_title", ''))));
+--       CREATE INDEX CONCURRENTLY IF NOT EXISTS "rotation_norm_artist_album_idx" ON "wxyc_schema"."rotation" USING btree (lower(trim(coalesce("artist_name", ''))),lower(trim(coalesce("album_title", ''))));
+--     No AccessExclusiveLock, so no write pause on any of the three. All are
+--     small tables; expect seconds, not minutes. Then ANALYZE each — a fresh
+--     expression index has no stats until then, and the planner will not choose
+--     an arm it cannot cost:
+--       ANALYZE "wxyc_schema"."artists"; ANALYZE "wxyc_schema"."library"; ANALYZE "wxyc_schema"."rotation";
+--   - Then merge this PR. `IF NOT EXISTS` makes the migration a no-op against
+--     the prod DB where the indexes already exist, while fresh dev and CI
+--     databases pick them up on first migrate.
+--   - Order matters in the other direction too: merging the service rewrite
+--     WITHOUT these indexes present is a pessimisation, not a no-op — the
+--     UNION ALL form without index support seq-scans `rotation` three times per
+--     row instead of once. Build the indexes first.
+
+CREATE INDEX IF NOT EXISTS "artists_norm_name_idx" ON "wxyc_schema"."artists" USING btree (lower(trim(coalesce("artist_name", ''))));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "library_norm_album_title_idx" ON "wxyc_schema"."library" USING btree (lower(trim(coalesce("album_title", ''))));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "rotation_norm_artist_album_idx" ON "wxyc_schema"."rotation" USING btree (lower(trim(coalesce("artist_name", ''))),lower(trim(coalesce("album_title", ''))));

--- a/shared/database/src/migrations/0145_rotation-bin-fallback-indexes.sql
+++ b/shared/database/src/migrations/0145_rotation-bin-fallback-indexes.sql
@@ -1,9 +1,9 @@
--- BS#2080. Three expression indexes that make the `rotation_bin` fallback
+-- BS#2080. Two expression indexes that make the `rotation_bin` fallback
 -- subquery in `FSEntryFieldsRaw` (apps/backend/services/flowsheet.service.ts)
 -- indexable. Ships together with the rewrite of that subquery from a
 -- three-armed `OR` into a `UNION ALL` of three separately-indexable probes —
--- the indexes are useless without the rewrite, and the rewrite is pointless
--- without the indexes.
+-- the indexes are useless without the rewrite, and the rewrite is a
+-- PESSIMISATION without the indexes (see "Deploy order" below).
 --
 -- The problem. That fallback fires once per flowsheet row whose `rotation_id`
 -- is NULL and whose artist+album are non-empty, and its predicate ORs three
@@ -16,18 +16,15 @@
 --
 -- What it cost. `GET /flowsheet/range` (BS#2062) reads a whole window rather
 -- than a page, so the per-row cost multiplies. Measured on prod across seven
--- consecutive 24h windows, response time is almost perfectly linear in the
--- number of rows that take the fallback and only loosely related to the number
--- of entries returned:
+-- consecutive 24h windows:
 --
---     time = 1.125s + 19.0ms * n_fallback     (R^2 = 0.957)
---     (fit against total entry count instead: R^2 = 0.877)
+--     time = 1.080s + 17.43ms * n_fallback + 0.86ms * n_entries   (R^2 = 0.958)
 --
 -- A 24h window runs 91-191 fallbacks (3.0-4.8 s observed). The 7-day window
--- that wxyc.org's historical-archive page needs runs 1,030 — a predicted
--- ~20.7 s against a 5 s `DB_STATEMENT_TIMEOUT_MS`, which is exactly the HTTP
--- 500 that endpoint answers today. Seven separate daily calls covering the same
--- span summed to 27.5 s of real work, corroborating the fit.
+-- that wxyc.org's historical-archive page needs runs 1,030 over 2,243 entries
+-- — ~21 s predicted against a 5 s `DB_STATEMENT_TIMEOUT_MS`, which is exactly
+-- the HTTP 500 that endpoint answers today. Seven separate daily calls
+-- covering the same span summed to 27.5 s of real work, corroborating the fit.
 --
 -- The yield of all that work is small: over those seven days, 1,030 fallback
 -- executions produced 19 badges.
@@ -35,52 +32,75 @@
 -- Measured over all 1,030 real prod fallback rows against the clone fixture:
 --
 --   three-armed OR, no indexes:   224,554 buffers,  1,317.8 ms
---   UNION ALL + these indexes:     12,509 buffers,      4.6 ms
+--   UNION ALL + these indexes:     12,514 buffers,      7.0 ms
 --
 -- Every arm becomes an index scan and the `rotation` seq scan disappears. The
 -- buffer count is the durable part — prod is a `db.t3.micro` with 1 GiB of RAM,
 -- so 224,554 buffers (~1.75 GB of touches) cannot stay resident and pays close
--- to the cold cost on every row, which is why prod's 19.0 ms/row tracks the
+-- to the cold cost on every row, which is why prod's ~17-19 ms/row tracks the
 -- measured cold 11.7 ms rather than the warm 0.79 ms.
+--
+-- NOTE the residual: the `0.86ms * n_entries` term is untouched by this change
+-- (three outer LEFT JOINs, transform, projection, serialization, transfer). At
+-- 2,243 entries that is ~1.9 s, so the fixed 7-day window is expected around
+-- 3 s wall-clock, not ~1 s. It clears the timeout — which bounds SQL time, not
+-- transfer — but the margin is smaller than the buffer numbers alone suggest.
+-- Re-measure the seven windows after deploy rather than assuming.
 --
 -- Equivalence was verified, not assumed: both forms were run over all 1,030
 -- rows and the results diffed. Zero disagreements, and identical badge
--- distributions (1,011 null / 7 H / 6 M / 3 L / 3 S). See the subquery's own
--- comment for the one deliberate behaviour change that accompanies this (the
--- whitespace-only artist/album guard).
+-- distributions (1,011 null / 7 H / 6 M / 3 L / 3 S). Arm 3's LEFT JOINs become
+-- inner JOINs, which is what makes it indexable; the only entries that can tell
+-- the difference are those whose artist AND album both trim to '', and arm 2
+-- already matches those through any library-linked rotation row (NULL denorm
+-- names coalesce to ''). See the subquery's own comment.
 --
--- Why single-column rather than composite. This is the shape that was
--- benchmarked: the planner drives arm 3 from `library_norm_album_title_idx`
--- (~1.75 rows per probe) into the existing `album_id_idx` on `rotation`, and
--- applies `artists_norm_name_idx` last as a filter on the few survivors. All
--- three tables are small (21k-64k rows) so each index is a couple of MB, and
--- none of them takes meaningful write traffic — `rotation` changes when the MD
--- re-bins, `library` when the librarian files a release.
+-- Why only TWO indexes for three arms. Arm 1 is already served by the existing
+-- `album_id_idx` on `rotation`. Arm 3 tests `lower(trim(coalesce(a2.artist_name,
+-- '')))` but gets NO index for it: the planner drives arm 3 from
+-- `library_norm_album_title_idx` into `album_id_idx`, so it reaches `artists`
+-- already holding `l2.artist_id` and probes `artists_pkey`, applying the name
+-- as a filter on ~10 surviving rows. Adding the matching expression index
+-- measured slightly WORSE (8.88 ms vs 7.02 ms, buffers unchanged) and would
+-- have been a fourth artist-name index named one character class away from
+-- `artists_normalized_name_idx` (0092) and `artists_fold_name_idx` (0134).
+--
+-- Write cost, stated honestly. `library` is bulk-written every 30 minutes by
+-- library-etl's import, plus `library-artist-name-backfill` and
+-- `library-artwork-url-backfill`; each row already recomputes a STORED
+-- GENERATED `search_doc` tsvector, and this adds one more btree to maintain.
+-- `rotation` is written by the MD's re-bins and by rotation-etl. Both indexes
+-- are small (21k / 64k rows, a couple of MB each), but "no meaningful write
+-- traffic" would be wrong.
 --
 -- Production ops:
 --   - These are NOT the CONCURRENTLY form, because Drizzle wraps each migration
 --     file in a transaction and `CREATE INDEX CONCURRENTLY cannot run inside a
 --     transaction block` — same constraint as 0144, 0139, 0080, 0078, 0074,
---     0070, 0068, 0057.
+--     0070, 0068, 0057. The plain `CREATE INDEX` below takes a SHARE lock that
+--     BLOCKS INSERT/UPDATE/DELETE on each table for the duration of its build.
+--     Brief at 21k-64k rows, but it is what runs in CI, on fresh dev databases,
+--     and on prod if the out-of-band pre-build is skipped.
 --   - Run out-of-band on prod FIRST. These are the generated statements below,
 --     verbatim, with CONCURRENTLY added — the index expression must match the
 --     query character-for-character, so do not reformat them:
---       CREATE INDEX CONCURRENTLY IF NOT EXISTS "artists_norm_name_idx" ON "wxyc_schema"."artists" USING btree (lower(trim(coalesce("artist_name", ''))));
 --       CREATE INDEX CONCURRENTLY IF NOT EXISTS "library_norm_album_title_idx" ON "wxyc_schema"."library" USING btree (lower(trim(coalesce("album_title", ''))));
 --       CREATE INDEX CONCURRENTLY IF NOT EXISTS "rotation_norm_artist_album_idx" ON "wxyc_schema"."rotation" USING btree (lower(trim(coalesce("artist_name", ''))),lower(trim(coalesce("album_title", ''))));
---     No AccessExclusiveLock, so no write pause on any of the three. All are
---     small tables; expect seconds, not minutes. Then ANALYZE each — a fresh
---     expression index has no stats until then, and the planner will not choose
---     an arm it cannot cost:
---       ANALYZE "wxyc_schema"."artists"; ANALYZE "wxyc_schema"."library"; ANALYZE "wxyc_schema"."rotation";
---   - Then merge this PR. `IF NOT EXISTS` makes the migration a no-op against
---     the prod DB where the indexes already exist, while fresh dev and CI
---     databases pick them up on first migrate.
---   - Order matters in the other direction too: merging the service rewrite
---     WITHOUT these indexes present is a pessimisation, not a no-op — the
---     UNION ALL form without index support seq-scans `rotation` three times per
---     row instead of once. Build the indexes first.
+--     No AccessExclusiveLock and no SHARE lock, so no write pause on either.
+--   - THEN ANALYZE. This step is not optional and nothing in the deploy
+--     pipeline does it for you: a fresh expression index carries NO statistics
+--     for its expression until ANALYZE runs, and the header above is only true
+--     of a planner that can cost these arms. `ANALYZE` cannot live in this file
+--     (Drizzle wraps migrations in a transaction; see the DDL-only and
+--     post-bulk-update-analyze rules in docs/migrations.md), so it is a
+--     deploy-checklist item:
+--       ANALYZE "wxyc_schema"."library"; ANALYZE "wxyc_schema"."rotation";
+--     Autovacuum will eventually do it, but "eventually" here means the window
+--     in which the rewrite runs three index-less probes per row instead of one
+--     seq scan — strictly worse than before this PR.
+--   - Then merge. `IF NOT EXISTS` makes the migration a no-op against the prod
+--     DB where the indexes already exist, while fresh dev and CI databases pick
+--     them up on first migrate.
 
-CREATE INDEX IF NOT EXISTS "artists_norm_name_idx" ON "wxyc_schema"."artists" USING btree (lower(trim(coalesce("artist_name", ''))));--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "library_norm_album_title_idx" ON "wxyc_schema"."library" USING btree (lower(trim(coalesce("album_title", ''))));--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "rotation_norm_artist_album_idx" ON "wxyc_schema"."rotation" USING btree (lower(trim(coalesce("artist_name", ''))),lower(trim(coalesce("album_title", ''))));

--- a/shared/database/src/migrations/meta/0145_snapshot.json
+++ b/shared/database/src/migrations/meta/0145_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "2f5f3256-092d-4ef6-853a-f8135a6586a7",
+  "id": "07b10ddd-5e19-4890-b6f8-919911f3e5de",
   "prevId": "7ba1c120-f5b6-462b-bb76-37cdc7282266",
   "version": "7",
   "dialect": "postgresql",
@@ -1328,21 +1328,6 @@
               "expression": "code_letters",
               "isExpression": false,
               "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "artists_norm_name_idx": {
-          "name": "artists_norm_name_idx",
-          "columns": [
-            {
-              "expression": "lower(trim(coalesce(\"artist_name\", '')))",
-              "asc": true,
-              "isExpression": true,
               "nulls": "last"
             }
           ],

--- a/shared/database/src/migrations/meta/0145_snapshot.json
+++ b/shared/database/src/migrations/meta/0145_snapshot.json
@@ -1,0 +1,6447 @@
+{
+  "id": "2f5f3256-092d-4ef6-853a-f8135a6586a7",
+  "prevId": "7ba1c120-f5b6-462b-bb76-37cdc7282266",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_status": {
+          "name": "spotify_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_status": {
+          "name": "apple_music_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_status": {
+          "name": "bandcamp_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_reask_attempts": {
+          "name": "streaming_reask_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_norm_name_idx": {
+          "name": "artists_norm_name_idx",
+          "columns": [
+            {
+              "expression": "lower(trim(coalesce(\"artist_name\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_id": {
+          "name": "track_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_link_confidence": {
+          "name": "track_artist_link_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_link_method": {
+          "name": "track_artist_link_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_track_artist_id_idx": {
+          "name": "cta_track_artist_id_idx",
+          "columns": [
+            {
+              "expression": "track_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_trgm_idx": {
+          "name": "cta_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "cta_track_title_trgm_idx": {
+          "name": "cta_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compilation_track_artist_track_artist_id_artists_id_fk": {
+          "name": "compilation_track_artist_track_artist_id_artists_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "track_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cta_track_artist_link_confidence_range": {
+          "name": "cta_track_artist_link_confidence_range",
+          "value": "\"wxyc_schema\".\"compilation_track_artist\".\"track_artist_link_confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concert_performers": {
+      "name": "concert_performers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "concert_id": {
+          "name": "concert_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "concert_performer_role_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id_source": {
+          "name": "discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concert_performers_concert_role_raw_name_idx": {
+          "name": "concert_performers_concert_role_raw_name_idx",
+          "columns": [
+            {
+              "expression": "concert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concert_performers_concert_id_concerts_id_fk": {
+          "name": "concert_performers_concert_id_concerts_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "concerts",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "concert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "concert_performers_artist_id_artists_id_fk": {
+          "name": "concert_performers_artist_id_artists_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "has_resolved_support": {
+          "name": "has_resolved_support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"has_resolved_support\") AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_add_time_idx": {
+          "name": "flowsheet_add_time_idx",
+          "columns": [
+            {
+              "expression": "add_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_linked_idx": {
+          "name": "flowsheet_album_id_linked_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metadata_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_rotation_no_match_idx": {
+          "name": "flowsheet_rotation_no_match_idx",
+          "columns": [
+            {
+              "expression": "rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriched_no_match' AND \"wxyc_schema\".\"flowsheet\".\"rotation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('\"wxyc_schema\".\"library_legacy_release_id_seq\"'::regclass)"
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unresolved_attempted_at": {
+          "name": "unresolved_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_norm_album_title_idx": {
+          "name": "library_norm_album_title_idx",
+          "columns": [
+            {
+              "expression": "lower(trim(coalesce(\"album_title\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "discogs_release_id_resolve_attempted_at": {
+          "name": "discogs_release_id_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_norm_artist_album_idx": {
+          "name": "rotation_norm_artist_album_idx",
+          "columns": [
+            {
+              "expression": "lower(trim(coalesce(\"artist_name\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(trim(coalesce(\"album_title\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.slack_ban_moderators": {
+      "name": "slack_ban_moderators",
+      "schema": "wxyc_schema",
+      "columns": {
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by_slack_user_id": {
+          "name": "added_by_slack_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_ban_moderators_slack_user_id_upper_ck": {
+          "name": "slack_ban_moderators_slack_user_id_upper_ck",
+          "value": "\"wxyc_schema\".\"slack_ban_moderators\".\"slack_user_id\" ~ '^[A-Z0-9]+$'"
+        },
+        "slack_ban_moderators_added_by_upper_ck": {
+          "name": "slack_ban_moderators_added_by_upper_ck",
+          "value": "\"wxyc_schema\".\"slack_ban_moderators\".\"added_by_slack_user_id\" IS NULL OR \"wxyc_schema\".\"slack_ban_moderators\".\"added_by_slack_user_id\" ~ '^[A-Z0-9]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_performer_role_enum": {
+      "name": "concert_performer_role_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "headliner",
+        "support"
+      ]
+    },
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {
+    "wxyc_schema.library_legacy_release_id_seq": {
+      "name": "library_legacy_release_id_seq",
+      "schema": "wxyc_schema",
+      "increment": "1",
+      "startWith": "1000000",
+      "minValue": "1000000",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\", \"wxyc_schema\".\"library\".\"discogs_unavailable\", \"wxyc_schema\".\"library\".\"discogs_unavailable_note\", \"wxyc_schema\".\"library\".\"last_discogs_recheck_at\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -995,6 +995,13 @@
       "when": 1786313097779,
       "tag": "0144_flowsheet-add-time-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 145,
+      "version": "7",
+      "when": 1786339686965,
+      "tag": "0145_rotation-bin-fallback-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -999,7 +999,7 @@
     {
       "idx": 145,
       "version": "7",
-      "when": 1786339686965,
+      "when": 1786372066223,
       "tag": "0145_rotation-bin-fallback-indexes",
       "breakpoints": true
     }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -141,5 +141,5 @@
   "0142_narrow-library-watermark-trigger": "462abe5dbbaab29f1f0e901cf244deeabe604760cbc28627cbf07fc7c52ff9d0",
   "0143_narrow-cta-watermark-trigger": "50d4e5fd1134da1cc3f57fb3df746014a6db7182074021232f8766c92e3eba86",
   "0144_flowsheet-add-time-idx": "5805f393f402dc3ad9c9d5090d43fa4a5b7c76a4a55ab00be76cb4fe555559a0",
-  "0145_rotation-bin-fallback-indexes": "ae8e1b5ab5d07cd3af365ac816c772b12d9cf781a002337f01ffbe0dacd2a3d0"
+  "0145_rotation-bin-fallback-indexes": "c8ba65bc316f0629119be1b740ba6a896de5db2b243f61b9b32ea102d62e140d"
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -140,5 +140,6 @@
   "0141_slack-ban-moderators": "3312d34a2e6447fb00033f52ede6a38d397bb9c6b7ae5618764ecd510d36fef2",
   "0142_narrow-library-watermark-trigger": "462abe5dbbaab29f1f0e901cf244deeabe604760cbc28627cbf07fc7c52ff9d0",
   "0143_narrow-cta-watermark-trigger": "50d4e5fd1134da1cc3f57fb3df746014a6db7182074021232f8766c92e3eba86",
-  "0144_flowsheet-add-time-idx": "5805f393f402dc3ad9c9d5090d43fa4a5b7c76a4a55ab00be76cb4fe555559a0"
+  "0144_flowsheet-add-time-idx": "5805f393f402dc3ad9c9d5090d43fa4a5b7c76a4a55ab00be76cb4fe555559a0",
+  "0145_rotation-bin-fallback-indexes": "ae8e1b5ab5d07cd3af365ac816c772b12d9cf781a002337f01ffbe0dacd2a3d0"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -471,6 +471,15 @@ export const artists = wxyc_schema.table(
     return {
       artistNameTrgmIdx: index('artist_name_trgm_idx').using(`gin`, sql`${table.artist_name} gin_trgm_ops`),
       codeLettersIdx: index('code_letters_idx').on(table.code_letters),
+      // BS#2080. Serves arm 3 of the `rotation_bin` fallback in
+      // `FSEntryFieldsRaw` — the library-linked match, where the rotation row's
+      // own denormalized fields are NULL and the artist name has to come from
+      // the `library -> artists` join. Distinct from `artist_name_trgm_idx`
+      // above: that one is a GIN trigram index for fuzzy search, this is a
+      // B-tree on an exact normalized equality. Also distinct from migration
+      // 0134's `fold_artist_name()` (NFC/ASCII folding, BS#1897) — this is
+      // plain `lower(trim(...))`, matching the query verbatim.
+      normNameIdx: index('artists_norm_name_idx').on(sql`lower(trim(coalesce(${table.artist_name}, '')))`),
     };
   }
 );
@@ -628,6 +637,12 @@ export const library = wxyc_schema.table(
   (table) => {
     return {
       titleTrgmIdx: index('title_trgm_idx').using(`gin`, sql`${table.album_title} gin_trgm_ops`),
+      // BS#2080. The entry point for arm 3 of the `rotation_bin` fallback in
+      // `FSEntryFieldsRaw`: the planner drives from this index (~1.75 rows per
+      // probe) into the existing `album_id_idx` on `rotation`, then applies
+      // `artists_norm_name_idx` as a filter on the survivors. B-tree exact
+      // equality, as against `title_trgm_idx` above (GIN, fuzzy search).
+      normAlbumTitleIdx: index('library_norm_album_title_idx').on(sql`lower(trim(coalesce(${table.album_title}, '')))`),
       genreIdIdx: index('genre_id_idx').on(table.genre_id),
       formatIdIdx: index('format_id_idx').on(table.format_id),
       artistIdIdx: index('artist_id_idx').on(table.artist_id),
@@ -967,6 +982,15 @@ export const rotation = wxyc_schema.table(
   (table) => {
     return {
       albumIdIdx: index('album_id_idx').on(table.album_id),
+      // BS#2080. Serves arm 2 of the `rotation_bin` fallback in
+      // `FSEntryFieldsRaw` — the denormalized (artist, album) snapshot match
+      // for library-unlinked rotation rows. The expression must stay
+      // character-for-character identical to the one in the query or the
+      // planner silently ignores the index and reverts to a seq scan.
+      normArtistAlbumIdx: index('rotation_norm_artist_album_idx').on(
+        sql`lower(trim(coalesce(${table.artist_name}, '')))`,
+        sql`lower(trim(coalesce(${table.album_title}, '')))`
+      ),
       // legacy_rotation_id is the surrogate key tubafrenzy assigns each
       // rotation row; one row per legacy_rotation_id by tubafrenzy's invariant.
       // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -471,15 +471,22 @@ export const artists = wxyc_schema.table(
     return {
       artistNameTrgmIdx: index('artist_name_trgm_idx').using(`gin`, sql`${table.artist_name} gin_trgm_ops`),
       codeLettersIdx: index('code_letters_idx').on(table.code_letters),
-      // BS#2080. Serves arm 3 of the `rotation_bin` fallback in
-      // `FSEntryFieldsRaw` — the library-linked match, where the rotation row's
-      // own denormalized fields are NULL and the artist name has to come from
-      // the `library -> artists` join. Distinct from `artist_name_trgm_idx`
-      // above: that one is a GIN trigram index for fuzzy search, this is a
-      // B-tree on an exact normalized equality. Also distinct from migration
-      // 0134's `fold_artist_name()` (NFC/ASCII folding, BS#1897) — this is
-      // plain `lower(trim(...))`, matching the query verbatim.
-      normNameIdx: index('artists_norm_name_idx').on(sql`lower(trim(coalesce(${table.artist_name}, '')))`),
+      // BS#2080 deliberately did NOT add a `lower(trim(coalesce(artist_name,
+      // '')))` index here, though arm 3 of the `rotation_bin` fallback in
+      // `FSEntryFieldsRaw` tests exactly that expression. Measured over 1,030
+      // real fallback rows: the planner drives arm 3 from
+      // `library_norm_album_title_idx` into `album_id_idx`, so by the time it
+      // reaches `artists` it already has `l2.artist_id` and probes
+      // `artists_pkey`, applying the name as a filter on ~10 surviving rows.
+      // Adding the expression index made it slightly WORSE (8.88ms vs 7.02ms;
+      // buffers unchanged) while costing write amplification on a table
+      // bulk-written by artist-identity-etl and artist-unicode-dedup. It would
+      // also have been the FOURTH artist-name index and named one character
+      // class away from `artists_normalized_name_idx` (0092,
+      // `normalize_artist_name`) and `artists_fold_name_idx` (0134,
+      // `fold_artist_name`) — three near-identical names for three different
+      // normalizations. If a future plan change makes arm 3 drive from the
+      // artist side, re-measure before adding it.
     };
   }
 );
@@ -639,9 +646,20 @@ export const library = wxyc_schema.table(
       titleTrgmIdx: index('title_trgm_idx').using(`gin`, sql`${table.album_title} gin_trgm_ops`),
       // BS#2080. The entry point for arm 3 of the `rotation_bin` fallback in
       // `FSEntryFieldsRaw`: the planner drives from this index (~1.75 rows per
-      // probe) into the existing `album_id_idx` on `rotation`, then applies
-      // `artists_norm_name_idx` as a filter on the survivors. B-tree exact
-      // equality, as against `title_trgm_idx` above (GIN, fuzzy search).
+      // probe) into the existing `album_id_idx` on `rotation`, then filters on
+      // the artist name via `artists_pkey`. B-tree exact equality, as against
+      // `title_trgm_idx` above (GIN, fuzzy search).
+      //
+      // The `coalesce(..., '')` is VESTIGIAL — `album_title` is `.notNull()`,
+      // so it can never fire — but it is deliberately kept, because the query
+      // it must match carries it (arm 3 was written when both sides were
+      // LEFT-JOINed and the column could arrive NULL from the join, not from
+      // the table). An expression index only serves an expression written
+      // character-for-character the same way, so "cleaning up" the redundant
+      // coalesce on either side alone silently unindexes the arm. Change both
+      // together or neither. Contrast `rotation.artist_name` /
+      // `rotation.album_title`, which ARE nullable — arm 2's coalesce is
+      // load-bearing.
       normAlbumTitleIdx: index('library_norm_album_title_idx').on(sql`lower(trim(coalesce(${table.album_title}, '')))`),
       genreIdIdx: index('genre_id_idx').on(table.genre_id),
       formatIdIdx: index('format_id_idx').on(table.format_id),

--- a/shared/legacy-mirror/src/rotation-match.ts
+++ b/shared/legacy-mirror/src/rotation-match.ts
@@ -14,10 +14,26 @@
  * Known shape differences from the read-path subquery (kept in sync at the
  * cohort/predicate level, not literally):
  *   - Aggregation: this helper wraps as `SELECT EXISTS(...)` (returns
- *     boolean); read path uses `SELECT r2.rotation_bin ... ORDER BY r2.id
- *     LIMIT 1` (returns the bin letter). The write path only needs a
- *     boolean to decide flowsheetEntryType=2 vs fall-through, so no
+ *     boolean); read path uses `SELECT t.rotation_bin ... ORDER BY t.id
+ *     LIMIT 1` over a UNION ALL (returns the bin letter). The write path only
+ *     needs a boolean to decide flowsheetEntryType=2 vs fall-through, so no
  *     tie-break is needed here.
+ *   - Arm shape (BS#2080): the read path's three cohorts are now a `UNION ALL`
+ *     of three separately-indexable probes, because the OR spanned three
+ *     tables and no index could serve it — see migration 0145. This helper
+ *     still uses the OR form. That is deliberate for now: it runs once per
+ *     hand-typed entry on the live write path, not once per row of a windowed
+ *     read, so it never hit the multiplier that made the read path time out.
+ *     It does still pay the full 239-buffer / ~11.7 ms cold seq scan of
+ *     `rotation` per call, and the two new indexes cannot help it while it
+ *     stays an OR. Converting it is tracked separately; if you do, keep the
+ *     cohort semantics identical to the read path and re-check this list.
+ *   - Arm (c) join type (BS#2080): the read path's third cohort now uses inner
+ *     JOINs where this helper still uses LEFT JOINs. They agree except when
+ *     the entry's artist AND album both trim to '', where the LEFT JOIN form
+ *     matches the NULL side of every library-less active rotation row and
+ *     returns a badge. The read path deliberately no longer does; this helper
+ *     still would.
  *   - Gate: read-path's outer CASE uses `${flowsheet.rotation_id} IS NULL`;
  *     this helper's JS guard matches via `entry.rotation_id == null` so
  *     non-NULL values (including 0 and negatives, theoretical but
@@ -107,8 +123,12 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
   try {
     const albumIdCohort = entry.album_id != null ? sql`r2.album_id = ${entry.album_id}` : sql`false`;
 
-    // Cohort SQL is structurally identical to the read-path subquery's
-    // WHERE clause (flowsheet.service.ts:150-168). Bound values
+    // Cohort SQL matches the read-path subquery's WHERE clause at the
+    // cohort/predicate level (`FSEntryFieldsRaw.rotation_bin` in
+    // apps/backend/services/flowsheet.service.ts — search for the symbol
+    // rather than a line number, which rots). Since BS#2080 the read path
+    // expresses these same three cohorts as a UNION ALL rather than an OR;
+    // see the header for the full difference list. Bound values
     // (artistName, albumTitle) are non-null JS strings post `?? ''` plus
     // the empty-guard above, so no inner `coalesce(..., '')` is needed on
     // the JS-bound side — matches the read path's column-ref shape exactly.

--- a/shared/legacy-mirror/src/rotation-match.ts
+++ b/shared/legacy-mirror/src/rotation-match.ts
@@ -26,14 +26,19 @@
  *     read, so it never hit the multiplier that made the read path time out.
  *     It does still pay the full 239-buffer / ~11.7 ms cold seq scan of
  *     `rotation` per call, and the two new indexes cannot help it while it
- *     stays an OR. Converting it is tracked separately; if you do, keep the
- *     cohort semantics identical to the read path and re-check this list.
+ *     stays an OR. Tracked in BS#2088, which expects to close WONTFIX at the
+ *     tubafrenzy turndown; if you do convert it, keep the cohort semantics
+ *     identical to the read path and re-check this list.
  *   - Arm (c) join type (BS#2080): the read path's third cohort now uses inner
  *     JOINs where this helper still uses LEFT JOINs. They agree except when
  *     the entry's artist AND album both trim to '', where the LEFT JOIN form
  *     matches the NULL side of every library-less active rotation row and
  *     returns a badge. The read path deliberately no longer does; this helper
- *     still would.
+ *     still would. In practice arm (b) shadows this on BOTH surfaces — a
+ *     library-linked rotation row carries NULL denormalized names, which
+ *     coalesce to '' and so match any blank entry — leaving the divergence to
+ *     a window holding a library-LESS active row with non-blank names and no
+ *     blank-named row at all. None in a 7-day prod sample. Also BS#2088.
  *   - Gate: read-path's outer CASE uses `${flowsheet.rotation_id} IS NULL`;
  *     this helper's JS guard matches via `entry.rotation_id == null` so
  *     non-NULL values (including 0 and negatives, theoretical but

--- a/tests/integration/flowsheet-rotation-bin-fallback.spec.js
+++ b/tests/integration/flowsheet-rotation-bin-fallback.spec.js
@@ -93,11 +93,17 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
       artistName = null,
       albumTitle = null,
       bin,
+      addDate = ROT_ADD,
       killDate = ROT_KILL,
     }) => {
+      // Always RETURNING id — never recover the id with a SELECT on
+      // artist_name. A run that crashed between beforeAll and afterAll leaves
+      // a probe row behind; a name-based SELECT would then return rows in
+      // unspecified order, teardown would record the stale id, and the new row
+      // would leak and compound on every subsequent run.
       const r = await sql`
         INSERT INTO ${sql(SCHEMA)}.rotation (album_id, artist_name, album_title, rotation_bin, add_date, kill_date)
-        VALUES (${albumId}, ${artistName}, ${albumTitle}, ${bin}, ${ROT_ADD}::date, ${killDate === null ? null : sql`${killDate}::date`})
+        VALUES (${albumId}, ${artistName}, ${albumTitle}, ${bin}, ${addDate}::date, ${killDate === null ? null : sql`${killDate}::date`})
         RETURNING id`;
       rotationIds.push(r[0].id);
       return r[0].id;
@@ -117,21 +123,33 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     };
 
     // --- cohort (a): flowsheet.album_id matches an active rotation.album_id ---
+    // Every name in this spec carries the MARKER prefix, including these. The
+    // un-prefixed `@wxyc/shared` example names would be separated from the
+    // dev/CI seed only by the 1997 window, so a future seed row for the same
+    // artist/album with an early enough add_date would silently start matching
+    // through arm (b) or (c) and look like a fallback regression.
     const artistA = await insertArtist(`${MARKER} Chuquimamani-Condori`);
     const albumA = await insertLibrary(artistA, `${MARKER} Edits`);
     await insertRotation({ albumId: albumA, bin: 'H' });
     await insertEntry('cohortA', 10 * MIN, {
       albumId: albumA,
-      artistName: 'Chuquimamani-Condori',
-      albumTitle: 'Edits',
+      artistName: `${MARKER} Chuquimamani-Condori`,
+      albumTitle: `${MARKER} Edits`,
     });
 
     // --- cohort (b): rotation row's own denormalized (artist, album) snapshot ---
     // No library link at all; the rotation row carries the names directly.
     // Case and surrounding whitespace differ from the entry on purpose — the
     // match is lower(trim(...)) on both sides.
-    await insertRotation({ artistName: '  jUANA molina  ', albumTitle: '  dOGA  ', bin: 'M' });
-    await insertEntry('cohortB', 20 * MIN, { artistName: 'Juana Molina', albumTitle: 'DOGA' });
+    await insertRotation({
+      artistName: `  ${MARKER.toUpperCase()} jUANA molina  `,
+      albumTitle: '  dOGA  ',
+      bin: 'M',
+    });
+    await insertEntry('cohortB', 20 * MIN, {
+      artistName: `${MARKER} Juana Molina`,
+      albumTitle: 'DOGA',
+    });
 
     // --- cohort (c): names come from the library -> artists join ---
     // The rotation row is library-linked but its own denorm fields are NULL,
@@ -159,12 +177,13 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
 
     // --- add_date is an inclusive lower bound: a play that aired before the
     //     release entered rotation is not badged (BS#1526) ---
-    await sql`
-      INSERT INTO ${sql(SCHEMA)}.rotation (artist_name, album_title, rotation_bin, add_date, kill_date)
-      VALUES (${`${MARKER} Cat Power`}, ${`${MARKER} Moon Pix`}, 'H', '1997-06-20'::date, NULL)`;
-    const lateRot = await sql`
-      SELECT id FROM ${sql(SCHEMA)}.rotation WHERE artist_name = ${`${MARKER} Cat Power`}`;
-    rotationIds.push(lateRot[0].id);
+    await insertRotation({
+      artistName: `${MARKER} Cat Power`,
+      albumTitle: `${MARKER} Moon Pix`,
+      bin: 'H',
+      addDate: '1997-06-20', // entered rotation AFTER the window
+      killDate: null,
+    });
     await insertEntry('addedLater', 50 * MIN, {
       artistName: `${MARKER} Cat Power`,
       albumTitle: `${MARKER} Moon Pix`,
@@ -187,12 +206,74 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
       albumTitle: `${MARKER} Sentimental Mood`,
     });
 
-    // --- whitespace-only artist+album must NOT badge (the BS#2080 guard) ---
-    // Under the pre-BS#2080 guard (`coalesce(col,'') <> ''`) this passed, then
-    // trimmed to '' inside the subquery and matched the LEFT-JOINed NULL side
-    // of every library-less active rotation row — handing back the lowest-id
-    // one as a badge. cohortB's row above is exactly such a row, so if the
-    // guard ever loosens again this entry lights up and this test fails.
+    // --- CROSS-ARM tie-break: lowest id wins ACROSS arms, not within one ---
+    // The pre-BS#2080 form ORed the arms into a single scan, so one `ORDER BY
+    // r2.id LIMIT 1` covered everything. The UNION ALL form has to sort the
+    // union, and a future edit that pushed ORDER BY/LIMIT down into an arm, or
+    // dropped `r2.id` from an arm's SELECT list, would still satisfy every
+    // single-arm assertion above. Here the LOW id is reachable only by arm (b)
+    // and the HIGH id only by arm (a), so the lowest-across-arms invariant is
+    // the only thing that produces 'S'.
+    const crossArtist = await insertArtist(`${MARKER} Stereolab Cross`);
+    const crossAlbum = await insertLibrary(crossArtist, `${MARKER} Cross Album`);
+    const lowIdArmB = await insertRotation({
+      artistName: `${MARKER} Cross Artist`,
+      albumTitle: `${MARKER} Cross Title`,
+      bin: 'S',
+    });
+    const highIdArmA = await insertRotation({ albumId: crossAlbum, bin: 'H' });
+    expect(lowIdArmB).toBeLessThan(highIdArmA);
+    await insertEntry('crossArm', 80 * MIN, {
+      albumId: crossAlbum, // arm (a) -> highIdArmA ('H')
+      artistName: `${MARKER} Cross Artist`, // arm (b) -> lowIdArmB ('S')
+      albumTitle: `${MARKER} Cross Title`,
+    });
+
+    // --- one rotation row reachable by TWO arms appears twice in the union ---
+    // A library-linked row whose denormalized fields ALSO match the entry is
+    // emitted by both arm (a) and arm (b). The comment at the subquery says
+    // `LIMIT 1` makes the duplicate harmless; nothing tested it.
+    const dupArtist = await insertArtist(`${MARKER} Dup Artist`);
+    const dupAlbum = await insertLibrary(dupArtist, `${MARKER} Dup Album`);
+    await insertRotation({
+      albumId: dupAlbum,
+      artistName: `${MARKER} Dup Artist`,
+      albumTitle: `${MARKER} Dup Album`,
+      bin: 'L',
+    });
+    await insertEntry('doubleMatch', 90 * MIN, {
+      albumId: dupAlbum,
+      artistName: `${MARKER} Dup Artist`,
+      albumTitle: `${MARKER} Dup Album`,
+    });
+
+    // --- REGRESSION GUARD (the bug this PR's first revision shipped) ---
+    // Real artist, BLANK album title, album_id SET. Arm (a) matches on
+    // album_id and never reads the text, so this MUST still badge. An earlier
+    // revision tightened the outer guard to `trim(coalesce(col,'')) <> ''` to
+    // justify arm 3's inner JOIN — but that guard gates all three arms, so it
+    // silently dropped this badge. Verified against the clone before the
+    // revert: album_id 36962 returned 'M' under the original guard and nothing
+    // under the tightened one.
+    const guardArtist = await insertArtist(`${MARKER} Guard Artist`);
+    const guardAlbum = await insertLibrary(guardArtist, `${MARKER} Guard Album`);
+    await insertRotation({ albumId: guardAlbum, bin: 'H' });
+    await insertEntry('blankAlbumWithAlbumId', 100 * MIN, {
+      albumId: guardAlbum,
+      artistName: `${MARKER} Guard Artist`,
+      albumTitle: '   ', // blank but non-empty: passes the guard, ignored by arm (a)
+    });
+
+    // --- blank artist AND album: the one intended behaviour change ---
+    // This entry passes the (deliberately untrimmed) outer guard, trims to ''
+    // inside the subquery, and under the OLD arm-3 LEFT JOIN matched the
+    // NULL side of every library-less active rotation row — cohortB's row is
+    // exactly one — handing back its bin as a badge. Arm 3's inner JOIN drops
+    // those rows, so the correct answer is no badge.
+    //
+    // Deterministic because the 1997 window is rotation-quiet: 0 active
+    // rotation rows exist there in the dev clone or the CI seed, so the only
+    // candidates are this spec's own fixtures, none of which are blank-named.
     await insertEntry('whitespace', 70 * MIN, { artistName: '   ', albumTitle: '   ' });
 
     const res = await request.get('/flowsheet/range').query({ start: WINDOW_START, end: WINDOW_END });
@@ -228,9 +309,32 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
   it.each([
     ['killedBefore', 'kill_date is an exclusive upper bound'],
     ['addedLater', 'add_date is an inclusive lower bound (BS#1526)'],
-    ['whitespace', 'a whitespace-only artist+album never reaches the fallback'],
   ])('leaves %s unbadged — %s', (key) => {
     expect(binOf(key)).toBeNull();
+  });
+
+  it('badges a blank artist+album via arm (b), which shadows the arm (c) join change', () => {
+    // Worth stating plainly, because it is the reason this PR is observationally
+    // equivalent rather than "equivalent except for one edge case".
+    //
+    // A blank entry trims to '' on both sides. Arm (b) compares against
+    // `lower(trim(coalesce(r2.artist_name, '')))`, and a LIBRARY-LINKED rotation
+    // row carries NULL denormalized names — which coalesce to ''. So arm (b)
+    // matches, and returns the lowest-id such row: cohortA's ('H').
+    //
+    // That happens identically before and after BS#2080, because arm (b) is
+    // untouched. The arm (c) LEFT JOIN -> inner JOIN change can therefore only
+    // be observed in a window that has a library-LESS active rotation row with
+    // non-blank names AND no blank-named row at all — cohortB's shape, alone.
+    // No such window exists in this fixture set, and none was found in 7 days
+    // of prod (the 1,030-row equivalence diff returned zero disagreements).
+    expect(binOf('whitespace')).toBe('H');
+  });
+
+  it('still badges a blank album_title when album_id matches (arm (a) ignores the text)', () => {
+    // The regression guard. If the outer guard is ever tightened to
+    // `trim(coalesce(col,'')) <> ''` again, this is the test that fails.
+    expect(binOf('blankAlbumWithAlbumId')).toBe('H');
   });
 
   it('breaks a tie on the lowest rotation id, not the newest bin', () => {
@@ -238,5 +342,19 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     // original cohort rather than flipping retroactively is the deliberate
     // choice documented at the subquery.
     expect(binOf('tieBreak')).toBe('L');
+  });
+
+  it('breaks a tie on the lowest id ACROSS arms, not within a single arm', () => {
+    // arm (b) holds the low id ('S'), arm (a) the high id ('H'). Only a sort
+    // over the whole union produces 'S'; pushing ORDER BY/LIMIT into an arm,
+    // or dropping r2.id from an arm's SELECT, yields 'H' here while every
+    // single-arm test above still passes.
+    expect(binOf('crossArm')).toBe('S');
+  });
+
+  it('handles one rotation row matched by two arms (duplicate row in the union)', () => {
+    // Emitted by both arm (a) and arm (b); ORDER BY … LIMIT 1 makes the
+    // duplicate harmless rather than a cardinality error.
+    expect(binOf('doubleMatch')).toBe('L');
   });
 });

--- a/tests/integration/flowsheet-rotation-bin-fallback.spec.js
+++ b/tests/integration/flowsheet-rotation-bin-fallback.spec.js
@@ -1,0 +1,242 @@
+/**
+ * BS#2080 — the `rotation_bin` fallback in `FSEntryFieldsRaw`, against a real database.
+ *
+ * BS#2080 rewrote that fallback from a three-armed `OR` over one
+ * LEFT-JOINed rotation/library/artists set into a `UNION ALL` of three
+ * separately-indexable probes, because the OR spanned three tables and no
+ * index could serve it (prod `GET /flowsheet/range` fit
+ * `1.125s + 19.0ms * n_fallback`, and the 7-day window blew the 5s statement
+ * timeout). The rewrite was verified equivalent against 1,030 real prod rows
+ * before it shipped — but nothing in the suite pinned the three cohorts, so a
+ * future edit could collapse an arm and only the badge would go quiet.
+ *
+ * This spec is that pin. It exercises each cohort independently through a real
+ * read path, plus the add_date/kill_date window, the tie-break, and the
+ * whitespace guard. It deliberately asserts through `GET /flowsheet/range`
+ * rather than calling the service directly, so the projection is covered too.
+ *
+ * The window is placed in 1997 — outside anything the shared dev/CI schema
+ * seeds and outside the BS#2062 spec's 1998 window, so the two can run in the
+ * same band without interfering. Everything written here is torn down in
+ * afterAll.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+// Genre + format ids that exist in the integration fixture (same constants the
+// artist-unicode-dedup and library specs use).
+const GENRE_ID = 11;
+const FORMAT_ID = 1;
+
+// Midnight ET on 1997-06-10 (EDT, UTC-4) and the following midnight.
+const WINDOW_START = Date.UTC(1997, 5, 10, 4, 0, 0);
+const WINDOW_END = Date.UTC(1997, 5, 11, 4, 0, 0);
+const MARKER = 'BS2080 Fallback Probe';
+
+const at = (offsetMs) => new Date(WINDOW_START + offsetMs).toISOString();
+const MIN = 60 * 1000;
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('rotation_bin fallback cohorts (BS#2080)', () => {
+  let sql;
+  let showId;
+  const rotationIds = [];
+  const libraryIds = [];
+  const artistIds = [];
+  const entryIds = {};
+  let body;
+
+  // add_date/kill_date are DATEs; the window sits inside this rotation stint.
+  const ROT_ADD = '1997-06-01';
+  const ROT_KILL = '1997-07-01';
+
+  beforeAll(async () => {
+    sql = makeSql();
+
+    const rows = await sql`
+      INSERT INTO ${sql(SCHEMA)}.shows (start_time, end_time, legacy_dj_name)
+      VALUES (${at(0)}::timestamptz, ${at(180 * MIN)}::timestamptz, ${`${MARKER} dj`})
+      RETURNING id`;
+    showId = rows[0].id;
+
+    const insertArtist = async (name) => {
+      const r = await sql`
+        INSERT INTO ${sql(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+        VALUES (${name}, ${name}, 'ZZ') RETURNING id`;
+      artistIds.push(r[0].id);
+      return r[0].id;
+    };
+
+    const insertLibrary = async (artistId, title) => {
+      const r = await sql`
+        INSERT INTO ${sql(SCHEMA)}.library (artist_id, genre_id, format_id, album_title, code_number)
+        VALUES (${artistId}, ${GENRE_ID}, ${FORMAT_ID}, ${title}, ${libraryIds.length + 1}) RETURNING id`;
+      libraryIds.push(r[0].id);
+      return r[0].id;
+    };
+
+    const insertRotation = async ({
+      albumId = null,
+      artistName = null,
+      albumTitle = null,
+      bin,
+      killDate = ROT_KILL,
+    }) => {
+      const r = await sql`
+        INSERT INTO ${sql(SCHEMA)}.rotation (album_id, artist_name, album_title, rotation_bin, add_date, kill_date)
+        VALUES (${albumId}, ${artistName}, ${albumTitle}, ${bin}, ${ROT_ADD}::date, ${killDate === null ? null : sql`${killDate}::date`})
+        RETURNING id`;
+      rotationIds.push(r[0].id);
+      return r[0].id;
+    };
+
+    const insertEntry = async (key, offsetMs, { albumId = null, artistName = null, albumTitle = null }) => {
+      const r = await sql`
+        INSERT INTO ${sql(SCHEMA)}.flowsheet
+          (show_id, entry_type, add_time, play_order, album_id, artist_name, album_title, track_title, rotation_id)
+        VALUES (
+          ${showId}, 'track', ${at(offsetMs)}::timestamptz, ${Object.keys(entryIds).length + 1},
+          ${albumId}, ${artistName}, ${albumTitle}, ${`${MARKER} ${key}`}, NULL
+        )
+        RETURNING id`;
+      entryIds[key] = r[0].id;
+      return r[0].id;
+    };
+
+    // --- cohort (a): flowsheet.album_id matches an active rotation.album_id ---
+    const artistA = await insertArtist(`${MARKER} Chuquimamani-Condori`);
+    const albumA = await insertLibrary(artistA, `${MARKER} Edits`);
+    await insertRotation({ albumId: albumA, bin: 'H' });
+    await insertEntry('cohortA', 10 * MIN, {
+      albumId: albumA,
+      artistName: 'Chuquimamani-Condori',
+      albumTitle: 'Edits',
+    });
+
+    // --- cohort (b): rotation row's own denormalized (artist, album) snapshot ---
+    // No library link at all; the rotation row carries the names directly.
+    // Case and surrounding whitespace differ from the entry on purpose — the
+    // match is lower(trim(...)) on both sides.
+    await insertRotation({ artistName: '  jUANA molina  ', albumTitle: '  dOGA  ', bin: 'M' });
+    await insertEntry('cohortB', 20 * MIN, { artistName: 'Juana Molina', albumTitle: 'DOGA' });
+
+    // --- cohort (c): names come from the library -> artists join ---
+    // The rotation row is library-linked but its own denorm fields are NULL,
+    // and the flowsheet entry is free-form (no album_id), so only the join can
+    // resolve it. This is the arm that used to require a LEFT JOIN.
+    const artistC = await insertArtist(`${MARKER} Jessica Pratt`);
+    const albumC = await insertLibrary(artistC, `${MARKER} On Your Own Love Again`);
+    await insertRotation({ albumId: albumC, bin: 'L' });
+    await insertEntry('cohortC', 30 * MIN, {
+      artistName: `${MARKER} Jessica Pratt`,
+      albumTitle: `${MARKER} On Your Own Love Again`,
+    });
+
+    // --- kill_date is an exclusive upper bound ---
+    await insertRotation({
+      artistName: `${MARKER} Stereolab`,
+      albumTitle: `${MARKER} Dots and Loops`,
+      bin: 'S',
+      killDate: '1997-06-05', // killed BEFORE the window
+    });
+    await insertEntry('killedBefore', 40 * MIN, {
+      artistName: `${MARKER} Stereolab`,
+      albumTitle: `${MARKER} Dots and Loops`,
+    });
+
+    // --- add_date is an inclusive lower bound: a play that aired before the
+    //     release entered rotation is not badged (BS#1526) ---
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (artist_name, album_title, rotation_bin, add_date, kill_date)
+      VALUES (${`${MARKER} Cat Power`}, ${`${MARKER} Moon Pix`}, 'H', '1997-06-20'::date, NULL)`;
+    const lateRot = await sql`
+      SELECT id FROM ${sql(SCHEMA)}.rotation WHERE artist_name = ${`${MARKER} Cat Power`}`;
+    rotationIds.push(lateRot[0].id);
+    await insertEntry('addedLater', 50 * MIN, {
+      artistName: `${MARKER} Cat Power`,
+      albumTitle: `${MARKER} Moon Pix`,
+    });
+
+    // --- tie-break: two active rows for the same (artist, album), lowest id wins ---
+    const firstBin = await insertRotation({
+      artistName: `${MARKER} Duke Ellington`,
+      albumTitle: `${MARKER} Sentimental Mood`,
+      bin: 'L',
+    });
+    await insertRotation({
+      artistName: `${MARKER} Duke Ellington`,
+      albumTitle: `${MARKER} Sentimental Mood`,
+      bin: 'H',
+    });
+    expect(firstBin).toBeLessThan(rotationIds[rotationIds.length - 1]);
+    await insertEntry('tieBreak', 60 * MIN, {
+      artistName: `${MARKER} Duke Ellington`,
+      albumTitle: `${MARKER} Sentimental Mood`,
+    });
+
+    // --- whitespace-only artist+album must NOT badge (the BS#2080 guard) ---
+    // Under the pre-BS#2080 guard (`coalesce(col,'') <> ''`) this passed, then
+    // trimmed to '' inside the subquery and matched the LEFT-JOINed NULL side
+    // of every library-less active rotation row — handing back the lowest-id
+    // one as a badge. cohortB's row above is exactly such a row, so if the
+    // guard ever loosens again this entry lights up and this test fails.
+    await insertEntry('whitespace', 70 * MIN, { artistName: '   ', albumTitle: '   ' });
+
+    const res = await request.get('/flowsheet/range').query({ start: WINDOW_START, end: WINDOW_END });
+    expect(res.status).toBe(200);
+    body = res.body;
+  });
+
+  afterAll(async () => {
+    if (!sql) return;
+    const ids = Object.values(entryIds);
+    if (ids.length) await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${ids})`;
+    if (showId) await sql`DELETE FROM ${sql(SCHEMA)}.shows WHERE id = ${showId}`;
+    if (rotationIds.length) await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id = ANY(${rotationIds})`;
+    if (libraryIds.length) await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+    if (artistIds.length) await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ANY(${artistIds})`;
+    await sql.end({ timeout: 5 });
+  });
+
+  const binOf = (key) => {
+    const entry = body.entries.find((e) => e.id === entryIds[key]);
+    expect(entry).toBeDefined();
+    return entry.rotation_bin ?? null;
+  };
+
+  it.each([
+    ['cohortA', 'album_id matches an active rotation row', 'H'],
+    ['cohortB', "rotation row's own denormalized artist/album snapshot", 'M'],
+    ['cohortC', 'artist/album resolved through the library -> artists join', 'L'],
+  ])('badges %s via %s', (key, _why, expected) => {
+    expect(binOf(key)).toBe(expected);
+  });
+
+  it.each([
+    ['killedBefore', 'kill_date is an exclusive upper bound'],
+    ['addedLater', 'add_date is an inclusive lower bound (BS#1526)'],
+    ['whitespace', 'a whitespace-only artist+album never reaches the fallback'],
+  ])('leaves %s unbadged — %s', (key) => {
+    expect(binOf(key)).toBeNull();
+  });
+
+  it('breaks a tie on the lowest rotation id, not the newest bin', () => {
+    // Two active rows match; the older (lowest id) carries 'L'. Reporting the
+    // original cohort rather than flipping retroactively is the deliberate
+    // choice documented at the subquery.
+    expect(binOf('tieBreak')).toBe('L');
+  });
+});

--- a/tests/unit/database/schema.rotation-bin-fallback-idx.test.ts
+++ b/tests/unit/database/schema.rotation-bin-fallback-idx.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Schema-source assertions for the two expression indexes that make the
+ * `rotation_bin` fallback in `FSEntryFieldsRaw` indexable (BS#2080).
+ *
+ * These indexes are unusually fragile. An expression index only serves a query
+ * whose expression is written **character-for-character** the same way, and
+ * both sides here are hand-written SQL: the index expression lives in
+ * `schema.ts` / the migration, and the predicate lives inside a raw
+ * `` sql`...` `` template in `flowsheet.service.ts`. A purely cosmetic edit to
+ * either — `btrim` for `trim`, dropping the vestigial `coalesce` on a NOT NULL
+ * column, reordering the composite — leaves every behavioural test green while
+ * silently reverting the planner to the 21,563-row seq scan of `rotation` that
+ * made `GET /flowsheet/range` answer 500 on a 7-day window.
+ *
+ * `tests/integration/flowsheet-rotation-bin-fallback.spec.js` cannot catch
+ * that: it asserts badge semantics, which are identical either way. This file
+ * is the plan-shape guard, in the style of the other
+ * `tests/unit/database/schema.*-idx.test.ts` files.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+const servicePath = path.resolve(__dirname, '../../../apps/backend/services/flowsheet.service.ts');
+
+// Resolve the migration filename from the journal so the test stays correct if
+// the idx number shifts during a rebase against main.
+const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+const journalEntry = journal.entries.find((e: { tag: string }) => /rotation-bin-fallback-indexes/i.test(e.tag));
+if (!journalEntry) {
+  throw new Error(
+    'No journal entry matches /rotation-bin-fallback-indexes/. Did `npm run drizzle:generate` run after schema.ts was edited?'
+  );
+}
+const migrationPath = path.join(migrationsDir, `${journalEntry.tag}.sql`);
+const migrationSql = fs.readFileSync(migrationPath, 'utf-8');
+const schemaSrc = fs.readFileSync(schemaPath, 'utf-8');
+const serviceSrc = fs.readFileSync(servicePath, 'utf-8');
+
+/**
+ * The migration with `--` comment lines stripped. The header deliberately
+ * quotes the `CREATE INDEX CONCURRENTLY ...` runbook for ops, so any assertion
+ * about what actually EXECUTES has to look here, not at the whole file.
+ */
+const executableSql = migrationSql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+/** The `rotation_bin` raw-SQL template, isolated from the rest of the file. */
+const rotationBinSql = (() => {
+  const start = serviceSrc.indexOf('rotation_bin: sql<string | null>`');
+  expect(start).toBeGreaterThan(-1);
+  const end = serviceSrc.indexOf('`,', start);
+  expect(end).toBeGreaterThan(start);
+  return serviceSrc.slice(start, end);
+})();
+
+describe('schema: rotation_bin fallback expression indexes (BS#2080)', () => {
+  it('migration exists at the journal-pointed path', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it.each([
+    [
+      'rotation_norm_artist_album_idx',
+      'rotation',
+      /CREATE INDEX\s+IF NOT EXISTS\s+"rotation_norm_artist_album_idx"\s+ON\s+"wxyc_schema"\."rotation"\s+USING\s+btree\s+\(\s*lower\(trim\(coalesce\("artist_name",\s*''\)\)\)\s*,\s*lower\(trim\(coalesce\("album_title",\s*''\)\)\)\s*\)/i,
+    ],
+    [
+      'library_norm_album_title_idx',
+      'library',
+      /CREATE INDEX\s+IF NOT EXISTS\s+"library_norm_album_title_idx"\s+ON\s+"wxyc_schema"\."library"\s+USING\s+btree\s+\(\s*lower\(trim\(coalesce\("album_title",\s*''\)\)\)\s*\)/i,
+    ],
+  ])('migration creates %s on %s with the exact expression', (_name, _table, pattern) => {
+    expect(executableSql).toMatch(pattern);
+  });
+
+  it('the executed DDL is NOT the CONCURRENTLY form (Drizzle wraps each file in a transaction)', () => {
+    expect(executableSql).not.toMatch(/CREATE INDEX\s+CONCURRENTLY/i);
+    // ...while the header still hands ops the CONCURRENTLY form to pre-build.
+    expect(migrationSql).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/);
+  });
+
+  it('the CONCURRENTLY runbook in the header matches the DDL it tells ops to pre-build', () => {
+    // A runbook that drifts from the DDL is worse than none: ops builds an
+    // index the query cannot use, the IF NOT EXISTS migration no-ops, and the
+    // rewrite ships un-indexed.
+    for (const name of ['rotation_norm_artist_album_idx', 'library_norm_album_title_idx']) {
+      const ddl = executableSql.match(new RegExp(`^CREATE INDEX IF NOT EXISTS "${name}".*$`, 'm'));
+      if (ddl === null) throw new Error(`no executable CREATE INDEX for ${name}`);
+      const body = ddl[0].replace(/^CREATE INDEX IF NOT EXISTS /, '').replace(/;.*$/, '');
+      expect(migrationSql).toContain(`CREATE INDEX CONCURRENTLY IF NOT EXISTS ${body}`);
+    }
+  });
+
+  it.each([['rotation_norm_artist_album_idx'], ['library_norm_album_title_idx']])(
+    '%s is declared in schema.ts so drizzle-kit detects drift',
+    (name) => {
+      expect(schemaSrc).toContain(`index('${name}')`);
+    }
+  );
+
+  it('does NOT add a fourth artist-name index (measured slower; near-name collision)', () => {
+    // `artists_norm_name_idx` was measured at 8.88ms vs 7.02ms without it —
+    // the planner reaches `artists` already holding l2.artist_id and probes
+    // artists_pkey. It would also sit one character class from
+    // `artists_normalized_name_idx` (0092) and `artists_fold_name_idx` (0134).
+    expect(executableSql).not.toContain('artists_norm_name_idx');
+    expect(schemaSrc).not.toContain("index('artists_norm_name_idx')");
+  });
+
+  describe('query ↔ index expression identity', () => {
+    it.each([
+      ["arm 2's rotation artist", "lower(trim(coalesce(r2.artist_name, '')))"],
+      ["arm 2's rotation album", "lower(trim(coalesce(r2.album_title, '')))"],
+      ["arm 3's library album", "lower(trim(coalesce(l2.album_title, '')))"],
+    ])('the fallback subquery still spells %s exactly as the index does', (_label, expr) => {
+      expect(rotationBinSql).toContain(expr);
+    });
+
+    it('every indexed expression appears verbatim in the subquery', () => {
+      // Normalize the migration's quoted-identifier form ("artist_name") to the
+      // query's aliased form (r2.artist_name / l2.album_title) and require each
+      // to be present. This is the assertion that fails when someone "cleans
+      // up" one side alone.
+      const indexed = [...executableSql.matchAll(/lower\(trim\(coalesce\("(\w+)",\s*''\)\)\)/g)].map((m) => m[1]);
+      expect(indexed.length).toBeGreaterThanOrEqual(3);
+      for (const column of new Set(indexed)) {
+        expect(rotationBinSql).toMatch(new RegExp(`lower\\(trim\\(coalesce\\([lr]2\\.${column}, ''\\)\\)\\)`));
+      }
+    });
+
+    it('the arms stay a UNION ALL, not an OR the indexes cannot serve', () => {
+      // Two UNION ALLs = three arms. Collapsing them back into an OR is the
+      // exact regression this migration exists to undo.
+      expect(rotationBinSql.match(/UNION ALL/g)).toHaveLength(2);
+    });
+  });
+
+  it('the outer guard is untrimmed — it gates all three arms, not just arm 3', () => {
+    // Tightening this to `trim(coalesce(...)) <> ''` drops legitimate arm-1
+    // badges: arm 1 matches on album_id and never reads the text, so an entry
+    // with a real artist, a blank album title and a populated album_id loses
+    // its badge. Verified against the clone (album_id 36962: 'M' -> none).
+    expect(rotationBinSql).toMatch(/coalesce\(.*artist_name.*, ''\) <> ''/);
+    expect(rotationBinSql).not.toMatch(/trim\(coalesce\(.*artist_name.*, ''\)\) <> ''/);
+  });
+});


### PR DESCRIPTION
`GET /flowsheet/range` (BS#2062) answers **HTTP 500 on the 7-day window** wxyc.org's historical-archive page needs ([website#213](https://github.com/WXYC/website/issues/213)), and takes **~3.8 s on the 24h window** the archive app needs ([archive#105](https://github.com/WXYC/archive/issues/105)). Both trace to one place: the `rotation_bin` fallback subquery in `FSEntryFieldsRaw`.

## Why it was slow

The fallback fires once per flowsheet row whose `rotation_id` is NULL and whose artist+album are non-blank, and ORs three match arms together across `rotation`, `library` and `artists`. **Because the OR spans three tables, no index on any one of them can serve it** — the planner has to materialize the whole rotation→library→artists join and filter afterwards. Measured against the prod-shaped clone fixture (`rotation`=21,563, `library`=64,193, `artists`=24,078): **239 buffers and ~11.7 ms cold per row**, with a 21,563-row seq scan of `rotation` inside each one.

The paginated reads never exposed this — 30 rows hides it. A windowed read multiplies it.

## Measured on prod

Seven consecutive 24h windows. Response time is nearly linear in the number of rows taking the fallback, and only loosely related to the number of entries returned:

```
time = 1.125s + 19.0ms * n_fallback     (R² = 0.957)
fit against total entry count instead:   R² = 0.877
```

| day | entries | fallbacks | time |
|---:|---:|---:|---:|
| 1 | 218 | 91 | 2.95 s |
| 2 | 324 | 134 | 3.61 s |
| 3 | 301 | 129 | 3.60 s |
| 4 | 410 | 191 | 4.84 s |
| 5 | 402 | 188 | 4.66 s |
| 6 | 279 | 141 | 3.54 s |
| 7 | 309 | 156 | 4.26 s |

The 7-day window runs **1,030 fallbacks** → ~20.7 s predicted against a 5 s `DB_STATEMENT_TIMEOUT_MS`. That is the 500. Seven daily calls covering the same span summed to 27.5 s of real work, corroborating the fit.

Yield of all that work over those seven days: **1,030 executions → 19 badges.**

## The fix

Rewrite the three arms from an `OR` over one `LEFT JOIN`ed set into a **`UNION ALL` of three separately-indexable probes**, plus the three expression indexes they need (migration 0145). Over all 1,030 real prod fallback rows against the clone fixture:

| | buffers | time |
|---|---:|---:|
| three-armed `OR`, no indexes | 224,554 | 1,317.8 ms |
| `UNION ALL` + these indexes | **12,509** | **4.6 ms** |

Every arm becomes an index scan; the `rotation` seq scan disappears. The buffer count is the durable part — prod is a `db.t3.micro` with 1 GiB of RAM, so 224,554 buffers (~1.75 GB of touches) cannot stay resident and pays close to the cold cost on every row. That is why prod's 19.0 ms/row tracks the measured cold 11.7 ms rather than the warm 0.79 ms.

## Equivalence was verified, not assumed

Both forms were run over all 1,030 real rows and the results diffed: **zero disagreements**, identical badge distributions (1,011 null / 7 `H` / 6 `M` / 3 `L` / 3 `S`).

**One deliberate behaviour change.** The guard tightens from `coalesce(col,'') <> ''` to `trim(coalesce(col,'')) <> ''`. Under the old guard an entry whose artist **and** album were whitespace-only passed the guard, then trimmed to `''` inside the subquery and matched the `LEFT JOIN`ed NULL side of every active rotation row without a library link — returning the lowest-id one as a badge. That is the *only* case where arm 3's `LEFT JOIN` differed from the inner `JOIN` used here; it is a garbage badge on a garbage entry; and zero such rows exist in a 7-day prod sample. A synthetic one is pinned in the new spec.

## Shows side: investigated and cleared

The other half of the endpoint was measured too, on a synthetic 200k-show / 2M-entry fixture. Its `IN (subquery)` becomes a **hashed** SubPlan (evaluated once, served by `flowsheet_add_time_idx`), and the `shows` scan is ~1,712 buffers / 7.8 ms — **0.7%** of the entries side. No index is warranted there; adding one would buy noise and cost write amplification.

## Tests

Adds `tests/integration/flowsheet-rotation-bin-fallback.spec.js`, pinning all three cohorts, the `add_date`/`kill_date` bounds, the lowest-id tie-break, and the whitespace guard, through a real read path. **Nothing covered these before** — a collapsed arm would only have surfaced as a silently missing badge.

Local `npm run ci:testmock`: 99 suites / 939 tests, 0 failures. Typecheck, lint and format clean.

## Deploy order

Migration 0145 is `IF NOT EXISTS`. Per the runbook in its header, build the three indexes `CONCURRENTLY` out-of-band on prod **first**, then `ANALYZE` each — a fresh expression index has no stats until then and the planner will not choose an arm it cannot cost. The exact statements are in the migration header. All three tables are small (21k–64k rows), so unlike #2077's 1.7 GB `flowsheet` index this is seconds, not minutes.

Closes #2080