### PR TITLE
Drop /ok and /healthcheck liveness transactions and Express middleware spans

### DIFF
--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -23,12 +23,14 @@ COPY ./package* ./
 COPY ./apps/auth/package* ./apps/auth/
 COPY ./shared/database/package* ./shared/database/
 COPY ./shared/authentication/package* ./shared/authentication/
+COPY ./shared/observability/package* ./shared/observability/
 
 RUN npm install --omit=dev && rm -f .npmrc
 
 COPY --from=builder ./auth-builder/apps/auth/dist ./apps/auth/dist
 COPY --from=builder ./auth-builder/shared/database/dist ./shared/database/dist
 COPY --from=builder ./auth-builder/shared/authentication/dist ./shared/authentication/dist
+COPY --from=builder ./auth-builder/shared/observability/dist ./shared/observability/dist
 
 # Inherit the @wxyc/database 5s default. Auth handlers finish in
 # milliseconds (better-auth's queries are JWKS lookups, session reads,

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -26,6 +26,7 @@ COPY ./shared/authentication/package* ./shared/authentication/
 COPY ./shared/lml-client/package* ./shared/lml-client/
 COPY ./shared/metadata/package* ./shared/metadata/
 COPY ./shared/legacy-mirror/package* ./shared/legacy-mirror/
+COPY ./shared/observability/package* ./shared/observability/
 
 RUN npm install --omit=dev && rm -f .npmrc
 
@@ -35,6 +36,7 @@ COPY --from=builder ./builder/shared/authentication/dist ./shared/authentication
 COPY --from=builder ./builder/shared/lml-client/dist ./shared/lml-client/dist
 COPY --from=builder ./builder/shared/metadata/dist ./shared/metadata/dist
 COPY --from=builder ./builder/shared/legacy-mirror/dist ./shared/legacy-mirror/dist
+COPY --from=builder ./builder/shared/observability/dist ./shared/observability/dist
 
 # Inherit the @wxyc/database 5s default. Backend HTTP handlers always finish
 # in milliseconds; anything longer than 5s is an orphan from a request that

--- a/apps/auth/instrument.ts
+++ b/apps/auth/instrument.ts
@@ -12,8 +12,10 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE,
   environment: process.env.NODE_ENV || 'development',
   tracesSampleRate: resolveTracesSampleRate(),
-  // Drops /ok and /healthcheck liveness transactions and strips Express
-  // middleware bookkeeping spans from every other transaction (BS#2089).
+  // Drops the /auth/ok and /healthcheck liveness probes — matched on request
+  // path, since better-auth's mount makes /auth/ok's transaction "GET /auth" —
+  // and strips Express middleware bookkeeping spans from every surviving
+  // transaction (BS#2089).
   // Error reporting (beforeSend / setupExpressErrorHandler) is untouched —
   // wxyc-canary depends on /healthcheck errors surfacing there.
   beforeSendTransaction: filterSentryTransactionEvent,

--- a/apps/auth/instrument.ts
+++ b/apps/auth/instrument.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import * as Sentry from '@sentry/node';
+import { filterSentryTransactionEvent } from '@wxyc/observability';
 import { resolveTracesSampleRate } from './sentry-config.js';
 
 // Load .env before Sentry.init() so SENTRY_DSN is available.
@@ -11,4 +12,9 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE,
   environment: process.env.NODE_ENV || 'development',
   tracesSampleRate: resolveTracesSampleRate(),
+  // Drops /ok and /healthcheck liveness transactions and strips Express
+  // middleware bookkeeping spans from every other transaction (BS#2089).
+  // Error reporting (beforeSend / setupExpressErrorHandler) is untouched —
+  // wxyc-canary depends on /healthcheck errors surfacing there.
+  beforeSendTransaction: filterSentryTransactionEvent,
 });

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,6 +19,7 @@
     "@sentry/node": "^10.69.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
+    "@wxyc/observability": "^1.0.0",
     "@wxyc/shared": "^3.3.0",
     "better-auth": "^1.6.26",
     "cors": "^2.8.6",

