### PR TITLE
feat(playlist): emit on-air status on the v=2 recentEntries payload

### DIFF
--- a/apps/backend/controllers/playlist.controller.ts
+++ b/apps/backend/controllers/playlist.controller.ts
@@ -34,8 +34,8 @@ function parseN(raw: unknown, def: number, max: number): number {
  *
  * Query params:
  *   v — wire-format version. `v=2` → grouped `{playcuts, talksets,
- *       breakpoints}` (iOS). Absent or any other value → v=1 flat array
- *       (Android's contract — Android sends no `v`). BS#1866.
+ *       breakpoints[, onAir]}` (iOS). Absent or any other value → v=1 flat
+ *       array (Android's contract — Android sends no `v`). BS#1866.
  *   n — entry count. v=2: playcuts returned (default 50, clamped [1, 100]).
  *       v=1: total entries returned (default 200, clamped [1, 200]).
  *
@@ -44,14 +44,20 @@ function parseN(raw: unknown, def: number, max: number): number {
  * BS#2103, the full `/flowsheet` metadata set (streaming links, bio,
  * genres/styles, release year, artist id, upcoming show, critic reviews)
  * under the camelCase keys shipped iOS 3.2 decodes — see
- * playlist-proxy.service.ts. v=1 carries none of it (tubafrenzy's v=1 never
- * carried artwork either — Android resolves its own).
+ * playlist-proxy.service.ts. Since BS#2105, the v=2 envelope also carries a
+ * top-level `onAir` field (a sibling of `playcuts`, not a per-playcut field)
+ * so the on-air banner renders on this legacy path too — see
+ * playlist-proxy.service.ts's `WireOnAir`/`encodeOnAir` for its (hazardous,
+ * Swift-synthesized) wire shape. v=1 carries neither enrichment nor `onAir`
+ * (tubafrenzy's v=1 never carried artwork either — Android resolves its own).
  *
  * Headers:
- *   Cache-Control: public, max-age=30
+ *   Cache-Control: public, max-age=30 — also the effective staleness bound on
+ *     `onAir`, since this route has no separate on-air-specific cache policy.
  *   X-Last-Modified: max entry `timeCreated` in the served window (BS#1866),
  *     exposed via Access-Control-Expose-Headers for the browser page's
- *     conditional-fetch parity.
+ *     conditional-fetch parity. NOT a valid change-detector for `onAir` — see
+ *     `lastModifiedFromTimestamps`'s doc comment in playlist-proxy.service.ts.
  *
  * A DB failure is caught here and written as a DIRECT 503 response — it must
  * not be thrown into the error pipeline, because `sentryErrorFilter` captures

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -487,15 +487,29 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
   // make it that wave's critical path. Starting it here instead hides it
   // entirely behind the 200-row window query.
   //
-  // `.catch(() => undefined)` is attached to THIS promise, not wrapped around
-  // the whole Promise.all. getRecentEntries has no other try/catch: a
-  // rejection here would otherwise propagate to playlist.controller.ts, which
-  // fail-softs to a 503 for the ENTIRE legacy mobile fleet. An on-air blip
-  // must cost only the banner (the `onAir` key is omitted below when this
-  // resolves `undefined`), never the playlist.
+  // The catch is attached to THIS promise, not wrapped around the whole
+  // Promise.all. getRecentEntries has no other try/catch: a rejection here
+  // would otherwise propagate to playlist.controller.ts, which fail-softs to
+  // a 503 for the ENTIRE legacy mobile fleet. An on-air blip must cost only
+  // the banner (the `onAir` key is omitted below when this resolves
+  // `undefined`), never the playlist.
+  //
+  // Logged to stderr, NOT Sentry — deliberately diverging from the otherwise
+  // identical catch in flowsheet.controller.ts's `getOnAirDJName().catch()`,
+  // which does `Sentry.captureException`. This endpoint is unauthenticated and
+  // polled on a fixed interval by every legacy mobile client, so a persistent
+  // failure here would emit one Sentry event per poll per device — the
+  // catalog-search 503 flood that playlist.controller.ts's own DB-failure path
+  // was written to avoid (see its `console.error` and the comment above it).
+  // A silent swallow would be worse still: the banner would vanish fleet-wide
+  // with an absent JSON key as the only symptom, so the error does get
+  // recorded, just on the channel this endpoint can afford.
   const [rows, onAirDjName] = await Promise.all([
     fetchRecentRows(MAX_ENTRIES),
-    getOnAirDJName().catch(() => undefined),
+    getOnAirDJName().catch((err: unknown) => {
+      console.error('[playlist] Failed to resolve on-air status; omitting the banner:', err);
+      return undefined;
+    }),
   ]);
 
   const playcutRows: RecentRow[] = [];

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -48,6 +48,17 @@
  * data has to come to them on this endpoint. See `enrichPlaycutMetadata`.
  * v=1 (Android) is deliberately untouched.
  *
+ * On-air status (BS#2105). The v=2 grouped envelope additionally carries a
+ * top-level `onAir` field, a sibling of `playcuts`/`talksets`/`breakpoints`,
+ * so a 3.2 client on this legacy path renders the on-air banner with the live
+ * DJ's handle instead of hiding it. Unlike every other field on this
+ * endpoint, `onAir`'s wire shape is NOT a plain object — it is whatever
+ * Swift's SYNTHESIZED `Codable` produces for the shipped `OnAir` enum
+ * (`{"dj":{"_0":name}}` / `{"automation":{}}`), which is why it goes through
+ * a dedicated `WireOnAir` union and `encodeOnAir` helper rather than the
+ * ad-hoc object literals the rest of this file builds. See `encodeOnAir`.
+ * v=1 (Android) is untouched here too.
+ *
  * Exported API:
  *   getRecentEntries(n) — query Postgres for the current playlist grouped
  *                         by entry type, sliced to n playcuts. Async (was
@@ -63,7 +74,7 @@ import {
   suppressMislabeledStreamingUrls,
 } from '../utils/album-metadata-projection.js';
 import type { ConcertDTO } from './concerts.service.js';
-import { attachUpcomingShows, attachCriticReviews } from './flowsheet.service.js';
+import { attachUpcomingShows, attachCriticReviews, getOnAirDJName } from './flowsheet.service.js';
 
 const MAX_ENTRIES = 200;
 const HOUR_MS = 3_600_000;
@@ -197,6 +208,47 @@ function setUrlField(target: GroupedPlaycut, key: UrlWireKey, value: string | nu
   }
 }
 
+/**
+ * The wire shape iOS 3.2's `OnAir` enum's SYNTHESIZED Codable expects
+ * (BS#2105) — not something anyone would guess from the JSON alone.
+ *
+ * `OnAir` (`Shared/Playlist/Sources/Playlist/OnAir.swift`) is `enum OnAir {
+ * case dj(String); case automation; case unknown }` with no custom
+ * `init(from:)`, so it decodes/encodes via Swift's default synthesized
+ * `Codable`. Measured by executing the real encoder against the shipped enum,
+ * not inferred:
+ *   `JSONEncoder().encode(OnAir.dj("bill b"))` -> `{"dj":{"_0":"bill b"}}`
+ *   `JSONEncoder().encode(OnAir.automation)`   -> `{"automation":{}}`
+ * `_0` is the synthesized label Swift gives an unlabeled single associated
+ * value. The `_0` literal exists in exactly this ONE place in the codebase —
+ * {@link encodeOnAir} is the only function permitted to construct it.
+ *
+ * `.unknown` has no wire form here: the caller omits the `onAir` key entirely
+ * rather than emit `{"unknown":{}}` — both decode to `OnAir.unknown` (an
+ * absent key falls through `?? .unknown` in `Playlist.init(from:)`), but the
+ * explicit form costs bytes for nothing.
+ */
+export type WireOnAir = { dj: { _0: string } } | { automation: Record<string, never> };
+
+/**
+ * Encode `getOnAirDJName()`'s two DEFINITIVE outcomes into {@link WireOnAir}.
+ *
+ * `getOnAirDJName`'s own contract: a non-null name means a human is on air
+ * (including the `ANONYMOUS_ON_AIR_NAME` = `"WXYC"` fallback for a legacy
+ * sign-on with no resolvable handle); `null` is reserved EXCLUSIVELY for
+ * confirmed automation. This mirrors that exactly, just re-keyed for this
+ * endpoint's hazardous Swift-synthesized shape instead of `/flowsheet`'s
+ * plain `{dj_name}` projection (`flowsheet.controller.ts`).
+ *
+ * The THIRD outcome — the resolver rejected — never reaches this function.
+ * It is handled at the call site by omitting the `onAir` key entirely (see
+ * `getRecentEntries`), which is also why this signature takes `string |
+ * null` rather than `string | null | undefined`.
+ */
+function encodeOnAir(name: string | null): WireOnAir {
+  return name !== null ? { dj: { _0: name } } : { automation: {} };
+}
+
 // --- Types ---
 
 /**
@@ -277,6 +329,21 @@ export interface GroupedResponse {
   playcuts: GroupedPlaycut[];
   talksets: BaseEntry[];
   breakpoints: BaseEntry[];
+  /**
+   * On-air status (BS#2105), a sibling of `playcuts`/`talksets`/`breakpoints`
+   * rather than a per-playcut field. Present as {@link WireOnAir} when
+   * `getOnAirDJName()` resolved (either a named DJ or confirmed automation);
+   * OMITTED entirely when the resolver rejected — never `{"unknown":{}}`.
+   *
+   * Declared LAST deliberately: `JSON.stringify` emits insertion order, and
+   * the cross-repo golden (`tests/fixtures/recent-entries-v2-wire-golden.json`)
+   * pins the resulting bytes. `getRecentEntries` below sets it last via a
+   * trailing conditional spread for the same reason. This differs from
+   * `Playlist`'s Swift `CodingKeys` order (`playcuts, breakpoints, talksets,
+   * showMarkers, onAir`) — irrelevant to the decoder, load-bearing only for
+   * the golden diff.
+   */
+  onAir?: WireOnAir;
 }
 
 type RecentRow = {
@@ -413,7 +480,23 @@ async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
  * the playcuts sub-array at read time.
  */
 export async function getRecentEntries(n: number): Promise<GroupedResponse> {
-  const rows = await fetchRecentRows(MAX_ENTRIES);
+  // BS#2105: resolve on-air status concurrently with the window query, not
+  // behind it. getOnAirDJName has no dependency on `rows`, and it is itself
+  // two SEQUENTIAL queries (getNShows(1) + at most one user PK lookup) —
+  // parking it in the enrichment Promise.all below (round trip 2 of 3) could
+  // make it that wave's critical path. Starting it here instead hides it
+  // entirely behind the 200-row window query.
+  //
+  // `.catch(() => undefined)` is attached to THIS promise, not wrapped around
+  // the whole Promise.all. getRecentEntries has no other try/catch: a
+  // rejection here would otherwise propagate to playlist.controller.ts, which
+  // fail-softs to a 503 for the ENTIRE legacy mobile fleet. An on-air blip
+  // must cost only the banner (the `onAir` key is omitted below when this
+  // resolves `undefined`), never the playlist.
+  const [rows, onAirDjName] = await Promise.all([
+    fetchRecentRows(MAX_ENTRIES),
+    getOnAirDJName().catch(() => undefined),
+  ]);
 
   const playcutRows: RecentRow[] = [];
   const talksetRows: RecentRow[] = [];
@@ -486,6 +569,9 @@ export async function getRecentEntries(n: number): Promise<GroupedResponse> {
     playcuts,
     talksets: talksetRows.map(toBaseEntry),
     breakpoints: breakpointRows.map(toBaseEntry),
+    // Last key deliberately — see the GroupedResponse.onAir doc comment.
+    // Omitted (not `{"unknown":{}}`) when the resolver rejected above.
+    ...(onAirDjName !== undefined && { onAir: encodeOnAir(onAirDjName) }),
   };
 }
 
@@ -611,6 +697,14 @@ export async function getRecentEntriesFlat(n: number): Promise<FlatEntry[]> {
  * appears. Computed from the served payload, so the v=2 value can miss a
  * showDelimiter that the grouped shape drops — inconsequential, since v=2
  * (iOS) never sends `?since`, and the bridge's `?since` path stays on legacy.
+ *
+ * The same gap makes `X-Last-Modified` NOT a valid change-detector for
+ * `onAir` (BS#2105): a sign-on/sign-off writes no playcut/talkset/breakpoint
+ * of its own, so this header does not move the moment the banner would.
+ * Freshness for `onAir` is bounded instead by the endpoint's own
+ * `Cache-Control: public, max-age=30` (set in playlist.controller.ts) — up to
+ * 30s of staleness at any caching intermediary, on top of the client's poll
+ * interval, is accepted here as a documented tradeoff, not a bug to reopen.
  */
 export function lastModifiedFromTimestamps(timestamps: number[]): number {
   return timestamps.length > 0 ? Math.max(...timestamps) : 0;

--- a/tests/fixtures/recent-entries-v2-wire-golden.json
+++ b/tests/fixtures/recent-entries-v2-wire-golden.json
@@ -286,5 +286,10 @@
     }
   ],
   "talksets": [],
-  "breakpoints": []
+  "breakpoints": [],
+  "onAir": {
+    "dj": {
+      "_0": "BS2105 Probe DJ"
+    }
+  }
 }

--- a/tests/unit/services/playlist-proxy-wire-golden.test.ts
+++ b/tests/unit/services/playlist-proxy-wire-golden.test.ts
@@ -40,6 +40,14 @@
  * degenerate `text[]` members (`[null]`, which has a truthy `.length` and
  * throws on `decodeIfPresent([String].self)`). They are pinned here so the
  * guards that close them cannot be removed silently by a future refactor.
+ *
+ * BS#2105 added the top-level `onAir` field (a sibling of `playcuts`, not a
+ * per-playcut field) to this same golden — see the "onAir wire encoding"
+ * block below. Its wire shape is Swift's SYNTHESIZED Codable encoding for the
+ * shipped `OnAir` enum, unrelated to and much stranger than anything in the
+ * per-playcut matrix above; `getOnAirDJName` must be mocked explicitly here
+ * for the same reason the two flowsheet.service attaches already are (see
+ * the module mock below).
  */
 /* eslint-disable security/detect-non-literal-fs-filename --
  * Every path here is GOLDEN_PATH, a module constant built from __dirname. There
@@ -134,10 +142,16 @@ jest.mock('drizzle-orm', () => ({
 type AttachTarget = { upcoming_show?: unknown; critic_reviews?: unknown };
 const mockAttachUpcomingShows = jest.fn((entries: AttachTarget[]) => Promise.resolve(entries));
 const mockAttachCriticReviews = jest.fn((entries: AttachTarget[]) => Promise.resolve(entries));
+// BS#2105: must be mocked explicitly — an unmocked jest.fn() returns
+// `undefined`, not a Promise, and `getOnAirDJName().catch(...)` would throw
+// synchronously on the missing `.catch`, silently pinning garbage into the
+// golden. See playlist-proxy.service.test.ts for the same trap.
+const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   attachUpcomingShows: (entries: AttachTarget[]) => mockAttachUpcomingShows(entries),
   attachCriticReviews: (entries: AttachTarget[]) => mockAttachCriticReviews(entries),
+  getOnAirDJName: () => mockGetOnAirDJName(),
 }));
 
 jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -158,7 +172,7 @@ const GOLDEN_PATH = join(__dirname, '../../fixtures/recent-entries-v2-wire-golde
  * file from the fixture, so regenerating one without acknowledging the other is
  * a red test rather than a silent change.
  */
-const GOLDEN_SHA256 = 'a789b99b863374b44ba2c8ca0c3393d9659987ff1e403e1be90834c500a49313';
+const GOLDEN_SHA256 = '46a1064409f65356e076390bd209c198d0a8748ccb23bd51b5fb7ae1409c8f70';
 
 /** Fixed ids and add_times — the payload must be byte-reproducible. */
 function row(id: number, albumId: number | null, artist: string, album: string, track: string, seconds: number) {
@@ -319,6 +333,11 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     mockArtworkInnerJoin.mockReturnValue(artworkChain);
     mockArtworkWhere.mockReturnValue(artworkChain);
     mockExecute.mockResolvedValue([]);
+
+    // BS#2105: the golden pins a human DJ on air. The other two states
+    // ({automation} and the key omitted on a rejection) are pinned by the
+    // dedicated tests below, which override this per-test.
+    mockGetOnAirDJName.mockResolvedValue('BS2105 Probe DJ');
 
     mockLimit.mockResolvedValue(ROWS);
     mockMetadataWhere.mockResolvedValue(METADATA);
@@ -523,5 +542,45 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     // trimmed) discogs URL carries her status with it.
     expect(byArtist('Juana Molina').metadataStatus).toBe('enriched_match');
     expect(byArtist('Nilüfer Yanya').metadataStatus).toBe('enriched_match');
+  });
+
+  // BS#2105: onAir's wire shape is Swift's SYNTHESIZED Codable encoding for
+  // the shipped `OnAir` enum, not a plain object anyone would guess. The
+  // golden above pins one state (a human DJ) byte-for-byte; these three pin
+  // the full tri-state matrix deliberately, since `getOnAirDJName` must be
+  // mocked explicitly here (see the module-mock comment above) and a missed
+  // mock would otherwise silently pin garbage rather than fail loud.
+  describe('onAir wire encoding (BS#2105)', () => {
+    it('emits {dj:{_0:name}} for a resolved DJ handle — the golden state', () => {
+      const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8'));
+      expect(golden.onAir).toEqual({ dj: { _0: 'BS2105 Probe DJ' } });
+    });
+
+    it('emits {automation:{}} when getOnAirDJName resolves null', async () => {
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const payload = await getRecentEntries(50);
+
+      expect(payload.onAir).toEqual({ automation: {} });
+    });
+
+    it('omits the onAir key — never {"unknown":{}} — when getOnAirDJName rejects', async () => {
+      mockGetOnAirDJName.mockRejectedValue(new Error('DB connection reset'));
+
+      const payload = await getRecentEntries(50);
+
+      expect(Object.prototype.hasOwnProperty.call(payload, 'onAir')).toBe(false);
+      // The blip cost only the banner — the rest of the golden payload is
+      // still fully populated.
+      expect(payload.playcuts).toHaveLength(14);
+    });
+
+    it('is the last key in the envelope', async () => {
+      mockGetOnAirDJName.mockResolvedValue('BS2105 Probe DJ');
+
+      const payload = await getRecentEntries(50);
+
+      expect(Object.keys(payload)).toEqual(['playcuts', 'talksets', 'breakpoints', 'onAir']);
+    });
   });
 });

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -1377,7 +1377,14 @@ describe('playlist-proxy.service', () => {
   });
 
   // BS#2105: on-air status as a top-level `onAir` sibling of `playcuts`, so a
-  // 3.2 client on the legacy v=1 path renders the on-air banner. `onAir`'s
+  // 3.2 client reading this endpoint renders the on-air banner. Note the two
+  // unrelated "v1/v2" axes this feature sits between: iOS calls the whole
+  // legacy `/playlists/recentEntries` endpoint its "v1" API (vs `/flowsheet`,
+  // its v2) — but WITHIN this endpoint, `v` selects the wire format, and
+  // `onAir` ships only on the `?v=2` GROUPED shape that `getRecentEntries`
+  // serves. The `?v=1` flat shape is Android's contract and is untouched; the
+  // last test in this block pins that. Everywhere in this file, bare "v=1" and
+  // "v=2" mean the wire format, never the API generation. `onAir`'s
   // wire shape is not `/flowsheet`'s `{dj_name}` — it is whatever Swift's
   // SYNTHESIZED Codable produces for the shipped `enum OnAir { case
   // dj(String); case automation; case unknown }`, which is why the encoder is
@@ -1439,10 +1446,27 @@ describe('playlist-proxy.service', () => {
     });
 
     it('resolves getOnAirDJName concurrently with the window query, before the metadata batch', async () => {
+      // The pin is STRUCTURAL, not order-based: the window query does not
+      // settle until getOnAirDJName has been invoked. A sequential rewrite —
+      // `const rows = await fetchRecentRows(...)` followed by `await
+      // getOnAirDJName()` — can never reach the second call, so it deadlocks
+      // and this test times out instead of passing.
+      //
+      // An invocation-order assertion (`callOrder[0] === 'rows'`, then
+      // `'onair'`) does NOT pin this: a sequential rewrite produces that exact
+      // same order and stays green. Since parking getOnAirDJName behind the
+      // window query — making its two sequential round trips the critical path
+      // — is precisely the regression BS#2105 exists to prevent, the test has
+      // to be able to fail on it.
+      let releaseWindowQuery!: () => void;
+      const windowQueryReleased = new Promise<void>((resolve) => {
+        releaseWindowQuery = resolve;
+      });
+
       const callOrder: string[] = [];
       mockLimit.mockImplementation(() => {
         callOrder.push('rows');
-        return Promise.resolve([jessicaPrattRow]);
+        return windowQueryReleased.then(() => [jessicaPrattRow]);
       });
       mockMetadataWhere.mockImplementation(() => {
         callOrder.push('metadata');
@@ -1450,16 +1474,15 @@ describe('playlist-proxy.service', () => {
       });
       mockGetOnAirDJName.mockImplementation(() => {
         callOrder.push('onair');
+        releaseWindowQuery();
         return Promise.resolve('bill b');
       });
 
-      await getRecentEntries(50);
+      const result = await getRecentEntries(50);
 
-      // getOnAirDJName is invoked in the SAME wave as fetchRecentRows — not
-      // parked behind it in the existing enrichment Promise.all, which would
-      // make its two sequential queries that wave's critical path.
-      expect(callOrder[0]).toBe('rows');
-      expect(callOrder[1]).toBe('onair');
+      expect(mockGetOnAirDJName).toHaveBeenCalledTimes(1);
+      expect(result.onAir).toEqual({ dj: { _0: 'bill b' } });
+      // And still ahead of the enrichment wave (round trip 2 of 3).
       expect(callOrder.indexOf('onair')).toBeLessThan(callOrder.indexOf('metadata'));
     });
 

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -203,10 +203,18 @@ type AttachTarget = {
 };
 const mockAttachUpcomingShows = jest.fn((entries: AttachTarget[]) => Promise.resolve(entries));
 const mockAttachCriticReviews = jest.fn((entries: AttachTarget[]) => Promise.resolve(entries));
+// BS#2105: must be mocked explicitly, same reason as the two attaches above —
+// an unmocked `jest.fn()` returns `undefined`, not a Promise, and
+// `getOnAirDJName().catch(...)` would throw synchronously on the missing
+// `.catch`. Default resolves `null` (confirmed automation) in beforeEach so
+// every pre-existing test in this file gets a defined, non-crashing value
+// without having to know this field exists.
+const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   attachUpcomingShows: (entries: AttachTarget[]) => mockAttachUpcomingShows(entries),
   attachCriticReviews: (entries: AttachTarget[]) => mockAttachCriticReviews(entries),
+  getOnAirDJName: () => mockGetOnAirDJName(),
 }));
 
 // Suppress console output in tests
@@ -379,6 +387,10 @@ describe('playlist-proxy.service', () => {
     mockMetadataWhere.mockResolvedValue([]); // metadata query default: no rows
     mockAttachUpcomingShows.mockImplementation((entries) => Promise.resolve(entries));
     mockAttachCriticReviews.mockImplementation((entries) => Promise.resolve(entries));
+    // BS#2105 default: confirmed automation. Tests that care about the on-air
+    // state override this explicitly; everything else gets a defined,
+    // non-crashing value.
+    mockGetOnAirDJName.mockResolvedValue(null);
   });
 
   describe('getRecentEntries — grouping and entry_type mapping', () => {
@@ -1361,6 +1373,104 @@ describe('playlist-proxy.service', () => {
         'segue',
         'songTitle',
       ]);
+    });
+  });
+
+  // BS#2105: on-air status as a top-level `onAir` sibling of `playcuts`, so a
+  // 3.2 client on the legacy v=1 path renders the on-air banner. `onAir`'s
+  // wire shape is not `/flowsheet`'s `{dj_name}` — it is whatever Swift's
+  // SYNTHESIZED Codable produces for the shipped `enum OnAir { case
+  // dj(String); case automation; case unknown }`, which is why the encoder is
+  // a dedicated `WireOnAir` union + `encodeOnAir` helper rather than a literal
+  // object built inline.
+  describe('getRecentEntries — on-air status (BS#2105)', () => {
+    it('emits {dj:{_0:name}} when a human DJ is on air', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+      mockGetOnAirDJName.mockResolvedValue('bill b');
+
+      const result = await getRecentEntries(50);
+
+      expect(result.onAir).toEqual({ dj: { _0: 'bill b' } });
+    });
+
+    it('emits {automation:{}} when getOnAirDJName resolves null (confirmed automation)', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const result = await getRecentEntries(50);
+
+      expect(result.onAir).toEqual({ automation: {} });
+    });
+
+    it('omits the onAir key entirely — never {"unknown":{}} — when getOnAirDJName rejects', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, talksetRow, breakpointRow]);
+      mockGetOnAirDJName.mockRejectedValue(new Error('DB connection reset'));
+
+      const result = await getRecentEntries(50);
+
+      expect(Object.prototype.hasOwnProperty.call(result, 'onAir')).toBe(false);
+    });
+
+    // The highest-risk slip the issue calls out: getRecentEntries has no
+    // internal try/catch, and any rejection propagates to
+    // playlist.controller.ts, which 503s the ENTIRE legacy mobile fleet. A
+    // rejecting getOnAirDJName must cost only the banner (previous test),
+    // never turn into a 503 for everyone else's playlist.
+    it('still resolves (never rejects) with a full playlist when getOnAirDJName rejects', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow, talksetRow, breakpointRow]);
+      mockGetOnAirDJName.mockRejectedValue(new Error('DB connection reset'));
+
+      await expect(getRecentEntries(50)).resolves.toEqual(
+        expect.objectContaining({
+          playcuts: expect.arrayContaining([expect.objectContaining({ artistName: 'Jessica Pratt' })]),
+          talksets: expect.arrayContaining([expect.objectContaining({ id: talksetRow.id })]),
+          breakpoints: expect.arrayContaining([expect.objectContaining({ id: breakpointRow.id })]),
+        })
+      );
+    });
+
+    it('places onAir as the LAST key in the envelope (wire-visible insertion order)', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+      mockGetOnAirDJName.mockResolvedValue('bill b');
+
+      const result = await getRecentEntries(50);
+
+      expect(Object.keys(result)).toEqual(['playcuts', 'talksets', 'breakpoints', 'onAir']);
+    });
+
+    it('resolves getOnAirDJName concurrently with the window query, before the metadata batch', async () => {
+      const callOrder: string[] = [];
+      mockLimit.mockImplementation(() => {
+        callOrder.push('rows');
+        return Promise.resolve([jessicaPrattRow]);
+      });
+      mockMetadataWhere.mockImplementation(() => {
+        callOrder.push('metadata');
+        return Promise.resolve([]);
+      });
+      mockGetOnAirDJName.mockImplementation(() => {
+        callOrder.push('onair');
+        return Promise.resolve('bill b');
+      });
+
+      await getRecentEntries(50);
+
+      // getOnAirDJName is invoked in the SAME wave as fetchRecentRows — not
+      // parked behind it in the existing enrichment Promise.all, which would
+      // make its two sequential queries that wave's critical path.
+      expect(callOrder[0]).toBe('rows');
+      expect(callOrder[1]).toBe('onair');
+      expect(callOrder.indexOf('onair')).toBeLessThan(callOrder.indexOf('metadata'));
+    });
+
+    it('does not call getOnAirDJName or emit onAir on the v=1 flat path (Android contract)', async () => {
+      mockLimit.mockResolvedValue([jessicaPrattRow]);
+      mockGetOnAirDJName.mockResolvedValue('bill b');
+
+      const [entry] = await getRecentEntriesFlat(50);
+
+      expect(mockGetOnAirDJName).not.toHaveBeenCalled();
+      expect(Object.prototype.hasOwnProperty.call(entry, 'onAir')).toBe(false);
     });
   });
 


