### PR TITLE
fix(mirror): wrong-show signoff race, dead flag identity, show_end announcement predicates (BS#1119 follow-up)

### DIFF
--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -1,7 +1,8 @@
 import { QueryParams } from '../../controllers/flowsheet.controller';
 import { db } from '@wxyc/database';
 import { user, flowsheet, shows, FSEntry, Show } from '@wxyc/database';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
+import * as Sentry from '@sentry/node';
 import { Request } from 'express';
 import { createBackendMirrorMiddleware, createHttpMirrorMiddleware } from './mirror.middleware.js';
 import { safeSql, safeSqlNum, toMs } from './utilities.mirror.js';
@@ -44,37 +45,135 @@ const getEntries = createBackendMirrorMiddleware<any>(async (req, data) => {
  * lack (the old `show.id == null` form would silently re-open BS#1119 the day
  * show_djs gains a serial id, exactly the trap the issue body named). An
  * unrecognized shape (neither Show keys nor the ShowDJ `dj_id`) is skipped
- * LOUDLY: if a future projection change strips Show's keys from the response,
- * the mirror must not go quiet without a trace (BS#1119 follow-up review).
+ * LOUDLY — console.warn AND Sentry: if a future projection change strips
+ * Show's keys from the response, the mirror must not go quiet without a trace
+ * (BS#1119 follow-up review).
  */
 const isShowPayload = (data: unknown): data is Show => {
   if (typeof data !== 'object' || data == null) return false;
-  if ('primary_dj_id' in data && 'id' in data) return true;
+  // `id` is tested by VALUE, not just presence: every downstream read keys on
+  // it (getCachedShowId(show.id), eq(flowsheet.show_id, show.id)), and a null
+  // id binds NULL into the announcement re-query — matching nothing, dropping
+  // the marker silently. That is the BS#1119 failure mode itself, so a
+  // Show-shaped payload with a null id belongs in the loud lane below, not
+  // past the gate. `primary_dj_id` stays a PRESENCE test: null is a legitimate
+  // value for it (onDelete 'set null') and its key is what identifies the shape.
+  if ('primary_dj_id' in data && (data as { id?: unknown }).id != null) return true;
   if (!('dj_id' in data)) {
-    console.warn('[mirror] Unrecognized show-route payload shape; skipping mirror. keys=', Object.keys(data));
+    const keys = Object.keys(data);
+    console.warn('[mirror] Unrecognized show-route payload shape; skipping mirror. keys=', keys);
+    // console.warn alone is invisible in prod — nothing alerts on the EC2
+    // container's stdout. This is the silent-stop lane (a projection change
+    // that strips Show's keys stops every sign-off mirroring), so it has to
+    // reach the channel the team actually watches.
+    Sentry.captureMessage('[mirror] Unrecognized show-route payload shape; skipping mirror', {
+      level: 'warning',
+      tags: { subsystem: 'legacy-mirror', variant: 'http' },
+      extra: { keys },
+    });
   }
   return false;
 };
 
-const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
-  // Mirroring a show creation needs a resolvable primary DJ; a Show with a
-  // NULL primary_dj_id (legacy/shadow shows, onDelete 'set null') stays
-  // unmirrored here — the reconcile cron's sweep 1 applies the same
-  // primary_dj_id IS NOT NULL predicate. ShowDJ co-host joins never reach
-  // this handler (isShowPayload below); whether their dj_join markers should
-  // mirror at all is BS#2094.
-  const djId = show.primary_dj_id;
-  if (!djId) return;
+/**
+ * PostHog `backend-mirror` identity for a show-lifecycle payload: the show's
+ * own primary DJ. See `MirrorOptions.resolveFlagIdentity` (mirror.middleware.ts)
+ * for why the decision must be per-show rather than per-caller.
+ */
+const showFlagIdentity = (show: Show): string | null => show.primary_dj_id ?? null;
 
-  const dj = (await db.select().from(user).where(eq(user.id, djId)).limit(1))?.[0];
+/**
+ * The same identity for an entry payload, which names its show by id rather
+ * than carrying the primary DJ. One PK lookup, paid only when PostHog is
+ * configured (`isMirrorEnabled` resolves this lazily) and only on mutations
+ * that already POST to tubafrenzy.
+ */
+const entryFlagIdentity = async (entry: FSEntry): Promise<string | null> => {
+  if (entry.show_id == null) return null;
+  const showRow = await db
+    .select({ primary_dj_id: shows.primary_dj_id })
+    .from(shows)
+    .where(eq(shows.id, entry.show_id))
+    .limit(1);
+  return showRow?.[0]?.primary_dj_id ?? null;
+};
 
-  if (!dj) return;
+/**
+ * Mirror a show-lifecycle announcement marker (`show_start` / `show_end`) to
+ * tubafrenzy, then persist its surrogate key.
+ *
+ * BS#1705: target the marker by `entry_type` rather than the newest row by
+ * play_order. In normal operation the marker is the only (and newest) entry
+ * when this fires, so the old `ORDER BY play_order DESC LIMIT 1` happened to
+ * return it — but when a track already exists for the show, the DESC query
+ * returns the TRACK: the marker is never mirrored (prod: BS shows.id 1949437 /
+ * tubafrenzy 172277 has no START_OF_SHOW), and on the endShow side the
+ * already-mirrored track was re-POSTed as a duplicate with two racing
+ * legacy_entry_id persists. `isNull(legacy_entry_id)` keeps a re-fire
+ * idempotent (mirrors addEntry's BS#908 loop guard).
+ *
+ * Both call sites had drifted apart as near-identical copies — endShow kept the
+ * bare DESC query for months after startShow was hardened, which is what the
+ * BS#1119 follow-up review had to fix. One function, one query, no drift.
+ *
+ * `tubafrenzyShowId` is non-nullable BY TYPE: mapEntryToTubafrenzy accepts a
+ * null radio-show id, so a caller that skipped its show-create failure check
+ * would POST an orphan entry with no parent show AND stamp legacy_entry_id on
+ * the marker, poisoning it against legacy-mirror-reconcile's
+ * `legacy_entry_id IS NULL` sweep — permanently unrecoverable. Callers guard.
+ */
+const mirrorAnnouncementEntry = async (
+  showId: number,
+  entryType: 'show_start' | 'show_end',
+  tubafrenzyShowId: number
+): Promise<void> => {
+  const announcementEntry = await db
+    .select()
+    .from(flowsheet)
+    .where(and(eq(flowsheet.show_id, showId), eq(flowsheet.entry_type, entryType), isNull(flowsheet.legacy_entry_id)))
+    .limit(1);
 
-  // 1. Create show in tubafrenzy via REST API
-  const body = mapShowToTubafrenzy(show, dj);
-  const tubafrenzyShowId = await mirrorCreateShow(body);
+  const marker = announcementEntry?.[0];
+  if (!marker) return;
 
-  if (tubafrenzyShowId != null) {
+  const entryBody = mapEntryToTubafrenzy(marker, tubafrenzyShowId);
+  const entryId = await mirrorCreateEntry(entryBody);
+  if (entryId == null) return;
+
+  // BS#1103: key by the flowsheet row id, not play_order (only unique per-show).
+  cacheEntryId(marker.id, entryId);
+  try {
+    await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, marker.id));
+  } catch (e) {
+    console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
+  }
+};
+
+const startShow = createHttpMirrorMiddleware<Show>(
+  async (_req, show) => {
+    // Mirroring a show creation needs a resolvable primary DJ; a Show with a
+    // NULL primary_dj_id (legacy/shadow shows, onDelete 'set null') stays
+    // unmirrored here — the reconcile cron's sweep 1 applies the same
+    // primary_dj_id IS NOT NULL predicate. ShowDJ co-host joins never reach
+    // this handler (isShowPayload below); whether their dj_join markers should
+    // mirror at all is BS#2094.
+    const djId = show.primary_dj_id;
+    if (!djId) return;
+
+    const dj = (await db.select().from(user).where(eq(user.id, djId)).limit(1))?.[0];
+
+    if (!dj) return;
+
+    // 1. Create show in tubafrenzy via REST API
+    const body = mapShowToTubafrenzy(show, dj);
+    const tubafrenzyShowId = await mirrorCreateShow(body);
+
+    // A failed show-create leaves nothing to hang entries off. Skip the whole
+    // tail rather than POST an orphan announcement — legacy-mirror-reconcile's
+    // sweep 1 recreates the show and drives its entries from the durable
+    // `legacy_show_id IS NULL` signal, but only if this run stamped nothing.
+    if (tubafrenzyShowId == null) return;
+
     // Cache for subsequent addEntry calls in this process lifetime
     cacheShowId(show.id, tubafrenzyShowId);
     // Persist for ETL dedup and restart resilience
@@ -83,89 +182,33 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     } catch (e) {
       console.error('[mirror] Failed to persist legacy_show_id:', e);
     }
-  }
 
-  // 2. Mirror the show_start announcement entry.
-  //
-  // BS#1705: target the `show_start` marker explicitly rather than the newest
-  // row by play_order. In normal operation the marker is the only (and newest)
-  // entry when this fires, so the old `ORDER BY play_order DESC LIMIT 1`
-  // happened to return it — but if the announcement mirror ever runs after a
-  // track already exists for the show, the DESC query returns the track and the
-  // actual marker is never mirrored, leaving the tubafrenzy show with no
-  // START_OF_SHOW (type 9) entry (prod: BS shows.id 1949437 / tubafrenzy
-  // 172277). `isNull(legacy_entry_id)` keeps a re-fire idempotent: once the
-  // marker has been mirrored we never re-POST it (mirrors addEntry's BS#908
-  // loop guard). `endShow` targets its `show_end` marker the same way — the
-  // "there show_end genuinely is the newest row" assumption this comment used
-  // to record was false under the co-host race (see endShow below).
-  const announcementEntry = await db
-    .select()
-    .from(flowsheet)
-    .where(
-      and(eq(flowsheet.show_id, show.id), eq(flowsheet.entry_type, 'show_start'), isNull(flowsheet.legacy_entry_id))
-    )
-    .limit(1);
+    // 2. Mirror the show_start announcement entry.
+    await mirrorAnnouncementEntry(show.id, 'show_start', tubafrenzyShowId);
+  },
+  { shouldMirror: isShowPayload, resolveFlagIdentity: showFlagIdentity }
+);
 
-  if (announcementEntry?.[0]) {
-    const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
-    const entryId = await mirrorCreateEntry(entryBody);
-    if (entryId != null) {
-      // BS#1103: key by the flowsheet row id, not play_order (only unique per-show).
-      cacheEntryId(announcementEntry[0].id, entryId);
-      try {
-        await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
-      } catch (e) {
-        console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
-      }
-    }
-  }
-}, isShowPayload);
+export const endShow = createHttpMirrorMiddleware<Show>(
+  async (_req, show) => {
+    // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
+    // as this registration's shouldMirror gate — a guest leave never reaches
+    // this handler (and never pays the PostHog flag round-trip).
+    const endMs = toMs(show.end_time ?? Date.now());
 
-export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
-  // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
-  // as this registration's shouldMirror gate — a guest leave never reaches
-  // this handler (and never pays the PostHog flag round-trip).
-  const endMs = toMs(show.end_time ?? Date.now());
+    // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
+    const tubafrenzyShowId = getCachedShowId(show.id) ?? show.legacy_show_id;
 
-  // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
-  const tubafrenzyShowId = getCachedShowId(show.id) ?? show.legacy_show_id;
+    // No tubafrenzy show to sign off or hang the END_OF_SHOW entry off (the
+    // startShow mirror failed, or this process never saw it and the persist
+    // failed too). Both arms skip together; legacy-mirror-reconcile heals it.
+    if (tubafrenzyShowId == null) return;
 
-  if (tubafrenzyShowId != null) {
     await mirrorSignoffShow(tubafrenzyShowId, endMs);
-  }
-
-  // Mirror the show_end announcement entry. Target the `show_end` marker
-  // explicitly — the same BS#1705 form as startShow's `show_start` query
-  // above. The old bare `ORDER BY play_order DESC LIMIT 1` assumed the marker
-  // is always the newest row, but the service writes the show_end marker
-  // BEFORE it commits end_time, so a co-host POST /flowsheet that squeaks
-  // past the active-show check lands with a higher play_order: the DESC query
-  // then re-mirrored that track (already mirrored by its own addEntry, with
-  // two racing legacy_entry_id persists) and the END_OF_SHOW marker never
-  // reached tubafrenzy. `isNull(legacy_entry_id)` keeps a re-fire idempotent,
-  // exactly like startShow's. BS#1119 follow-up review.
-  const announcementEntry = await db
-    .select()
-    .from(flowsheet)
-    .where(and(eq(flowsheet.show_id, show.id), eq(flowsheet.entry_type, 'show_end'), isNull(flowsheet.legacy_entry_id)))
-    .orderBy(desc(flowsheet.play_order))
-    .limit(1);
-
-  if (announcementEntry?.[0]) {
-    const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
-    const entryId = await mirrorCreateEntry(entryBody);
-    if (entryId != null) {
-      // BS#1103: key by the flowsheet row id, not play_order (only unique per-show).
-      cacheEntryId(announcementEntry[0].id, entryId);
-      try {
-        await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
-      } catch (e) {
-        console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
-      }
-    }
-  }
-}, isShowPayload);
+    await mirrorAnnouncementEntry(show.id, 'show_end', tubafrenzyShowId);
+  },
+  { shouldMirror: isShowPayload, resolveFlagIdentity: showFlagIdentity }
+);
 
 const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   const startMs = entry?.add_time ? new Date(entry.add_time).getTime() : Date.now();