--- a/apps/backend/instrument.ts
+++ b/apps/backend/instrument.ts
@@ -12,8 +12,10 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE,
   environment: process.env.NODE_ENV || 'development',
   tracesSampleRate: resolveTracesSampleRate(),
-  // Drops /ok and /healthcheck liveness transactions and strips Express
-  // middleware bookkeeping spans from every other transaction (BS#2089).
+  // Drops the /auth/ok and /healthcheck liveness probes — matched on request
+  // path, since better-auth's mount makes /auth/ok's transaction "GET /auth" —
+  // and strips Express middleware bookkeeping spans from every surviving
+  // transaction (BS#2089).
   // Error reporting (beforeSend / setupExpressErrorHandler) is untouched —
   // wxyc-canary depends on /healthcheck errors surfacing there.
   beforeSendTransaction: filterSentryTransactionEvent,

--- a/apps/backend/instrument.ts
+++ b/apps/backend/instrument.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import * as Sentry from '@sentry/node';
+import { filterSentryTransactionEvent } from '@wxyc/observability';
 import { resolveTracesSampleRate } from './sentry-config.js';
 
 // Load .env before Sentry.init() so SENTRY_DSN is available.
@@ -11,4 +12,9 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE,
   environment: process.env.NODE_ENV || 'development',
   tracesSampleRate: resolveTracesSampleRate(),
+  // Drops /ok and /healthcheck liveness transactions and strips Express
+  // middleware bookkeeping spans from every other transaction (BS#2089).
+  // Error reporting (beforeSend / setupExpressErrorHandler) is untouched —
+  // wxyc-canary depends on /healthcheck errors surfacing there.
+  beforeSendTransaction: filterSentryTransactionEvent,
 });

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,6 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
+    "@wxyc/observability": "^1.0.0",
     "@wxyc/shared": "^3.3.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",

--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -25,6 +25,8 @@ const config: Config = {
     '^@wxyc/lml-client$': '<rootDir>/shared/lml-client/src/index.ts',
     // @wxyc/metadata: resolve to source for the same reason as @wxyc/lml-client.
     '^@wxyc/metadata$': '<rootDir>/shared/metadata/src/index.ts',
+    // @wxyc/observability: resolve to source for the same reason as @wxyc/lml-client.
+    '^@wxyc/observability$': '<rootDir>/shared/observability/src/index.ts',
     // @wxyc/legacy-mirror: resolve to source (BS#1707). The tubafrenzy mirror
     // client moved here from apps/backend/middleware/legacy/; the app-path
     // http.mirror.ts / rotation-match.mirror.ts shims re-export it. rotation-match

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@sentry/node": "^10.69.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
+        "@wxyc/observability": "^1.0.0",
         "@wxyc/shared": "^3.3.0",
         "better-auth": "^1.6.26",
         "cors": "^2.8.6",
@@ -109,6 +110,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
+        "@wxyc/observability": "^1.0.0",
         "@wxyc/shared": "^3.3.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
@@ -6379,6 +6381,10 @@
     },
     "node_modules/@wxyc/metadata-no-match-digest": {
       "resolved": "jobs/metadata-no-match-digest",
+      "link": true
+    },
+    "node_modules/@wxyc/observability": {
+      "resolved": "shared/observability",
       "link": true
     },
     "node_modules/@wxyc/rotation-artist-backfill": {
@@ -14717,6 +14723,18 @@
       "license": "MIT",
       "dependencies": {
         "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.5.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "shared/observability": {
+      "name": "@wxyc/observability",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.69.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "npm run lint:prebuild && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
-    "lint:prebuild": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client --workspace=@wxyc/metadata --workspace=@wxyc/legacy-mirror",
+    "lint:prebuild": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client --workspace=@wxyc/metadata --workspace=@wxyc/legacy-mirror --workspace=@wxyc/observability",
     "//lint": "8192 heap: eslint holds typed AST + program graph for every workspace; OOMs at node's default ~4GB ceiling on this monorepo.",
     "lint": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
     "lint:fix": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
@@ -16,7 +16,7 @@
     "format": "prettier --cache --cache-location .cache/prettier/ --write .",
     "format:check": "prettier --cache --cache-location .cache/prettier/ --check .",
     "build": "npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=apps/** --workspace=jobs/**",
-    "predev": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client --workspace=@wxyc/metadata --workspace=@wxyc/legacy-mirror",
+    "predev": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client --workspace=@wxyc/metadata --workspace=@wxyc/legacy-mirror --workspace=@wxyc/observability",
     "dev": "dotenvx run -f .env -- concurrently \"npm:dev:auth\" \"npm:dev:backend\"",
     "dev:backend": "npm run dev --workspace=@wxyc/backend",
     "dev:auth": "npm run dev --workspace=@wxyc/auth-service",

--- a/shared/observability/package.json
+++ b/shared/observability/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@wxyc/observability",
+  "version": "1.0.0",
+  "description": "Shared Sentry transaction/span filter predicates (BS#2089). Single source of truth for dropping liveness-route transactions (/ok, /healthcheck) and Express middleware bookkeeping spans, consumed by apps/backend/instrument.ts and apps/auth/instrument.ts so both containers apply byte-identical filtering.",
+  "author": "WXYC",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sentry/core": "^10.69.0",
+    "@sentry/node": "^10.69.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
+  },
+  "types": "dist/index.d.ts"
+}

