### PR TITLE
fix(library): add genre-scoped artist-name pre-check to addArtist

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -328,13 +328,16 @@ export const addArtist: RequestHandler = async (req: Request<object, object, New
   // The code-triple check runs first and wins a collision on both axes: a
   // taken code blocks the write outright no matter what name accompanies it,
   // so it is reported over a name conflict the caller could otherwise route
-  // around by picking a free code. Keeping it first (unmodified from before
-  // this pre-check existed) makes that precedence a byproduct of ordering
-  // rather than a runtime branch, so it can't drift out of sync.
+  // around by picking a free code. Keeping it first makes that precedence a
+  // byproduct of ordering rather than a runtime branch, so it can't drift out
+  // of sync. `reason` gives this 409 the same positive discriminant as the
+  // name-conflict branch below, so a client never has to infer "code
+  // conflict" from the absence of a field.
   const existingArtist = await libraryService.getArtistByCode(body.code_letters, body.genre_id, body.code_number);
   if (existingArtist) {
     res.status(409).json({
       message: 'Artist code already exists for that genre and code letters.',
+      reason: 'artist_code_conflict',
       artist: existingArtist,
     });
     return;

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -325,11 +325,35 @@ export const addArtist: RequestHandler = async (req: Request<object, object, New
     throw new WxycError('Missing Request Parameters: artist_name, code_letters, genre_id, or code_number', 400);
   }
 
+  // The code-triple check runs first and wins a collision on both axes: a
+  // taken code blocks the write outright no matter what name accompanies it,
+  // so it is reported over a name conflict the caller could otherwise route
+  // around by picking a free code. Keeping it first (unmodified from before
+  // this pre-check existed) makes that precedence a byproduct of ordering
+  // rather than a runtime branch, so it can't drift out of sync.
   const existingArtist = await libraryService.getArtistByCode(body.code_letters, body.genre_id, body.code_number);
   if (existingArtist) {
     res.status(409).json({
       message: 'Artist code already exists for that genre and code letters.',
       artist: existingArtist,
+    });
+    return;
+  }
+
+  // Genre-scoped name pre-check, reusing the code-triple check's matcher
+  // semantics (Unicode-form + diacritic + case fold, backed by
+  // `artists_fold_name_idx`) so a name that only differs by composition form
+  // still collides. `reason` is the discriminant a client uses to tell this
+  // conflict apart from the code-triple one above -- the two call for
+  // different remedies (use the named artist vs. pick another code), so
+  // collapsing them into one shape would leave a client unable to choose.
+  const conflictingArtistId = await libraryService.artistIdFromName(body.artist_name, body.genre_id);
+  if (conflictingArtistId) {
+    const conflictingArtist = await libraryService.getArtistById(conflictingArtistId);
+    res.status(409).json({
+      message: 'Artist name already exists in that genre.',
+      reason: 'artist_name_conflict',
+      artist: conflictingArtist,
     });
     return;
   }

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -343,16 +343,22 @@ export const addArtist: RequestHandler = async (req: Request<object, object, New
     return;
   }
 
-  // Genre-scoped name pre-check, reusing the code-triple check's matcher
-  // semantics (Unicode-form + diacritic + case fold, backed by
-  // `artists_fold_name_idx`) so a name that only differs by composition form
-  // still collides. `reason` is the discriminant a client uses to tell this
-  // conflict apart from the code-triple one above -- the two call for
-  // different remedies (use the named artist vs. pick another code), so
-  // collapsing them into one shape would leave a client unable to choose.
+  // Genre-scoped name pre-check via `artistIdFromName`, whose matcher folds
+  // Unicode form, diacritics and case onto one key (backed by
+  // `artists_fold_name_idx`) so a name differing only by composition form
+  // still collides. That fold is this check's alone -- the code-triple check
+  // above compares `code_letters` byte-for-byte -- so do not describe the two
+  // as sharing matcher semantics. `reason` is the discriminant a client uses
+  // to tell the two conflicts apart: they call for different remedies (use the
+  // named artist vs. pick another code), so one shape would leave a client
+  // unable to choose.
   const conflictingArtistId = await libraryService.artistIdFromName(body.artist_name, body.genre_id);
-  if (conflictingArtistId) {
-    const conflictingArtist = await libraryService.getArtistById(conflictingArtistId);
+  const conflictingArtist = conflictingArtistId ? await libraryService.getArtistById(conflictingArtistId) : null;
+  // A miss on the second lookup means the row was deleted between the two
+  // queries, so the name is free again: proceed rather than answer 409 with an
+  // `artist` the client cannot act on. Neither lookup is backed by a database
+  // constraint, so a concurrent writer can still win this race either way.
+  if (conflictingArtist) {
     res.status(409).json({
       message: 'Artist name already exists in that genre.',
       reason: 'artist_name_conflict',

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1893,6 +1893,27 @@ export const getArtistByCode = async (
   return response[0] ?? null;
 };
 
+/**
+ * Look up an artist by id in the same `{ artist_id, artist_name, code_letters }`
+ * shape `getArtistByCode` returns, so a 409 conflict payload can carry either
+ * lookup's result through one consistent wire shape.
+ */
+export const getArtistById = async (
+  artist_id: number
+): Promise<{ artist_id: number; artist_name: string; code_letters: string } | null> => {
+  const response = await db
+    .select({
+      artist_id: artists.id,
+      artist_name: artists.artist_name,
+      code_letters: artists.code_letters,
+    })
+    .from(artists)
+    .where(eq(artists.id, artist_id))
+    .limit(1);
+
+  return response[0] ?? null;
+};
+
 export const generateAlbumCodeNumber = async (artist_id: number): Promise<number> => {
   const response = await db
     .select({ code_number: library.code_number })

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -696,7 +696,7 @@ describe('Library Artists', () => {
         expect(second.body.artist.artist_id).toBe(first.body.id);
       });
 
-      test('prefers the code-triple conflict over a simultaneous name conflict, with the unchanged code-conflict shape', async () => {
+      test('prefers the code-triple conflict over a simultaneous name conflict, tagged with its own discriminant', async () => {
         const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-3);
         const artistName = `ZZName Both ${uniqueSuffix}`;
         const codeLetters = `W${uniqueSuffix.slice(0, 2)}`;
@@ -715,9 +715,9 @@ describe('Library Artists', () => {
 
         expect(second.body).toEqual({
           message: 'Artist code already exists for that genre and code letters.',
+          reason: 'artist_code_conflict',
           artist: { artist_id: first.body.id, artist_name: artistName, code_letters: codeLetters },
         });
-        expect(second.body).not.toHaveProperty('reason');
       });
     });
   });

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -605,6 +605,121 @@ describe('Library Artists', () => {
 
       expect(res.body.alphabetical_name).toBe(`Band ${uniqueSuffix}, The`);
     });
+
+    describe('genre-scoped artist-name pre-check', () => {
+      test('returns a distinguishable 409 when the artist name already exists in the target genre', async () => {
+        const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-3);
+        const artistName = `ZZName Dup ${uniqueSuffix}`;
+
+        const first = await auth
+          .post('/library/artists')
+          .send({
+            artist_name: artistName,
+            code_letters: `Z${uniqueSuffix.slice(0, 1)}A`,
+            genre_id: 11,
+            code_number: 501,
+          })
+          .expect(201);
+
+        const second = await auth
+          .post('/library/artists')
+          .send({
+            artist_name: artistName,
+            code_letters: `Z${uniqueSuffix.slice(0, 1)}B`,
+            genre_id: 11,
+            code_number: 502,
+          })
+          .expect(409);
+
+        expect(second.body).toEqual({
+          message: 'Artist name already exists in that genre.',
+          reason: 'artist_name_conflict',
+          artist: { artist_id: first.body.id, artist_name: artistName, code_letters: `Z${uniqueSuffix.slice(0, 1)}A` },
+        });
+
+        // No second row was inserted for the conflicting name.
+        const search = await auth
+          .get('/library/artists/search')
+          .query({ genre_id: 11, q: artistName, limit: 10 })
+          .expect(200);
+        expect(search.body.artists).toHaveLength(1);
+        expect(search.body.artists[0].id).toBe(first.body.id);
+      });
+
+      test('creates successfully when the same name exists only in a different genre', async () => {
+        const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-3);
+        const artistName = `ZZName Genre ${uniqueSuffix}`;
+
+        await auth
+          .post('/library/artists')
+          .send({
+            artist_name: artistName,
+            code_letters: `Y${uniqueSuffix.slice(0, 1)}A`,
+            genre_id: 11,
+            code_number: 503,
+          })
+          .expect(201);
+
+        const res = await auth
+          .post('/library/artists')
+          .send({
+            artist_name: artistName,
+            code_letters: `Y${uniqueSuffix.slice(0, 1)}B`,
+            genre_id: 6,
+            code_number: 504,
+          })
+          .expect(201);
+
+        expect(res.body.artist_name).toBe(artistName);
+        expect(res.body.genre_id).toBe(6);
+      });
+
+      test('catches a Unicode-form duplicate (NFD input against an NFC-stored name) in the same genre', async () => {
+        const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-3);
+        // ü = U+00FC (precomposed) vs u + U+0308 (combining diaeresis) — same
+        // rendered text, byte-distinct until fold_artist_name normalizes both.
+        const nameNfc = `ZZName Nilüfer ${uniqueSuffix}`.normalize('NFC');
+        const nameNfd = `ZZName Nilüfer ${uniqueSuffix}`.normalize('NFD');
+        expect(nameNfc).not.toBe(nameNfd);
+
+        const first = await auth
+          .post('/library/artists')
+          .send({ artist_name: nameNfc, code_letters: `X${uniqueSuffix.slice(0, 1)}A`, genre_id: 11, code_number: 505 })
+          .expect(201);
+
+        const second = await auth
+          .post('/library/artists')
+          .send({ artist_name: nameNfd, code_letters: `X${uniqueSuffix.slice(0, 1)}B`, genre_id: 11, code_number: 506 })
+          .expect(409);
+
+        expect(second.body.reason).toBe('artist_name_conflict');
+        expect(second.body.artist.artist_id).toBe(first.body.id);
+      });
+
+      test('prefers the code-triple conflict over a simultaneous name conflict, with the unchanged code-conflict shape', async () => {
+        const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-3);
+        const artistName = `ZZName Both ${uniqueSuffix}`;
+        const codeLetters = `W${uniqueSuffix.slice(0, 2)}`;
+
+        const first = await auth
+          .post('/library/artists')
+          .send({ artist_name: artistName, code_letters: codeLetters, genre_id: 11, code_number: 507 })
+          .expect(201);
+
+        // Same name AND same code triple as the artist above -- both checks
+        // would fire independently; the code-triple 409 must win.
+        const second = await auth
+          .post('/library/artists')
+          .send({ artist_name: artistName, code_letters: codeLetters, genre_id: 11, code_number: 507 })
+          .expect(409);
+
+        expect(second.body).toEqual({
+          message: 'Artist code already exists for that genre and code letters.',
+          artist: { artist_id: first.body.id, artist_name: artistName, code_letters: codeLetters },
+        });
+        expect(second.body).not.toHaveProperty('reason');
+      });
+    });
   });
 });
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -724,7 +724,7 @@ describe('library.controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
     });
 