### PR DESCRIPTION
Shipped iOS 3.2 renders no DJ handle at the top of the playlist screen, and never could: the legacy `GET /playlists/recentEntries?v=2` envelope carries no on-air signal at all. #2103 enriched this endpoint's per-playcut fields; the on-air signal is a top-level sibling of `playcuts` and was out of that ticket's scope. This adds it.

Closes #2105

## The wire shape is Swift's synthesized enum encoding

3.2's `OnAir` is `enum OnAir { case dj(String); case automation; case unknown }` with **no custom `init(from:)`**, so it decodes via Swift's default synthesized `Codable`. Measured by executing the real encoder against the shipped enum rather than reasoning about what the JSON "should" look like:

```
JSONEncoder().encode(OnAir.dj("bill b"))  ->  {"dj":{"_0":"bill b"}}
JSONEncoder().encode(OnAir.automation)    ->  {"automation":{}}
```

`_0` is the synthesized label Swift gives an unlabeled single associated value. It is ugly, and it is the literal contract of a binary that cannot be changed. The three states map as: a name → `{"dj":{"_0":name}}`; `null` (confirmed automation) → `{"automation":{}}`; resolver failed → the key is **omitted entirely**.

Two shapes that look right and are not:

- The wire key is camelCase `onAir` here, not `/flowsheet`'s snake_case `on_air`. `{"onAir":{"dj_name":"bill b"}}` throws `DecodingError` out of `Playlist.init(from:)` and **blanks the entire playlist** — strictly worse than sending nothing. Same catastrophe class as #2103's `wireUrl`.
- `/flowsheet` signals automation with a JSON `null`. That does not translate — but not because it throws. `decodeIfPresent`'s default is `guard try contains(key) && !decodeNil(forKey: key) else { return nil }`, so `"onAir": null` falls through to `?? .unknown` and behaves identically to omitting the key: the banner hides instead of saying "Auto DJ". A *silent* wrong answer rather than a loud one, and therefore the likelier bug to ship unnoticed. Both failure modes are pinned in the cross-repo decode tests so the reason for the odd `_0` shape lives in a test rather than a comment.