--- a/shared/observability/src/index.ts
+++ b/shared/observability/src/index.ts
@@ -1,0 +1,1 @@
+export { isLivenessTransaction, isExpressMiddlewareSpan, filterSentryTransactionEvent } from './sentry-filters.js';

--- a/shared/observability/src/index.ts
+++ b/shared/observability/src/index.ts
@@ -1,1 +1,1 @@
-export { isLivenessTransaction, isExpressMiddlewareSpan, filterSentryTransactionEvent } from './sentry-filters.js';
+export { isLivenessRequestPath, isExpressMiddlewareSpan, filterSentryTransactionEvent } from './sentry-filters.js';

--- a/shared/observability/src/sentry-filters.ts
+++ b/shared/observability/src/sentry-filters.ts
@@ -1,29 +1,60 @@
 import type { SpanJSON, TransactionEvent } from '@sentry/core';
 
 /**
- * Transaction names that are pure liveness probes with no diagnostic value
- * in Sentry's performance product (BS#2089). Both are plain `GET` routes, so
- * Sentry's Express auto-instrumentation names their transaction after the
- * route path with no parameterization:
- *   - `GET /ok` — better-auth's built-in liveness endpoint, mounted under
- *     `/auth` in `apps/auth/instrument.ts`. Hit directly by infra health
- *     checks; ~40k requests / 14d, ~7 spans each, purely plugin-hook
- *     bookkeeping.
- *   - `GET /healthcheck` — the app-level liveness route in both
- *     `apps/backend/app.ts` and `apps/auth/app.ts`. `apps/auth`'s handler
- *     proxies to `/auth/ok`; `apps/backend`'s runs a DB probe. Neither's
- *     *transaction* carries anything an operator would trace into — the
- *     probe result is already in the response body and, on failure, in a
- *     captured *error* event, which this filter does not touch.
+ * Request paths that are pure liveness probes with no diagnostic value in
+ * Sentry's performance product (BS#2089).
+ *
+ * **Match on the request path, not the transaction name.** The obvious
+ * implementation — comparing `event.transaction` against `'GET /ok'` — is a
+ * silent no-op in production. Sentry's Express auto-instrumentation names a
+ * transaction after the *mount* path, not the path the client requested, and
+ * better-auth is mounted as a single handler at `/auth`. Every request under
+ * it, `/auth/ok` included, is therefore recorded as `GET /auth`. Verified
+ * against 14 days of production data (2026-08-10): `GET /auth` had 72,833
+ * transactions while `GET /ok` and `GET /healthcheck` had **zero events
+ * org-wide** — no transaction by either name has ever existed.
+ *
+ * The paths:
+ *   - `/auth/ok` — better-auth's built-in liveness endpoint, hit directly by
+ *     infra health checks. ~40k requests / 14d at ~7 spans each, all
+ *     plugin-hook bookkeeping. This is the volume this filter exists to shed.
+ *   - `/healthcheck` — the app-level liveness route in both
+ *     `apps/backend/app.ts` and `apps/auth/app.ts` (`apps/auth`'s proxies to
+ *     `/auth/ok`; `apps/backend`'s runs a DB probe). It currently produces no
+ *     transaction at all — hence the zero above — so listing it sheds nothing
+ *     today. It is kept so the probe stays shed if that ever changes; a path
+ *     in a Set costs nothing, and re-deriving this the next time span volume
+ *     spikes does.
  *
  * Dropping these transactions has no effect on error reporting: `wxyc-canary`
  * alerts on `/healthcheck` failures via `beforeSend`/`setupExpressErrorHandler`
  * capture, which is a separate pipeline from `beforeSendTransaction`.
  */