-    it('returns 409 with the existing artist when the code triple already exists, in the pre-existing shape', async () => {
+    it('returns 409 with the existing artist and an explicit code-conflict discriminant when the code triple already exists', async () => {
       mockGetArtistByCode.mockResolvedValue({ artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' });
 
       const res = mockResponse();
@@ -733,6 +733,7 @@ describe('library.controller', () => {
       expect(res.status).toHaveBeenCalledWith(409);
       expect(res.json).toHaveBeenCalledWith({
         message: 'Artist code already exists for that genre and code letters.',
+        reason: 'artist_code_conflict',
         artist: { artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' },
       });
       expect(mockInsertArtist).not.toHaveBeenCalled();
@@ -768,6 +769,7 @@ describe('library.controller', () => {
 
       expect(res.json).toHaveBeenCalledWith({
         message: 'Artist code already exists for that genre and code letters.',
+        reason: 'artist_code_conflict',
         artist: { artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' },
       });
       // Short-circuits before the name pre-check even runs.

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -760,6 +760,25 @@ describe('library.controller', () => {
       expect(mockInsertArtist).not.toHaveBeenCalled();
     });
 
+    it('creates the artist when the name match disappears between the two lookups', async () => {
+      mockArtistIdFromName.mockResolvedValue(7);
+      mockGetArtistById.mockResolvedValue(null);
+      mockInsertArtist.mockResolvedValue({
+        id: 55,
+        artist_name: 'Chuquimamani-Condori',
+        alphabetical_name: 'Chuquimamani-Condori',
+        code_letters: 'CH',
+      });
+
+      const res = mockResponse();
+      await addArtist(req(), res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockInsertArtist).toHaveBeenCalled();
+      // Never a 409 that asserts a conflicting artist it cannot name.
+      expect(res.json).not.toHaveBeenCalledWith(expect.objectContaining({ artist: null }));
+    });
+
     it('prefers the code-triple conflict over a simultaneous name conflict, deterministically', async () => {
       mockGetArtistByCode.mockResolvedValue({ artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' });
       mockArtistIdFromName.mockResolvedValue(7);

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -9,6 +9,13 @@ const mockFuzzySearchLibrary = jest.fn<() => Promise<unknown[]>>();
 const mockEnrichWithArtwork = jest.fn<(results: unknown[]) => Promise<unknown[]>>();
 const mockArtistIdFromName = jest.fn<(name: string, genreId: number) => Promise<number>>();
 const mockGetArtistNameById = jest.fn<(id: number) => Promise<string | null>>();
+type ArtistConflictRow = { artist_id: number; artist_name: string; code_letters: string };
+const mockGetArtistByCode =
+  jest.fn<(codeLetters: string, genreId: number, codeNumber: number) => Promise<ArtistConflictRow | null>>();
+const mockGetArtistById = jest.fn<(artistId: number) => Promise<ArtistConflictRow | null>>();
+const mockInsertArtist = jest.fn<(artist: Record<string, unknown>) => Promise<Record<string, unknown>>>();
+const mockInsertArtistGenreCrossreference =
+  jest.fn<(artistId: number, genreId: number, codeNumber: number) => Promise<unknown>>();
 const mockInsertAlbum = jest.fn<(album: Record<string, unknown>) => Promise<Record<string, unknown>>>();
 const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number>>();
 const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
@@ -71,9 +78,10 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   mapLookupToCanonicalEntity: mockMapLookupToCanonicalEntity,
   artistIdFromName: mockArtistIdFromName,
   getArtistNameById: mockGetArtistNameById,
-  insertArtist: jest.fn(),
-  insertArtistGenreCrossreference: jest.fn(),
-  getArtistByCode: jest.fn(),
+  insertArtist: mockInsertArtist,
+  insertArtistGenreCrossreference: mockInsertArtistGenreCrossreference,
+  getArtistByCode: mockGetArtistByCode,
+  getArtistById: mockGetArtistById,
   generateAlbumCodeNumber: mockGenerateAlbumCodeNumber,
   generateArtistNumber: jest.fn(),
   getGenresFromDB: jest.fn(),
@@ -152,6 +160,7 @@ import {
   markFound,
   searchForAlbum,
   addAlbum,
+  addArtist,
   getAlbum,
   getRotationTracks,
   updateAlbum,
@@ -675,6 +684,95 @@ describe('library.controller', () => {
 
         consoleWarnSpy.mockRestore();
       });
+    });
+  });
+
+  describe('addArtist', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetArtistByCode.mockResolvedValue(null);
+      mockArtistIdFromName.mockResolvedValue(0);
+    });
+
+    const req = (overrides: Record<string, unknown> = {}) =>
+      ({
+        body: {
+          artist_name: 'Chuquimamani-Condori',
+          code_letters: 'CH',
+          genre_id: 15,
+          code_number: 12,
+          ...overrides,
+        },
+      }) as unknown as Request;
+
+    it('creates a new artist when neither the code triple nor the name conflicts in that genre', async () => {
+      mockInsertArtist.mockResolvedValue({
+        id: 55,
+        artist_name: 'Chuquimamani-Condori',
+        alphabetical_name: 'Chuquimamani-Condori',
+        code_letters: 'CH',
+      });
+
+      const res = mockResponse();
+      await addArtist(req(), res, next);
+
+      expect(mockGetArtistByCode).toHaveBeenCalledWith('CH', 15, 12);
+      expect(mockArtistIdFromName).toHaveBeenCalledWith('Chuquimamani-Condori', 15);
+      expect(mockInsertArtist).toHaveBeenCalledWith(
+        expect.objectContaining({ artist_name: 'Chuquimamani-Condori', code_letters: 'CH' })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 409 with the existing artist when the code triple already exists, in the pre-existing shape', async () => {
+      mockGetArtistByCode.mockResolvedValue({ artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' });
+
+      const res = mockResponse();
+      await addArtist(req(), res, next);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Artist code already exists for that genre and code letters.',
+        artist: { artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' },
+      });
+      expect(mockInsertArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns a distinguishable 409 when only the artist name conflicts in that genre', async () => {
+      mockArtistIdFromName.mockResolvedValue(7);
+      mockGetArtistById.mockResolvedValue({ artist_id: 7, artist_name: 'Nilüfer Yanya', code_letters: 'NI' });
+
+      const res = mockResponse();
+      await addArtist(req({ artist_name: 'Nilüfer Yanya', code_letters: 'ZZ' }), res, next);
+
+      expect(mockGetArtistById).toHaveBeenCalledWith(7);
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'artist_name_conflict',
+          artist: { artist_id: 7, artist_name: 'Nilüfer Yanya', code_letters: 'NI' },
+        })
+      );
+      // Distinguishable from the code-triple 409: different reason and message text.
+      const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ message: string }];
+      expect(payload.message).not.toBe('Artist code already exists for that genre and code letters.');
+      expect(mockInsertArtist).not.toHaveBeenCalled();
+    });
+
+    it('prefers the code-triple conflict over a simultaneous name conflict, deterministically', async () => {
+      mockGetArtistByCode.mockResolvedValue({ artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' });
+      mockArtistIdFromName.mockResolvedValue(7);
+
+      const res = mockResponse();
+      await addArtist(req(), res, next);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Artist code already exists for that genre and code letters.',
+        artist: { artist_id: 3, artist_name: 'Jockstrap', code_letters: 'CH' },
+      });
+      // Short-circuits before the name pre-check even runs.
+      expect(mockArtistIdFromName).not.toHaveBeenCalled();
+      expect(mockInsertArtist).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

`addArtist` (`POST /library/artists`) pre-checked only the `(code_letters, genre_id, code_number)` triple before inserting, so a client could silently create a second `artists` row whose name already exists in the same genre — the dj-site typeahead's advisory guard was the only thing standing in the way, and it never blocked a submission. This adds a genre-scoped artist-name pre-check alongside the existing code-triple check, reusing `artistIdFromName` (no new matcher query) so the check is Unicode-form + diacritic + case-insensitive, matching what already backs the BS#1897 dedup job.

Closes #2101

## The two conflict cases

- **Code-triple conflict** (pre-existing): `(code_letters, genre_id, code_number)` already belongs to another artist. Status, message text and `artist` payload are unchanged; it now additionally carries `reason: 'artist_code_conflict'`.
- **Artist-name conflict** (new): the submitted name folds to an existing artist's name in the target genre. Response carries a `reason: 'artist_name_conflict'` field the code-triple response never sets, plus the conflicting artist in the same `{ artist_id, artist_name, code_letters }` shape as the code-triple response's `artist` field.

A client distinguishes the two by checking `reason`. **Both** branches now carry a positive discriminant — `'artist_code_conflict'` and `'artist_name_conflict'` — so nothing has to be inferred from a missing key. A client written against an earlier revision of this branch, which read the code case as "no `reason` field", still works: it will not match `'artist_name_conflict'` and so falls through to its code-conflict path, which is where a code conflict belongs.

Any existing consumer that only reads `artist.artist_name` is unaffected — the `artist` payload is unchanged on both.

## Precedence when both collide

The code-triple check still runs first, unmodified, and short-circuits before the new name check ever runs — so it deterministically wins a simultaneous collision. Documented in a comment at the call site: a taken code blocks the write outright regardless of name, while a name conflict still leaves the request able to succeed against a different code, so surfacing the code conflict first is the more actionable message.

## Investigation (per the issue's constraints)

- **Internal callers tolerating a duplicate name**: none. `insertArtist` (the service function `addArtist` calls) has exactly one call site in the whole repo — this controller. `jobs/library-etl`'s `ensureArtist`/`findArtistId` write directly to `artists` via their own fold-matched check-then-insert logic (BS#1095) and never route through `addArtist` or `insertArtist`; they already dedupe on the same `fold_artist_name` semantics this change reuses. No ETL job, bulk import, or legacy-mirror path depends on `addArtist` accepting a duplicate name.
- **wxyc-shared `api.yaml` contract**: `POST /library/artists` documents only a `200` response (the controller actually returns `201`, a pre-existing drift unrelated to this change) and no `409` at all — neither the pre-existing code-triple conflict nor the new name conflict is part of the published contract. No `api.yaml` update is required for this PR; flagging the `200`-vs-`201` drift as a separate, pre-existing documentation gap worth a follow-up.

## What changed

- `apps/backend/services/library.service.ts`: added `getArtistById(artist_id)`, mirroring `getArtistByCode`'s `{ artist_id, artist_name, code_letters }` return shape, so the new conflict payload can carry the matched artist the same way the code-triple conflict does.
- `apps/backend/controllers/library.controller.ts`: `addArtist` now runs the name pre-check (via `artistIdFromName`) after the existing code check, returning 409 with the `reason` discriminant on a hit; comment documents the precedence rule as a constraint, not history.

## Tests

Unit (`tests/unit/controllers/library.controller.test.ts`, new `addArtist` describe block):
- `creates a new artist when neither the code triple nor the name conflicts in that genre`
- `returns 409 with the existing artist when the code triple already exists, in the pre-existing shape`
- `returns a distinguishable 409 when only the artist name conflicts in that genre`
- `creates the artist when the name match disappears between the two lookups`
- `prefers the code-triple conflict over a simultaneous name conflict, deterministically`

Integration (`tests/integration/library.spec.js`, new `genre-scoped artist-name pre-check` describe block, real Postgres):
- `returns a distinguishable 409 when the artist name already exists in the target genre` (also asserts no second row is inserted)
- `creates successfully when the same name exists only in a different genre`
- `catches a Unicode-form duplicate (NFD input against an NFC-stored name) in the same genre`
- `prefers the code-triple conflict over a simultaneous name conflict, asserting its `artist_code_conflict` discriminant`

## Deploy ordering

**Soft gate, not a blocker.** dj-site `main` already reads this PR's discriminant (`lib/features/catalog/adminCreateArtistValidation.ts`, `isArtistNameConflictData`), and it is written to tolerate the field's absence — its doc comment names that case exactly: *"every other value — including a body with no `reason` field at all, which is exactly what today's deployed backend sends on its one 409 — is the code-triple case."*

So dj-site in production is correct today and stays correct whenever this deploys. What it cannot do until then is show the name-conflict message: a duplicate-name submission currently surfaces the generic code-conflict copy, which points the Music Director at the wrong remedy. That is the user-visible cost of the gap, and it is the reason to land this rather than an argument for sequencing anything around it.

## What this does not fix

Neither pre-check is backed by a database constraint — `artists_fold_name_idx` is a plain non-unique btree by design (migration `0134`), and nothing constrains the code triple. This PR narrows the duplicate-name window to the gap between the check and the insert; it cannot close it, and two concurrent requests can still both write. The same absence makes `getArtistByCode`'s `LIMIT 1` (no `ORDER BY`) nondeterministic whenever duplicates exist.

Tracked in #2106, which also covers a third finding on the code axis: `insertArtist` NFC-normalizes `code_letters` on write while `getArtistByCode` compares the raw request value, so a diacritic-bearing code submitted in NFD form misses the pre-check entirely. Deliberately out of scope here — the fix requires a schema decision (the invariant spans two tables, so no single-table unique index expresses it).

## Test plan

- [x] `npm run test:unit` — 427 suites / 7041 tests pass
- [x] `npm run ci:testmock` (Docker CI-equivalent) — 99/99 non-skipped suites pass, including the new integration coverage
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] Confirmed the two new unit tests fail against the pre-fix controller (stashed the production edit, re-ran, restored) before implementing
- [x] Confirmed the vanished-match test fails against the prior revision of this branch (409 where 201 is expected) before fixing

## Related

- Closes WXYC/Backend-Service#2101
- WXYC/Backend-Service#2106 — the constraint gap this PR narrows but cannot close

