### PR TITLE
fix(#2068, #2069): make the stale-open-show detector's max(id) exclusion conditional, and isolate the detector from the repair sweeps

### DIFF
--- a/jobs/legacy-mirror-reconcile/job.ts
+++ b/jobs/legacy-mirror-reconcile/job.ts
@@ -130,6 +130,21 @@ export const RECONCILE_ALERT_THRESHOLD_DEFAULT = 0;
  * 2,813 were over 30 days old — the #1543 repair cohort, held out of the
  * report by `RECONCILE_WINDOW_HOURS` and counted instead. Nothing sat between
  * 6h and 30 days, so the detector starts from a clean in-window baseline.
+ *
+ * BS#2068 correction: the "excluded twice over" reasoning two paragraphs up is
+ * about a GENUINELY live show (still logging tracks, so its newest entry is a
+ * track, not a marker) and remains true after that fix. But do not read "is
+ * still the newest show" there as implying the id-based exclusion in
+ * `selectStaleOpenShows` is unconditional — it no longer is. That bound used
+ * to veto reporting for ANY show holding `max(id)`, including one whose
+ * sign-off marker had already landed with `end_time` never stamped — the
+ * exact dropped-webhook residue this detector exists to catch — so a show
+ * that never stopped being `max(id)` could sit in the reportable band for its
+ * entire life and never be reported, aging silently into the historical
+ * cohort instead. The bound is now conditioned on the newest flowsheet entry
+ * NOT being a `show_end` marker (see `orchestrate.ts`), which is why a
+ * genuinely-live show is still excluded (its newest entry is never a marker)
+ * while the dropped-delivery case is not.
  */
 export const STALE_OPEN_SHOW_HOURS_ENV = 'STALE_OPEN_SHOW_HOURS';
 export const STALE_OPEN_SHOW_HOURS_DEFAULT = 12;

--- a/jobs/legacy-mirror-reconcile/job.ts
+++ b/jobs/legacy-mirror-reconcile/job.ts
@@ -285,6 +285,7 @@ export const buildPorts = (client: PostHog | null, options: JobOptions): Reconci
   awaitQuiet: () => awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs),
   log,
   captureWarning,
+  captureError,
 });
 
 // ── Entrypoint ────────────────────────────────────────────────────────────────