-const LIVENESS_TRANSACTION_NAMES = new Set(['GET /ok', 'GET /healthcheck']);
+const LIVENESS_PATHS = new Set(['/auth/ok', '/healthcheck']);
 
-export function isLivenessTransaction(transactionName: string | undefined): boolean {
-  return transactionName !== undefined && LIVENESS_TRANSACTION_NAMES.has(transactionName);
+/**
+ * `event.request.url` is populated by the SDK's `requestdata` event processor
+ * (an absolute URL when the request carried a Host header, a bare path
+ * otherwise), and event processors run in `prepareEvent` — before
+ * `beforeSendTransaction`. Sentry's server-side scrubbing renders this field
+ * as `[Filtered]` in stored data, but that happens after ingestion; the value
+ * seen here is the raw one.
+ */
+export function isLivenessRequestPath(url: string | undefined): boolean {
+  if (!url) return false;
+
+  let pathname: string;
+  try {
+    // The base makes a bare-path URL parse; it is discarded either way.
+    pathname = new URL(url, 'http://localhost').pathname;
+  } catch {
+    return false;
+  }
+
+  // `/auth/ok/` is the same probe as `/auth/ok`.
+  const normalized = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+
+  return LIVENESS_PATHS.has(normalized);
 }
 
 /**
@@ -44,13 +75,13 @@ export function isExpressMiddlewareSpan(span: Pick<SpanJSON, 'op'>): boolean {
 /**
  * `beforeSendTransaction` for both `apps/backend/instrument.ts` and
  * `apps/auth/instrument.ts` (BS#2089). Returning `null` drops the whole
- * transaction event, so liveness routes are filtered here rather than via
+ * transaction event, so liveness probes are filtered here rather than via
  * `beforeSendSpan` — the SDK's `beforeSendSpan` type can only modify a span,
  * not drop it. Express middleware bookkeeping spans are stripped from
  * `event.spans` on every surviving transaction.
  */
 export function filterSentryTransactionEvent(event: TransactionEvent): TransactionEvent | null {
-  if (isLivenessTransaction(event.transaction)) return null;
+  if (isLivenessRequestPath(event.request?.url)) return null;
 
   if (!event.spans || event.spans.length === 0) return event;
 

--- a/shared/observability/src/sentry-filters.ts
+++ b/shared/observability/src/sentry-filters.ts
@@ -1,0 +1,61 @@
+import type { SpanJSON, TransactionEvent } from '@sentry/core';
+
+/**
+ * Transaction names that are pure liveness probes with no diagnostic value
+ * in Sentry's performance product (BS#2089). Both are plain `GET` routes, so
+ * Sentry's Express auto-instrumentation names their transaction after the
+ * route path with no parameterization:
+ *   - `GET /ok` — better-auth's built-in liveness endpoint, mounted under
+ *     `/auth` in `apps/auth/instrument.ts`. Hit directly by infra health
+ *     checks; ~40k requests / 14d, ~7 spans each, purely plugin-hook
+ *     bookkeeping.
+ *   - `GET /healthcheck` — the app-level liveness route in both
+ *     `apps/backend/app.ts` and `apps/auth/app.ts`. `apps/auth`'s handler
+ *     proxies to `/auth/ok`; `apps/backend`'s runs a DB probe. Neither's
+ *     *transaction* carries anything an operator would trace into — the
+ *     probe result is already in the response body and, on failure, in a
+ *     captured *error* event, which this filter does not touch.
+ *
+ * Dropping these transactions has no effect on error reporting: `wxyc-canary`
+ * alerts on `/healthcheck` failures via `beforeSend`/`setupExpressErrorHandler`
+ * capture, which is a separate pipeline from `beforeSendTransaction`.
+ */
+const LIVENESS_TRANSACTION_NAMES = new Set(['GET /ok', 'GET /healthcheck']);
+
+export function isLivenessTransaction(transactionName: string | undefined): boolean {
+  return transactionName !== undefined && LIVENESS_TRANSACTION_NAMES.has(transactionName);
+}
+
+/**
+ * Express's per-middleware auto-instrumentation span op (`corsMiddleware`,
+ * `jsonParser`, route-local handlers, etc.) — each records only "this
+ * middleware ran," not a route or timing signal an operator would read.
+ * Deliberately narrower than `router.express` (route resolution) and
+ * `request_handler.express` (the route handler itself), which carry the
+ * information you actually want when tracing a slow request and must pass
+ * through untouched.
+ */
+const EXPRESS_MIDDLEWARE_SPAN_OP = 'middleware.express';
+
+export function isExpressMiddlewareSpan(span: Pick<SpanJSON, 'op'>): boolean {
+  return span.op === EXPRESS_MIDDLEWARE_SPAN_OP;
+}
+
+/**
+ * `beforeSendTransaction` for both `apps/backend/instrument.ts` and
+ * `apps/auth/instrument.ts` (BS#2089). Returning `null` drops the whole
+ * transaction event, so liveness routes are filtered here rather than via
+ * `beforeSendSpan` — the SDK's `beforeSendSpan` type can only modify a span,
+ * not drop it. Express middleware bookkeeping spans are stripped from
+ * `event.spans` on every surviving transaction.
+ */
+export function filterSentryTransactionEvent(event: TransactionEvent): TransactionEvent | null {
+  if (isLivenessTransaction(event.transaction)) return null;
+
+  if (!event.spans || event.spans.length === 0) return event;
+
+  const spans = event.spans.filter((span) => !isExpressMiddlewareSpan(span));
+  if (spans.length === event.spans.length) return event;
+
+  return { ...event, spans };
+}

--- a/shared/observability/tsconfig.build.json
+++ b/shared/observability/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["./tsconfig.json"],
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false
+  }
+}