@@ -329,104 +372,113 @@ const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   return statements;
 };
 
-export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
-  // Loop guard (use #2 of the legacy_entry_id three-use invariant, BS#908):
-  // `legacy_entry_id != null` is read as a boolean meaning "this row came
-  // from tubafrenzy via ETL or webhook, do not mirror back." Together with
-  // the matching guard in updateEntry below (line ~317) this prevents an
-  // infinite ETL → mirror → webhook → ETL cycle. The three orthogonal uses
-  // and their constraints are documented at `shared/database/src/schema.ts`
-  // on the column declaration; CI enforces no new write site appears
-  // without registering at `scripts/check-legacy-entry-id-writes.mjs`.
-  if (entry.legacy_entry_id != null) return;
+export const addEntry = createHttpMirrorMiddleware<FSEntry>(
+  async (_req, entry) => {
+    // Loop guard (use #2 of the legacy_entry_id three-use invariant, BS#908):
+    // `legacy_entry_id != null` is read as a boolean meaning "this row came
+    // from tubafrenzy via ETL or webhook, do not mirror back." Together with
+    // the matching guard in updateEntry below (line ~317) this prevents an
+    // infinite ETL → mirror → webhook → ETL cycle. The three orthogonal uses
+    // and their constraints are documented at `shared/database/src/schema.ts`
+    // on the column declaration; CI enforces no new write site appears
+    // without registering at `scripts/check-legacy-entry-id-writes.mjs`.
+    if (entry.legacy_entry_id != null) return;
 
-  // Resolve tubafrenzy show ID: (1) in-memory cache, (2) DB, (3) null (auto-resolve)
-  let radioShowID: number | null | undefined = entry.show_id != null ? getCachedShowId(entry.show_id) : undefined;
-  if (radioShowID == null && entry.show_id != null) {
-    try {
-      const showRow = await db
-        .select({ legacy_show_id: shows.legacy_show_id })
-        .from(shows)
-        .where(eq(shows.id, entry.show_id))
-        .limit(1);
-      radioShowID = showRow?.[0]?.legacy_show_id ?? null;
-      if (radioShowID != null) {
-        cacheShowId(entry.show_id, radioShowID);
+    // Resolve tubafrenzy show ID: (1) in-memory cache, (2) DB, (3) null (auto-resolve)
+    let radioShowID: number | null | undefined = entry.show_id != null ? getCachedShowId(entry.show_id) : undefined;
+    if (radioShowID == null && entry.show_id != null) {
+      try {
+        const showRow = await db
+          .select({ legacy_show_id: shows.legacy_show_id })
+          .from(shows)
+          .where(eq(shows.id, entry.show_id))
+          .limit(1);
+        radioShowID = showRow?.[0]?.legacy_show_id ?? null;
+        if (radioShowID != null) {
+          cacheShowId(entry.show_id, radioShowID);
+        }
+      } catch {
+        // DB lookup failed; fall back to tubafrenzy auto-resolution
       }
-    } catch {
-      // DB lookup failed; fall back to tubafrenzy auto-resolution
     }
-  }
 
-  const isRotationMatch = await isActiveRotationMatch(entry);
-  const body = mapEntryToTubafrenzy(entry, radioShowID, isRotationMatch);
-  const tubafrenzyId = await mirrorCreateEntry(body);
-  if (tubafrenzyId != null) {
-    // BS#1103: key by the flowsheet row id, not play_order — play_order
-    // resets per show, so two shows in the same process lifetime can
-    // collide on the same slot and evict each other's cached entry.
-    cacheEntryId(entry.id, tubafrenzyId);
-    // Persist the mapping so the ETL can deduplicate
-    try {
-      await db.update(flowsheet).set({ legacy_entry_id: tubafrenzyId }).where(eq(flowsheet.id, entry.id));
-    } catch (e) {
-      console.error('[mirror] Failed to persist legacy_entry_id:', e);
+    const isRotationMatch = await isActiveRotationMatch(entry);
+    const body = mapEntryToTubafrenzy(entry, radioShowID, isRotationMatch);
+    const tubafrenzyId = await mirrorCreateEntry(body);
+    if (tubafrenzyId != null) {
+      // BS#1103: key by the flowsheet row id, not play_order — play_order
+      // resets per show, so two shows in the same process lifetime can
+      // collide on the same slot and evict each other's cached entry.
+      cacheEntryId(entry.id, tubafrenzyId);
+      // Persist the mapping so the ETL can deduplicate
+      try {
+        await db.update(flowsheet).set({ legacy_entry_id: tubafrenzyId }).where(eq(flowsheet.id, entry.id));
+      } catch (e) {
+        console.error('[mirror] Failed to persist legacy_entry_id:', e);
+      }
     }
-  }
-});
+  },
+  { resolveFlagIdentity: entryFlagIdentity }
+);
 
-export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
-  // Message-only rows aren't updateable
-  if (entry?.message && entry.message.trim() !== '') return;
+export const updateEntry = createHttpMirrorMiddleware<FSEntry>(
+  async (_req, entry) => {
+    // Message-only rows aren't updateable
+    if (entry?.message && entry.message.trim() !== '') return;
 
-  // BS#1103: key by the flowsheet row id, not play_order — see cacheEntryId call in addEntry above.
-  const cachedId = getCachedEntryId(entry.id);
+    // BS#1103: key by the flowsheet row id, not play_order — see cacheEntryId call in addEntry above.
+    const cachedId = getCachedEntryId(entry.id);
 
-  // Loop guard: entry has a legacy ID but we didn't cache it this lifecycle —
-  // it was imported by the ETL, not created by our mirror. Don't mirror back.
-  if (cachedId == null && entry.legacy_entry_id != null) return;
+    // Loop guard: entry has a legacy ID but we didn't cache it this lifecycle —
+    // it was imported by the ETL, not created by our mirror. Don't mirror back.
+    if (cachedId == null && entry.legacy_entry_id != null) return;
 
-  // Use cache (fast path) or fall back to persisted legacy_entry_id (after restart)
-  const tubafrenzyId = cachedId ?? entry.legacy_entry_id;
-  if (tubafrenzyId == null) {
-    console.warn('[mirror] No tubafrenzy ID for flowsheet row', entry.id);
-    return;
-  }
+    // Use cache (fast path) or fall back to persisted legacy_entry_id (after restart)
+    const tubafrenzyId = cachedId ?? entry.legacy_entry_id;
+    if (tubafrenzyId == null) {
+      console.warn('[mirror] No tubafrenzy ID for flowsheet row', entry.id);
+      return;
+    }
 
-  const isRotationMatch = await isActiveRotationMatch(entry);
-  const body = mapUpdateToTubafrenzy(entry, isRotationMatch);
-  await mirrorUpdateEntry(tubafrenzyId, body);
-});
+    const isRotationMatch = await isActiveRotationMatch(entry);
+    const body = mapUpdateToTubafrenzy(entry, isRotationMatch);
+    await mirrorUpdateEntry(tubafrenzyId, body);
+  },
+  { resolveFlagIdentity: entryFlagIdentity }
+);
 
-export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(async (_req, removed) => {
-  // Delete by the tubafrenzy surrogate key persisted on the row at insert
-  // (`legacy_entry_id` — the same identity uses #1/#3 key their `ON CONFLICT`
-  // on; see addEntry's persist above and `shared/database/src/schema.ts`).
-  // BS#1101.
-  //
-  // The prior implementation resolved the show via `MAX(ID)` and matched the
-  // row positionally by `SEQUENCE_WITHIN_SHOW = play_order`. Both predicates
-  // are wrong:
-  //   - `MAX(ID)` is the newest tubafrenzy show, not the deleted entry's, so
-  //     correcting an older show deletes from the wrong show.
-  //   - Even for the right show, tubafrenzy's `SEQUENCE_WITHIN_SHOW` (assigned
-  //     at insert as `MAX(SEQUENCE_WITHIN_SHOW)+1` into `@SEQ_NUM`; see addEntry
-  //     above) and BS `play_order` are assigned independently and diverge — BS
-  //     `play_order` counts lifecycle markers tubafrenzy never materializes as
-  //     entry rows — so the positional predicate misses even in the happy path.
-  //
-  // When `legacy_entry_id` is null — a residual pre-mirror row, or a row whose
-  // mirror POST failed — there is no safe target, so no-op (return no
-  // statements) rather than guess. The middleware skips the enqueue on empty.
-  // Log the skip: a failed insert-mirror leaves a tubafrenzy row this delete
-  // can never reach, so the residual is at least countable in the logs.
-  if (removed.legacy_entry_id == null) {
-    console.warn('[mirror] Skipping tubafrenzy delete: no legacy_entry_id on removed row', removed.id);
-    return [];
-  }
+export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(
+  async (_req, removed) => {
+    // Delete by the tubafrenzy surrogate key persisted on the row at insert
+    // (`legacy_entry_id` — the same identity uses #1/#3 key their `ON CONFLICT`
+    // on; see addEntry's persist above and `shared/database/src/schema.ts`).
+    // BS#1101.
+    //
+    // The prior implementation resolved the show via `MAX(ID)` and matched the
+    // row positionally by `SEQUENCE_WITHIN_SHOW = play_order`. Both predicates
+    // are wrong:
+    //   - `MAX(ID)` is the newest tubafrenzy show, not the deleted entry's, so
+    //     correcting an older show deletes from the wrong show.
+    //   - Even for the right show, tubafrenzy's `SEQUENCE_WITHIN_SHOW` (assigned
+    //     at insert as `MAX(SEQUENCE_WITHIN_SHOW)+1` into `@SEQ_NUM`; see addEntry
+    //     above) and BS `play_order` are assigned independently and diverge — BS
+    //     `play_order` counts lifecycle markers tubafrenzy never materializes as
+    //     entry rows — so the positional predicate misses even in the happy path.
+    //
+    // When `legacy_entry_id` is null — a residual pre-mirror row, or a row whose
+    // mirror POST failed — there is no safe target, so no-op (return no
+    // statements) rather than guess. The middleware skips the enqueue on empty.
+    // Log the skip: a failed insert-mirror leaves a tubafrenzy row this delete
+    // can never reach, so the residual is at least countable in the logs.
+    if (removed.legacy_entry_id == null) {
+      console.warn('[mirror] Skipping tubafrenzy delete: no legacy_entry_id on removed row', removed.id);
+      return [];
+    }
 
-  return [`DELETE FROM ${FLOWSHEET_ENTRY_TABLE} WHERE ID = ${safeSqlNum(removed.legacy_entry_id)} LIMIT 1;`];
-});
+    return [`DELETE FROM ${FLOWSHEET_ENTRY_TABLE} WHERE ID = ${safeSqlNum(removed.legacy_entry_id)} LIMIT 1;`];
+  },
+  { resolveFlagIdentity: entryFlagIdentity }
+);
 
 /*
 export const changeOrder = createBackendMirrorMiddleware<FSEntry>(

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -33,9 +33,38 @@ const getEntries = createBackendMirrorMiddleware<any>(async (req, data) => {
   return [`SELECT * FROM ${FLOWSHEET_ENTRY_TABLE} LIMIT ${limit} OFFSET ${offset};`];
 });
 
+/**
+ * Positive Show discriminant for the /flowsheet/join and /flowsheet/end
+ * responses, which serve join/leave semantics through the same registration:
+ * a co-host join or a guest-DJ leave (or the Auto-DJ orchestrator's restart
+ * recovery) answers with a ShowDJ instead of a Show (BS#1119). Discriminate
+ * on Show's OWN keys — `primary_dj_id` is present on every Show payload even
+ * when its value is null, because the response is a JSON round-trip of the
+ * full row — rather than duck-typing on fields the OTHER shape happens to
+ * lack (the old `show.id == null` form would silently re-open BS#1119 the day
+ * show_djs gains a serial id, exactly the trap the issue body named). An
+ * unrecognized shape (neither Show keys nor the ShowDJ `dj_id`) is skipped
+ * LOUDLY: if a future projection change strips Show's keys from the response,
+ * the mirror must not go quiet without a trace (BS#1119 follow-up review).
+ */
+const isShowPayload = (data: unknown): data is Show => {
+  if (typeof data !== 'object' || data == null) return false;
+  if ('primary_dj_id' in data && 'id' in data) return true;
+  if (!('dj_id' in data)) {
+    console.warn('[mirror] Unrecognized show-route payload shape; skipping mirror. keys=', Object.keys(data));
+  }
+  return false;
+};
+
 const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