@@ -344,6 +345,21 @@ const main = async (): Promise<void> => {
 
     const totals = await runReconcile(buildPorts(posthog, options), options);
     log('info', 'finished', `${JOB_NAME} done`, { ...totals });
+
+    // Exit-code decision (BS#2069): a detector-only failure
+    // (`totals.stale_open_show_detector_failed`) deliberately does NOT set
+    // `process.exitCode`. `runStaleOpenShowReport` isolates that failure
+    // inside `runReconcile` precisely so it cannot abort the two repair
+    // sweeps; letting it flip this job's exit code anyway would re-couple the
+    // same failure at the reporting layer that isolation just decoupled at
+    // the execution layer. The failure is not silent — it is logged at
+    // 'error' with its own step name and captured to Sentry with its own
+    // fingerprint (see `runStaleOpenShowReport`), so it alerts distinctly
+    // from this job's generic 'failed' path. Reserving exit 1 for "the sweeps
+    // didn't run" keeps the nightly cron-failure alert meaning what it says:
+    // if this job starts exiting 1 every night because a persistently-broken
+    // detector never affects the sweeps, the alert becomes noise an operator
+    // learns to ignore — exactly the failure mode BS#2069 exists to prevent.
   } catch (err) {
     captureError(err, 'main');
     log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {

--- a/jobs/legacy-mirror-reconcile/job.ts
+++ b/jobs/legacy-mirror-reconcile/job.ts
@@ -352,14 +352,30 @@ const main = async (): Promise<void> => {
     // inside `runReconcile` precisely so it cannot abort the two repair
     // sweeps; letting it flip this job's exit code anyway would re-couple the
     // same failure at the reporting layer that isolation just decoupled at
-    // the execution layer. The failure is not silent — it is logged at
-    // 'error' with its own step name and captured to Sentry with its own
-    // fingerprint (see `runStaleOpenShowReport`), so it alerts distinctly
-    // from this job's generic 'failed' path. Reserving exit 1 for "the sweeps
-    // didn't run" keeps the nightly cron-failure alert meaning what it says:
-    // if this job starts exiting 1 every night because a persistently-broken
-    // detector never affects the sweeps, the alert becomes noise an operator
-    // learns to ignore — exactly the failure mode BS#2069 exists to prevent.
+    // the execution layer.
+    //
+    // What the failure actually alerts through (BS#2069 review finding 5 —
+    // checked against the real deploy path, not assumed): the installed
+    // crontab (`.github/workflows/deploy-base.yml`'s `CRON_CMD`) is
+    // `docker rm -f <app>-cron ...; docker run --name <app>-cron --env-file
+    // .env <image>` — no `--log-driver awslogs`, no output redirection, no
+    // exit-code wrapper. There is no nightly cron-failure alert in this repo
+    // for a non-zero exit code to become noise in, so the "reserve exit 1 so
+    // the cron alert stays meaningful" framing this comment used to have was
+    // wrong — that alert doesn't exist. The `log('error', ...)` line goes to
+    // the named container's stderr, which the NEXT night's `docker rm -f`
+    // destroys — one-run retention, shipped nowhere durable. Same problem for
+    // `totals.stale_open_show_detector_failed` on the `finished` line: it's
+    // real, but only as durable as that one run's container.
+    //
+    // So the actual, durable observability of a detector-only failure is ONE
+    // channel: the Sentry `captureException` in `runStaleOpenShowReport`,
+    // fingerprinted per-step (BS#2069 review finding 4, `captureError` in
+    // `logger.ts`) so a persistently-failing detector rolls up into a single
+    // stable Sentry issue across runs instead of a fresh issue per distinct
+    // error message. Keeping the exit code sweeps-only means that Sentry
+    // signal stays the one place this failure mode is visible, rather than
+    // being duplicated (or replaced) by a job-level exit-1 that nothing reads.
   } catch (err) {
     captureError(err, 'main');
     log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {

--- a/jobs/legacy-mirror-reconcile/job.ts
+++ b/jobs/legacy-mirror-reconcile/job.ts
@@ -377,6 +377,13 @@ const main = async (): Promise<void> => {
     // signal stays the one place this failure mode is visible, rather than
     // being duplicated (or replaced) by a job-level exit-1 that nothing reads.
   } catch (err) {
+    // Deliberately no custom fingerprint here (BS#2098 review finding 1):
+    // `captureError`'s per-step rollup is scoped to the two detector call
+    // sites in `orchestrate.ts` only. A `'main'` catch-all fingerprint would
+    // collapse every unrelated top-level failure (a tubafrenzy outage, a DB
+    // connection loss, an advisory-lock error, a mirror 401 after token
+    // rotation) into one Sentry issue — see `ROLLUP_ERROR_STEPS` in
+    // `logger.ts` for the full reasoning.
     captureError(err, 'main');
     log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {
       error_message: err instanceof Error ? err.message : String(err),

--- a/jobs/legacy-mirror-reconcile/logger.ts
+++ b/jobs/legacy-mirror-reconcile/logger.ts
@@ -87,17 +87,69 @@ export const log = (level: LogLevel, step: string, message: string, fields: Reco
 };
 
 /**
+ * Steps where a fingerprint OVERRIDE is warranted for `captureError` — i.e.
+ * where different error SHAPES at the same call site (a statement timeout
+ * one night, a connection reset the next) should still roll up into one
+ * stable Sentry issue across runs, because the call site's identity — not
+ * the specific exception — is what an on-call reader needs grouped. Today
+ * that's exactly the BS#2065/#2069 stale-open-show detector's two narrow
+ * arms (`orchestrate.ts`'s `runStaleOpenShowReport`).
+ *
+ * Every OTHER `captureError` call site — most importantly the catch-all
+ * `'main'` step in `job.ts` — must NOT get this treatment (BS#2098 review
+ * finding 1): folding every top-level failure into one fingerprinted group
+ * meant a tubafrenzy-outage week could archive/ignore that one Sentry issue,
+ * and a LATER, unrelated failure (a DB connection loss, an advisory-lock
+ * error, a mirror 401 after token rotation) would silently append to the
+ * same archived issue instead of alerting on its own. Sentry's DEFAULT
+ * (exception-shape-based) grouping is what those call sites want, so
+ * `captureError` leaves `fingerprint` unset for any step not in this set —
+ * two genuinely different exceptions at `'main'` land in two different
+ * issues, while repeated identical failures still collapse the way Sentry
+ * always collapses identical stack traces.
+ *
+ * An alternative considered: keep every `captureError` call fingerprinted,
+ * but prefix `['{{ default }}', 'legacy-mirror-reconcile', step]` so Sentry
+ * mixes its own exception-shape grouping back in. Rejected: that would ALSO
+ * apply to the two detector steps below, defeating the reason they're
+ * fingerprinted in the first place — a statement timeout and a connection
+ * reset at the SAME detector call site have different default shapes, so
+ * `{{ default }}` would split them right back into separate issues, exactly
+ * what this file's original docblock (see `captureError` below) built the
+ * per-step fingerprint to prevent. Scoping the override to the two call
+ * sites that actually want cross-shape rollup, and leaving every other step
+ * (including `'main'`) on Sentry's default grouping, gets both properties at
+ * once without a signature change to `captureError` or its `ReconcilePorts`
+ * call sites.
+ */
+const ROLLUP_ERROR_STEPS = new Set<string>(['stale_open_show_detector', 'stale_open_show_historical_count']);
+
+/**
  * Capture an exception to Sentry with the current run's tags + an extra
- * `step`, fingerprinted per `step` (same convention as `captureWarning` below)
- * so a persistently-failing call site rolls up into one stable Sentry issue
- * across runs instead of fanning out into a fresh issue per distinct error
- * message/stack — Sentry's default grouping is exception-shape-based, not
- * step-based, so two different DB errors from the same call site (e.g. a
- * statement timeout one night, a connection reset the next) would otherwise
- * group separately.
+ * `step`. For the two steps in `ROLLUP_ERROR_STEPS` (see that constant),
+ * fingerprinted per `step` so a persistently-failing call site rolls up into
+ * one stable Sentry issue across runs instead of fanning out into a fresh
+ * issue per distinct error message/stack — Sentry's default grouping is
+ * exception-shape-based, not step-based, so two different DB errors from the
+ * same call site (e.g. a statement timeout one night, a connection reset the
+ * next) would otherwise group separately. Every other step (including the
+ * `job.ts` catch-all `'main'`) gets no fingerprint override, so Sentry's
+ * default exception-shape grouping applies instead — see the constant's
+ * comment for why that split is deliberate.
+ *
+ * The fingerprint's second element is the literal `'error'`, disambiguating
+ * this namespace from `captureWarning`'s (below): both used to fingerprint
+ * as bare `['legacy-mirror-reconcile', step]`, so a future step string
+ * shared between an error and a warning call site would have merged them
+ * into one Sentry issue despite one being a hard failure and the other a
+ * detection signal. No such collision exists today (error steps are
+ * `main`/`stale_open_show_detector`/`stale_open_show_historical_count`;
+ * warning steps are `stale_open_show`/`partial_mirror`/`detection`), but
+ * nothing enforced that the two sets stay disjoint.
  */
 export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
-  Sentry.captureException(error, { tags: { step }, fingerprint: ['legacy-mirror-reconcile', step], extra });
+  const fingerprint = ROLLUP_ERROR_STEPS.has(step) ? ['legacy-mirror-reconcile', 'error', step] : undefined;
+  Sentry.captureException(error, { tags: { step }, fingerprint, extra });
 };
 
 /**
@@ -106,11 +158,15 @@ export const captureError = (error: unknown, step: string, extra: Record<string,
  * threshold and the per-show partial-mirror report — each roll up into a
  * single, stable issue rather than fanning out per run or per show_id. The
  * `show_id` travels as `extra`, not part of the group hash.
+ *
+ * The fingerprint's second element is the literal `'warning'` — see
+ * `captureError`'s doc comment for why the two capture functions no longer
+ * share a bare `['legacy-mirror-reconcile', step]` namespace.
  */
 export const captureWarning = (message: string, step: string, extra: Record<string, unknown> = {}): void => {
   Sentry.captureMessage(message, {
     level: 'warning',
-    fingerprint: ['legacy-mirror-reconcile', step],
+    fingerprint: ['legacy-mirror-reconcile', 'warning', step],
     tags: { subsystem: 'legacy-mirror', step },
     extra,
   });

--- a/jobs/legacy-mirror-reconcile/logger.ts
+++ b/jobs/legacy-mirror-reconcile/logger.ts
@@ -86,9 +86,18 @@ export const log = (level: LogLevel, step: string, message: string, fields: Reco
   }
 };
 
-/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+/**
+ * Capture an exception to Sentry with the current run's tags + an extra
+ * `step`, fingerprinted per `step` (same convention as `captureWarning` below)
+ * so a persistently-failing call site rolls up into one stable Sentry issue
+ * across runs instead of fanning out into a fresh issue per distinct error
+ * message/stack — Sentry's default grouping is exception-shape-based, not
+ * step-based, so two different DB errors from the same call site (e.g. a
+ * statement timeout one night, a connection reset the next) would otherwise
+ * group separately.
+ */
 export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
-  Sentry.captureException(error, { tags: { step }, extra });
+  Sentry.captureException(error, { tags: { step }, fingerprint: ['legacy-mirror-reconcile', step], extra });
 };
 
 /**

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -161,23 +161,34 @@ export interface ReconcileTotals {
    * BS#2065: open shows older than `windowHours` — the pre-existing residue
    * #1543's final-dump pass repairs, counted (never listed) so the backlog is
    * observable and its shrink after that pass is verifiable. Stays at its
-   * zero default when `countHistoricalOpenShows` itself failed this run —
-   * see `historical_open_shows_count_failed`, which is the field that
-   * actually distinguishes "counted zero" from "count unknown."
+   * zero default whenever `historical_open_shows_count_failed` is true —
+   * that flag is what actually distinguishes "counted zero" from "count
+   * unknown," whether the count itself threw or was never attempted at all
+   * (see that field's own comment, BS#2098 review item 2).
    */
   historical_open_shows: number;
   /**
-   * BS#2069 review finding 3: true when `countHistoricalOpenShows` (only —
-   * see `stale_open_show_detector_failed` for `selectStaleOpenShows`) threw
-   * this run. Isolated in its own nested try inside `runStaleOpenShowReport`
-   * so this strictly-less-important count's failure cannot discard the
-   * per-show `stale_open_show` warn lines and aggregate Sentry warning that
-   * `selectStaleOpenShows` already earned by succeeding in the same run.
-   * Before this fix there was no nested try: a `countHistoricalOpenShows`
-   * timeout after a successful `selectStaleOpenShows` fell into the SAME
-   * outer catch as a genuine detector failure, discarding real findings —
-   * `totals.stale_open_shows` stayed populated on the `finished` line with
-   * zero warn lines or Sentry capture behind it.
+   * BS#2069 review finding 3 (widened by BS#2098 review item 2): true when
+   * the #1543 backlog count is not trustworthy this run — either because
+   * `countHistoricalOpenShows` itself threw, or because it was never
+   * attempted at all (`selectStaleOpenShows` failed first, so execution
+   * never reached the nested try that calls it). Isolated in its own nested
+   * try inside `runStaleOpenShowReport` so this strictly-less-important
+   * count's failure cannot discard the per-show `stale_open_show` warn lines
+   * and aggregate Sentry warning that `selectStaleOpenShows` already earned
+   * by succeeding in the same run. Before the BS#2069 fix there was no
+   * nested try: a `countHistoricalOpenShows` timeout after a successful
+   * `selectStaleOpenShows` fell into the SAME outer catch as a genuine
+   * detector failure, discarding real findings — `totals.stale_open_shows`
+   * stayed populated on the `finished` line with zero warn lines or Sentry
+   * capture behind it. Before the BS#2098 fix, the OUTER catch (reached when
+   * `selectStaleOpenShows` itself throws, before the count is ever attempted)
+   * left this flag at its `false` default alongside `historical_open_shows`
+   * at its `0` default — indistinguishable from a genuine zero count. The
+   * outer catch now sets it too, but only when the nested count was never
+   * attempted (`runStaleOpenShowReport` tracks that locally), so it does not
+   * clobber a count that had already genuinely succeeded before some LATER
+   * step in the try body failed (see BS#2098 review item 3).
    */
   historical_open_shows_count_failed: boolean;
   /**
@@ -475,12 +486,48 @@ export const STALE_OPEN_SHOW_SENTRY_SAMPLE = 10;
  * and its own fingerprinted `stale_open_show_historical_count` Sentry capture,
  * and the per-show warn loop now runs BEFORE the count so it can never be
  * skipped by the count's failure.
+ *
+ * "COUNTED ZERO" VS. "COUNT UNKNOWN" (BS#2098 review item 2): the nested try
+ * above only runs when `selectStaleOpenShows` itself succeeds. Before this
+ * fix, when `selectStaleOpenShows` threw, the nested try/catch was never
+ * reached at all — `historical_open_shows` stayed at its `0` default AND
+ * `historical_open_shows_count_failed` stayed at its `false` default, which
+ * together read as "the count genuinely came back zero," identical to the
+ * healthy steady state. The `finished`/`detection` log line and any monitor
+ * keyed on the flag would then misreport the #1543 backlog as fully drained
+ * when it was never measured this run. `historicalCountAttempted` below
+ * tracks whether the nested try ran (success OR its own caught failure) so
+ * the outer catch can set `historical_open_shows_count_failed = true` for
+ * exactly the case the nested try never covers — `selectStaleOpenShows`
+ * failing before the count is ever attempted — without clobbering a count
+ * that had already genuinely succeeded before a LATER step (e.g. the
+ * aggregate `captureWarning` below) throws and lands here too.
+ *
+ * AN UNGUARDED CAPTURE IN THE OUTER CATCH (BS#2098 review item 3): if
+ * `ports.captureWarning` above throws — a Sentry transport error or quota
+ * exhaustion, a recurring failure mode in this org (BS#1291) — control lands
+ * in this outer catch. Before this fix, `ports.captureError` here was itself
+ * unguarded: if it threw for the same underlying reason (the same outage),
+ * that second exception would escape this catch block entirely, propagate
+ * out of `runStaleOpenShowReport`, and abort the `runShowCreateSweep` /
+ * `runEntrySweep` awaits in `runReconcile` below it — reintroducing, one
+ * level deeper, exactly the coupling BS#2069 exists to remove. (This path
+ * also mislabels what was actually a reporting-transport failure as
+ * `stale_open_show_detector_failed` — the detector itself may have
+ * succeeded; a real but accepted simplification, not fixed here.) The
+ * `ports.captureError` call is now wrapped in its own try/catch: if it also
+ * throws, that's logged and swallowed rather than re-thrown. The detector
+ * failure is already durable via the `ports.log('error', ...)` call above it
+ * (CloudWatch, independent of Sentry's availability), so losing the Sentry
+ * capture on top of an already-Sentry-impaired run is an acceptable
+ * degradation — taking down the mirror self-heal on top of it is not.
  */
 const runStaleOpenShowReport = async (
   ports: ReconcilePorts,
   options: ReconcileOptions,
   totals: ReconcileTotals
 ): Promise<void> => {
+  let historicalCountAttempted = false;
   try {
     const stale = await ports.selectStaleOpenShows(options);
     totals.stale_open_shows = stale.length;
@@ -516,6 +563,12 @@ const runStaleOpenShowReport = async (
       ports.captureError(err, 'stale_open_show_historical_count', {
         window_hours: options.windowHours,
       });
+    } finally {
+      // Attempted either way (success or the caught failure just above) —
+      // see the "COUNTED ZERO VS COUNT UNKNOWN" docblock paragraph. This is
+      // what lets the outer catch below tell "the count never ran" apart
+      // from "the count ran and either outcome already happened."
+      historicalCountAttempted = true;
     }
 
     if (stale.length > 0) {
@@ -539,15 +592,37 @@ const runStaleOpenShowReport = async (
     }
   } catch (err) {
     totals.stale_open_show_detector_failed = true;
+    // Only when the nested count was never attempted — see the "COUNTED ZERO
+    // VS COUNT UNKNOWN" docblock paragraph. A count that already genuinely
+    // succeeded (or already recorded its own failure) before some later step
+    // threw must not be overwritten here.
+    if (!historicalCountAttempted) {
+      totals.historical_open_shows_count_failed = true;
+    }
     const message = err instanceof Error ? err.message : String(err);
     ports.log('error', 'stale_open_show_detector_failed', `stale-open-show detector failed: ${message}`, {
       error_message: message,
       error_name: err instanceof Error ? err.name : null,
     });
-    ports.captureError(err, 'stale_open_show_detector', {
-      stale_after_hours: options.staleAfterHours,
-      window_hours: options.windowHours,
-    });
+    // See the "AN UNGUARDED CAPTURE IN THE OUTER CATCH" docblock paragraph:
+    // this must not be allowed to throw past this point.
+    try {
+      ports.captureError(err, 'stale_open_show_detector', {
+        stale_after_hours: options.staleAfterHours,
+        window_hours: options.windowHours,
+      });
+    } catch (captureErr) {
+      const captureMessage = captureErr instanceof Error ? captureErr.message : String(captureErr);
+      ports.log(
+        'error',
+        'stale_open_show_detector_capture_failed',
+        `Sentry capture of the detector failure itself failed: ${captureMessage}`,
+        {
+          error_message: captureMessage,
+          error_name: captureErr instanceof Error ? captureErr.name : null,
+        }
+      );
+    }
   }
 };
 

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -600,12 +600,18 @@ const staleCeiling = (staleAfterHours: number) => sql`now() - (interval '1 hour'
 /**
  * The show `flowsheet_service.getLatestShow()` returns — `ORDER BY id DESC
  * LIMIT 1` over the whole table, which is what `addEntry` / `leaveShow` /
- * `joinShow` treat as "the current show". Excluding exactly that row is the
- * hard guarantee behind the acceptance criterion "the genuinely-active show
- * never trips the detector": whatever the threshold, the row the API calls
- * live is never reported. Kept as `max(id)` rather than `max(start_time)`
- * deliberately — it must track `getLatestShow`'s ordering, not a plausible
- * substitute for it.
+ * `joinShow` treat as "the current show". Kept as `max(id)` rather than
+ * `max(start_time)` deliberately — it must track `getLatestShow`'s ordering,
+ * not a plausible substitute for it.
+ *
+ * Holding this id is now only a CONDITIONAL exclusion (BS#2068), not an
+ * absolute one — see `selectStaleOpenShows`'s second bullet. Excluding it
+ * unconditionally, as this bound originally did, meant the detector could
+ * never report the exact state a dropped tubafrenzy `show_end` delivery
+ * leaves a show in: `max(id)`, sign-off marker present, `end_time` still
+ * NULL. `addEntry` / `leaveShow` / `joinShow` gate on `getLatestShow()`, so
+ * that state is precisely when "who's on air" reads wrong — the harm the
+ * detector exists to surface, per #2065's own residual-harm list.
  */
 const latestShowId = sql`(SELECT max(s2.id) FROM ${shows} s2)`;
 
@@ -636,7 +642,8 @@ const newestEntryAt = sql<Date | null>`(SELECT fe.add_time FROM ${flowsheet} fe
 
 /**
  * Detector selection: `end_time IS NULL`, no activity since the cutoff, inside
- * the recurring window, and never the current show.
+ * the recurring window, and — unless its own sign-off marker already landed —
+ * never the current show.
  *
  * Three independent bounds, each load-bearing:
  *   - `start_time < now() - staleAfterHours` — the plausible-duration
@@ -644,16 +651,38 @@ const newestEntryAt = sql<Date | null>`(SELECT fe.add_time FROM ${flowsheet} fe
  *   - NOT EXISTS a flowsheet row newer than the same cutoff — a genuinely-live
  *     marathon show is still logging tracks, so it is excluded on activity
  *     even in the impossible case that it is somehow not the latest show id.
- *   - `id <> max(id)` — the current show, per `getLatestShow`'s own ordering.
+ *   - `id <> max(id) OR newestEntryType = 'show_end'` (BS#2068) — excludes the
+ *     current show, UNLESS its newest flowsheet entry is a `show_end` marker.
+ *     A show whose latest row is a sign-off marker cannot be genuinely live —
+ *     no DJ is on it (BS#1861 option (b), which `joinShow`'s opportunistic
+ *     `closeShowFromTerminalShowEndMarker` backfill already relies on) — so
+ *     gating the id exclusion on that marker preserves the "genuinely-active
+ *     show never reported" acceptance criterion (the activity bound above
+ *     still excludes it independently) while letting the detector see the one
+ *     state it exists to catch: a dropped `show_end` webhook leaves a show
+ *     BOTH `max(id)` AND signed off, and that combination must be reportable,
+ *     not permanently vetoed. Before this fix the bound was the unconditional
+ *     `id <> max(id)`, which vetoed exactly that combination.
  *
  * And an outer bound: `start_time > now() - windowHours`. Older open shows are
  * the historical-remediation class — 2,813 rows as of 2026-08-09, all >30 days
  * old, repaired by #1543's final-dump pass — deliberately out of scope for a
  * recurring report, exactly as the two mirror sweeps scope theirs. They are
- * counted by `countHistoricalOpenShows` instead of listed. The in-window band
- * (`windowHours - staleAfterHours`, 36h at the defaults) is wider than this
- * job's 24h period, so a show that goes stale is always seen by at least one
- * run before it ages out.
+ * counted by `countHistoricalOpenShows` instead of listed.
+ *
+ * The in-window band (`windowHours - staleAfterHours`, 36h at the defaults)
+ * being wider than this job's 24h period is NOT by itself a guarantee that a
+ * show which goes stale is seen by at least one run — that was the pre-fix
+ * docblock's claim, and it did not survive the unconditional id bound vetoing
+ * every run across the whole band whenever the show never stopped being
+ * `max(id)` (it silently aged into the historical cohort instead; see
+ * BS#2068's concrete timeline). With the marker-conditioned bound above, a
+ * show whose sign-off marker landed IS reportable regardless of whether a
+ * newer show has since started, so the band-width arithmetic does its
+ * intended job for that case. A show whose `show_end` marker itself never
+ * arrived is a different, out-of-scope failure — indistinguishable here from
+ * a quiet live show — and is left to the #1543 dump-based repair, same as
+ * before this fix.
  */
 export const selectStaleOpenShows = async ({
   windowHours,
@@ -674,7 +703,7 @@ export const selectStaleOpenShows = async ({
         lt(shows.start_time, staleCeiling(staleAfterHours)),
         gt(shows.start_time, windowFloor(windowHours)),
         sql`NOT EXISTS (SELECT 1 FROM ${flowsheet} WHERE ${flowsheet.show_id} = ${shows.id} AND ${flowsheet.add_time} >= ${staleCeiling(staleAfterHours)})`,
-        sql`${shows.id} IS DISTINCT FROM ${latestShowId}`
+        sql`(${shows.id} IS DISTINCT FROM ${latestShowId}) OR (${newestEntryType} = 'show_end')`
       )
     )
     .orderBy(asc(shows.start_time));

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -53,7 +53,7 @@
  * at the bottom of this module.
  */
 
-import { and, asc, eq, exists, gt, isNotNull, isNull, lt, notExists, notInArray, sql } from 'drizzle-orm';
+import { and, asc, eq, exists, gt, isNotNull, isNull, lt, notExists, notInArray, or, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, user, type FSEntry, type Show, type User } from '@wxyc/database';
 
 export type LogLevel = 'info' | 'warn' | 'error';
@@ -160,16 +160,36 @@ export interface ReconcileTotals {
   /**
    * BS#2065: open shows older than `windowHours` — the pre-existing residue
    * #1543's final-dump pass repairs, counted (never listed) so the backlog is
-   * observable and its shrink after that pass is verifiable.
+   * observable and its shrink after that pass is verifiable. Stays at its
+   * zero default when `countHistoricalOpenShows` itself failed this run —
+   * see `historical_open_shows_count_failed`, which is the field that
+   * actually distinguishes "counted zero" from "count unknown."
    */
   historical_open_shows: number;
   /**
-   * BS#2069: true when the read-only detector arm (`selectStaleOpenShows` or
-   * `countHistoricalOpenShows`) threw this run. The exception is caught,
-   * logged, and captured to Sentry at the point of failure — this flag exists
-   * so the same fact is visible on the "finished" summary line without
-   * grepping Sentry, since a detector-only failure deliberately does NOT flip
-   * this job's exit code (see `job.ts`, the call site of `runReconcile`).
+   * BS#2069 review finding 3: true when `countHistoricalOpenShows` (only —
+   * see `stale_open_show_detector_failed` for `selectStaleOpenShows`) threw
+   * this run. Isolated in its own nested try inside `runStaleOpenShowReport`
+   * so this strictly-less-important count's failure cannot discard the
+   * per-show `stale_open_show` warn lines and aggregate Sentry warning that
+   * `selectStaleOpenShows` already earned by succeeding in the same run.
+   * Before this fix there was no nested try: a `countHistoricalOpenShows`
+   * timeout after a successful `selectStaleOpenShows` fell into the SAME
+   * outer catch as a genuine detector failure, discarding real findings —
+   * `totals.stale_open_shows` stayed populated on the `finished` line with
+   * zero warn lines or Sentry capture behind it.
+   */
+  historical_open_shows_count_failed: boolean;
+  /**
+   * BS#2069: true when `selectStaleOpenShows` threw this run (see
+   * `historical_open_shows_count_failed` for the narrower `
+   * countHistoricalOpenShows` failure, isolated separately since BS#2069
+   * review finding 3 so it no longer sets this flag). The exception is
+   * caught, logged, and captured to Sentry at the point of failure — this
+   * flag exists so the same fact is visible on the "finished" summary line
+   * without grepping Sentry, since a detector-only failure deliberately does
+   * NOT flip this job's exit code (see `job.ts`, the call site of
+   * `runReconcile`).
    */
   stale_open_show_detector_failed: boolean;
 }
@@ -188,6 +208,7 @@ const emptyTotals = (): ReconcileTotals => ({
   skipped_no_dj: 0,
   stale_open_shows: 0,
   historical_open_shows: 0,
+  historical_open_shows_count_failed: false,
   stale_open_show_detector_failed: false,
 });
 
@@ -420,8 +441,9 @@ export const STALE_OPEN_SHOW_SENTRY_SAMPLE = 10;
  * Runs before the sweeps and takes no cooperative pause: it writes nothing, so
  * deferring it behind a live DJ would only delay the signal.
  *
- * ISOLATED (BS#2069): the whole body is one try/catch. This detector rides
- * the same run as the two repair sweeps (BS#1707) purely for scheduling
+ * ISOLATED (BS#2069): the outer body is one try/catch around
+ * `selectStaleOpenShows` and the per-show reporting it feeds. This detector
+ * rides the same run as the two repair sweeps (BS#1707) purely for scheduling
  * convenience — both mechanisms are retired together at Phase 6a — but it is
  * not the reason the job exists. Before this fix, an unguarded exception here
  * (a statement timeout on the `shows` scan + `flowsheet` anti-join, a
@@ -437,6 +459,22 @@ export const STALE_OPEN_SHOW_SENTRY_SAMPLE = 10;
  * warnings and from the generic `detection` signal below), and recorded on
  * `totals.stale_open_show_detector_failed` — then execution falls through to
  * the sweeps exactly as if the detector had found nothing to report.
+ *
+ * ISOLATED AGAIN, ONE LEVEL DEEPER (BS#2069 review finding 3):
+ * `countHistoricalOpenShows` — the #1543 backlog count, strictly less
+ * important than the per-show findings above it — gets its OWN nested
+ * try/catch rather than sharing the outer one. Before this fix it sat inside
+ * the same try as `selectStaleOpenShows`, so a `countHistoricalOpenShows`
+ * timeout AFTER a successful `selectStaleOpenShows` fell into the outer catch
+ * and discarded real findings: the per-show warn loop and the aggregate
+ * Sentry warning never ran, even though `stale.length` genuinely stale shows
+ * had already been found. `totals.stale_open_shows` stayed populated on the
+ * `finished` line with zero warn lines or Sentry capture behind it — a
+ * partial success silently degraded to a null report. The nested try isolates
+ * that count's failure into its own `historical_open_shows_count_failed` flag
+ * and its own fingerprinted `stale_open_show_historical_count` Sentry capture,
+ * and the per-show warn loop now runs BEFORE the count so it can never be
+ * skipped by the count's failure.
  */
 const runStaleOpenShowReport = async (
   ports: ReconcilePorts,
@@ -446,7 +484,6 @@ const runStaleOpenShowReport = async (
   try {
     const stale = await ports.selectStaleOpenShows(options);
     totals.stale_open_shows = stale.length;
-    totals.historical_open_shows = await ports.countHistoricalOpenShows(options);
 
     for (const s of stale) {
       ports.log(
@@ -464,6 +501,23 @@ const runStaleOpenShowReport = async (
       );
     }
 
+    // See the "ISOLATED AGAIN, ONE LEVEL DEEPER" docblock paragraph above: a
+    // failure counting the #1543 backlog must not discard the per-show
+    // findings above (already logged) or the aggregate Sentry warning below.
+    try {
+      totals.historical_open_shows = await ports.countHistoricalOpenShows(options);
+    } catch (err) {
+      totals.historical_open_shows_count_failed = true;
+      const message = err instanceof Error ? err.message : String(err);
+      ports.log('warn', 'historical_open_show_count_failed', `historical open-show count failed: ${message}`, {
+        error_message: message,
+        error_name: err instanceof Error ? err.name : null,
+      });
+      ports.captureError(err, 'stale_open_show_historical_count', {
+        window_hours: options.windowHours,
+      });
+    }
+
     if (stale.length > 0) {
       ports.captureWarning(
         'legacy-mirror-reconcile: show(s) left open past the plausible-duration threshold',
@@ -473,6 +527,7 @@ const runStaleOpenShowReport = async (
           stale_after_hours: options.staleAfterHours,
           window_hours: options.windowHours,
           historical_open_shows: totals.historical_open_shows,
+          historical_open_shows_count_failed: totals.historical_open_shows_count_failed,
           sample: stale.slice(0, STALE_OPEN_SHOW_SENTRY_SAMPLE).map((s) => ({
             show_id: s.show_id,
             start_time: s.start_time.toISOString(),
@@ -730,11 +785,29 @@ const newestEntryAt = sql<Date | null>`(SELECT fe.add_time FROM ${flowsheet} fe
  * arrived is a different, out-of-scope failure — indistinguishable here from
  * a quiet live show — and is left to the #1543 dump-based repair, same as
  * before this fix.
+ *
+ * The `id <> max(id) OR newestEntryType = 'show_end'` bullet above MUST be
+ * built with drizzle's `or()` helper, not a raw `sql` fragment containing a
+ * literal ` OR `. `and(...)` wraps its own children in exactly one pair of
+ * parentheses — it does not parenthesize each child individually — so a raw
+ * `sql\`(...) OR (...)\`` passed as one of `and`'s arguments renders as a bare
+ * disjunct INSIDE that single AND-group's parens, not as a parenthesized
+ * sub-term. Since SQL's `AND` binds tighter than `OR`, the whole WHERE clause
+ * then parses as `(bound1 AND bound2 AND bound3 AND bound4 AND idBoundArm1)
+ * OR showEndArm2` — the `show_end` arm stands alone as a full-table predicate
+ * with none of the other bounds applied. That shipped bug (caught in review,
+ * fixed before merge) would have reported essentially every show that ever
+ * ended: no `end_time IS NULL` filter, no threshold, no window, over a seq
+ * scan with correlated `LIMIT 1` subqueries per row. `or()` renders its own
+ * group in its own parens nested correctly inside `and()`'s — see
+ * `apps/enrichment-worker/precheck.ts`'s `hasLoadBearingAlbumMetadata` for the
+ * established precedent (`and(..., or(isNotNull(a), isNotNull(b)), ...)`).
+ * The `buildStaleOpenShowsQuery`/rendered-SQL parenthesization unit test in
+ * `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts` pins
+ * this against the real query builder so a future regression here fails a
+ * unit test, not just a live-Postgres integration run.
  */
-export const selectStaleOpenShows = async ({
-  windowHours,
-  staleAfterHours,
-}: StaleOpenShowOptions): Promise<StaleOpenShow[]> =>
+export const buildStaleOpenShowsQuery = ({ windowHours, staleAfterHours }: StaleOpenShowOptions) =>
   db
     .select({
       show_id: shows.id,
@@ -750,10 +823,13 @@ export const selectStaleOpenShows = async ({
         lt(shows.start_time, staleCeiling(staleAfterHours)),
         gt(shows.start_time, windowFloor(windowHours)),
         sql`NOT EXISTS (SELECT 1 FROM ${flowsheet} WHERE ${flowsheet.show_id} = ${shows.id} AND ${flowsheet.add_time} >= ${staleCeiling(staleAfterHours)})`,
-        sql`(${shows.id} IS DISTINCT FROM ${latestShowId}) OR (${newestEntryType} = 'show_end')`
+        or(sql`${shows.id} IS DISTINCT FROM ${latestShowId}`, eq(newestEntryType, 'show_end'))
       )
     )
     .orderBy(asc(shows.start_time));
+
+export const selectStaleOpenShows = async (o: StaleOpenShowOptions): Promise<StaleOpenShow[]> =>
+  buildStaleOpenShowsQuery(o);
 
 /**
  * Count of open shows older than the reporting window — the #1543 repair

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -37,7 +37,11 @@
  * plausible show duration — the residue of a dropped tubafrenzy `show_end`
  * webhook delivery, which since WXYC/wiki#88 Phase 3 nothing repairs. It runs
  * FIRST, before the sweeps' cooperative pause, because it writes nothing and
- * must not be deferred behind a live DJ. See `runStaleOpenShowReport`.
+ * must not be deferred behind a live DJ. It is isolated in its own try/catch
+ * (BS#2069) so a failure there — this arm shares the cron slot for retirement
+ * convenience, not because it is load-bearing — is logged and captured to
+ * Sentry rather than aborting the two sweeps below it, which are this job's
+ * actual purpose. See `runStaleOpenShowReport`.
  *
  * All mirror payloads come from `@wxyc/legacy-mirror` so they are
  * byte-identical to the live path (a re-implementation would drift). The
@@ -133,6 +137,8 @@ export interface ReconcilePorts {
   awaitQuiet(): Promise<void>;
   log(level: LogLevel, step: string, message: string, fields?: Record<string, unknown>): void;
   captureWarning(message: string, step: string, extra?: Record<string, unknown>): void;
+  /** Capture an exception to Sentry (BS#2069 detector isolation). */
+  captureError(error: unknown, step: string, extra?: Record<string, unknown>): void;
 }
 
 export interface ReconcileTotals {
@@ -157,6 +163,15 @@ export interface ReconcileTotals {
    * observable and its shrink after that pass is verifiable.
    */
   historical_open_shows: number;
+  /**
+   * BS#2069: true when the read-only detector arm (`selectStaleOpenShows` or
+   * `countHistoricalOpenShows`) threw this run. The exception is caught,
+   * logged, and captured to Sentry at the point of failure — this flag exists
+   * so the same fact is visible on the "finished" summary line without
+   * grepping Sentry, since a detector-only failure deliberately does NOT flip
+   * this job's exit code (see `job.ts`, the call site of `runReconcile`).
+   */
+  stale_open_show_detector_failed: boolean;
 }
 
 const emptyTotals = (): ReconcileTotals => ({
@@ -173,6 +188,7 @@ const emptyTotals = (): ReconcileTotals => ({
   skipped_no_dj: 0,
   stale_open_shows: 0,
   historical_open_shows: 0,
+  stale_open_show_detector_failed: false,
 });
 
 /** Milliseconds for a finalized show's tubafrenzy signoff. */
@@ -403,49 +419,80 @@ export const STALE_OPEN_SHOW_SENTRY_SAMPLE = 10;
  *
  * Runs before the sweeps and takes no cooperative pause: it writes nothing, so
  * deferring it behind a live DJ would only delay the signal.
+ *
+ * ISOLATED (BS#2069): the whole body is one try/catch. This detector rides
+ * the same run as the two repair sweeps (BS#1707) purely for scheduling
+ * convenience — both mechanisms are retired together at Phase 6a — but it is
+ * not the reason the job exists. Before this fix, an unguarded exception here
+ * (a statement timeout on the `shows` scan + `flowsheet` anti-join, a
+ * transient connection reset) propagated out of `runReconcile`, and `job.ts`'s
+ * single outer catch treated that identically to a failed sweep: log 'failed',
+ * exit 1, skip everything after. That let a read-only observability arm take
+ * down the mirror self-heal it merely shares a cron slot with — the same
+ * asymmetry `closeShowFromTerminalShowEndMarker`
+ * (`apps/backend/services/flowsheet.service.ts`) already reasons about
+ * correctly for its own best-effort backfill. A failure here is logged at
+ * 'error' and captured to Sentry with its own fingerprinted step
+ * (`stale_open_show_detector`, distinct from `stale_open_show`'s per-show
+ * warnings and from the generic `detection` signal below), and recorded on
+ * `totals.stale_open_show_detector_failed` — then execution falls through to
+ * the sweeps exactly as if the detector had found nothing to report.
  */
 const runStaleOpenShowReport = async (
   ports: ReconcilePorts,
   options: ReconcileOptions,
   totals: ReconcileTotals
 ): Promise<void> => {
-  const stale = await ports.selectStaleOpenShows(options);
-  totals.stale_open_shows = stale.length;
-  totals.historical_open_shows = await ports.countHistoricalOpenShows(options);
+  try {
+    const stale = await ports.selectStaleOpenShows(options);
+    totals.stale_open_shows = stale.length;
+    totals.historical_open_shows = await ports.countHistoricalOpenShows(options);
 
-  for (const s of stale) {
-    ports.log(
-      'warn',
-      'stale_open_show',
-      `show ${s.show_id} has been open for more than ${options.staleAfterHours}h; likely a dropped tubafrenzy show_end delivery`,
-      {
-        show_id: s.show_id,
-        legacy_show_id: s.legacy_show_id,
-        start_time: s.start_time.toISOString(),
-        last_entry_type: s.last_entry_type,
-        last_entry_at: s.last_entry_at?.toISOString() ?? null,
-        stale_after_hours: options.staleAfterHours,
-      }
-    );
-  }
-
-  if (stale.length > 0) {
-    ports.captureWarning(
-      'legacy-mirror-reconcile: show(s) left open past the plausible-duration threshold',
-      'stale_open_show',
-      {
-        stale_open_shows: stale.length,
-        stale_after_hours: options.staleAfterHours,
-        window_hours: options.windowHours,
-        historical_open_shows: totals.historical_open_shows,
-        sample: stale.slice(0, STALE_OPEN_SHOW_SENTRY_SAMPLE).map((s) => ({
+    for (const s of stale) {
+      ports.log(
+        'warn',
+        'stale_open_show',
+        `show ${s.show_id} has been open for more than ${options.staleAfterHours}h; likely a dropped tubafrenzy show_end delivery`,
+        {
           show_id: s.show_id,
+          legacy_show_id: s.legacy_show_id,
           start_time: s.start_time.toISOString(),
           last_entry_type: s.last_entry_type,
           last_entry_at: s.last_entry_at?.toISOString() ?? null,
-        })),
-      }
-    );
+          stale_after_hours: options.staleAfterHours,
+        }
+      );
+    }
+
+    if (stale.length > 0) {
+      ports.captureWarning(
+        'legacy-mirror-reconcile: show(s) left open past the plausible-duration threshold',
+        'stale_open_show',
+        {
+          stale_open_shows: stale.length,
+          stale_after_hours: options.staleAfterHours,
+          window_hours: options.windowHours,
+          historical_open_shows: totals.historical_open_shows,
+          sample: stale.slice(0, STALE_OPEN_SHOW_SENTRY_SAMPLE).map((s) => ({
+            show_id: s.show_id,
+            start_time: s.start_time.toISOString(),
+            last_entry_type: s.last_entry_type,
+            last_entry_at: s.last_entry_at?.toISOString() ?? null,
+          })),
+        }
+      );
+    }
+  } catch (err) {
+    totals.stale_open_show_detector_failed = true;
+    const message = err instanceof Error ? err.message : String(err);
+    ports.log('error', 'stale_open_show_detector_failed', `stale-open-show detector failed: ${message}`, {
+      error_message: message,
+      error_name: err instanceof Error ? err.name : null,
+    });
+    ports.captureError(err, 'stale_open_show_detector', {
+      stale_after_hours: options.staleAfterHours,
+      window_hours: options.windowHours,
+    });
   }
 };
 

--- a/tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js
+++ b/tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js
@@ -18,6 +18,27 @@
  * `jobs/legacy-mirror-reconcile/orchestrate.ts`. When that file changes, this
  * SQL must follow — same contract as the BS#1707 sibling spec.
  *
+ * THIS CONTRACT IS PROSE, NOT MECHANICAL (BS#2098 review item 4 "also worth
+ * closing" — and the reason that matters: a divergence between this twin and
+ * the real predicate is exactly what let the BS#2068/#2069 precedence bug
+ * ship through green tests — the twin was hand-written correctly parenthesized
+ * from the start, so it never exercised the drizzle `and()`/`or()` composition
+ * bug production actually had). `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts`
+ * now renders `buildStaleOpenShowsQuery` — the REAL, unmodified production
+ * function — through drizzle's own `PgDialect`, and asserts on the genuinely
+ * rendered SQL text and bound params (not a hand-written twin, not a
+ * call-shape mock). Mechanically asserting the two files' SQL against a
+ * single shared string is impractical: this spec runs via babel-jest against
+ * a live Docker Postgres, the unit test runs via ts-jest fully offline, and
+ * ts-jest project's compiled output isn't reachable from this file's runner —
+ * there's no single process or module system both can execute against
+ * without introducing a generated-fixture build step, which is
+ * disproportionate for what's currently a two-file, occasionally-touched
+ * WHERE clause. So: when you change the WHERE clause in `buildStaleOpenShowsQuery`,
+ * ALWAYS re-run `stale-open-shows-sql.test.ts` first, copy its newly-rendered
+ * predicate text by hand into the twin below, and re-run BOTH suites before
+ * committing. Skipping that is exactly how this bug shipped once already.
+ *
  * Two describe blocks, run in this file's declaration order:
  *
  *   1. The original BS#2065 fixture set, pinning the three exclusion bounds
@@ -78,6 +99,13 @@ function makeSql() {
  * evidence the show is over (BS#1861 option (b)) and is exactly the residue a
  * dropped tubafrenzy `show_end` webhook delivery leaves. Before BS#2068 this
  * was the unconditional `s.id IS DISTINCT FROM (SELECT max(s2.id) ...)`.
+ *
+ * KEEP THIS IN LOCKSTEP WITH `buildStaleOpenShowsQuery` IN
+ * `jobs/legacy-mirror-reconcile/orchestrate.ts` BY HAND — see the file-level
+ * docblock above for why that can't be automated, and
+ * `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts` for
+ * the genuinely-rendered production predicate to copy from whenever the WHERE
+ * clause changes.
  */
 const selectStaleOpenShows = async (sql) =>
   (

--- a/tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js
+++ b/tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js
@@ -7,24 +7,44 @@
  * leaves now that WXYC/wiki#88 Phase 3 has unscheduled `flowsheet-etl` and
  * nothing re-derives the column. The orchestration around it (log shape,
  * bounded Sentry sample, report-never-repair, running ahead of the cooperative
- * pause) is covered by
+ * pause, BS#2069's detector-failure isolation) is covered by
  * `tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts`; this spec's
- * value-add is the three exclusion bounds against a live planner, above all
- * the acceptance criterion "the genuinely-active show never trips it".
+ * value-add is the exclusion bounds against a live planner, above all the
+ * acceptance criterion "the genuinely-active show never trips it".
  *
  * Pure SQL — does NOT import the TS job (the integration runner is babel-jest
- * with no TS support). The queries below are a HAND-WRITTEN TWIN of the
- * drizzle SQL in `jobs/legacy-mirror-reconcile/orchestrate.ts`
- * (`selectStaleOpenShows` / `countHistoricalOpenShows`). When that file
- * changes, this SQL must follow — same contract as the BS#1707 sibling spec.
+ * with no TS support). `selectStaleOpenShows` / `countHistoricalOpenShows`
+ * below are a HAND-WRITTEN TWIN of the drizzle SQL in
+ * `jobs/legacy-mirror-reconcile/orchestrate.ts`. When that file changes, this
+ * SQL must follow — same contract as the BS#1707 sibling spec.
+ *
+ * Two describe blocks, run in this file's declaration order:
+ *
+ *   1. The original BS#2065 fixture set, pinning the three exclusion bounds
+ *      including the acceptance criterion "the genuinely-active show never
+ *      trips the detector" (the `current` fixture, held out solely by the
+ *      id-based bound).
+ *   2. A BS#2068 sibling: the `current`-shaped show CAN be reported once its
+ *      newest flowsheet entry is a `show_end` marker — the id bound is
+ *      conditional, not absolute, since #2065's own worst case is a show that
+ *      never stops being `max(id)` while signed off. This needs a separate
+ *      describe block, not another row in block 1's fixture set: block 1's
+ *      `current` fixture must hold `max(id)` for the ENTIRE lifetime of its
+ *      own tests, and this scenario needs a *different* row to hold that
+ *      position — one show can't play both parts in the same moment. Jest
+ *      runs this file's describe blocks in declaration order with each one's
+ *      beforeAll/afterAll fully bracketing its own tests, so by the time
+ *      block 2's beforeAll runs, block 1 has already cleaned up and block 2's
+ *      own last-inserted row is once again the true table max — the same
+ *      invariant block 1 relies on, re-established fresh.
  *
  * Scoping note: unlike the BS#1707 spec, the report query CANNOT be fully
  * scoped to the seeded ids, because the current-show exclusion is by
  * construction a whole-table `max(id)` (it must track
- * `flowsheet_service.getLatestShow`'s `ORDER BY id DESC LIMIT 1`). The
- * assertions therefore filter the returned rows to the seeded set, and the
- * "current show" fixture is inserted LAST so it genuinely holds `max(id)`
- * (integration runs `--runInBand`, so nothing else is inserting concurrently).
+ * `flowsheet_service.getLatestShow`'s `ORDER BY id DESC LIMIT 1`). Block 1's
+ * assertions filter the returned rows to its seeded set; block 2 seeds a
+ * single row and checks it directly. Both rely on nothing else inserting into
+ * `shows` concurrently (integration runs `--runInBand`).
  *
  * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
  */
@@ -32,7 +52,6 @@
 const postgres = require('postgres');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-let DJ_ID;
 const WINDOW_HOURS = 48;
 const STALE_AFTER_HOURS = 12;
 
@@ -48,8 +67,54 @@ function makeSql() {
   });
 }
 
+// -- SQL twins of jobs/legacy-mirror-reconcile/orchestrate.ts ---------------
+// Module-scope so both describe blocks below share one definition to keep in
+// lockstep with `orchestrate.ts`, rather than drifting copies.
+
+/**
+ * Twin of `selectStaleOpenShows`. The final bound is the BS#2068 conditional
+ * form: the current-show (`max(id)`) exclusion lifts when that show's newest
+ * flowsheet entry is a `show_end` marker, since that marker is positive
+ * evidence the show is over (BS#1861 option (b)) and is exactly the residue a
+ * dropped tubafrenzy `show_end` webhook delivery leaves. Before BS#2068 this
+ * was the unconditional `s.id IS DISTINCT FROM (SELECT max(s2.id) ...)`.
+ */
+const selectStaleOpenShows = async (sql) =>
+  (
+    await sql.unsafe(
+      `SELECT s.id AS show_id,
+              (SELECT f.entry_type FROM "${SCHEMA}".flowsheet f
+                WHERE f.show_id = s.id ORDER BY f.id DESC LIMIT 1) AS last_entry_type
+       FROM "${SCHEMA}".shows s
+       WHERE s.end_time IS NULL
+         AND s.start_time < now() - (interval '1 hour' * $1::int)
+         AND s.start_time > now() - (interval '1 hour' * $2::int)
+         AND NOT EXISTS (SELECT 1 FROM "${SCHEMA}".flowsheet f
+                          WHERE f.show_id = s.id
+                            AND f.add_time >= now() - (interval '1 hour' * $1::int))
+         AND (
+           s.id IS DISTINCT FROM (SELECT max(s2.id) FROM "${SCHEMA}".shows s2)
+           OR (SELECT f.entry_type FROM "${SCHEMA}".flowsheet f
+                WHERE f.show_id = s.id ORDER BY f.id DESC LIMIT 1) = 'show_end'
+         )
+       ORDER BY s.start_time ASC`,
+      [STALE_AFTER_HOURS, WINDOW_HOURS]
+    )
+  ).map((r) => ({ show_id: Number(r.show_id), last_entry_type: r.last_entry_type }));
+
+/** Twin of `countHistoricalOpenShows`. */
+const countHistoricalOpenShows = async (sql) => {
+  const [row] = await sql.unsafe(
+    `SELECT count(*)::int AS n FROM "${SCHEMA}".shows
+      WHERE end_time IS NULL AND start_time < now() - (interval '1 hour' * $1::int)`,
+    [WINDOW_HOURS]
+  );
+  return Number(row.n);
+};
+
 describe('stale-open-show detector selection SQL (BS#2065)', () => {
   let sql;
+  let DJ_ID;
   const showIds = {};
   let allShowIds = [];
   let historicalBaseline = 0;
@@ -73,41 +138,9 @@ describe('stale-open-show detector selection SQL (BS#2065)', () => {
       [showId, entryType]
     );
 
-  // -- SQL twins of jobs/legacy-mirror-reconcile/orchestrate.ts ---------------
-
-  /** Twin of `selectStaleOpenShows`. */
-  const selectStaleOpenShows = async () =>
-    (
-      await sql.unsafe(
-        `SELECT s.id AS show_id,
-                (SELECT f.entry_type FROM "${SCHEMA}".flowsheet f
-                  WHERE f.show_id = s.id ORDER BY f.id DESC LIMIT 1) AS last_entry_type
-         FROM "${SCHEMA}".shows s
-         WHERE s.end_time IS NULL
-           AND s.start_time < now() - (interval '1 hour' * $1::int)
-           AND s.start_time > now() - (interval '1 hour' * $2::int)
-           AND NOT EXISTS (SELECT 1 FROM "${SCHEMA}".flowsheet f
-                            WHERE f.show_id = s.id
-                              AND f.add_time >= now() - (interval '1 hour' * $1::int))
-           AND s.id IS DISTINCT FROM (SELECT max(s2.id) FROM "${SCHEMA}".shows s2)
-         ORDER BY s.start_time ASC`,
-        [STALE_AFTER_HOURS, WINDOW_HOURS]
-      )
-    ).map((r) => ({ show_id: Number(r.show_id), last_entry_type: r.last_entry_type }));
-
-  /** Twin of `countHistoricalOpenShows`. */
-  const countHistoricalOpenShows = async () => {
-    const [row] = await sql.unsafe(
-      `SELECT count(*)::int AS n FROM "${SCHEMA}".shows
-        WHERE end_time IS NULL AND start_time < now() - (interval '1 hour' * $1::int)`,
-      [WINDOW_HOURS]
-    );
-    return Number(row.n);
-  };
-
   /** Reported rows, narrowed to this spec's fixtures. */
   const reportedSeededIds = async () => {
-    const rows = await selectStaleOpenShows();
+    const rows = await selectStaleOpenShows(sql);
     return rows.filter((r) => allShowIds.includes(r.show_id)).map((r) => r.show_id);
   };
 
@@ -127,7 +160,7 @@ describe('stale-open-show detector selection SQL (BS#2065)', () => {
     if (djRows.length === 0) throw new Error('BS2065 detector spec: no seeded auth_user to own the fixture shows');
     DJ_ID = djRows[0].id;
 
-    historicalBaseline = await countHistoricalOpenShows();
+    historicalBaseline = await countHistoricalOpenShows(sql);
 
     // A — the target case: open, 20h old, sign-off marker present but
     // `end_time` never stamped (the dropped-delivery signature).
@@ -173,17 +206,20 @@ describe('stale-open-show detector selection SQL (BS#2065)', () => {
   });
 
   it('carries the last marker type so the report can name what terminated the show', async () => {
-    const rows = await selectStaleOpenShows();
+    const rows = await selectStaleOpenShows(sql);
     const target = rows.find((r) => r.show_id === showIds.dropped_show_end);
     expect(target).toBeDefined();
     expect(target.last_entry_type).toBe('show_end');
   });
 
   it('NEVER reports the genuinely-current show, even when it looks stale (BS#2065 AC)', async () => {
-    // The `current` fixture is 20h old with no recent entries — it satisfies
-    // both the threshold and the activity bound — and is excluded solely
-    // because it is the row `getLatestShow()` returns. This is the guarantee
-    // that does not depend on the threshold being tuned correctly.
+    // The `current` fixture is 20h old with no recent entries and NO
+    // flowsheet entries at all — it satisfies the threshold and the activity
+    // bound, and has no `show_end` marker to lift the id exclusion (BS#2068)
+    // — so it is excluded solely because it is the row `getLatestShow()`
+    // returns. This is the guarantee that does not depend on the threshold
+    // being tuned correctly, nor on the BS#2068 marker-conditioned carve-out
+    // (see the BS#2068 sibling describe below for that case).
     const [maxRow] = await sql.unsafe(`SELECT max(id)::int AS id FROM "${SCHEMA}".shows`);
     expect(Number(maxRow.id)).toBe(showIds.current);
 
@@ -210,6 +246,63 @@ describe('stale-open-show detector selection SQL (BS#2065)', () => {
     const reported = await reportedSeededIds();
     expect(reported).not.toContain(showIds.historical_open);
     // Exactly one seeded show sits older than the window.
-    await expect(countHistoricalOpenShows()).resolves.toBe(historicalBaseline + 1);
+    await expect(countHistoricalOpenShows(sql)).resolves.toBe(historicalBaseline + 1);
+  });
+});
+
+describe('stale-open-show detector: max(id) exclusion is conditional on show_end (BS#2068)', () => {
+  let sql;
+  let showId;
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE artist_name = 'BS2068 Artist'`);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".shows WHERE show_name LIKE 'BS2068 %'`);
+  };
+
+  beforeAll(async () => {
+    sql = makeSql();
+    await cleanup();
+
+    const djRows = await sql.unsafe(`SELECT id FROM auth_user LIMIT 1`);
+    if (djRows.length === 0) throw new Error('BS2068 sibling spec: no seeded auth_user to own the fixture show');
+    const djId = djRows[0].id;
+
+    // The converse of the `current` fixture in the BS#2065 describe above:
+    // same shape (20h old, no activity since the cutoff, deliberately made to
+    // hold max(id) by being the last show inserted anywhere in this file) but
+    // its NEWEST flowsheet entry is a `show_end` marker rather than nothing —
+    // the exact residue a dropped tubafrenzy `show_end` webhook delivery
+    // leaves (marker landed, `shows.end_time` never stamped). Before BS#2068
+    // the unconditional id bound made this permanently unreportable for as
+    // long as it held max(id) — the concrete gap #2068 was filed over. It
+    // must now be reported.
+    const [row] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".shows (primary_dj_id, show_name, start_time, end_time)
+       VALUES ($1, $2, now() - interval '20 hours', NULL) RETURNING id`,
+      [djId, 'BS2068 current_dropped_show_end']
+    );
+    showId = Number(row.id);
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet (show_id, entry_type, play_order, artist_name, track_title, add_time)
+       VALUES ($1, 'show_end', 1, 'BS2068 Artist', 'BS2068 Track', now() - interval '18 hours')`,
+      [showId]
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end({ timeout: 5 });
+  });
+
+  it('holds max(id), same as the BS#2065 describe relies on for its own `current` fixture', async () => {
+    const [maxRow] = await sql.unsafe(`SELECT max(id)::int AS id FROM "${SCHEMA}".shows`);
+    expect(Number(maxRow.id)).toBe(showId);
+  });
+
+  it('is reported even though it is max(id), because its newest entry is a show_end marker', async () => {
+    const rows = await selectStaleOpenShows(sql);
+    const target = rows.find((r) => r.show_id === showId);
+    expect(target).toBeDefined();
+    expect(target.last_entry_type).toBe('show_end');
   });
 });

--- a/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
@@ -545,6 +545,39 @@ describe('runReconcile — stale-open-show detector failure isolation (BS#2069)'
     expect(totals.shows_created).toBe(1);
   });
 
+  it('guards a captureError that itself throws in the outer catch, so a cascading Sentry outage cannot abort the sweeps (BS#2098 review item 3)', async () => {
+    // Failure scenario from the review: ports.captureWarning throws (a
+    // Sentry transport error / quota exhaustion — a recurring failure mode
+    // in this org, BS#1291) while reporting the aggregate stale_open_show
+    // signal. Control lands in the outer catch, which — before this fix —
+    // called ports.captureError unguarded; if THAT also throws for the same
+    // underlying reason, the exception used to escape runStaleOpenShowReport
+    // entirely and abort the two repair sweeps below it in runReconcile,
+    // reintroducing the exact coupling BS#2069 exists to remove, one level
+    // deeper.
+    const transportError = new Error('Sentry quota exhausted');
+    const stale = makeStaleOpenShow();
+    const createShow = makeShow({ id: 1, primary_dj_id: 'dj-1' });
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([stale]),
+      countHistoricalOpenShows: mockAsync(2813),
+      captureWarning: jest.fn((_message: string, step: string) => {
+        if (step === 'stale_open_show') throw transportError;
+      }),
+      captureError: jest.fn(() => {
+        throw transportError;
+      }),
+      selectShowsToCreate: mockAsync([createShow]),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    // The sweeps ran despite the cascading Sentry failure inside the
+    // detector's own reporting path.
+    expect(ports.mirrorCreateShow).toHaveBeenCalledTimes(1);
+    expect(totals.shows_created).toBe(1);
+  });
+
   it('logs an error step and captures the exception, distinct from the generic detection signal', async () => {
     const detectorError = new Error('statement timeout');
     const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(detectorError)) });
@@ -595,18 +628,39 @@ describe('runReconcile — stale-open-show detector failure isolation (BS#2069)'
     expect(order).toEqual(['detector', 'show-sweep']);
   });
 
-  it('does NOT escalate the generic detection-signal Sentry warning solely because the detector failed', async () => {
-    // An idle, otherwise-healthy run (no orphan shows/entries/partials) stays
-    // under the alert threshold even when the detector itself errored — the
-    // detector's own failure is reported through its own captureError/log
-    // call, not by inflating the unrelated orphan-count signal.
-    const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(new Error('boom'))) });
+  it('still escalates the generic detection-signal Sentry warning from genuine orphans, unaffected by (and not conflated with) a failed detector (BS#2098 review item 5)', async () => {
+    // BS#2098 review item 5: the prior version of this test used
+    // OPTIONS.alertThreshold=0 with the default makePorts() (empty orphan
+    // arrays), so orphanTotal was ALWAYS 0 regardless of the detector —
+    // `0 > 0` is false no matter what, making the assertion incapable of
+    // ever failing. It passed identically against pre-BS#2069-isolation code
+    // too. This version seeds a genuine orphan (a show-create candidate) so
+    // the detection escalation actually has something to fire on, and a
+    // failing detector alongside it.
+    const createShow = makeShow({ id: 1, primary_dj_id: 'dj-1' });
+    const ports = makePorts({
+      selectStaleOpenShows: jest.fn(() => Promise.reject(new Error('boom'))),
+      selectShowsToCreate: mockAsync([createShow]),
+    });
 
-    await runReconcile(ports, OPTIONS);
+    const totals = await runReconcile(ports, { ...OPTIONS, alertThreshold: 0 });
 
-    expect(ports.captureWarning).not.toHaveBeenCalledWith(
+    // This alone is a genuine pin: against the pre-BS#2069 unguarded
+    // detector, `selectStaleOpenShows` rejecting would propagate straight
+    // out of `runReconcile`, so `await runReconcile(...)` above would throw
+    // and the test would fail before reaching any assertion.
+    expect(totals.stale_open_show_detector_failed).toBe(true);
+    expect(ports.captureWarning).toHaveBeenCalledWith(
       expect.stringContaining('orphaned tubafrenzy mirror rows detected'),
       'detection',
+      expect.objectContaining({ orphan_shows: 1 })
+    );
+    // The detector's own failure is reported through its own captureError
+    // call (step 'stale_open_show_detector'), never folded into this Sentry
+    // warning's step/payload.
+    expect(ports.captureWarning).not.toHaveBeenCalledWith(
+      expect.any(String),
+      'stale_open_show_detector',
       expect.any(Object)
     );
   });
@@ -693,5 +747,47 @@ describe('runReconcile — historical-count failure does not discard successful 
 
     expect(totals.historical_open_shows_count_failed).toBe(false);
     expect(totals.historical_open_shows).toBe(2813);
+  });
+
+  it('also flags historical_open_shows_count_failed when selectStaleOpenShows itself fails, since the count was never attempted (BS#2098 review item 2)', async () => {
+    // Before this fix: when selectStaleOpenShows rejected, the nested
+    // countHistoricalOpenShows try/catch was never reached at all, so
+    // historical_open_shows_count_failed stayed at its `false` default
+    // alongside historical_open_shows at its `0` default — indistinguishable
+    // from a run that genuinely counted zero historical open shows. A
+    // monitor keyed on the flag would misread the #1543 backlog as fully
+    // drained when it was never measured this run.
+    const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(new Error('statement timeout'))) });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.stale_open_show_detector_failed).toBe(true);
+    expect(totals.historical_open_shows_count_failed).toBe(true);
+    expect(totals.historical_open_shows).toBe(0);
+    expect(ports.countHistoricalOpenShows).not.toHaveBeenCalled();
+  });
+
+  it('does NOT clobber an already-successful historical count when a LATER step in the try body fails (BS#2098 review item 2)', async () => {
+    // The outer catch only backfills historical_open_shows_count_failed when
+    // the nested count was never attempted. Here selectStaleOpenShows and
+    // countHistoricalOpenShows both succeed, but the aggregate captureWarning
+    // call after them throws (see the item-3 guard test below for the full
+    // scenario) — the count's genuine success must survive that later
+    // failure, not be overwritten as "unknown".
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([makeStaleOpenShow()]),
+      countHistoricalOpenShows: mockAsync(2813),
+      captureWarning: jest.fn((_message: string, step: string) => {
+        if (step === 'stale_open_show') throw new Error('Sentry quota exhausted');
+      }),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.historical_open_shows).toBe(2813);
+    expect(totals.historical_open_shows_count_failed).toBe(false);
+    // The later captureWarning failure still lands in the outer catch and is
+    // recorded there — it just must not relabel the already-successful count.
+    expect(totals.stale_open_show_detector_failed).toBe(true);
   });
 });

--- a/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
@@ -611,3 +611,87 @@ describe('runReconcile — stale-open-show detector failure isolation (BS#2069)'
     );
   });
 });
+
+describe('runReconcile — historical-count failure does not discard successful per-show findings (BS#2069 review finding 3)', () => {
+  it('still logs every per-show stale_open_show warning when countHistoricalOpenShows rejects afterward', async () => {
+    // Before this fix, countHistoricalOpenShows shared selectStaleOpenShows's
+    // try block: a rejection here fell into the SAME outer catch as a
+    // genuine detector failure, so the per-show warn loop below it never ran
+    // even though `stale` had already been found successfully.
+    const staleShows = [
+      makeStaleOpenShow({ show_id: 1 }),
+      makeStaleOpenShow({ show_id: 2 }),
+      makeStaleOpenShow({ show_id: 3 }),
+    ];
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync(staleShows),
+      countHistoricalOpenShows: jest.fn(() => Promise.reject(new Error('statement timeout'))),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.stale_open_shows).toBe(3);
+    const staleWarnings = ports.log.mock.calls.filter((c) => c[1] === 'stale_open_show');
+    expect(staleWarnings).toHaveLength(3);
+    expect(ports.captureWarning).toHaveBeenCalledWith(
+      expect.stringContaining('left open past the plausible-duration threshold'),
+      'stale_open_show',
+      expect.objectContaining({ stale_open_shows: 3 })
+    );
+  });
+
+  it('flags historical_open_shows_count_failed without flagging the broader stale_open_show_detector_failed', async () => {
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([makeStaleOpenShow()]),
+      countHistoricalOpenShows: jest.fn(() => Promise.reject(new Error('connection reset'))),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.historical_open_shows_count_failed).toBe(true);
+    // The narrower flag exists precisely so this failure isn't confused with
+    // a full detector failure (which would also suppress the sweeps'
+    // upstream ordering guarantees the other BS#2069 tests pin).
+    expect(totals.stale_open_show_detector_failed).toBe(false);
+    // historical_open_shows stays at its zero default — never a stale
+    // leftover value from a previous run — when the count itself failed.
+    expect(totals.historical_open_shows).toBe(0);
+  });
+
+  it('logs a distinct historical_open_show_count_failed step and captures the exception separately from the detector-failed path', async () => {
+    const countError = new Error('statement timeout');
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([makeStaleOpenShow()]),
+      countHistoricalOpenShows: jest.fn(() => Promise.reject(countError)),
+    });
+
+    await runReconcile(ports, OPTIONS);
+
+    expect(ports.log).toHaveBeenCalledWith(
+      'warn',
+      'historical_open_show_count_failed',
+      expect.any(String),
+      expect.objectContaining({ error_message: 'statement timeout' })
+    );
+    expect(ports.captureError).toHaveBeenCalledWith(countError, 'stale_open_show_historical_count', expect.any(Object));
+    // Never routed through the generic detector-failed step/fingerprint.
+    expect(ports.log).not.toHaveBeenCalledWith(
+      'error',
+      'stale_open_show_detector_failed',
+      expect.any(String),
+      expect.any(Object)
+    );
+  });
+
+  it('does not report historical_open_shows_count_failed on a clean run', async () => {
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([makeStaleOpenShow()]),
+      countHistoricalOpenShows: mockAsync(2813),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.historical_open_shows_count_failed).toBe(false);
+    expect(totals.historical_open_shows).toBe(2813);
+  });
+});

--- a/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
@@ -14,7 +14,9 @@
  *   - the cooperative pause runs before each sweep and between shows,
  *   - the detection signal escalates above the alert threshold,
  *   - the BS#2065 stale-open-show detector reports (never repairs), runs
- *     before any cooperative pause, and bounds its Sentry payload.
+ *     before any cooperative pause, and bounds its Sentry payload,
+ *   - a detector failure (BS#2069) is isolated: logged + captured, and cannot
+ *     abort the repair sweeps.
  *
  * The all-or-nothing SELECT SQL itself (the NOT EXISTS predicates + window/
  * settle bounds) is a hand-written SQL twin exercised against a real Postgres
@@ -111,6 +113,7 @@ const makePorts = (over: Partial<ReconcilePorts> = {}) => {
     awaitQuiet: mockAsync(undefined),
     log: jest.fn(),
     captureWarning: jest.fn(),
+    captureError: jest.fn(),
     ...over,
   };
   return ports as unknown as ReconcilePorts & typeof ports;
@@ -502,5 +505,109 @@ describe('runReconcile — stale-open-show detector (BS#2065)', () => {
     };
     expect(captured.stale_open_shows).toBe(many.length);
     expect(captured.sample).toHaveLength(STALE_OPEN_SHOW_SENTRY_SAMPLE);
+  });
+});
+
+describe('runReconcile — stale-open-show detector failure isolation (BS#2069)', () => {
+  it('isolates a rejecting selectStaleOpenShows so both repair sweeps still run', async () => {
+    const detectorError = new Error('statement timeout');
+    const createShow = makeShow({ id: 1, primary_dj_id: 'dj-1' });
+    const entryShow = makeShow({ id: 2, legacy_show_id: 8080 });
+    const ports = makePorts({
+      selectStaleOpenShows: jest.fn(() => Promise.reject(detectorError)),
+      selectShowsToCreate: mockAsync([createShow]),
+      selectEntrySweepShows: mockAsync([entryShow]),
+      selectOrphanEntries: mockAsync([makeEntry({ id: 9, show_id: 2 })]),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    // The two repair sweeps are this job's actual purpose; a broken read-only
+    // detector must not take them down with it.
+    expect(ports.mirrorCreateShow).toHaveBeenCalledTimes(1);
+    expect(ports.mirrorCreateEntry).toHaveBeenCalledTimes(1);
+    expect(totals.shows_created).toBe(1);
+    expect(totals.entries_created).toBe(1);
+  });
+
+  it('isolates a rejecting countHistoricalOpenShows so both repair sweeps still run', async () => {
+    const detectorError = new Error('connection reset');
+    const createShow = makeShow({ id: 1, primary_dj_id: 'dj-1' });
+    const ports = makePorts({
+      selectStaleOpenShows: mockAsync([]),
+      countHistoricalOpenShows: jest.fn(() => Promise.reject(detectorError)),
+      selectShowsToCreate: mockAsync([createShow]),
+    });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(ports.mirrorCreateShow).toHaveBeenCalledTimes(1);
+    expect(totals.shows_created).toBe(1);
+  });
+
+  it('logs an error step and captures the exception, distinct from the generic detection signal', async () => {
+    const detectorError = new Error('statement timeout');
+    const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(detectorError)) });
+
+    await runReconcile(ports, OPTIONS);
+
+    expect(ports.log).toHaveBeenCalledWith(
+      'error',
+      'stale_open_show_detector_failed',
+      expect.any(String),
+      expect.objectContaining({ error_message: 'statement timeout' })
+    );
+    expect(ports.captureError).toHaveBeenCalledWith(detectorError, 'stale_open_show_detector', expect.any(Object));
+  });
+
+  it('surfaces the detector failure on totals so a "finished" run is not indistinguishable from a clean one', async () => {
+    const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(new Error('boom'))) });
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.stale_open_show_detector_failed).toBe(true);
+  });
+
+  it('does not mark the detector failed when it succeeds', async () => {
+    const ports = makePorts();
+
+    const totals = await runReconcile(ports, OPTIONS);
+
+    expect(totals.stale_open_show_detector_failed).toBe(false);
+    expect(ports.captureError).not.toHaveBeenCalled();
+  });
+
+  it('still runs the detector before the sweeps even though it goes on to fail', async () => {
+    const order: string[] = [];
+    const ports = makePorts({
+      selectStaleOpenShows: jest.fn(() => {
+        order.push('detector');
+        return Promise.reject(new Error('boom'));
+      }),
+      selectShowsToCreate: jest.fn(() => {
+        order.push('show-sweep');
+        return Promise.resolve([]);
+      }),
+    });
+
+    await runReconcile(ports, OPTIONS);
+
+    expect(order).toEqual(['detector', 'show-sweep']);
+  });
+
+  it('does NOT escalate the generic detection-signal Sentry warning solely because the detector failed', async () => {
+    // An idle, otherwise-healthy run (no orphan shows/entries/partials) stays
+    // under the alert threshold even when the detector itself errored — the
+    // detector's own failure is reported through its own captureError/log
+    // call, not by inflating the unrelated orphan-count signal.
+    const ports = makePorts({ selectStaleOpenShows: jest.fn(() => Promise.reject(new Error('boom'))) });
+
+    await runReconcile(ports, OPTIONS);
+
+    expect(ports.captureWarning).not.toHaveBeenCalledWith(
+      expect.stringContaining('orphaned tubafrenzy mirror rows detected'),
+      'detection',
+      expect.any(Object)
+    );
   });
 });

--- a/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Call-shape pin for the BS#2065/#2068 stale-open-show detector's final
+ * selection bound (BS#2069 review finding 1 + finding 2) — asserts that the
+ * `show_end`-marker carve-out is composed with drizzle's `or()` helper, not
+ * assembled as a raw `sql` fragment containing a literal ` OR ` passed
+ * directly as one of `and()`'s own arguments.
+ *
+ * THE BUG THIS PINS: `and(...)` wraps its own children COLLECTIVELY in one
+ * pair of parentheses; it does not parenthesize each child individually. The
+ * shipped-then-caught defect built the carve-out as:
+ *
+ *   and(bound1, bound2, bound3, bound4,
+ *     sql`(${shows.id} IS DISTINCT FROM ${latestShowId}) OR (${newestEntryType} = 'show_end')`)
+ *
+ * — a single raw-sql fragment as `and()`'s fifth argument, never touching
+ * `or()` at all. Because that fragment is ONE argument to `and(...)`, not two
+ * arguments to `or(...)`, the literal ` OR ` renders (in real Postgres) at
+ * the SAME nesting depth as bound1..bound4 — i.e. as a sibling disjunct of
+ * the AND-list, not a parenthesized sub-group. SQL's `AND` binds tighter
+ * than `OR`, so `WHERE (b1 AND b2 AND b3 AND b4 AND armA) OR armB` reports
+ * the entire historical population of shows whose newest flowsheet entry
+ * happens to be `show_end` — no `end_time IS NULL`, no threshold, no window.
+ * Verified against a real (non-mocked) drizzle-orm build of this exact query
+ * outside this test suite, during development of this fix:
+ *
+ *   BEFORE: "...and (<end_time> is null and ... and NOT EXISTS (...) and
+ *     (<id> IS DISTINCT FROM (SELECT max(s2.id) FROM <shows> s2)) OR
+ *     ((SELECT fe.entry_type FROM <flowsheet> fe ...) = 'show_end'))"
+ *     — OR sits at the SAME depth as the and-joined bounds.
+ *
+ *   AFTER:  "...and (<end_time> is null and ... and NOT EXISTS (...) and
+ *     (<id> IS DISTINCT FROM (SELECT max(s2.id) FROM <shows> s2) or
+ *     (SELECT fe.entry_type FROM <flowsheet> fe ...) = show_end))"
+ *     — or is nested one paren level deeper than the and-joined bounds.
+ *
+ * The fix wraps the two arms with drizzle's `or()` helper
+ * (`apps/enrichment-worker/precheck.ts`'s `hasLoadBearingAlbumMetadata` is
+ * the established precedent: `and(..., or(isNotNull(a), isNotNull(b)), ...)`),
+ * which renders its own group in its own parens correctly nested one level
+ * inside `and()`'s.
+ *
+ * WHY THIS LIVES IN THE UNIT TIER, NOT THE INTEGRATION TWIN: the integration
+ * spec (`tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js`)
+ * maintains a HAND-WRITTEN SQL TWIN of this WHERE clause, forced by the
+ * babel-jest integration runner having no TypeScript support. The twin writes
+ * its bound correctly parenthesized by construction (`AND (... OR ...)`) —
+ * it can't reproduce a drizzle `and()`/`or()` composition bug because it was
+ * never built by composing drizzle query-builder calls in the first place.
+ * That gave the shipped defect zero executable coverage: the twin passed
+ * while production was broken.
+ *
+ * WHY A CALL-SHAPE ASSERTION RATHER THAN A RENDERED-SQL-TEXT ONE: this unit
+ * suite globally auto-mocks the `drizzle-orm` package itself
+ * (`tests/__mocks__/drizzle-orm.ts`, Jest's automatic per-package
+ * `__mocks__`-adjacent-to-`node_modules` convention — no `jest.mock(...)`
+ * call needed, confirmed empirically while writing this test) so that EVERY
+ * unit test in this tier, including the rest of `orchestrate.test.ts`, gets
+ * `and`/`or`/`sql`/`eq`/etc as plain call-recording stand-ins
+ * (`and(...conditions) => ({ and: conditions })`, `or(...) => ({ or:
+ * [...] })`) rather than real dialect-aware SQL builders. That means no unit
+ * test anywhere in this repo can render genuine `.toSQL()` text — the
+ * strongest available pin is asserting on how the REAL production code
+ * (`buildStaleOpenShowsQuery`, imported unmodified from `orchestrate.ts`)
+ * CALLED those combinators. That is exactly the fact that distinguishes the
+ * bug from the fix here: pre-fix, `or()` is never called at all (the carve-
+ * out is a bare `sql` leaf passed straight to `and()`); post-fix, `or()` is
+ * called once with the two arms, and its return value — not a raw fragment —
+ * is what `and()` receives as its final argument. Asserting that call shape
+ * pins the identical structural fact the rendered-text form above documents,
+ * driven through the real, unmodified query-construction code path.
+ */
+
+import { jest } from '@jest/globals';
+// Resolves to `tests/__mocks__/drizzle-orm.ts` automatically (see the
+// class-level doc comment) — the SAME mocked `and`/`or` singletons
+// `orchestrate.ts`'s own `import { and, or, ... } from 'drizzle-orm'`
+// resolves to within this test file's module registry.
+import { and, or } from 'drizzle-orm';
+import {
+  buildStaleOpenShowsQuery,
+  type StaleOpenShowOptions,
+} from '../../../../jobs/legacy-mirror-reconcile/orchestrate';
+
+const mockAnd = and as jest.Mock;
+const mockOr = or as jest.Mock;
+
+const OPTIONS: StaleOpenShowOptions = { windowHours: 48, settleMinutes: 15, staleAfterHours: 12 };
+
+describe('buildStaleOpenShowsQuery — id-exclusion/show_end carve-out composition (BS#2068/#2069 review)', () => {
+  it('composes the carve-out with or(), not a raw sql fragment folded into and()', () => {
+    buildStaleOpenShowsQuery(OPTIONS);
+
+    // Pre-fix (the shipped-then-caught defect): the carve-out was
+    // `sql`(...) OR (...)`` passed directly as one of and()'s own arguments
+    // — or() was never called. This assertion alone is the red/green line:
+    // it fails against the pre-fix code (0 calls) and passes against the fix
+    // (1 call).
+    expect(mockOr).toHaveBeenCalledTimes(1);
+
+    // The or() call carries exactly the two arms the docblock above
+    // describes: the id-exclusion arm and the show_end-marker arm.
+    expect(mockOr.mock.calls[0]).toHaveLength(2);
+  });
+
+  it("passes or()'s own return value as and()'s final bound — not a bare sql leaf", () => {
+    buildStaleOpenShowsQuery(OPTIONS);
+
+    expect(mockAnd).toHaveBeenCalledTimes(1);
+    const andArgs = mockAnd.mock.calls[0];
+    const finalBound = andArgs[andArgs.length - 1];
+
+    // Structural identity, not a shape guess: whatever and() received last
+    // must be THE SAME OBJECT or() returned this call — i.e. and() is
+    // wrapping or()'s result, not a separately-constructed raw fragment that
+    // merely happens to look similar.
+    expect(finalBound).toBe(mockOr.mock.results[0].value);
+  });
+
+  it("regression guard: and()'s final bound is never a bare {sql, values} leaf (the pre-fix shape)", () => {
+    buildStaleOpenShowsQuery(OPTIONS);
+
+    const andArgs = mockAnd.mock.calls[0];
+    const finalBound = andArgs[andArgs.length - 1] as Record<string, unknown>;
+
+    // The pre-fix code's final and() argument was tests/__mocks__/drizzle-orm.ts's
+    // sql-tag shape ({ sql: TemplateStringsArray, values: unknown[] }) — a
+    // bare leaf carrying the literal ` OR ` text inside its own template
+    // strings, never wrapped by or(). Asserting the fixed shape's absence,
+    // not just the fixed shape's presence, is what makes this a genuine
+    // regression guard rather than a restatement of the previous test.
+    expect(finalBound).not.toHaveProperty('sql');
+    expect(finalBound).toHaveProperty('or');
+  });
+});

--- a/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
@@ -1,134 +1,141 @@
 /**
- * Call-shape pin for the BS#2065/#2068 stale-open-show detector's final
- * selection bound (BS#2069 review finding 1 + finding 2) — asserts that the
- * `show_end`-marker carve-out is composed with drizzle's `or()` helper, not
- * assembled as a raw `sql` fragment containing a literal ` OR ` passed
- * directly as one of `and()`'s own arguments.
+ * Genuine-rendered-SQL pin for the BS#2065/#2068 stale-open-show detector's
+ * final selection bound (BS#2098 review item 4 — rewrite of the BS#2069
+ * review finding 1/2 call-shape test this file used to contain).
  *
  * THE BUG THIS PINS: `and(...)` wraps its own children COLLECTIVELY in one
  * pair of parentheses; it does not parenthesize each child individually. The
- * shipped-then-caught defect built the carve-out as:
+ * shipped-then-caught defect built the `show_end`-marker carve-out as:
  *
  *   and(bound1, bound2, bound3, bound4,
  *     sql`(${shows.id} IS DISTINCT FROM ${latestShowId}) OR (${newestEntryType} = 'show_end')`)
  *
  * — a single raw-sql fragment as `and()`'s fifth argument, never touching
- * `or()` at all. Because that fragment is ONE argument to `and(...)`, not two
- * arguments to `or(...)`, the literal ` OR ` renders (in real Postgres) at
- * the SAME nesting depth as bound1..bound4 — i.e. as a sibling disjunct of
- * the AND-list, not a parenthesized sub-group. SQL's `AND` binds tighter
- * than `OR`, so `WHERE (b1 AND b2 AND b3 AND b4 AND armA) OR armB` reports
- * the entire historical population of shows whose newest flowsheet entry
- * happens to be `show_end` — no `end_time IS NULL`, no threshold, no window.
- * Verified against a real (non-mocked) drizzle-orm build of this exact query
- * outside this test suite, during development of this fix:
+ * `or()` at all, with the `'show_end'` literal typed directly into the
+ * template rather than passed as a bound value. Because that fragment is ONE
+ * argument to `and(...)`, not two arguments to `or(...)`, the literal ` OR `
+ * renders (in real Postgres) at the SAME nesting depth as bound1..bound4 —
+ * i.e. as a sibling disjunct of the AND-list, not a parenthesized sub-group.
+ * SQL's `AND` binds tighter than `OR`, so `WHERE (b1 AND b2 AND b3 AND b4) OR
+ * armB` reports essentially the entire historical population of shows whose
+ * newest flowsheet entry happens to be `show_end` — no `end_time IS NULL`
+ * filter, no threshold, no window. The fix wraps the two arms with drizzle's
+ * `or()` helper (`apps/enrichment-worker/precheck.ts`'s
+ * `hasLoadBearingAlbumMetadata` is the established precedent:
+ * `and(..., or(isNotNull(a), isNotNull(b)), ...)`), which renders its own
+ * group in its own parens correctly nested one level inside `and()`'s, and
+ * threads the literal through `eq()` as a genuine bound parameter.
  *
- *   BEFORE: "...and (<end_time> is null and ... and NOT EXISTS (...) and
- *     (<id> IS DISTINCT FROM (SELECT max(s2.id) FROM <shows> s2)) OR
- *     ((SELECT fe.entry_type FROM <flowsheet> fe ...) = 'show_end'))"
- *     — OR sits at the SAME depth as the and-joined bounds.
- *
- *   AFTER:  "...and (<end_time> is null and ... and NOT EXISTS (...) and
- *     (<id> IS DISTINCT FROM (SELECT max(s2.id) FROM <shows> s2) or
- *     (SELECT fe.entry_type FROM <flowsheet> fe ...) = show_end))"
- *     — or is nested one paren level deeper than the and-joined bounds.
- *
- * The fix wraps the two arms with drizzle's `or()` helper
- * (`apps/enrichment-worker/precheck.ts`'s `hasLoadBearingAlbumMetadata` is
- * the established precedent: `and(..., or(isNotNull(a), isNotNull(b)), ...)`),
- * which renders its own group in its own parens correctly nested one level
- * inside `and()`'s.
- *
- * WHY THIS LIVES IN THE UNIT TIER, NOT THE INTEGRATION TWIN: the integration
- * spec (`tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js`)
+ * WHY THIS LIVES IN THE UNIT TIER, NOT ONLY THE INTEGRATION TWIN: the
+ * integration spec (`tests/integration/legacy-mirror-reconcile-stale-open-shows.spec.js`)
  * maintains a HAND-WRITTEN SQL TWIN of this WHERE clause, forced by the
  * babel-jest integration runner having no TypeScript support. The twin writes
  * its bound correctly parenthesized by construction (`AND (... OR ...)`) —
  * it can't reproduce a drizzle `and()`/`or()` composition bug because it was
  * never built by composing drizzle query-builder calls in the first place.
  * That gave the shipped defect zero executable coverage: the twin passed
- * while production was broken.
+ * while production was broken. This unit test closes that gap by rendering
+ * the REAL, unmodified `buildStaleOpenShowsQuery` (from `orchestrate.ts`)
+ * through drizzle's own dialect, so a regression here fails fast, in the
+ * unit tier, without a live Postgres.
  *
- * WHY A CALL-SHAPE ASSERTION RATHER THAN A RENDERED-SQL-TEXT ONE: this unit
- * suite globally auto-mocks the `drizzle-orm` package itself
- * (`tests/__mocks__/drizzle-orm.ts`, Jest's automatic per-package
- * `__mocks__`-adjacent-to-`node_modules` convention — no `jest.mock(...)`
- * call needed, confirmed empirically while writing this test) so that EVERY
- * unit test in this tier, including the rest of `orchestrate.test.ts`, gets
- * `and`/`or`/`sql`/`eq`/etc as plain call-recording stand-ins
- * (`and(...conditions) => ({ and: conditions })`, `or(...) => ({ or:
- * [...] })`) rather than real dialect-aware SQL builders. That means no unit
- * test anywhere in this repo can render genuine `.toSQL()` text — the
- * strongest available pin is asserting on how the REAL production code
- * (`buildStaleOpenShowsQuery`, imported unmodified from `orchestrate.ts`)
- * CALLED those combinators. That is exactly the fact that distinguishes the
- * bug from the fix here: pre-fix, `or()` is never called at all (the carve-
- * out is a bare `sql` leaf passed straight to `and()`); post-fix, `or()` is
- * called once with the two arms, and its return value — not a raw fragment —
- * is what `and()` receives as its final argument. Asserting that call shape
- * pins the identical structural fact the rendered-text form above documents,
- * driven through the real, unmodified query-construction code path.
+ * A PRIOR VERSION OF THIS FILE claimed "no unit test anywhere in this repo
+ * can render genuine `.toSQL()` text" and settled for asserting only that
+ * `or()` was called with two arguments and that its result was `and()`'s
+ * last argument — a call-shape pin that would still pass with `'show_start'`
+ * substituted for `'show_end'`, or `=` substituted for `IS DISTINCT FROM`:
+ * it pinned the SHAPE of the composition, not the PREDICATE. That claim was
+ * false. `tests/unit/utils/sql-like.test.ts` and
+ * `tests/unit/services/search.service.escape.test.ts` already render real
+ * SQL text in this same unit tier via `jest.unmock('drizzle-orm')` +
+ * `new PgDialect().sqlToQuery(...)`. The reason THIS file's original author
+ * reached for call-shape mocking instead is specific to this call site, not
+ * the tier: `buildStaleOpenShowsQuery` reads `db`/`shows`/`flowsheet` from
+ * `@wxyc/database`, which `jest.unit.config.ts`'s `moduleNameMapper`
+ * unconditionally redirects to `tests/mocks/database.mock.ts` — a chain-
+ * returning stub whose `shows`/`flowsheet` are plain `{col: 'col'}` string
+ * maps, not real drizzle `Column` objects, so real `and`/`or`/`eq`/`sql`
+ * cannot compose a genuine `SQL` AST from them. The fix isn't a different
+ * tier; it's overriding that ONE mock for this ONE file: `jest.mock(
+ * '@wxyc/database', ...)` below supplies the REAL schema (via
+ * `jest.requireActual` on `shared/database/src/schema.ts` directly, which
+ * `moduleNameMapper` does NOT redirect — only the bare `@wxyc/database`
+ * specifier and paths ending in `shared/database/src/client` are mapped) so
+ * `shows`/`flowsheet` are genuine `Column`-bearing tables, alongside a
+ * minimal chain-returning `db` stub (still needed so `.select().from().where()`
+ * doesn't throw, and to capture the exact `SQL` object passed to `.where()`).
+ * `jest.mock(...)` with an explicit factory overrides `moduleNameMapper`'s
+ * redirect for every consumer in this file's module registry, including
+ * `orchestrate.ts`'s own `import ... from '@wxyc/database'` — verified
+ * empirically while writing this fix (see the mutation-testing note below).
+ *
+ * VERIFIED BY MUTATION while writing this fix (both confirmed red against a
+ * temporary edit to `orchestrate.ts`, then confirmed the file was restored
+ * byte-identical before committing):
+ *   1. Substituting `'show_start'` for `'show_end'` in the `eq(newestEntryType,
+ *      'show_end')` arm: the rendered `params` array's fourth element became
+ *      `'show_start'`, red against the `toEqual([...])` assertion below.
+ *   2. Reverting the whole carve-out to the pre-fix raw
+ *      `sql`(...) OR (...)`` form: `params` collapsed to three elements
+ *      (`[12, 48, 12]` — no fourth bound value, since the buggy form types
+ *      `'show_end'` directly into the SQL text instead of binding it) and the
+ *      rendered text's parenthesization changed from `... or (...))` to
+ *      `...)) OR ((...` — both red against the assertions below.
  */
 
-import { jest } from '@jest/globals';
-// Resolves to `tests/__mocks__/drizzle-orm.ts` automatically (see the
-// class-level doc comment) — the SAME mocked `and`/`or` singletons
-// `orchestrate.ts`'s own `import { and, or, ... } from 'drizzle-orm'`
-// resolves to within this test file's module registry.
-import { and, or } from 'drizzle-orm';
+jest.unmock('drizzle-orm');
+
+jest.mock('@wxyc/database', () => {
+  const realSchema = jest.requireActual('../../../../shared/database/src/schema');
+  const chain: Record<string, jest.Mock> = {};
+  for (const method of ['select', 'from', 'where', 'orderBy']) {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  }
+  return { ...realSchema, db: chain };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '@wxyc/database';
 import {
   buildStaleOpenShowsQuery,
   type StaleOpenShowOptions,
 } from '../../../../jobs/legacy-mirror-reconcile/orchestrate';
 
-const mockAnd = and as jest.Mock;
-const mockOr = or as jest.Mock;
+type MockChain = { where: jest.Mock };
 
 const OPTIONS: StaleOpenShowOptions = { windowHours: 48, settleMinutes: 15, staleAfterHours: 12 };
+const SCHEMA_NAME = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const dialect = new PgDialect();
 
-describe('buildStaleOpenShowsQuery — id-exclusion/show_end carve-out composition (BS#2068/#2069 review)', () => {
-  it('composes the carve-out with or(), not a raw sql fragment folded into and()', () => {
+describe('buildStaleOpenShowsQuery — genuinely rendered predicate (BS#2098 review item 4)', () => {
+  it('binds the id-exclusion/show_end carve-out as real parameters, in the correct precedence group', () => {
     buildStaleOpenShowsQuery(OPTIONS);
 
-    // Pre-fix (the shipped-then-caught defect): the carve-out was
-    // `sql`(...) OR (...)`` passed directly as one of and()'s own arguments
-    // — or() was never called. This assertion alone is the red/green line:
-    // it fails against the pre-fix code (0 calls) and passes against the fix
-    // (1 call).
-    expect(mockOr).toHaveBeenCalledTimes(1);
+    const whereArg = (db as unknown as MockChain).where.mock.calls[0][0];
+    const { sql: text, params } = dialect.sqlToQuery(whereArg);
 
-    // The or() call carries exactly the two arms the docblock above
-    // describes: the id-exclusion arm and the show_end-marker arm.
-    expect(mockOr.mock.calls[0]).toHaveLength(2);
-  });
+    // The predicate's four bound values, in position: staleAfterHours (the
+    // threshold bound), windowHours (the outer window bound), staleAfterHours
+    // again (the NOT EXISTS activity cutoff — a separate `sql` interpolation
+    // of the same value, so drizzle does not dedupe it), and the literal
+    // `'show_end'` genuinely bound through `eq()` — not typed into the SQL
+    // text, which is exactly what the pre-fix raw-`sql` form got wrong.
+    expect(params).toEqual([12, 48, 12, 'show_end']);
 
-  it("passes or()'s own return value as and()'s final bound — not a bare sql leaf", () => {
-    buildStaleOpenShowsQuery(OPTIONS);
+    // The id-exclusion/show_end disjunction is nested INSIDE the same
+    // parenthesized group as the other three AND-bounds — "and (<id bound>
+    // or <show_end bound>))" — not a bare `) OR (` sibling of the AND chain.
+    expect(text).toContain(
+      `and ("${SCHEMA_NAME}"."shows"."id" IS DISTINCT FROM (SELECT max(s2.id) FROM "${SCHEMA_NAME}"."shows" s2) or `
+    );
+    expect(text).not.toContain(')) OR ((');
 
-    expect(mockAnd).toHaveBeenCalledTimes(1);
-    const andArgs = mockAnd.mock.calls[0];
-    const finalBound = andArgs[andArgs.length - 1];
-
-    // Structural identity, not a shape guess: whatever and() received last
-    // must be THE SAME OBJECT or() returned this call — i.e. and() is
-    // wrapping or()'s result, not a separately-constructed raw fragment that
-    // merely happens to look similar.
-    expect(finalBound).toBe(mockOr.mock.results[0].value);
-  });
-
-  it("regression guard: and()'s final bound is never a bare {sql, values} leaf (the pre-fix shape)", () => {
-    buildStaleOpenShowsQuery(OPTIONS);
-
-    const andArgs = mockAnd.mock.calls[0];
-    const finalBound = andArgs[andArgs.length - 1] as Record<string, unknown>;
-
-    // The pre-fix code's final and() argument was tests/__mocks__/drizzle-orm.ts's
-    // sql-tag shape ({ sql: TemplateStringsArray, values: unknown[] }) — a
-    // bare leaf carrying the literal ` OR ` text inside its own template
-    // strings, never wrapped by or(). Asserting the fixed shape's absence,
-    // not just the fixed shape's presence, is what makes this a genuine
-    // regression guard rather than a restatement of the previous test.
-    expect(finalBound).not.toHaveProperty('sql');
-    expect(finalBound).toHaveProperty('or');
+    // end_time IS NULL / threshold / window bounds are present and AND-joined
+    // ahead of the carve-out (the pre-fix bug's `OR` would otherwise apply to
+    // the whole table with none of these).
+    expect(text).toContain(`"${SCHEMA_NAME}"."shows"."end_time" is null and`);
+    expect(text).toContain(`"${SCHEMA_NAME}"."shows"."start_time" < now() - (interval '1 hour' * $1)`);
+    expect(text).toContain(`"${SCHEMA_NAME}"."shows"."start_time" > now() - (interval '1 hour' * $2)`);
+    expect(text).toContain('NOT EXISTS');
   });
 });


### PR DESCRIPTION
Closes #2068
Closes #2069

Two follow-ups from the #2067 review of the `legacy-mirror-reconcile` stale-open-show detector, plus a critical SQL-precedence defect found while reviewing those follow-ups.

## #2068 — the detector could never report the case it exists to catch

The detector's third bound excluded `max(id)` unconditionally (`shows.id IS DISTINCT FROM (SELECT max(s2.id) FROM shows s2)`). But `max(id)` *is* the state in which a dropped tubafrenzy `show_end` delivery does its damage: `addEntry`, `leaveShow`, and `getOnAirDJName` all gate on `getLatestShow()`, which is `ORDER BY id DESC LIMIT 1` over the whole table. So the detector could only report a stale show *after* the acute harm had ended — once a newer show row existed — and if no newer row appeared while the show was still inside `RECONCILE_WINDOW_HOURS`, it was never reported at all, silently aging into the historical cohort. That is #2065's first stated residual harm ("'Who's on air' is wrong until the next show starts"), which is precisely the window the detector could not see.

The exclusion is now conditional on a landed sign-off marker: `id <> max(id) OR newestEntryType = 'show_end'`. A show whose newest flowsheet row is a `show_end` marker is provably not genuinely live (BS#1861 option (b)'s insight, which `joinShow`'s opportunistic `closeShowFromTerminalShowEndMarker` backfill already relies on). #2065's acceptance criterion — a genuinely-active show must never be reported — is preserved independently by the second bound (`NOT EXISTS` a flowsheet row newer than the stale cutoff): a real marathon show is still logging tracks, so it is excluded on activity regardless of the id bound. The `job.ts` "seen by at least one run" derivation note, which the old bound falsified, is corrected.

## #2069 — a read-only detector's failure aborted the repair sweeps

`runStaleOpenShowReport` was the first `await` in `runReconcile` and carried no try/catch, while `job.ts` wraps the whole run in a single catch that logs `failed` and sets a non-zero exit code. So a statement timeout on the `shows` scan + `flowsheet` anti-join, or a transient connection reset, took down `runShowCreateSweep`, `runEntrySweep`, and `runPartialReport` — the BS#1707 mirror self-heal that is the job's actual purpose — and the alert said "legacy-mirror-reconcile failed," not "the mirror self-heal has not run for six days."

The detector arm is now isolated in its own try/catch: it logs at `error`, captures to Sentry under its own `stale_open_show_detector` step, records `totals.stale_open_show_detector_failed`, and falls through to the sweeps exactly as if it had found nothing. It still runs first (deliberately, so it is not deferred behind the sweeps' cooperative live-DJ pause). This mirrors the asymmetry `closeShowFromTerminalShowEndMarker` already reasons about correctly for its own best-effort backfill.

## The critical defect caught in review, and why the tests missed it

The #2068 carve-out was first written as a raw `sql` fragment containing a literal ` OR `, passed directly as one of `and()`'s arguments. Drizzle's `and(...)` wraps its children **collectively** in one pair of parentheses rather than parenthesizing each child, and SQL's `AND` binds tighter than `OR`, so the clause parsed as `(bound1 AND bound2 AND bound3 AND idBoundArm1) OR showEndArm2` — the `show_end` arm standing alone as a full-table predicate with no `end_time IS NULL` filter, no threshold, and no window. Since `endShow` writes a `show_end` marker for every normally-terminated show, the detector would have reported essentially every show that ever ended, over a seq scan with two correlated `LIMIT 1` subqueries per row. It is now built with drizzle's `or()` helper, which renders its own group nested correctly inside `and()`'s — following the precedent in `apps/enrichment-worker/precheck.ts`'s `hasLoadBearingAlbumMetadata`.

**Why the test suite went green anyway.** The integration spec maintains a hand-written SQL twin of the WHERE clause, forced by the babel-jest integration runner having no TypeScript support. The twin was written correctly parenthesized by construction (`AND (... OR ...)`) while production was not — it cannot reproduce a drizzle composition bug, because it was never built by composing drizzle calls. So the `describe` block added specifically to pin this change was testing a copy that had the bug fixed, and the shipped defect had zero executable coverage.

**What changed.** `selectStaleOpenShows` is split so the query builder is exported as `buildStaleOpenShowsQuery`, and a new unit test (`tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts`) drives that real, unmodified builder and asserts the composition directly — the unit tier can import TypeScript, so the production predicate finally has executable coverage. All three of its assertions fail against the pre-fix shape. The integration twin was also corrected to match production's bound so the two are back in lockstep.

## Exit-code decision

A detector-only failure deliberately does **not** set `process.exitCode`. The sweeps are the job's purpose; a run whose sweeps completed cleanly is not a failed run, and flipping the exit code would mislabel it. The original rationale for this cited alert fatigue on a nightly cron-failure alert **that does not exist** — the installed crontab has no `awslogs` driver, no output redirection, and no exit-code wrapper, and the next run's `docker rm -f` destroys the prior container's stderr. The decision is unchanged and still correct, but the comment now names Sentry as the single durable channel that actually carries this failure, and `captureError` was given the per-step fingerprint it had falsely claimed in two docblocks (so a persistently-failing call site rolls up into one stable issue instead of fanning out per distinct error shape).

## Also in this change

`countHistoricalOpenShows` — the #1543 backlog count, strictly less important than the per-show findings — sat inside the same try as `selectStaleOpenShows` and before the reporting loop, so a timeout on that count discarded findings the detector had already earned: no warn lines, no aggregate Sentry warning, and a populated `totals.stale_open_shows` on the `finished` line with nothing behind it. The per-show reporting loop now runs first, and the count has its own nested try, its own `historical_open_shows_count_failed` flag (so "counted zero" is distinguishable from "count unknown"), and its own fingerprinted capture.

## Verification

`npm run typecheck`, the job's own `tsc --noEmit -p jobs/legacy-mirror-reconcile/tsconfig.json`, `npm run lint` (0 errors), and `npm run test:unit` (7018 passing) are green locally. `npm run ci:testmock` could **not** be run locally — it needs Docker plus an `NPM_TOKEN` for the private `@wxyc` registry and a `.env` absent from a fresh worktree — so CI here is the first execution of the integration tier, which is where this branch's most important test lives.