## Changes

`apps/backend/services/playlist-proxy.service.ts`:

- `WireOnAir` discriminated union + a single `encodeOnAir(name: string | null)` helper. The `_0` literal exists in exactly one place in the codebase — the type is the cheapest place to make the intuitive-but-fatal shape uncompilable.
- `onAir?: WireOnAir` added to `GroupedResponse` as the **last** key. `JSON.stringify` emits insertion order and the cross-repo golden pins the bytes, so placement is wire-visible.
- The name comes from `getOnAirDJName()`, not a reimplementation — it already encodes the precedence chain (`dj_name_override` → primary DJ's `user.djName` → `legacy_dj_name`), the `ANONYMOUS_ON_AIR_NAME` = `"WXYC"` fallback for handleless tubafrenzy sign-ons, and the deliberate avoidance of `show_djs`. Its `null`-means-automation invariant is preserved exactly.

Two details that are load-bearing rather than stylistic:

**The resolve is hoisted into the first wave, not the enrichment one.** `getOnAirDJName` has no dependency on the fetched rows, and it is itself two *sequential* queries while every member of the existing `Promise.all` (round trip 2 of 3) is single-shot — parking it there could make it that wave's critical path. Starting it concurrently with `fetchRecentRows(200)` hides it entirely behind the window query.

**`.catch(() => undefined)` is attached to that promise, not wrapped around the `Promise.all`.** `getRecentEntries` has no other try/catch: a rejection would propagate to `playlist.controller.ts`, which fail-softs to a **503 for the entire legacy mobile fleet**. The banner is auxiliary — an on-air query blip must cost the banner, not the playlist. A unit test pins this.

`v=1` (`getRecentEntriesFlat`, Android's contract) is untouched, asserted by test.

## Freshness, documented in code

`Cache-Control: public, max-age=30` covers the whole envelope, so the banner can lag a sign-on by up to 30s at any intermediary, on top of the client's poll interval. Accepted as a documented tradeoff. Related: `X-Last-Modified` for `v=2` is computed from the *served* payload, and `show_start`/`show_end` rows are dropped by `classifyEntryType` — so a sign-on with no playcut yet does not move the header. It is not a valid change-detector for on-air. Both are now comments where a future reader will hit them.

## Testing

- 7 new tests in `playlist-proxy.service.test.ts`: all three states, key-omitted-on-reject, still-resolves-200-on-reject, last-key ordering, first-wave concurrency, v=1 non-participation.
- 4 new tests in `playlist-proxy-wire-golden.test.ts`; golden regenerated. New `GOLDEN_SHA256` is `46a1064409f65356e076390bd209c198d0a8748ccb23bd51b5fb7ae1409c8f70`.
- `getOnAirDJName` is **explicitly mocked** in both suites. They mock `@wxyc/database` only, and that mock's query-builder chain resolves solely on terminal `.returning()` / `.execute()`; `getNShows`'s `.select().from().orderBy().offset().limit()` has none, so an unmocked call would hand back the mock chain object and the golden would silently pin garbage — defeating its entire purpose for this field.

Local: `typecheck` clean, `lint` 0 errors, `format:check` clean, `test:unit` 7099/7099 across 428 suites.

## Cross-repo

The golden is checked into both repos and both assert the hash, so a serializer change fails here first. The iOS side is WXYC/wxyc-ios-64#911: refreshed fixture, updated `goldenSHA256`, and decode tests asserting `.dj("<name>")` / `.automation` / `.unknown` against the shipped `v3.2-AppStoreSubmission4` types, a v3.1 regression (`cc123fe1`) confirming the key is ignored, and both counterfactuals.

Not covered here: the TTFB re-measurement through `wxyc.info` needs production traffic.