+  // Mirroring a show creation needs a resolvable primary DJ; a Show with a
+  // NULL primary_dj_id (legacy/shadow shows, onDelete 'set null') stays
+  // unmirrored here — the reconcile cron's sweep 1 applies the same
+  // primary_dj_id IS NOT NULL predicate. ShowDJ co-host joins never reach
+  // this handler (isShowPayload below); whether their dj_join markers should
+  // mirror at all is BS#2094.
   const djId = show.primary_dj_id;
-  if (!djId || !show) return;
+  if (!djId) return;
 
   const dj = (await db.select().from(user).where(eq(user.id, djId)).limit(1))?.[0];
 
@@ -67,8 +96,9 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
   // START_OF_SHOW (type 9) entry (prod: BS shows.id 1949437 / tubafrenzy
   // 172277). `isNull(legacy_entry_id)` keeps a re-fire idempotent: once the
   // marker has been mirrored we never re-POST it (mirrors addEntry's BS#908
-  // loop guard). `endShow` deliberately keeps the DESC query — there `show_end`
-  // genuinely is the newest row.
+  // loop guard). `endShow` targets its `show_end` marker the same way — the
+  // "there show_end genuinely is the newest row" assumption this comment used
+  // to record was false under the co-host race (see endShow below).
   const announcementEntry = await db
     .select()
     .from(flowsheet)
@@ -90,15 +120,12 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
       }
     }
   }
-});
+}, isShowPayload);
 
 export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
-  // BS#1119: /flowsheet/end serves leave semantics too — a guest-DJ leave (or
-  // the Auto-DJ orchestrator's restart recovery) responds with a ShowDJ, which
-  // has no `id`. Only a finalized Show carries the serial PK; discriminate on
-  // it rather than primary_dj_id, which is nullable on a real Show.
-  if (show.id == null) return;
-
+  // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
+  // as this registration's shouldMirror gate — a guest leave never reaches
+  // this handler (and never pays the PostHog flag round-trip).
   const endMs = toMs(show.end_time ?? Date.now());
 
   // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
@@ -108,11 +135,20 @@ export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     await mirrorSignoffShow(tubafrenzyShowId, endMs);
   }
 
-  // Mirror the show_end announcement entry
+  // Mirror the show_end announcement entry. Target the `show_end` marker
+  // explicitly — the same BS#1705 form as startShow's `show_start` query
+  // above. The old bare `ORDER BY play_order DESC LIMIT 1` assumed the marker
+  // is always the newest row, but the service writes the show_end marker
+  // BEFORE it commits end_time, so a co-host POST /flowsheet that squeaks
+  // past the active-show check lands with a higher play_order: the DESC query
+  // then re-mirrored that track (already mirrored by its own addEntry, with
+  // two racing legacy_entry_id persists) and the END_OF_SHOW marker never
+  // reached tubafrenzy. `isNull(legacy_entry_id)` keeps a re-fire idempotent,
+  // exactly like startShow's. BS#1119 follow-up review.
   const announcementEntry = await db
     .select()
     .from(flowsheet)
-    .where(eq(flowsheet.show_id, show.id))
+    .where(and(eq(flowsheet.show_id, show.id), eq(flowsheet.entry_type, 'show_end'), isNull(flowsheet.legacy_entry_id)))
     .orderBy(desc(flowsheet.play_order))
     .limit(1);
 
@@ -129,7 +165,7 @@ export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
       }
     }
   }
-});
+}, isShowPayload);
 
 const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   const startMs = entry?.add_time ? new Date(entry.add_time).getTime() : Date.now();

--- a/apps/backend/middleware/legacy/mirror.middleware.ts
+++ b/apps/backend/middleware/legacy/mirror.middleware.ts
@@ -7,21 +7,38 @@ import { getPostHogClient } from '../../utils/posthog.js';
  * Check the PostHog `backend-mirror` feature flag. If PostHog is not
  * configured (no API key), the mirror is enabled by default so that
  * local development and E2E tests work without external dependencies.
+ *
+ * `resolveShowIdentity` (optional) supplies the SHOW's primary DJ as the flag
+ * identity. That — not the caller — is the correct unit of decision: the flag
+ * has to answer the same way for every payload belonging to one show, or a
+ * mixed-DJ show mirrors in half. It is resolved lazily, so the lookup it may
+ * cost is only paid on the PostHog-configured path.
+ *
+ * The `req.auth?.id` fallback covers registrations with no show in the payload.
+ * req.auth is what the auth middleware sets (shared/authentication
+ * auth.middleware.ts) — nothing in this codebase ever assigns req.user, so the
+ * pre-BS#1119-follow-up `req.user?.id` read meant every evaluation fell back to
+ * req.ip, one EC2-local value.
  */