--- a/shared/observability/tsconfig.json
+++ b/shared/observability/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./.cache/tsconfig.tsbuildinfo",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "types": ["node"]
+  }
+}

--- a/shared/observability/tsup.config.ts
+++ b/shared/observability/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  tsconfig: './tsconfig.build.json',
+  outDir: 'dist',
+  clean: true,
+  sourcemap: true,
+  external: ['@sentry/core', '@sentry/node'],
+});

--- a/tests/unit/config/sentry-transaction-filter.test.ts
+++ b/tests/unit/config/sentry-transaction-filter.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { SpanJSON, TransactionEvent } from '@sentry/core';
+import { filterSentryTransactionEvent, isExpressMiddlewareSpan, isLivenessTransaction } from '@wxyc/observability';
+
+function makeSpan(overrides: Partial<SpanJSON> = {}): SpanJSON {
+  return {
+    data: {},
+    op: 'http.server',
+    span_id: 'span1',
+    start_timestamp: 0,
+    trace_id: 'trace1',
+    ...overrides,
+  };
+}
+
+function makeTransactionEvent(overrides: Partial<TransactionEvent> = {}): TransactionEvent {
+  return {
+    type: 'transaction',
+    transaction: 'GET /flowsheet',
+    spans: [],
+    ...overrides,
+  };
+}
+
+describe('isLivenessTransaction', () => {
+  it.each(['GET /ok', 'GET /healthcheck'])('flags %s as a liveness transaction', (name) => {
+    expect(isLivenessTransaction(name)).toBe(true);
+  });
+
+  it('does not flag a real route transaction', () => {
+    expect(isLivenessTransaction('GET /flowsheet')).toBe(false);
+  });
+
+  it('does not flag undefined', () => {
+    expect(isLivenessTransaction(undefined)).toBe(false);
+  });
+});
+
+describe('isExpressMiddlewareSpan', () => {
+  it('flags middleware.express spans', () => {
+    expect(isExpressMiddlewareSpan({ op: 'middleware.express' })).toBe(true);
+  });
+
+  it.each(['router.express', 'request_handler.express', 'http.server', undefined])('does not flag %s spans', (op) => {
+    expect(isExpressMiddlewareSpan({ op })).toBe(false);
+  });
+});
+
+describe('filterSentryTransactionEvent', () => {
+  it('drops GET /ok transactions entirely', () => {
+    const event = makeTransactionEvent({ transaction: 'GET /ok' });
+    expect(filterSentryTransactionEvent(event)).toBeNull();
+  });
+
+  it('drops GET /healthcheck transactions entirely', () => {
+    const event = makeTransactionEvent({ transaction: 'GET /healthcheck' });
+    expect(filterSentryTransactionEvent(event)).toBeNull();
+  });
+
+  it('strips middleware.express spans from a real transaction', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /flowsheet',
+      spans: [
+        makeSpan({ span_id: 'a', op: 'middleware.express', description: 'corsMiddleware' }),
+        makeSpan({ span_id: 'b', op: 'middleware.express', description: 'jsonParser' }),
+        makeSpan({ span_id: 'c', op: 'router.express', description: 'router - /flowsheet' }),
+      ],
+    });
+
+    const result = filterSentryTransactionEvent(event);
+    expect(result?.spans?.map((s) => s.span_id)).toEqual(['c']);
+  });
+
+  it('passes router.express and request_handler.express spans through untouched', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /library',
+      spans: [
+        makeSpan({ span_id: 'a', op: 'router.express' }),
+        makeSpan({ span_id: 'b', op: 'request_handler.express' }),
+      ],
+    });
+
+    const result = filterSentryTransactionEvent(event);
+    expect(result?.spans).toHaveLength(2);
+    expect(result?.spans?.map((s) => s.span_id)).toEqual(['a', 'b']);
+  });
+
+  it('passes a real transaction with no middleware spans through unmodified', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /flowsheet',
+      spans: [makeSpan({ span_id: 'a', op: 'router.express' })],
+    });
+
+    expect(filterSentryTransactionEvent(event)).toEqual(event);
+  });
+
+  it('passes through a transaction with no spans array', () => {
+    const event = makeTransactionEvent({ transaction: 'GET /djs', spans: undefined });
+    expect(filterSentryTransactionEvent(event)).toBe(event);
+  });
+});
+
+describe('instrument.ts wiring', () => {
+  it.each([
+    ['backend', '../../../apps/backend/instrument.ts'],
+    ['auth', '../../../apps/auth/instrument.ts'],
+  ])('%s Sentry.init passes the shared filterSentryTransactionEvent as beforeSendTransaction', (_app, relPath) => {
+    const source = readFileSync(resolve(__dirname, relPath), 'utf-8');
+    expect(source).toMatch(/from ['"]@wxyc\/observability['"]/);
+    expect(source).toMatch(/beforeSendTransaction:\s*filterSentryTransactionEvent/);
+  });
+});

--- a/tests/unit/config/sentry-transaction-filter.test.ts
+++ b/tests/unit/config/sentry-transaction-filter.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import type { SpanJSON, TransactionEvent } from '@sentry/core';
-import { filterSentryTransactionEvent, isExpressMiddlewareSpan, isLivenessTransaction } from '@wxyc/observability';
+import { filterSentryTransactionEvent, isExpressMiddlewareSpan, isLivenessRequestPath } from '@wxyc/observability';
 
 function makeSpan(overrides: Partial<SpanJSON> = {}): SpanJSON {
   return {
@@ -23,17 +23,38 @@ function makeTransactionEvent(overrides: Partial<TransactionEvent> = {}): Transa
   };
 }
 
-describe('isLivenessTransaction', () => {
-  it.each(['GET /ok', 'GET /healthcheck'])('flags %s as a liveness transaction', (name) => {
-    expect(isLivenessTransaction(name)).toBe(true);
+describe('isLivenessRequestPath', () => {
+  it.each([
+    'https://api.wxyc.org/auth/ok',
+    'http://localhost:8082/auth/ok',
+    'https://api.wxyc.org/auth/ok/',
+    'https://api.wxyc.org/auth/ok?probe=1',
+    '/auth/ok',
+    'https://api.wxyc.org/healthcheck',
+    '/healthcheck',
+  ])('flags %s as a liveness probe', (url) => {
+    expect(isLivenessRequestPath(url)).toBe(true);
   });
 
-  it('does not flag a real route transaction', () => {
-    expect(isLivenessTransaction('GET /flowsheet')).toBe(false);
+  it.each([
+    'https://api.wxyc.org/flowsheet',
+    // The better-auth mount itself is real traffic (sign-in, session reads) and
+    // must survive — only the /ok sub-path under it is a probe.
+    'https://api.wxyc.org/auth',
+    'https://api.wxyc.org/auth/sign-in/email',
+    'https://api.wxyc.org/auth/ok/nested',
+    // Not a prefix match: a route that merely ends in /ok is not the probe.
+    'https://api.wxyc.org/library/ok',
+  ])('does not flag %s', (url) => {
+    expect(isLivenessRequestPath(url)).toBe(false);
   });
 
   it('does not flag undefined', () => {
-    expect(isLivenessTransaction(undefined)).toBe(false);
+    expect(isLivenessRequestPath(undefined)).toBe(false);
+  });
+
+  it('does not throw on an unparseable url', () => {
+    expect(isLivenessRequestPath('http://[malformed')).toBe(false);
   });
 });
 
@@ -48,14 +69,37 @@ describe('isExpressMiddlewareSpan', () => {
 });
 
 describe('filterSentryTransactionEvent', () => {
-  it('drops GET /ok transactions entirely', () => {
-    const event = makeTransactionEvent({ transaction: 'GET /ok' });
+  // Regression guard for the defect this filter shipped with: better-auth is
+  // mounted at /auth, so Sentry names the /auth/ok probe's transaction
+  // "GET /auth", not "GET /ok". Matching the transaction name dropped nothing
+  // in production. These two cases pin the real shape.
+  it('drops the /auth/ok probe even though its transaction is named GET /auth', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /auth',
+      request: { url: 'https://api.wxyc.org/auth/ok' },
+    });
     expect(filterSentryTransactionEvent(event)).toBeNull();
   });
 
-  it('drops GET /healthcheck transactions entirely', () => {
-    const event = makeTransactionEvent({ transaction: 'GET /healthcheck' });
+  it('keeps real /auth traffic sharing that transaction name', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /auth',
+      request: { url: 'https://api.wxyc.org/auth/get-session' },
+    });
+    expect(filterSentryTransactionEvent(event)).toBe(event);
+  });
+
+  it('drops the /healthcheck probe', () => {
+    const event = makeTransactionEvent({
+      transaction: 'GET /healthcheck',
+      request: { url: 'https://api.wxyc.org/healthcheck' },
+    });
     expect(filterSentryTransactionEvent(event)).toBeNull();
+  });
+
+  it('keeps a transaction with no request data', () => {
+    const event = makeTransactionEvent({ transaction: 'GET /auth' });
+    expect(filterSentryTransactionEvent(event)).toBe(event);
   });
 
   it('strips middleware.express spans from a real transaction', () => {
@@ -109,5 +153,23 @@ describe('instrument.ts wiring', () => {
     const source = readFileSync(resolve(__dirname, relPath), 'utf-8');
     expect(source).toMatch(/from ['"]@wxyc\/observability['"]/);
     expect(source).toMatch(/beforeSendTransaction:\s*filterSentryTransactionEvent/);
+  });
+});
+
+// The runtime images install and copy shared workspaces by explicit
+// enumeration, so a new one is silently absent until it is listed in both
+// places. `@wxyc/observability` is imported by instrument.ts, which loads
+// before app code — a missing dist is a boot crash, and no CI job builds these
+// images. Pin both Dockerfiles here instead.
+describe('Dockerfile runtime stages ship @wxyc/observability', () => {
+  it.each([
+    ['backend', '../../../Dockerfile.backend', 'builder'],
+    ['auth', '../../../Dockerfile.auth', 'auth-builder'],
+  ])('Dockerfile.%s copies the package manifest and the built dist', (_app, relPath, builderDir) => {
+    const source = readFileSync(resolve(__dirname, relPath), 'utf-8');
+    expect(source).toContain('COPY ./shared/observability/package* ./shared/observability/');
+    expect(source).toContain(
+      `COPY --from=builder ./${builderDir}/shared/observability/dist ./shared/observability/dist`
+    );
   });
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,8 @@
       "@wxyc/authentication": ["shared/authentication/src"],
       "@wxyc/database": ["shared/database/src"],
       "@wxyc/lml-client": ["shared/lml-client/src"],
-      "@wxyc/metadata": ["shared/metadata/src"]
+      "@wxyc/metadata": ["shared/metadata/src"],
+      "@wxyc/observability": ["shared/observability/src"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Both prod containers were tracing at `tracesSampleRate = 1.0`, and Sentry's Express auto-instrumentation was emitting a transaction for every `GET /ok` (better-auth's liveness probe) and `GET /healthcheck` request, plus a `middleware.express`-op span for every middleware invocation (`corsMiddleware`, `jsonParser`, etc.) on every request. Together these were ~13% of the org's Sentry span budget with no diagnostic value.
- Adds a new `@wxyc/observability` workspace package with `filterSentryTransactionEvent`, a single `beforeSendTransaction` predicate shared by `apps/backend/instrument.ts` and `apps/auth/instrument.ts`: it drops the transaction entirely for `/ok` and `/healthcheck`, and strips `middleware.express` spans from every other transaction's `event.spans` — `router.express` and `request_handler.express` spans (route resolution + the handler itself) pass through untouched.
- Error reporting is untouched: `beforeSend` / `setupExpressErrorHandler` capture is a separate pipeline from `beforeSendTransaction`, so `wxyc-canary`'s `/healthcheck` failure alerts keep working.
- `resolveTracesSampleRate` in both `sentry-config.ts` files is unchanged.
- Verified `apps/enrichment-worker/instrument.ts` has its own separate resolver (default `0.1`, no shared filter) and is unaffected by this change.

## Test plan

- [x] New unit tests in `tests/unit/config/sentry-transaction-filter.test.ts`: liveness-route drop for `GET /ok` and `GET /healthcheck`, middleware-span stripping, and negative cases — a real transaction (`GET /flowsheet`) and real `router.express`/`request_handler.express` spans pass through untouched.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
- [x] `npm run test:unit` — 426 suites / 6991 tests pass.
- [x] `npm run build` succeeds across all workspaces, including `apps/backend` and `apps/auth` importing the new package.
- [ ] Post-deploy: confirm BS 24h span count drops ≥25%, `corsMiddleware`/`jsonParser` span counts go to zero, and `GET /auth` transaction count drops by roughly the `/ok` share.

## Follow-up

Per the issue's "out of scope" note, whether `GET /playlists/recentEntries` deserves a lower per-route rate via `tracesSampler` is a separate question, not addressed here. The issue also asks for a recorded decision on whether `SENTRY_TRACES_SAMPLE_RATE` stays unset (1.0) once these filters land — that's an operational decision for after this PR merges and the post-deploy verification above is confirmed.

Closes #2089