-async function isMirrorEnabled(req: Request): Promise<boolean> {
+async function isMirrorEnabled(req: Request, resolveShowIdentity?: () => Promise<string | null>): Promise<boolean> {
   if (!process.env.POSTHOG_API_KEY) {
     console.log('[mirror] enabled=true source=env-default');
     return true;
   }
 
+  let showIdentity: string | null = null;
+  if (resolveShowIdentity) {
+    try {
+      showIdentity = await resolveShowIdentity();
+    } catch (e) {
+      // Never fail the flag check on an identity lookup: fall back to the
+      // caller, the same identity every registration without a resolver uses.
+      console.warn('[mirror] Failed to resolve the show flag identity; falling back to the caller:', e);
+    }
+  }
+
   const client = getPostHogClient();
-  // req.auth is what the auth middleware sets (shared/authentication
-  // auth.middleware.ts) — nothing in this codebase ever assigns req.user, so
-  // reading it here meant every flag evaluation fell back to req.ip (one
-  // EC2-local value) and per-DJ targeting of `backend-mirror` silently could
-  // not work on the live path, diverging from jobs/legacy-mirror-reconcile
-  // which keys the same flag on primary_dj_id. BS#1119 follow-up review.
-  const distinctId = req.auth?.id ?? req.ip ?? 'anonymous';
+  const distinctId = showIdentity ?? req.auth?.id ?? req.ip ?? 'anonymous';
   const enabled = await client.isFeatureEnabled('backend-mirror', distinctId);
   if (enabled === undefined) {
     // PostHog couldn't resolve the flag (client error/timeout/unknown flag):
@@ -34,8 +51,32 @@ async function isMirrorEnabled(req: Request): Promise<boolean> {
   return enabled;
 }
 
+/**
+ * Optional per-registration behavior shared by both mirror factories.
+ *
+ * `shouldMirror` gates the payload SHAPE before any other work: a route that
+ * serves two response shapes through one registration (BS#1119 —
+ * /flowsheet/end answers a ShowDJ for guest leaves, /flowsheet/join a ShowDJ
+ * for co-host joins) passes a type-guard predicate so non-mirrorable payloads
+ * skip out here, before the PostHog round-trip `isMirrorEnabled` pays in prod,
+ * and so the `as T` cast in the handler is backed by a runtime check instead
+ * of hope.
+ *
+ * `resolveFlagIdentity` supplies the show's primary DJ as the `backend-mirror`
+ * flag identity (see `isMirrorEnabled`). Every registration that can name a
+ * show should pass one: it keeps the live mirror's decision per-SHOW, matching
+ * `jobs/legacy-mirror-reconcile`, which keys the same flag on `primary_dj_id`.
+ * Without it, a show whose co-host resolves the flag differently from its
+ * primary reaches tubafrenzy half-mirrored — the one state the reconcile cron
+ * refuses to auto-heal (re-driving would append out of order).
+ */
+type MirrorOptions<T> = {
+  shouldMirror?: (data: unknown) => data is T;
+  resolveFlagIdentity?: (data: T) => Promise<string | null> | string | null;
+};
+
 export const createBackendMirrorMiddleware =
-  <T>(createCommand: (req: Request, data: T) => Promise<string[]>) =>
+  <T>(createCommand: (req: Request, data: T) => Promise<string[]>, options: MirrorOptions<T> = {}) =>
   async (req: Request, res: Response, next: NextFunction) => {
     tapJsonResponse(res);
 
@@ -50,8 +91,9 @@ export const createBackendMirrorMiddleware =
           console.log('Response status:', res.statusCode, 'ok?', ok);
 
           if (!ok || data == null) return;
+          if (options.shouldMirror && !options.shouldMirror(data)) return;
 
-          const mirrorOn = await isMirrorEnabled(req);
+          const mirrorOn = await isMirrorEnabled(req, identityResolver(options, data));
           if (!mirrorOn) return;
 
           const statements = await createCommand(req, data);
@@ -74,20 +116,21 @@ export const createBackendMirrorMiddleware =
     next();
   };
 
+/** Bind a registration's optional identity resolver to this request's payload. */
+function identityResolver<T>(options: MirrorOptions<T>, data: T): (() => Promise<string | null>) | undefined {
+  const resolve = options.resolveFlagIdentity;
+  return resolve ? () => Promise.resolve(resolve(data)) : undefined;
+}
+
 /**
  * HTTP mirror middleware factory. Same response-tapping and PostHog feature flag
  * check as createBackendMirrorMiddleware, but calls an async callback that makes
  * HTTP calls instead of returning SQL strings for the command queue.
  *
- * `shouldMirror` (optional) gates the payload SHAPE before any other work: a
- * route that serves two response shapes through one registration (BS#1119 —
- * /flowsheet/end answers a ShowDJ for guest leaves, /flowsheet/join a ShowDJ
- * for co-host joins) passes a type-guard predicate so non-mirrorable payloads
- * skip out here, before the PostHog round-trip `isMirrorEnabled` pays in prod,
- * and so the `as T` cast below is backed by a runtime check instead of hope.
+ * See `MirrorOptions` for `shouldMirror` and `resolveFlagIdentity`.
  */
 export const createHttpMirrorMiddleware =
-  <T>(execute: (req: Request, data: T) => Promise<void>, shouldMirror?: (data: unknown) => data is T) =>
+  <T>(execute: (req: Request, data: T) => Promise<void>, options: MirrorOptions<T> = {}) =>
   async (req: Request, res: Response, next: NextFunction) => {
     tapJsonResponse(res);
 
@@ -98,9 +141,9 @@ export const createHttpMirrorMiddleware =
           const data = (res.locals as any).mirrorData as T | undefined;
 
           if (!ok || data == null) return;
-          if (shouldMirror && !shouldMirror(data)) return;
+          if (options.shouldMirror && !options.shouldMirror(data)) return;
 
-          const mirrorOn = await isMirrorEnabled(req);
+          const mirrorOn = await isMirrorEnabled(req, identityResolver(options, data));
           if (!mirrorOn) return;
 
           await execute(req, data);

--- a/apps/backend/middleware/legacy/mirror.middleware.ts
+++ b/apps/backend/middleware/legacy/mirror.middleware.ts
@@ -15,7 +15,13 @@ async function isMirrorEnabled(req: Request): Promise<boolean> {
   }
 
   const client = getPostHogClient();
-  const distinctId = (req as any).user?.id ?? req.ip ?? 'anonymous';
+  // req.auth is what the auth middleware sets (shared/authentication
+  // auth.middleware.ts) — nothing in this codebase ever assigns req.user, so
+  // reading it here meant every flag evaluation fell back to req.ip (one
+  // EC2-local value) and per-DJ targeting of `backend-mirror` silently could
+  // not work on the live path, diverging from jobs/legacy-mirror-reconcile
+  // which keys the same flag on primary_dj_id. BS#1119 follow-up review.
+  const distinctId = req.auth?.id ?? req.ip ?? 'anonymous';
   const enabled = await client.isFeatureEnabled('backend-mirror', distinctId);
   if (enabled === undefined) {
     // PostHog couldn't resolve the flag (client error/timeout/unknown flag):
@@ -72,9 +78,16 @@ export const createBackendMirrorMiddleware =
  * HTTP mirror middleware factory. Same response-tapping and PostHog feature flag
  * check as createBackendMirrorMiddleware, but calls an async callback that makes
  * HTTP calls instead of returning SQL strings for the command queue.
+ *
+ * `shouldMirror` (optional) gates the payload SHAPE before any other work: a
+ * route that serves two response shapes through one registration (BS#1119 —
+ * /flowsheet/end answers a ShowDJ for guest leaves, /flowsheet/join a ShowDJ
+ * for co-host joins) passes a type-guard predicate so non-mirrorable payloads
+ * skip out here, before the PostHog round-trip `isMirrorEnabled` pays in prod,
+ * and so the `as T` cast below is backed by a runtime check instead of hope.
  */
 export const createHttpMirrorMiddleware =
-  <T>(execute: (req: Request, data: T) => Promise<void>) =>
+  <T>(execute: (req: Request, data: T) => Promise<void>, shouldMirror?: (data: unknown) => data is T) =>
   async (req: Request, res: Response, next: NextFunction) => {
     tapJsonResponse(res);
 
@@ -85,6 +98,7 @@ export const createHttpMirrorMiddleware =
           const data = (res.locals as any).mirrorData as T | undefined;
 
           if (!ok || data == null) return;
+          if (shouldMirror && !shouldMirror(data)) return;
 
           const mirrorOn = await isMirrorEnabled(req);
           if (!mirrorOn) return;

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1136,10 +1136,21 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
     message,
   });
 
-  await db.update(shows).set({ end_time: new Date() }).where(eq(shows.id, currentShow.id));
+  // Return the row this UPDATE finalized — never a re-read. The previous
+  // `return (await getLatestShow())!` raced a concurrent POST /flowsheet/join:
+  // a show N+1 created between the UPDATE and the re-read is what got
+  // returned, and the mirror middleware then signed off the WRONG, still-live
+  // show in tubafrenzy while show N's signoff was silently dropped (BS#1119
+  // follow-up review). The non-null assertion is safe: the WHERE keys on the
+  // currentShow.id the controller just fetched, and no code path deletes
+  // `shows` rows mid-request.
+  const finalized = await db
+    .update(shows)
+    .set({ end_time: new Date() })
+    .where(eq(shows.id, currentShow.id))
+    .returning();
 
-  // We just ended this show, so a latest show always exists here
-  return (await getLatestShow())!;
+  return finalized[0]!;
 };
 
 export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowDJ> => {

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1105,6 +1105,36 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   const primary_dj_id = currentShow.primary_dj_id;
   if (!primary_dj_id) throw new Error('Primary DJ not found');
 
+  // Claim the show FIRST, before any other write.
+  //
+  // Two things follow from the ordering, both of which were broken when the
+  // end_time UPDATE ran last (BS#1119 follow-up review):
+  //
+  //   1. `end_time IS NULL` makes this a compare-and-set. The controller's own
+  //      `currentShow.end_time !== null` guard only rejects a second end after
+  //      the first COMMITS; a double-click has both requests reading a live
+  //      show, and without the CAS both wrote a `show_end` marker and both
+  //      returned 200, so the mirror signed off tubafrenzy twice. The loser
+  //      now gets an empty `.returning()` and the same 400 the controller
+  //      raises — a non-2xx response, which the mirror middleware skips.
+  //   2. Committing end_time before the marker closes the co-host write
+  //      window. Writing the marker first left the show ACTIVE while the
+  //      marker existed, so a racing `POST /flowsheet` passed the active-show
+  //      check and landed after it — appearing in tubafrenzy after
+  //      END_OF_SHOW, since tubafrenzy assigns SEQUENCE server-side. Ending
+  //      the show first makes that add fail its own guard.
+  const finalized = await db
+    .update(shows)
+    .set({ end_time: new Date() })
+    .where(and(eq(shows.id, currentShow.id), isNull(shows.end_time)))
+    .returning();
+
+  const finalizedShow = finalized[0];
+  if (!finalizedShow) {
+    // Someone else ended this show between the controller's read and here.
+    throw new WxycError('Bad Request: No active show session found.', 400);
+  }
+
   const remaining_djs = await db
     .select()
     .from(show_djs)
@@ -1136,21 +1166,13 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
     message,
   });
 
-  // Return the row this UPDATE finalized — never a re-read. The previous
+  // Return the row the UPDATE above finalized — never a re-read. The previous
   // `return (await getLatestShow())!` raced a concurrent POST /flowsheet/join:
   // a show N+1 created between the UPDATE and the re-read is what got
   // returned, and the mirror middleware then signed off the WRONG, still-live
   // show in tubafrenzy while show N's signoff was silently dropped (BS#1119
-  // follow-up review). The non-null assertion is safe: the WHERE keys on the
-  // currentShow.id the controller just fetched, and no code path deletes
-  // `shows` rows mid-request.
-  const finalized = await db
-    .update(shows)
-    .set({ end_time: new Date() })
-    .where(eq(shows.id, currentShow.id))
-    .returning();
-
-  return finalized[0]!;
+  // follow-up review).
+  return finalizedShow;
 };
 
 export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowDJ> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14734,6 +14734,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@sentry/core": "^10.69.0",
         "@sentry/node": "^10.69.0"
       },
       "devDependencies": {

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -88,8 +88,16 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     const entryPosts = tubafrenzyRequests.filter((r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry'));
     expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
+    // Select this track's POST explicitly, same as the test above: the
+    // beforeEach join's show_start announcement mirror is fire-and-forget and
+    // can land after it under load, and that marker POST carries
+    // flowsheetEntryType 9 — cross-request mirror ordering is not this test's
+    // contract.
+    const trackPost = entryPosts.find((r) => r.body.artistName === 'Jessica Pratt');
+    expect(trackPost).toBeDefined();
+
     // Non-library, non-rotation track should be type 0
-    expect(entryPosts[entryPosts.length - 1].body.flowsheetEntryType).toBe(0);
+    expect(trackPost.body.flowsheetEntryType).toBe(0);
   });
 
   test('mirror failure does not block primary response', async () => {
@@ -169,6 +177,12 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
   const isSignoff = (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff');
 
+  // The mock server records its own control endpoints in the per-service log,
+  // so `/_admin/requests/tubafrenzy` is itself appended to the log it returns.
+  // Any count that includes them can never stop growing — polling is what
+  // grows it. Count only real mirror traffic.
+  const countMirrorTraffic = (requests) => requests.filter((r) => !r.path.startsWith('/_admin')).length;
+
   // Poll the mock request log until predicate(requests) is truthy or the
   // timeout lapses (returns the last snapshot either way; the caller's
   // assertion produces the failure).
@@ -185,13 +199,26 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
   // settle interval, so an EARLIER test's in-flight fire-and-forget mirror
   // POST (the HTTP response resolves before the mirror does) cannot land
   // inside this test's observation window after resetMockApi.
+  //
+  // Returns whether it actually went quiet. Timing out is NOT the same
+  // outcome: traffic still arriving when the caller resets means the negative
+  // window below is measuring the previous show's tail, which can flake red on
+  // a stale signoff or — worse — pass while observing the wrong window. Report
+  // it rather than returning as if quiet.
   const waitForMirrorQuiescence = async (settleMs = 250, timeoutMs = 3000) => {
     const deadline = Date.now() + timeoutMs;
-    let last = (await getMockRequests('tubafrenzy')).length;
+    let last = countMirrorTraffic(await getMockRequests('tubafrenzy'));
     for (;;) {
       await new Promise((r) => setTimeout(r, settleMs));
-      const now = (await getMockRequests('tubafrenzy')).length;
-      if (now === last || Date.now() > deadline) return;
+      const now = countMirrorTraffic(await getMockRequests('tubafrenzy'));
+      if (now === last) return true;
+      if (Date.now() > deadline) {
+        console.warn(
+          `[mirror-http] mirror traffic never quiesced within ${timeoutMs}ms (${last} -> ${now} requests); ` +
+            'the following observation window may include earlier traffic'
+        );
+        return false;
+      }
       last = now;
     }
   };
@@ -218,7 +245,7 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
 
     // Drain the previous describe's in-flight mirror traffic before taking
     // the baseline reset.
-    await waitForMirrorQuiescence();
+    expect(await waitForMirrorQuiescence()).toBe(true);
     await resetMockApi();
 
     // Primary A starts the show, guest B joins as co-host. Assert the fixture
@@ -245,8 +272,11 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
       .expect(201);
     const entryId = addRes.body.id;
 
-    // Let join/add mirror traffic flush, then observe only the leave
-    await waitForMirrorQuiescence();
+    // Let join/add mirror traffic flush, then observe only the leave. Assert
+    // the drain actually completed: the assertions below are negative
+    // ("nothing arrives"), so leaked in-flight traffic would silently
+    // invalidate the window rather than fail on its own.
+    expect(await waitForMirrorQuiescence()).toBe(true);
     await resetMockApi();
 
     // Guest B calls /flowsheet/end — leave semantics, controller returns ShowDJ

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -59,10 +59,14 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     const entryPosts = tubafrenzyRequests.filter((r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry'));
     expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
-    const body = entryPosts[entryPosts.length - 1].body;
-    expect(body.artistName).toBe('Autechre');
-    expect(body.songTitle).toBe('VI Scose Poise');
-    expect(body.releaseTitle).toBe('Confield');
+    // Select the track's POST explicitly rather than assuming it arrived
+    // last: the beforeEach join's show_start announcement mirror is
+    // fire-and-forget and can land after this entry's POST under load —
+    // cross-request mirror ordering is not part of this test's contract.
+    const trackPost = entryPosts.find((r) => r.body.artistName === 'Autechre');
+    expect(trackPost).toBeDefined();
+    expect(trackPost.body.songTitle).toBe('VI Scose Poise');
+    expect(trackPost.body.releaseTitle).toBe('Confield');
   });
 
   test('mirror includes correct entry type for track entries', async () => {
@@ -154,31 +158,81 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
  * end-to-end signoff CONTRACT: a guest leave signs off zero times and leaves
  * the show live, while the primary's end signs off exactly once.
  *
- * The guard's unit-level regression pin lives in endshow-shape-guard.test.ts.
- * These black-box assertions hold with or without the `show.id == null` guard —
- * signoff is separately gated on a resolved tubafrenzy show id, so it stays
- * silent for a ShowDJ either way — so their value here is contract coverage
- * plus the primary-plus-guest fixture BS#1533's dj-scoping tests reuse.
+ * The shape discrimination's unit-level regression pins live in
+ * endshow-shape-guard.test.ts (the `isShowPayload` shouldMirror gate). These
+ * black-box assertions are contract coverage plus the primary-plus-guest
+ * fixture BS#1533's dj-scoping tests reuse — the fixture identity is asserted
+ * rather than assumed, and synchronization with the fire-and-forget mirror is
+ * poll-based (the CDC specs' waitForEvent precedent) except where the
+ * contract is "nothing arrives", which honestly needs a fixed settle window.
  */
 describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
   const isSignoff = (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff');
 
+  // Poll the mock request log until predicate(requests) is truthy or the
+  // timeout lapses (returns the last snapshot either way; the caller's
+  // assertion produces the failure).
+  const waitForMockRequests = async (predicate, timeoutMs = 4000, intervalMs = 50) => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const requests = await getMockRequests('tubafrenzy');
+      if (predicate(requests) || Date.now() > deadline) return requests;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  };
+
+  // Drain barrier: wait until no new tubafrenzy requests arrive for one
+  // settle interval, so an EARLIER test's in-flight fire-and-forget mirror
+  // POST (the HTTP response resolves before the mirror does) cannot land
+  // inside this test's observation window after resetMockApi.
+  const waitForMirrorQuiescence = async (settleMs = 250, timeoutMs = 3000) => {
+    const deadline = Date.now() + timeoutMs;
+    let last = (await getMockRequests('tubafrenzy')).length;
+    for (;;) {
+      await new Promise((r) => setTimeout(r, settleMs));
+      const now = (await getMockRequests('tubafrenzy')).length;
+      if (now === last || Date.now() > deadline) return;
+      last = now;
+    }
+  };
+
   afterEach(async () => {
     if (!mockApiAvailable) return;
     // Best-effort cleanup so a mid-test failure can't leak an open show into
-    // later specs (suite runs --runInBand against shared show state).
-    await fls_util.leave_show(global.secondary_dj_id, global.secondary_access_token);
-    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+    // later specs (suite runs --runInBand against shared show state). 200
+    // (left/ended) and 400 (wasn't a member) are both expected; anything else
+    // gets a trace line pointing here instead of failing a later suite.
+    for (const [djId, token] of [
+      [global.secondary_dj_id, global.secondary_access_token],
+      [global.primary_dj_id, global.access_token],
+    ]) {
+      const r = await fls_util.leave_show(djId, token);
+      if (![200, 400].includes(r.status)) {
+        console.warn(`[mirror-http cleanup] unexpected leave_show status ${r.status} for dj ${djId}`);
+      }
+    }
   });
 
   test('guest-DJ leave does not sign off the show; primary end signs off once', async () => {
     if (!mockApiAvailable) return;
 
+    // Drain the previous describe's in-flight mirror traffic before taking
+    // the baseline reset.
+    await waitForMirrorQuiescence();
     await resetMockApi();
 
-    // Primary A starts the show, guest B joins as co-host
-    await fls_util.join_show(global.primary_dj_id, global.access_token);
-    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+    // Primary A starts the show, guest B joins as co-host. Assert the fixture
+    // identity rather than assuming it: if an earlier spec leaked an open
+    // show, A's join would be a guest-join (ShowDJ response, no
+    // primary_dj_id) and every assertion below would pass or fail vacuously,
+    // misattributed to the BS#1119 contract.
+    const joinARes = await fls_util.join_show(global.primary_dj_id, global.access_token);
+    expect(joinARes.status).toBe(200);
+    const joinABody = await joinARes.json();
+    expect(joinABody.primary_dj_id).toBe(global.primary_dj_id);
+
+    const joinBRes = await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+    expect(joinBRes.status).toBe(200);
 
     const addRes = await request
       .post('/flowsheet')
@@ -192,22 +246,28 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
     const entryId = addRes.body.id;
 
     // Let join/add mirror traffic flush, then observe only the leave
-    await new Promise((r) => setTimeout(r, 300));
+    await waitForMirrorQuiescence();
     await resetMockApi();
 
     // Guest B calls /flowsheet/end — leave semantics, controller returns ShowDJ
     const leaveRes = await fls_util.leave_show(global.secondary_dj_id, global.secondary_access_token);
     expect(leaveRes.status).toBe(200);
 
+    // Negative window: fixed settle is the honest form when the contract is
+    // that NOTHING arrives — there is no positive event to poll for.
     await new Promise((r) => setTimeout(r, 300));
 
     // (a) No signoff reached tubafrenzy
     const afterLeave = await getMockRequests('tubafrenzy');
     expect(afterLeave.filter(isSignoff)).toHaveLength(0);
 
-    // (b) The show is still live for primary A
+    // (b) The show is still live for primary A, and B is off-air post-leave
+    // (distinguishes "gate correctly suppressed endShow" from "the leave was
+    // a no-op")
     const onAirRes = await request.get('/flowsheet/on-air').query({ dj_id: global.primary_dj_id }).expect(200);
     expect(onAirRes.body.is_live).toBe(true);
+    const onAirBRes = await request.get('/flowsheet/on-air').query({ dj_id: global.secondary_dj_id }).expect(200);
+    expect(onAirBRes.body.is_live).toBe(false);
 
     // (c) The prior flowsheet entry is untouched
     const entriesRes = await request.get('/flowsheet').query({ limit: 10 }).expect(200);
@@ -216,13 +276,16 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
     expect(entry.track_title).toBe('la paradoja');
     expect(entry.artist_name).toBe('Juana Molina');
 
-    // Positive control: primary A ends the show → exactly one signoff
+    // Positive control: primary A ends the show → exactly one signoff. Poll
+    // until the first signoff lands (fixed sleeps flake when the mirror chain
+    // exceeds them under CI load), then hold one settle window so a duplicate
+    // would still be caught by the exact-count assertion.
     await resetMockApi();
     const endRes = await fls_util.leave_show(global.primary_dj_id, global.access_token);
     expect(endRes.status).toBe(200);
 
-    await new Promise((r) => setTimeout(r, 300));
-
+    await waitForMockRequests((rs) => rs.filter(isSignoff).length >= 1);
+    await new Promise((r) => setTimeout(r, 250));
     const afterEnd = await getMockRequests('tubafrenzy');
     expect(afterEnd.filter(isSignoff)).toHaveLength(1);
   });

--- a/tests/unit/middleware/legacy/delete-entry-legacy-id.test.ts
+++ b/tests/unit/middleware/legacy/delete-entry-legacy-id.test.ts
@@ -55,13 +55,13 @@ jest.mock('@wxyc/database', () => ({
   db: {},
   user: {},
   flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
-  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id', primary_dj_id: 'primary_dj_id' },
 }));
 
 jest.mock('drizzle-orm', () => ({
   eq: jest.fn((...args: unknown[]) => args),
-  desc: jest.fn(),
-  asc: jest.fn(),
+  and: jest.fn((...args: unknown[]) => args),
+  isNull: jest.fn((column: unknown) => ['isNull', column]),
 }));
 
 jest.mock('posthog-node', () => ({

--- a/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
+++ b/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
@@ -54,12 +54,12 @@ const mockDbUpdate = jest.fn().mockReturnValue({
 // Configurable per-test: default resolves to [] (no announcement entry found)
 let mockSelectLimitResult: unknown[] = [];
 
+// where -> limit only. The announcement query lost its ORDER BY when both
+// lifecycle handlers moved to the shared `mirrorAnnouncementEntry` helper, so
+// an orderBy rung here would be dead scaffolding that hides a re-added sort.
 const mockDbSelect = jest.fn().mockReturnValue({
   from: jest.fn().mockReturnValue({
     where: jest.fn().mockReturnValue({
-      orderBy: jest.fn().mockReturnValue({
-        limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
-      }),
       limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
     }),
   }),
@@ -72,7 +72,7 @@ jest.mock('@wxyc/database', () => ({
   },
   user: {},
   flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id', entry_type: 'entry_type' },
-  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id', primary_dj_id: 'primary_dj_id' },
 }));
 
 // Passthrough builders, mirroring mirror.loop-prevention.test.ts. Only the
@@ -83,7 +83,6 @@ jest.mock('drizzle-orm', () => ({
   eq: jest.fn((...args: unknown[]) => args),
   and: jest.fn((...args: unknown[]) => args),
   isNull: jest.fn((column: unknown) => ['isNull', column]),
-  desc: jest.fn(),
 }));
 
 jest.mock('posthog-node', () => ({
@@ -94,8 +93,10 @@ jest.mock('posthog-node', () => ({
 }));
 
 const mockCaptureException = jest.fn();
+const mockCaptureMessage = jest.fn();
 jest.mock('@sentry/node', () => ({
   captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
 }));
 
 const mockIsActiveRotationMatch = jest.fn().mockResolvedValue(false);
@@ -152,8 +153,42 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
       await runMiddleware(flowsheetMirror.endShow, { unexpected: true });
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unrecognized show-route payload'), ['unexpected']);
+      // console.warn goes to container stdout, which nothing alerts on — the
+      // silent-stop lane has to reach Sentry to be a real signal.
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Unrecognized show-route payload'),
+        expect.objectContaining({ level: 'warning', extra: { keys: ['unexpected'] } })
+      );
       expect(mockDbSelect).not.toHaveBeenCalled();
       expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('skips a Show-SHAPED payload whose id is null, loudly (id is tested by value, not presence)', async () => {
+    // `'id' in data` would pass this: the key is there, the value is not. Every
+    // downstream read keys on it — getCachedShowId(null), and an
+    // eq(flowsheet.show_id, null) that binds NULL and matches nothing, silently
+    // dropping the marker. That is BS#1119's own failure mode, so it belongs in
+    // the loud lane rather than past the gate.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await runMiddleware(flowsheetMirror.endShow, {
+        id: null,
+        primary_dj_id: 'primary-dj-user-id',
+        end_time: '2026-07-06T16:00:00.000Z',
+      });
+
+      expect(mockDbSelect).not.toHaveBeenCalled();
+      expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+      expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unrecognized show-route payload'),
+        expect.any(Array)
+      );
+      expect(mockCaptureMessage).toHaveBeenCalled();
       expect(mockCaptureException).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
@@ -226,6 +261,31 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
 
     expect(mockGetCachedShowId).toHaveBeenCalledWith(202);
     expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171502, new Date('2026-07-06T16:00:00.000Z').getTime());
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('mirrors NEITHER arm when the show has no resolvable tubafrenzy id', async () => {
+    // Both lanes are exhausted: nothing cached, legacy_show_id NULL (the
+    // startShow mirror failed). The signoff was already guarded; the
+    // announcement arm used to fall through and POST an END_OF_SHOW with a
+    // null radio-show id — an orphan entry — and then stamp legacy_entry_id on
+    // the marker, hiding it from legacy-mirror-reconcile's
+    // `legacy_entry_id IS NULL` sweep permanently. One guard, both arms.
+    mockGetCachedShowId.mockReturnValue(undefined);
+    mockSelectLimitResult = [{ id: 8, show_id: 203, entry_type: 'show_end', legacy_entry_id: null }];
+    mockMirrorCreateEntry.mockResolvedValue(999002);
+
+    await runMiddleware(flowsheetMirror.endShow, {
+      id: 203,
+      primary_dj_id: 'primary-dj-user-id',
+      legacy_show_id: null,
+      start_time: '2026-07-06T14:00:00.000Z',
+      end_time: '2026-07-06T16:00:00.000Z',
+    });
+
+    expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+    expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+    expect(mockDbUpdate).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
+++ b/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
@@ -8,6 +8,14 @@
  * must not execute any endShow logic (signoff or the show_end announcement
  * re-query) on a ShowDJ payload.
  *
+ * Since the BS#1119 follow-up, the discrimination is the positive
+ * `isShowPayload` predicate passed as the registration's shouldMirror gate
+ * (mirror.middleware.ts), not an in-handler `show.id == null` check — these
+ * tests pin the gate's semantics: ShowDJ skips silently, an unrecognized
+ * shape skips LOUDLY (console.warn), and a real Show proceeds regardless of
+ * primary_dj_id nullability, resolving its tubafrenzy id through either the
+ * legacy_show_id column or the in-memory cache lane.
+ *
  * Harness follows mirror.loop-prevention.test.ts: real middleware, mocks only
  * at process boundaries (tubafrenzy HTTP client, database, PostHog, Sentry).
  */
@@ -17,6 +25,7 @@
 const mockMirrorSignoffShow = jest.fn().mockResolvedValue(undefined);
 const mockMirrorCreateEntry = jest.fn().mockResolvedValue(null);
 const mockGetCachedShowId = jest.fn().mockReturnValue(undefined);
+const mockCacheEntryId = jest.fn();
 const mockMapEntryToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
 
 jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
@@ -24,7 +33,7 @@ jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
   mirrorCreateShow: jest.fn(),
   mirrorSignoffShow: mockMirrorSignoffShow,
   mirrorUpdateEntry: jest.fn(),
-  cacheEntryId: jest.fn(),
+  cacheEntryId: mockCacheEntryId,
   cacheShowId: jest.fn(),
   getCachedEntryId: jest.fn(),
   getCachedShowId: mockGetCachedShowId,
@@ -35,9 +44,10 @@ jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
   mapUpdateToTubafrenzy: jest.fn(),
 }));
 
+const mockDbUpdateWhere = jest.fn().mockResolvedValue(undefined);
 const mockDbUpdate = jest.fn().mockReturnValue({
   set: jest.fn().mockReturnValue({
-    where: jest.fn().mockResolvedValue(undefined),
+    where: mockDbUpdateWhere,
   }),
 });
 
@@ -61,25 +71,19 @@ jest.mock('@wxyc/database', () => ({
     update: mockDbUpdate,
   },
   user: {},
-  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id', entry_type: 'entry_type' },
   shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
 }));
 
+// Passthrough builders, mirroring mirror.loop-prevention.test.ts. Only the
+// operators flowsheet.mirror.ts actually imports are mocked (and/desc/eq/
+// isNull) so a drift between this list and the module's import surface fails
+// loudly as `undefined is not a function` instead of silently no-oping.
 jest.mock('drizzle-orm', () => ({
-  // Faithfully simulate postgres-js rejecting an `undefined` bind. The BS#1119
-  // prod symptom is the show_end announcement re-query binding
-  // `eq(flowsheet.show_id, undefined)` — a ShowDJ has no `id` — which throws in
-  // the driver and lands in Sentry once per guest leave. Making eq() throw on an
-  // undefined operand lets the ShowDJ test pin that exact symptom (the mirror
-  // catching into Sentry) rather than only the proxy "db.select was reached".
-  eq: jest.fn((column: unknown, value: unknown) => {
-    if (value === undefined) {
-      throw new Error('cannot bind undefined to a query parameter (simulated postgres-js undefined bind)');
-    }
-    return [column, value];
-  }),
+  eq: jest.fn((...args: unknown[]) => args),
+  and: jest.fn((...args: unknown[]) => args),
+  isNull: jest.fn((column: unknown) => ['isNull', column]),
   desc: jest.fn(),
-  asc: jest.fn(),
 }));
 
 jest.mock('posthog-node', () => ({
@@ -108,6 +112,7 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCachedShowId.mockReturnValue(undefined);
+    mockMirrorCreateEntry.mockResolvedValue(null);
     mockSelectLimitResult = [];
   });
 
@@ -120,21 +125,42 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
   };
 
   it('executes no endShow logic when a guest-DJ leave returns a ShowDJ payload', async () => {
-    await runMiddleware(flowsheetMirror.endShow, showDJPayload);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await runMiddleware(flowsheetMirror.endShow, showDJPayload);
 
-    // Two independent regression pins — both flip red if the `show.id == null`
-    // guard is removed. Without the guard the show_end announcement re-query
-    // runs (mockDbSelect) and binds `show_id = undefined`, which the eq() mock
-    // rejects exactly as postgres-js does in prod — the mirror catches that
-    // throw into Sentry once per guest leave (mockCaptureException). The signoff
-    // is a secondary check: it stays silent either way because it is separately
-    // gated on a resolved tubafrenzy show id.
-    expect(mockDbSelect).not.toHaveBeenCalled();
-    expect(mockCaptureException).not.toHaveBeenCalled();
-    expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+      // The shouldMirror gate (isShowPayload) skips the handler entirely:
+      // nothing reaches Sentry, no announcement re-query runs, no signoff
+      // fires — and a recognized ShowDJ is a SILENT skip (the loud lane is
+      // reserved for unrecognized shapes, next test).
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockDbSelect).not.toHaveBeenCalled();
+      expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it('still signs off and mirrors the announcement when the primary DJ ends the show', async () => {
+  it('skips an unrecognized payload shape LOUDLY (console.warn) without running any mirror logic', async () => {
+    // Neither Show keys (id + primary_dj_id) nor the ShowDJ discriminant
+    // (dj_id): the shape a future projection change could produce if it
+    // strips Show's keys from the /flowsheet/end response. The mirror must
+    // not go quiet without a trace.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await runMiddleware(flowsheetMirror.endShow, { unexpected: true });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unrecognized show-route payload'), ['unexpected']);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+      expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('signs off, mirrors the show_end announcement, and persists its legacy_entry_id when the primary DJ ends the show', async () => {
     const endedShowPayload = {
       id: 200,
       primary_dj_id: 'primary-dj-user-id',
@@ -142,19 +168,31 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
       start_time: '2026-07-06T14:00:00.000Z',
       end_time: '2026-07-06T16:00:00.000Z',
     };
+    // The show_end marker row the announcement re-query finds.
+    const announcementRow = { id: 7, show_id: 200, entry_type: 'show_end', play_order: 3, legacy_entry_id: null };
+    mockSelectLimitResult = [announcementRow];
+    mockMirrorCreateEntry.mockResolvedValue(999001);
 
     await runMiddleware(flowsheetMirror.endShow, endedShowPayload);
 
     expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171500, new Date('2026-07-06T16:00:00.000Z').getTime());
-    // The show_end announcement re-query ran against the finalized show
-    expect(mockDbSelect).toHaveBeenCalled();
+    // The announcement arm actually ran end-to-end: mapped against the
+    // resolved tubafrenzy show, POSTed, cached by flowsheet row id (BS#1103),
+    // and persisted back to legacy_entry_id.
+    expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(announcementRow, 171500);
+    expect(mockMirrorCreateEntry).toHaveBeenCalledTimes(1);
+    expect(mockCacheEntryId).toHaveBeenCalledWith(7, 999001);
+    expect(mockDbUpdate).toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  it('still signs off a show whose primary DJ account was deleted mid-show', async () => {
-    // shows.primary_dj_id is nullable (onDelete: 'set null'). The guard must
-    // discriminate on `id`, not primary_dj_id truthiness — startShow's guard
-    // style would silently drop this signoff.
+  it('proceeds on a Show whose primary_dj_id is null (gate discriminates on Show keys, not primary_dj_id truthiness)', async () => {
+    // Guard-semantics pin ONLY: shows.primary_dj_id is nullable
+    // (onDelete: 'set null') and the payload still discriminates as a Show,
+    // so the mirror signs off. NOTE a real deleted-primary show cannot
+    // currently reach this mirror at all — the controller routes every
+    // caller to the guest-leave branch when primary_dj_id is NULL, which is
+    // its own defect: BS#2093.
     const orphanedShowPayload = {
       id: 201,
       primary_dj_id: null,
@@ -166,6 +204,28 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
     await runMiddleware(flowsheetMirror.endShow, orphanedShowPayload);
 
     expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171501, new Date('2026-07-06T16:00:00.000Z').getTime());
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('signs off through the in-memory cache lane when legacy_show_id is null (restart-resilience fallback order)', async () => {
+    // Pins the `getCachedShowId(show.id) ?? show.legacy_show_id` resolution:
+    // a show whose legacy_show_id persist failed but whose id is in the
+    // showIdMap must still sign off. Without this case, a wrong-discriminant
+    // mutant (e.g. gating on legacy_show_id instead of the Show shape) passes
+    // every other test in this file (BS#1119 follow-up review).
+    mockGetCachedShowId.mockReturnValue(171502);
+    const cacheOnlyShowPayload = {
+      id: 202,
+      primary_dj_id: 'primary-dj-user-id',
+      legacy_show_id: null,
+      start_time: '2026-07-06T14:00:00.000Z',
+      end_time: '2026-07-06T16:00:00.000Z',
+    };
+
+    await runMiddleware(flowsheetMirror.endShow, cacheOnlyShowPayload);
+
+    expect(mockGetCachedShowId).toHaveBeenCalledWith(202);
+    expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171502, new Date('2026-07-06T16:00:00.000Z').getTime());
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/middleware/legacy/entry-id-map-collision.test.ts
+++ b/tests/unit/middleware/legacy/entry-id-map-collision.test.ts
@@ -71,13 +71,13 @@ jest.mock('@wxyc/database', () => ({
   },
   user: {},
   flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
-  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id', primary_dj_id: 'primary_dj_id' },
 }));
 
 jest.mock('drizzle-orm', () => ({
   eq: jest.fn((...args: unknown[]) => args),
-  desc: jest.fn(),
-  asc: jest.fn(),
+  and: jest.fn((...args: unknown[]) => args),
+  isNull: jest.fn((column: unknown) => ['isNull', column]),
 }));
 
 jest.mock('posthog-node', () => ({

--- a/tests/unit/middleware/legacy/flowsheet.mirror.test.ts
+++ b/tests/unit/middleware/legacy/flowsheet.mirror.test.ts
@@ -25,8 +25,8 @@ jest.mock('@wxyc/database', () => ({
 
 jest.mock('drizzle-orm', () => ({
   eq: jest.fn(),
-  desc: jest.fn(),
-  asc: jest.fn(),
+  and: jest.fn(),
+  isNull: jest.fn(),
 }));
 
 jest.mock('posthog-node', () => ({

--- a/tests/unit/middleware/legacy/http-mirror-harness.ts
+++ b/tests/unit/middleware/legacy/http-mirror-harness.ts
@@ -83,9 +83,10 @@ export async function runMiddleware(
   // res.locals.mirrorData, then the mock emits finish.
   res.send(JSON.stringify(payload));
 
-  // Drain: one loop turn delivers the setTimeout(0) finish emit; the rest
-  // cover the awaits inside the handler chain (flag check → execute →
-  // per-handler db/http mock awaits).
+  // Drain: the first turn delivers createMockRes's setImmediate finish emit
+  // (deliberately NOT a setTimeout — see the note there); the rest cover the
+  // awaits inside the handler chain (flag check → execute → per-handler
+  // db/http mock awaits).
   for (let i = 0; i < 8; i++) {
     await new Promise((resolve) => setImmediate(resolve));
   }

--- a/tests/unit/middleware/legacy/http-mirror-harness.ts
+++ b/tests/unit/middleware/legacy/http-mirror-harness.ts
@@ -2,10 +2,18 @@
  * Shared harness for unit-testing the HTTP mirror middleware
  * (createHttpMirrorMiddleware handlers in flowsheet.mirror.ts).
  *
- * Simulates the Express response lifecycle the middleware taps: `send`
- * captures the JSON payload into `res.locals.mirrorData`, then `finish` fires
- * the mirror's async handler. jest.mock() calls stay in each test file (they
- * must be hoisted per-module); only the lifecycle plumbing lives here.
+ * Simulates the Express response lifecycle the middleware taps. The mock
+ * `send` deliberately does NOT capture the payload itself: the middleware's
+ * real `tapJsonResponse` wrapper (mirror.middleware.ts) intercepts `res.send`
+ * and owns the capture into `res.locals.mirrorData` — an earlier harness
+ * revision re-implemented that capture in the mock, which meant the tap's
+ * content-type gate, parse fallback, and BS#1513 stash short-circuit had zero
+ * effective coverage: deleting the tap's capture line kept every harness
+ * suite green (BS#1119 follow-up review). The mock only plays the part of
+ * Express's original `send`: it schedules the 'finish' event.
+ *
+ * jest.mock() calls stay in each test file (they must be hoisted per-module);
+ * only the lifecycle plumbing lives here.
  *
  * Not a test file — the `.test.ts` glob in jest.unit.config.ts skips it.
  */
@@ -21,14 +29,16 @@ export function createMockRes(statusCode: number) {
     getHeader: jest.fn().mockReturnValue('application/json'),
     send: jest.fn(),
     once: emitter.once.bind(emitter),
-    on: emitter.on.bind(emitter),
-    emit: emitter.emit.bind(emitter),
   };
 
-  // After send is called, emit 'finish' to trigger mirror logic
-  res.send.mockImplementation((data: unknown) => {
-    locals.mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
-    setTimeout(() => emitter.emit('finish'), 0);
+  // Plays Express's original send: emit 'finish' asynchronously, the way a
+  // real response finishes after the body is flushed. Capture is the real
+  // tap's job (see the header comment). setImmediate — NOT setTimeout(0) —
+  // so ordering against runMiddleware's setImmediate drain is deterministic:
+  // a 0ms timer is clamped to 1ms and the drain's turns can all complete
+  // before it ever fires, leaving the finish handler unrun.
+  res.send.mockImplementation(() => {
+    setImmediate(() => emitter.emit('finish'));
     return res;
   });
 
@@ -38,13 +48,23 @@ export function createMockRes(statusCode: number) {
 export function createMockReq() {
   return {
     ip: '127.0.0.1',
-    user: { id: 'test-user' },
+    // The shape the auth middleware actually sets (req.auth, not req.user) —
+    // isMirrorEnabled resolves its PostHog distinctId from req.auth.id.
+    auth: { id: 'test-user' },
   };
 }
 
 /**
  * Invoke a mirror middleware with a JSON payload and wait for the
  * fire-and-forget finish handler to complete.
+ *
+ * The completion barrier drains a handful of event-loop turns instead of
+ * sleeping wall-clock time (the earlier `setTimeout(50)` barrier hung under
+ * fake timers and paid 50ms per test): 'finish' fires on the first macrotask,
+ * and every await in the finish handler chain resolves against pre-resolved
+ * mocks, so a few full loop turns are deterministic headroom. If a mock ever
+ * gains real async latency, assertions fail immediately and loudly rather
+ * than passing vacuously inside a too-short sleep.
  */
 export async function runMiddleware(
   middleware: (req: unknown, res: unknown, next: unknown) => Promise<void> | void,
@@ -59,9 +79,14 @@ export async function runMiddleware(
   void middleware(req, res, next);
   expect(next).toHaveBeenCalled();
 
-  // Trigger send (which populates mirrorData and emits finish)
+  // Trigger send — the middleware's tap wrapper captures the payload into
+  // res.locals.mirrorData, then the mock emits finish.
   res.send(JSON.stringify(payload));
 
-  // Wait for async finish handler to complete
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  // Drain: one loop turn delivers the setTimeout(0) finish emit; the rest
+  // cover the awaits inside the handler chain (flag check → execute →
+  // per-handler db/http mock awaits).
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
 }

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -64,10 +64,15 @@ jest.mock('@wxyc/database', () => ({
   shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
 }));
 
+// Mirrors flowsheet.mirror.ts's actual drizzle-orm import surface
+// (and/desc/eq/isNull) — a mocked operator the module doesn't import is dead
+// weight, and an imported operator missing here fails as `undefined is not a
+// function` the first time a test exercises the path that calls it.
 jest.mock('drizzle-orm', () => ({
   eq: jest.fn((...args: unknown[]) => args),
+  and: jest.fn((...args: unknown[]) => args),
+  isNull: jest.fn((column: unknown) => ['isNull', column]),
   desc: jest.fn(),
-  asc: jest.fn(),
 }));
 
 jest.mock('posthog-node', () => ({

--- a/tests/unit/middleware/legacy/mirror.posthog.test.ts
+++ b/tests/unit/middleware/legacy/mirror.posthog.test.ts
@@ -22,7 +22,11 @@ import { Request, Response } from 'express';
 import { EventEmitter } from 'events';
 
 function createMockReqRes() {
-  const req = { user: { id: 'user-1' }, ip: '127.0.0.1' } as unknown as Request;
+  // req.auth is what the auth middleware sets — req.user is never assigned by
+  // anything in this codebase. Building the dead shape here is what let the
+  // `req.user?.id` read survive: every assertion silently ran against the
+  // req.ip fallback instead of a real DJ identity (BS#1119 follow-up review).
+  const req = { auth: { id: 'user-1' }, ip: '127.0.0.1' } as unknown as Request;
 
   const res = new EventEmitter() as Response & EventEmitter;
   res.statusCode = 200;
@@ -77,6 +81,56 @@ describe('PostHog client usage', () => {
     // getPostHogClient is called per-request, but it returns the same singleton
     expect(mockGetPostHogClient).toHaveBeenCalled();
     expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('evaluates the flag against the authenticated user, not the request IP', async () => {
+    // The regression pin for the identity itself: without asserting the
+    // distinctId, reverting to `req.user?.id` keeps this whole file green
+    // while every evaluation silently degrades to one EC2-local req.ip.
+    // Registrations that can name a show pass a resolveFlagIdentity instead
+    // (the show's primary DJ); this bare one falls back to the caller.
+    const middleware = createBackendMirrorMiddleware(jest.fn().mockResolvedValue(['SQL1']));
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalledWith('backend-mirror', 'user-1');
+  });
+
+  it('prefers a registration-supplied show identity over the caller', async () => {
+    // The per-SHOW decision: every payload in one show must resolve the same
+    // flag value, or a mixed-DJ show reaches tubafrenzy half-mirrored — the
+    // one state legacy-mirror-reconcile refuses to auto-heal.
+    const middleware = createBackendMirrorMiddleware<{ ok: boolean }>(jest.fn().mockResolvedValue(['SQL1']), {
+      resolveFlagIdentity: () => Promise.resolve('primary-dj-of-the-show'),
+    });
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalledWith('backend-mirror', 'primary-dj-of-the-show');
+  });
+
+  it('falls back to the caller when the show-identity lookup throws', async () => {
+    const middleware = createBackendMirrorMiddleware<{ ok: boolean }>(jest.fn().mockResolvedValue(['SQL1']), {
+      resolveFlagIdentity: () => Promise.reject(new Error('db down')),
+    });
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // A failed identity lookup must not fail the flag check closed, and must
+    // not throw into the mirror's Sentry path either.
+    expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalledWith('backend-mirror', 'user-1');
   });
 });
 

--- a/tests/unit/middleware/legacy/startshow-marker-mirror.test.ts
+++ b/tests/unit/middleware/legacy/startshow-marker-mirror.test.ts
@@ -11,10 +11,12 @@
  * tubafrenzy 172277).
  *
  * These tests drive the REAL middleware through a faithful mini query engine:
- * the `@wxyc/database` mock actually interprets the drizzle predicate/order so
- * the fixture `[show_start(play_order 1), track(play_order 2)]` resolves the
- * way postgres-js would. The old DESC query would resolve the track (red); the
- * entry_type-filtered query resolves the marker (green).
+ * the `@wxyc/database` mock actually interprets the drizzle predicate, so the
+ * fixture `[show_start(play_order 1), track(play_order 2)]` resolves the way
+ * postgres-js would. The old DESC query would resolve the track (red); the
+ * entry_type-filtered query resolves the marker (green). Both lifecycle
+ * handlers share one `mirrorAnnouncementEntry` helper, so the endShow describe
+ * below pins the same query through its own entry_type.
  *
  * Harness follows endshow-shape-guard.test.ts: real middleware, mocks only at
  * process boundaries (tubafrenzy HTTP client, database, PostHog, Sentry).
@@ -34,16 +36,6 @@ function matchPred(row: Record<string, unknown>, pred: any): boolean {
     default:
       return true;
   }
-}
-
-function applyOrder(rows: Record<string, unknown>[], order: any): Record<string, unknown>[] {
-  if (order?.kind === 'desc') {
-    return [...rows].sort((a, b) => Number(b[order.col] ?? 0) - Number(a[order.col] ?? 0));
-  }
-  if (order?.kind === 'asc') {
-    return [...rows].sort((a, b) => Number(a[order.col] ?? 0) - Number(b[order.col] ?? 0));
-  }
-  return rows;
 }
 
 // Per-test fixtures, keyed by table.
@@ -79,8 +71,12 @@ jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
   mapUpdateToTubafrenzy: jest.fn(),
 }));
 
+// No `orderBy` rung: the announcement query is predicate-only since both
+// call sites moved to the shared `mirrorAnnouncementEntry` helper. Leaving it
+// out is deliberate — re-adding an ORDER BY in production fails here loudly
+// ("orderBy is not a function") instead of being silently swallowed.
 const mockDbSelect = jest.fn(() => {
-  const state: { table: string | null; pred: unknown; order: unknown } = { table: null, pred: null, order: null };
+  const state: { table: string | null; pred: unknown } = { table: null, pred: null };
   const builder: Record<string, unknown> = {
     from: (table: { __table?: string }) => {
       state.table = table?.__table ?? null;
@@ -90,13 +86,8 @@ const mockDbSelect = jest.fn(() => {
       state.pred = pred;
       return builder;
     },
-    orderBy: (order: unknown) => {
-      state.order = order;
-      return builder;
-    },
     limit: (n: number) => {
-      let out = rowsFor(state.table).filter((r) => matchPred(r, state.pred));
-      if (state.order) out = applyOrder(out, state.order);
+      const out = rowsFor(state.table).filter((r) => matchPred(r, state.pred));
       return Promise.resolve(out.slice(0, n));
     },
   };
@@ -126,15 +117,16 @@ jest.mock('@wxyc/database', () => ({
     play_order: 'play_order',
     legacy_entry_id: 'legacy_entry_id',
   },
-  shows: { __table: 'shows', id: 'id', legacy_show_id: 'legacy_show_id' },
+  shows: { __table: 'shows', id: 'id', legacy_show_id: 'legacy_show_id', primary_dj_id: 'primary_dj_id' },
 }));
 
+// Exactly flowsheet.mirror.ts's import surface (and/eq/isNull) — a drift
+// between this list and the module's imports must fail loudly as "undefined
+// is not a function", never silently no-op.
 jest.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ kind: 'eq', col, val }),
   and: (...clauses: unknown[]) => ({ kind: 'and', clauses }),
   isNull: (col: unknown) => ({ kind: 'isNull', col }),
-  desc: (col: unknown) => ({ kind: 'desc', col }),
-  asc: (col: unknown) => ({ kind: 'asc', col }),
 }));
 
 jest.mock('posthog-node', () => ({
@@ -145,8 +137,10 @@ jest.mock('posthog-node', () => ({
 }));
 
 const mockCaptureException = jest.fn();
+const mockCaptureMessage = jest.fn();
 jest.mock('@sentry/node', () => ({
   captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
 }));
 
 jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
@@ -216,6 +210,20 @@ describe('startShow mirror announces the show_start marker (BS#1705)', () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
+  it('POSTs no announcement when the tubafrenzy show-create failed (no orphan entry, no poisoned marker)', async () => {
+    // mirrorCreateShow returning null means there is no parent radio show to
+    // hang the entry off. Mirroring it anyway would POST an orphan
+    // START_OF_SHOW *and* stamp legacy_entry_id on the marker, hiding it from
+    // legacy-mirror-reconcile's `legacy_entry_id IS NULL` sweep forever.
+    mockMirrorCreateShow.mockResolvedValueOnce(null);
+
+    await runMiddleware(flowsheetMirror.startShow, showPayload);
+
+    expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+    expect(updateCalls).toHaveLength(0);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
   it('does not re-POST the marker once it has already been mirrored (idempotent re-fire)', async () => {
     // Simulate a second startShow-mirror run after the marker was mirrored.
     marker.legacy_entry_id = 2632174;
@@ -230,7 +238,7 @@ describe('startShow mirror announces the show_start marker (BS#1705)', () => {
   });
 });
 
-describe('endShow mirror still announces the newest row — the show_end marker (BS#1705 regression)', () => {
+describe('endShow mirror announces the show_end MARKER under the co-host race (BS#1119 follow-up)', () => {
   const endedShowPayload = {
     id: SHOW_ID,
     primary_dj_id: DJ_ID,
@@ -239,25 +247,50 @@ describe('endShow mirror still announces the newest row — the show_end marker 
     end_time: '2026-06-20T20:00:00.000Z',
   };
 
-  // show_end is genuinely the newest row (highest play_order): endShow keeps
-  // the DESC-by-play_order query and must still resolve it.
-  const endTrack = { id: 6000, show_id: SHOW_ID, entry_type: 'track', play_order: 4, legacy_entry_id: null };
+  // The fixture that makes this suite a real regression pin: a co-host track
+  // that squeaked past the active-show check sits ABOVE the marker by
+  // play_order, and comes first in row order. Both mutants therefore resolve
+  // the TRACK — the pre-fix `ORDER BY play_order DESC LIMIT 1`, and a bare
+  // `WHERE show_id LIMIT 1` with the entry_type predicate deleted. Only the
+  // entry_type-filtered query resolves the marker.
+  const coHostTrack = { id: 6000, show_id: SHOW_ID, entry_type: 'track', play_order: 6, legacy_entry_id: null };
   const endMarker = { id: 6001, show_id: SHOW_ID, entry_type: 'show_end', play_order: 5, legacy_entry_id: null };
 
   beforeEach(() => {
     jest.clearAllMocks();
     updateCalls.length = 0;
     userRows = [{ id: DJ_ID, dj_name: 'dj hydra' }];
-    flowsheetRows = [endTrack, endMarker];
+    coHostTrack.legacy_entry_id = null;
+    endMarker.legacy_entry_id = null;
+    flowsheetRows = [coHostTrack, endMarker];
   });
 
-  it('mirrors the show_end marker as the announcement', async () => {
+  it('mirrors the show_end marker, not the higher-play_order co-host track', async () => {
     await runMiddleware(flowsheetMirror.endShow, endedShowPayload);
 
     expect(mockMapEntryToTubafrenzy).toHaveBeenCalledTimes(1);
     const announced = mockMapEntryToTubafrenzy.mock.calls[0][0] as typeof endMarker;
     expect(announced.entry_type).toBe('show_end');
     expect(announced.id).toBe(endMarker.id);
+
+    // legacy_entry_id is stamped on the MARKER, not the co-host track — a
+    // stamp on the track would both duplicate it in tubafrenzy (its own
+    // addEntry already mirrored it) and race that mirror's own persist.
+    const stamp = updateCalls.find((c) => c.setArg && 'legacy_entry_id' in c.setArg);
+    expect(stamp?.pred).toMatchObject({ kind: 'eq', col: 'id', val: endMarker.id });
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not re-POST the show_end marker once it has already been mirrored (idempotent re-fire)', async () => {
+    endMarker.legacy_entry_id = 2632180;
+    flowsheetRows = [coHostTrack, endMarker];
+
+    await runMiddleware(flowsheetMirror.endShow, endedShowPayload);
+
+    // The isNull(legacy_entry_id) guard filters the mirrored marker out — and
+    // must NOT fall through to the unmirrored co-host track instead.
+    expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
+++ b/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
@@ -25,6 +25,11 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
     const CURRENT_SHOW_ID = 2;
     const DJ_ID = 'dj-A';
 
+    // shows UPDATE (end_time) — the compare-and-set that claims the show. It
+    // is the FIRST write endShow makes (BS#1119 follow-up), so it heads the
+    // db.update queue; a non-empty .returning() means this caller won the CAS.
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: CURRENT_SHOW_ID, end_time: new Date() }]));
+
     // remaining_djs SELECT — DJ A is the only active member of show 2. The
     // prior-show row (show 1) is not returned because the SELECT already
     // filters by show_id, and isn't needed for the assertion either: the
@@ -49,12 +54,6 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
     db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
     // flowsheet insert (show_end)
     db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
-    // shows update (end_time)
-    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-    // getLatestShow()
-    const latestShowSelect = createMockQueryChain();
-    latestShowSelect.limit.mockResolvedValue([{ id: CURRENT_SHOW_ID, end_time: new Date() }]);
-    db.select.mockReturnValueOnce(latestShowSelect);
 
     await endShow({ id: CURRENT_SHOW_ID, primary_dj_id: DJ_ID } as unknown as Parameters<typeof endShow>[0]);
 

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -30,8 +30,9 @@ describe('endShow', () => {
     const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
     db.insert.mockReturnValueOnce(flowsheetInsert);
 
-    // shows update (end_time) — endShow returns this UPDATE's .returning()
-    // row directly (no getLatestShow re-read; BS#1119 follow-up)
+    // shows update (end_time) — the compare-and-set that claims the show. It
+    // runs FIRST now, and endShow returns its .returning() row directly (no
+    // getLatestShow re-read; BS#1119 follow-up)
     db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, end_time: new Date() }]));
 
     await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
@@ -66,5 +67,27 @@ describe('endShow', () => {
     // show_end row is kept (the show ended) but dj_name is null; endShow's
     // asymmetric-fallback emits the degraded message body.
     expect(flowsheetValues.dj_name).toBeNull();
+  });
+
+  it('rejects the loser of a concurrent double-end without writing a second show_end marker', async () => {
+    // The end_time UPDATE is a compare-and-set (`WHERE id = ? AND end_time IS
+    // NULL`) and runs FIRST, before any other write. The controller's own
+    // `end_time !== null` guard only rejects a second end after the first
+    // COMMITS — a double-click has both requests reading a live show, and
+    // without the CAS both wrote a marker and both returned 200, so the mirror
+    // signed tubafrenzy off twice. An empty `.returning()` is the loser.
+    db.update.mockReturnValueOnce(createMockQueryChain([]));
+
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+
+    await expect(
+      endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0])
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    // Claiming the show comes before every other write, so the loser leaves no
+    // trace at all: no second show_end marker, no guest-DJ deactivation.
+    expect(flowsheetInsert.values).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -30,13 +30,9 @@ describe('endShow', () => {
     const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
     db.insert.mockReturnValueOnce(flowsheetInsert);
 
-    // shows update (end_time)
-    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-
-    // getLatestShow() select chain — returns the show we just ended
-    const latestShowSelect = createMockQueryChain();
-    latestShowSelect.limit.mockResolvedValue([{ id: 42, end_time: new Date() }]);
-    db.select.mockReturnValueOnce(latestShowSelect);
+    // shows update (end_time) — endShow returns this UPDATE's .returning()
+    // row directly (no getLatestShow re-read; BS#1119 follow-up)
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, end_time: new Date() }]));
 
     await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
 
@@ -62,11 +58,7 @@ describe('endShow', () => {
 
     const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
     db.insert.mockReturnValueOnce(flowsheetInsert);
-    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-
-    const latestShowSelect = createMockQueryChain();
-    latestShowSelect.limit.mockResolvedValue([{ id: 42, end_time: new Date() }]);
-    db.select.mockReturnValueOnce(latestShowSelect);
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, end_time: new Date() }]));
 
     await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
 

--- a/tests/unit/services/flowsheet.markerText.test.ts
+++ b/tests/unit/services/flowsheet.markerText.test.ts
@@ -64,13 +64,9 @@ const setUpForEndShow = (djName: string | null, name: string | null) => {
   const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
   db.insert.mockReturnValueOnce(flowsheetInsert);
 
-  // shows update
-  db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-
-  // getLatestShow
-  const latestShowSelect = createMockQueryChain();
-  latestShowSelect.limit.mockResolvedValue([{ id: 42, end_time: new Date() }]);
-  db.select.mockReturnValueOnce(latestShowSelect);
+  // shows update — endShow returns this UPDATE's .returning() row directly
+  // (no getLatestShow re-read; that raced a concurrent join, BS#1119 follow-up)
+  db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, end_time: new Date() }]));
 
   return flowsheetInsert;
 };


### PR DESCRIPTION
Acts on the verified findings from the BS#1119 follow-up code review (the endshow mirror shape guard, PR #1540). Three production defects fixed, the discrimination hardened, and the test substrate made honest. Two findings need product calls and are spun off instead: #2093 (NULL-primary show can never be ended) and #2094 (co-host dj_join/dj_leave markers never mirror).

## Production fixes

**1. `endShow` wrong-show signoff race** (`flowsheet.service.ts`). The service returned `(await getLatestShow())!` after its `end_time` UPDATE. A `POST /flowsheet/join` landing between the UPDATE and the re-read created show N+1, which is what got returned — the mirror then signed off the *wrong, still-live* show in tubafrenzy (its id is already in the showIdMap from its own startShow) while show N's signoff was silently dropped. Now returns the UPDATE's own `.returning()` row.

**2. Dead per-DJ flag identity** (`mirror.middleware.ts`). `isMirrorEnabled` read `(req as any).user?.id`, but nothing ever sets `req.user` — the auth middleware sets `req.auth`. With `POSTHOG_API_KEY` configured, every live-mirror flag evaluation used `req.ip` (one EC2-local value) as identity, so per-DJ `backend-mirror` targeting was impossible and diverged from `jobs/legacy-mirror-reconcile`, which keys the same flag on `primary_dj_id`. Now reads `req.auth?.id`.

**3. `show_end` announcement query predicates** (`flowsheet.mirror.ts`). endShow's announcement re-query was bare `WHERE show_id ORDER BY play_order DESC LIMIT 1` — missing the `entry_type` + `isNull(legacy_entry_id)` predicates its startShow twin gained in BS#1705. The service writes the `show_end` marker *before* it commits `end_time`, so a co-host track that squeaked past the active-show check landed with a higher `play_order`: the DESC query re-mirrored that already-mirrored track as a duplicate (two racing `legacy_entry_id` persists) and the END_OF_SHOW marker never reached tubafrenzy. Re-fires were also non-idempotent. Now targets `entry_type = 'show_end' AND legacy_entry_id IS NULL`, exactly like startShow.

## Hardened discrimination

The ShowDJ-vs-Show check moves out of the endShow handler body into a positive `isShowPayload` discriminant passed as `createHttpMirrorMiddleware`'s new optional `shouldMirror` type-guard gate:

- **Positive, not negative**: a Show is detected by its own keys (`primary_dj_id` is present even when null — the payload is a JSON round-trip of the full row), instead of `show.id == null` duck-typing on what the *other* shape lacks. The issue body's named trap — `show_djs` gaining a serial `id` silently re-opening BS#1119 — is closed.
- **Loud unknown-shape lane**: a payload that is neither shape (e.g. a future projection change strips Show's keys) logs a `console.warn` instead of going quiet — the silent-skip failure mode the review flagged.
- **Cheaper**: ShowDJ traffic (every guest leave, every co-host join) skips before paying the prod PostHog `isFeatureEnabled` round-trip.
- `startShow` shares the gate and drops its dead `|| !show` clause; its behavior (skip Show-with-NULL-primary, skip ShowDJ) is unchanged and now documented against #2094.

## Test substrate

- **Harness** (`http-mirror-harness.ts`): no longer re-implements the tap's capture — `tapJsonResponse` finally has real coverage (deleting its capture line now fails the suites, verified during development). Completion barrier is a deterministic `setImmediate` drain, not a 50 ms real-timer sleep (fake-timer-proof, faster, and fails loudly instead of vacuously); the finish emit moved to `setImmediate` because a 0 ms timer's 1 ms clamp can lose the race against the drain. Mock req models `req.auth`.
- **Shape-guard suite**: now exercises the announcement arm end-to-end (map → POST → `cacheEntryId` → `legacy_entry_id` persist — previously the titled test never reached it), the cache-lane fallback `getCachedShowId(show.id) ?? legacy_show_id` (the case that catches a wrong-discriminant mutant), and the loud unknown-shape lane. The "deleted mid-show" test is retitled to the guard semantics it actually pins, pointing at #2093 for the real (unreachable-payload) defect. drizzle mock matches the module's true import surface (`and`/`desc`/`eq`/`isNull`).
- **Integration contract test** (`mirror-http.spec.js`): asserts its fixture identity (primary's join really started the show) instead of assuming it, drains in-flight mirror traffic from earlier suites before taking its baseline, polls for the positive signoff (CDC specs' precedent) instead of a fixed 300 ms sleep, keeps the fixed window only for the genuinely negative "nothing arrives" assertion, and verifies the guest is off-air post-leave. Cleanup tolerates 200/400 and warns on anything else. The pre-existing add-entry test now selects the track's POST explicitly rather than assuming it arrived last (cross-request mirror ordering was never its contract).
- Service `endShow` unit fixtures drop their dead `getLatestShow` queue entries, whose unconsumed `mockReturnValueOnce` values leaked across tests.

`package-lock.json` rides along: `shared/observability` (#2089 merge) declares `@sentry/core` without a root lock sync, which breaks `npm ci`.

## Verification

- `typecheck` / `lint` / `format:check` clean
- `test:unit`: 426 suites, 7,007 tests, all green
- `ci:testmock` (fresh volume): 99/99 suites, 942 tests green — including the reworked mirror suites and the announcement-arm coverage

## Related

- BS#1119 (origin; closed), #1540 (the reviewed PR), BS#1705 (the startShow predicate precedent), BS#1103 / BS#908 (cache/loop invariants preserved)
- #2093, #2094 — spun-off product calls
- #2088 — the rotation-match OR-form divergence (unchanged here)


---

## Review follow-ups (round 2)

A second review pass on the above. Five more production fixes, plus the regression pins the first round was missing.

**Per-show flag identity.** Fixing `req.user` -> `req.auth` made per-DJ targeting work for the first time, which newly exposed a split-brain show: a primary with `backend-mirror` ON and a co-host with it OFF yields a half-mirrored show, and `legacy-mirror-reconcile` classifies that as *partially* mirrored — the one state it refuses to auto-heal. The identity is now the SHOW's primary DJ, matching the reconcile cron, via a `resolveFlagIdentity` option on both middleware factories (from the payload for show lifecycle; one PK lookup for entries). Resolved lazily, so it costs nothing when PostHog is unconfigured, and falls back to the caller if the lookup throws. `shouldMirror` moves into the same options object.

**`endShow` compare-and-set, hoisted above the marker write.** The `end_time` UPDATE now carries `AND end_time IS NULL` and runs before any other write. The controller's `end_time !== null` guard only rejects a second end after the first *commits*, so a double-click had both requests writing a `show_end` marker and both returning 200 — two signoffs and two END_OF_SHOW entries, which `isNull(legacy_entry_id)` does not dedupe (each firing finds a different unmirrored marker). The loser now gets an empty `.returning()` and the controller's own 400. Hoisting also closes the co-host write window at the root rather than at one query: with `end_time` committed first, the racing `POST /flowsheet` fails its own active-show check instead of landing after END_OF_SHOW.

**`isShowPayload` tests `id` by value.** `'id' in data` was strictly weaker than the `show.id == null` check it replaced — a Show-shaped payload with a null `id` passed the gate and bound NULL into `eq(flowsheet.show_id, ...)`, matching nothing and dropping the marker. That is BS#1119's own failure mode, so it belongs in the loud lane.

**One announcement helper, one null guard.** `startShow` and `endShow` had drifted into near-identical copies differing only in the `entry_type` literal — that drift *is* the defect fix #3 above was correcting. Extracted to `mirrorAnnouncementEntry` taking a non-nullable `tubafrenzyShowId`, so the guard is structural: both handlers skip the whole tail when the show id is unresolvable, instead of POSTing an orphan entry with no parent show and stamping `legacy_entry_id` on the marker — which would hide it from the reconcile sweep permanently. The dead `ORDER BY play_order DESC` goes with it.

**Loud lane reaches Sentry.** A bare `console.warn` on EC2 stdout is as quiet in prod as the silent skip it replaced; the unknown-shape lane now also `captureMessage`s at warning level.

### Test substrate

- The `show_end` predicate, the flag identity, the null-`id` gate and the null-show-id guard each had **no** regression pin — all four mutants stayed green. Added, and each verified to fail on the reverted fix.
- The startshow suite's endShow fixture now puts the co-host track ABOVE the marker by play_order and first in row order, so both the DESC mutant and the bare-`LIMIT 1` mutant resolve the track.
- The PostHog suite built the dead `req.user` shape and asserted nothing about `distinctId` — it documented the bug it was meant to catch.
- drizzle mocks in all four harness suites now match the module's real import surface; the shape-guard mock drops its dead `orderBy` rung.
- `waitForMirrorQuiescence` could not distinguish quiesced from timed out — and asserting on it revealed **it had never worked**: the mock server records its own `/_admin/*` control endpoints in the per-service log, so polling the log grew the count being polled, and the drain always burned its full 3 s and returned as if quiet. Now counts only real mirror traffic and returns a boolean both call sites assert (the negative window is measured on a genuinely drained log; the test settles in 1.7 s instead of timing out at 3.1 s). The sibling add-entry test also stops assuming its POST arrived last.

### Verification (round 2)

- `typecheck` / `lint` / `format:check` clean
- `test:unit`: 426 suites, 7,015 tests green
- `ci:testmock` (fresh volume): 99/99 suites, 942 tests green
