### PR TITLE
Relicense to PolyForm Noncommercial 1.0.0

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,32 @@
+# Commercial Licensing
+
+This software is released under the [PolyForm Noncommercial License 1.0.0](./LICENSE). Commercial licenses are available separately.
+
+## You do not need a commercial license
+
+The public license already permits, free of charge and without asking us:
+
+- **Educational institutions** — universities, colleges, schools, and their departments
+- **Charitable organizations and nonprofits**, including other college and community radio stations
+- **Public research organizations** and **government institutions**
+- **Personal use** — study, research, experiment, hobby projects, and private entertainment
+
+The license grants this "regardless of the source of funding or obligations resulting from the funding," so grant-funded and university-funded work is covered. If you are a student station wanting to run your own flowsheet on this, you are already licensed. Go ahead.
+
+## You need a commercial license
+
+If you want to use this software for a commercial purpose — including selling it, selling a service built on it, or using it internally at a for-profit company — contact us and we will work out terms.
+
+**Contact:** legal@wxyc.org
+
+Please include:
+
+- Your organization
+- Which repositories you're interested in
+- A short description of the intended use
+
+We are a student-run radio station, not a software vendor, and we are reasonable to deal with.
+
+## Attribution
+
+Whether or not you need a commercial license, the public license requires that anyone you pass the software to also receives the license text and the `Required Notice:` lines at the bottom of [LICENSE](./LICENSE). Keep them intact.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,80 @@
-MIT License
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2023 WXYC
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+## Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+---
+
+Required Notice: Copyright WXYC 89.3 FM (https://wxyc.org)
+Required Notice: Source: https://github.com/WXYC/Backend-Service
+
+Commercial licenses are available. See COMMERCIAL.md.

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "author": "Jackson Meade",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/authentication": "^1.0.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "author": "AyBruno",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.1106.0",
     "@sentry/node": "^10.69.0",

--- a/apps/enrichment-worker/package.json
+++ b/apps/enrichment-worker/package.json
@@ -12,7 +12,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/dev_env/mock-api-server/package.json
+++ b/dev_env/mock-api-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wxyc-mock-api-server",
   "version": "1.0.0",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Mock API server for CI integration tests (LML, Slack, tubafrenzy)",
   "type": "module",
   "main": "dist/server.js",

--- a/jobs/album-critic-reviews-etl/package.json
+++ b/jobs/album-critic-reviews-etl/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_album_critic_reviews_etl:ci -f ../../Dockerfile.album-critic-reviews-etl ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.116.0",
     "@sentry/node": "^10.69.0",

--- a/jobs/album-level-backfill/package.json
+++ b/jobs/album-level-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_album_level_backfill:ci -f ../../Dockerfile.album-level-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/album-metadata-backfill/package.json
+++ b/jobs/album-metadata-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_album_metadata_backfill:ci -f ../../Dockerfile.album-metadata-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/album-reviews-etl/package.json
+++ b/jobs/album-reviews-etl/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_album_reviews_etl:ci -f ../../Dockerfile.album-reviews-etl ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/apple-music-url-backfill/package.json
+++ b/jobs/apple-music-url-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_apple_music_url_backfill:ci -f ../../Dockerfile.apple-music-url-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/artist-identity-etl/package.json
+++ b/jobs/artist-identity-etl/package.json
@@ -14,7 +14,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0",
     "postgres": "^3.4.9"

--- a/jobs/artist-search-alias-consumer/package.json
+++ b/jobs/artist-search-alias-consumer/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_artist_search_alias_consumer:ci -f ../../Dockerfile.artist-search-alias-consumer ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/artist-unicode-dedup/package.json
+++ b/jobs/artist-unicode-dedup/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_artist_unicode_dedup:ci -f ../../Dockerfile.artist-unicode-dedup ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/broken-fk-recovery/package.json
+++ b/jobs/broken-fk-recovery/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_broken_fk_recovery:ci -f ../../Dockerfile.broken-fk-recovery ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/catalog-popularity-freetext-resolve/package.json
+++ b/jobs/catalog-popularity-freetext-resolve/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_catalog_popularity_freetext_resolve:ci -f ../../Dockerfile.catalog-popularity-freetext-resolve ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/concerts-artist-lml-resolver/package.json
+++ b/jobs/concerts-artist-lml-resolver/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_concerts_artist_lml_resolver:ci -f ../../Dockerfile.concerts-artist-lml-resolver ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/concerts-artist-resolver/package.json
+++ b/jobs/concerts-artist-resolver/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_concerts_artist_resolver:ci -f ../../Dockerfile.concerts-artist-resolver ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/concerts-genre-enrichment/package.json
+++ b/jobs/concerts-genre-enrichment/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_concerts_genre_enrichment:ci -f ../../Dockerfile.concerts-genre-enrichment ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/concerts-poster-enrichment/package.json
+++ b/jobs/concerts-poster-enrichment/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_concerts_poster_enrichment:ci -f ../../Dockerfile.concerts-poster-enrichment ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/concerts-similar-artists-enrichment/package.json
+++ b/jobs/concerts-similar-artists-enrichment/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_concerts_similar_artists_enrichment:ci -f ../../Dockerfile.concerts-similar-artists-enrichment ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/flowsheet-artwork-repair/package.json
+++ b/jobs/flowsheet-artwork-repair/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_artwork_repair:ci -f ../../Dockerfile.flowsheet-artwork-repair ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/flowsheet-dj-name-backfill/package.json
+++ b/jobs/flowsheet-dj-name-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_dj_name_backfill:ci -f ../../Dockerfile.flowsheet-dj-name-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/flowsheet-etl/package.json
+++ b/jobs/flowsheet-etl/package.json
@@ -13,7 +13,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_etl:ci -f ../../Dockerfile.flowsheet-etl ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/flowsheet-ghost-row-sweep/package.json
+++ b/jobs/flowsheet-ghost-row-sweep/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_ghost_row_sweep:ci -f ../../Dockerfile.flowsheet-ghost-row-sweep ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/flowsheet-linkage-audit-backfill/package.json
+++ b/jobs/flowsheet-linkage-audit-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_linkage_audit_backfill:ci -f ../../Dockerfile.flowsheet-linkage-audit-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/flowsheet-linked-reenrichment/package.json
+++ b/jobs/flowsheet-linked-reenrichment/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_linked_reenrichment:ci -f ../../Dockerfile.flowsheet-linked-reenrichment ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/flowsheet-metadata-backfill/package.json
+++ b/jobs/flowsheet-metadata-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_metadata_backfill:ci -f ../../Dockerfile.flowsheet-metadata-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/flowsheet-reenrichment/package.json
+++ b/jobs/flowsheet-reenrichment/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_flowsheet_reenrichment:ci -f ../../Dockerfile.flowsheet-reenrichment ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/legacy-dj-name-remediation/package.json
+++ b/jobs/legacy-dj-name-remediation/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_legacy_dj_name_remediation:ci -f ../../Dockerfile.legacy-dj-name-remediation ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/legacy-linkage-resolve/package.json
+++ b/jobs/legacy-linkage-resolve/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_legacy_linkage_resolve:ci -f ../../Dockerfile.legacy-linkage-resolve ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/legacy-mirror-reconcile/package.json
+++ b/jobs/legacy-mirror-reconcile/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_legacy_mirror_reconcile:ci -f ../../Dockerfile.legacy-mirror-reconcile ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/library-artist-name-backfill/package.json
+++ b/jobs/library-artist-name-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_artist_name_backfill:ci -f ../../Dockerfile.library-artist-name-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/library-artwork-url-backfill/package.json
+++ b/jobs/library-artwork-url-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_artwork_url_backfill:ci -f ../../Dockerfile.library-artwork-url-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/library-call-number-dedup/package.json
+++ b/jobs/library-call-number-dedup/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_call_number_dedup:ci -f ../../Dockerfile.library-call-number-dedup ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/library-canonical-entity-backfill/package.json
+++ b/jobs/library-canonical-entity-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_canonical_entity_backfill:ci -f ../../Dockerfile.library-canonical-entity-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0"

--- a/jobs/library-discogs-unavailable-recheck/package.json
+++ b/jobs/library-discogs-unavailable-recheck/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_discogs_unavailable_recheck:ci -f ../../Dockerfile.library-discogs-unavailable-recheck ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/library-etl/package.json
+++ b/jobs/library-etl/package.json
@@ -13,7 +13,7 @@
     "dev": "tsup --watch"
   },
   "author": "Adrian Bruno",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/library-identity-consumer/package.json
+++ b/jobs/library-identity-consumer/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_library_identity_consumer:ci -f ../../Dockerfile.library-identity-consumer ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/metadata-no-match-digest/package.json
+++ b/jobs/metadata-no-match-digest/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_metadata_no_match_digest:ci -f ../../Dockerfile.metadata-no-match-digest ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1106.0",
     "@sentry/node": "^10.69.0",

--- a/jobs/rotation-artist-backfill/package.json
+++ b/jobs/rotation-artist-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_rotation_artist_backfill:ci -f ../../Dockerfile.rotation-artist-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/rotation-etl/package.json
+++ b/jobs/rotation-etl/package.json
@@ -13,7 +13,7 @@
     "docker:build": "docker build -t wxyc_rotation_etl:ci -f ../../Dockerfile.rotation-etl ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@wxyc/database": "^1.0.0"
   },

--- a/jobs/rotation-lml-identity-backfill/package.json
+++ b/jobs/rotation-lml-identity-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_rotation_lml_identity_backfill:ci -f ../../Dockerfile.rotation-lml-identity-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/rotation-release-id-backfill/package.json
+++ b/jobs/rotation-release-id-backfill/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_rotation_release_id_backfill:ci -f ../../Dockerfile.rotation-release-id-backfill ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/rotation-release-id-pollution-check/package.json
+++ b/jobs/rotation-release-id-pollution-check/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@wxyc/rotation-release-id-pollution-check",
   "version": "1.0.0",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,
   "description": "Weekly recurring rotation release-id pollution check (BS#1522): re-runs the #1517 audit scoring against prod and alerts per-rotation_id on mismatch + provenance anomalies",
   "job-type": "cron",

--- a/jobs/streaming-url-remediation/package.json
+++ b/jobs/streaming-url-remediation/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_streaming_url_remediation:ci -f ../../Dockerfile.streaming-url-remediation ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/streaming-url-upgrade/package.json
+++ b/jobs/streaming-url-upgrade/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_streaming_url_upgrade:ci -f ../../Dockerfile.streaming-url-upgrade ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/triangle-shows-etl/package.json
+++ b/jobs/triangle-shows-etl/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_triangle_shows_etl:ci -f ../../Dockerfile.triangle-shows-etl ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/jobs/va-apple-music-url-remediation/package.json
+++ b/jobs/va-apple-music-url-remediation/package.json
@@ -13,7 +13,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",

--- a/jobs/venue-events-scraper/package.json
+++ b/jobs/venue-events-scraper/package.json
@@ -12,7 +12,7 @@
     "docker:build": "docker build -t wxyc_venue_events_scraper:ci -f ../../Dockerfile.venue-events-scraper ../../",
     "dev": "tsup --watch"
   },
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@wxyc/backend-services",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "workspaces": [
         "apps/*",
         "jobs/*",
@@ -61,7 +61,7 @@
     "apps/auth": {
       "name": "@wxyc/auth-service",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/authentication": "^1.0.0",
@@ -100,7 +100,7 @@
     "apps/backend": {
       "name": "@wxyc/backend",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.1106.0",
         "@sentry/node": "^10.69.0",
@@ -163,7 +163,7 @@
     "apps/enrichment-worker": {
       "name": "@wxyc/enrichment-worker",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -181,7 +181,7 @@
     "jobs/album-critic-reviews-etl": {
       "name": "@wxyc/album-critic-reviews-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.116.0",
         "@sentry/node": "^10.69.0",
@@ -197,7 +197,7 @@
     "jobs/album-level-backfill": {
       "name": "@wxyc/album-level-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -214,7 +214,7 @@
     "jobs/album-metadata-backfill": {
       "name": "@wxyc/album-metadata-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -228,7 +228,7 @@
     "jobs/album-reviews-etl": {
       "name": "@wxyc/album-reviews-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -244,7 +244,7 @@
     "jobs/apple-music-url-backfill": {
       "name": "@wxyc/apple-music-url-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -260,7 +260,7 @@
     "jobs/artist-identity-etl": {
       "name": "@wxyc/artist-identity-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0",
         "postgres": "^3.4.9"
@@ -275,7 +275,7 @@
     "jobs/artist-search-alias-consumer": {
       "name": "@wxyc/artist-search-alias-consumer",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -290,7 +290,7 @@
     "jobs/artist-unicode-dedup": {
       "name": "@wxyc/artist-unicode-dedup",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -304,7 +304,7 @@
     "jobs/broken-fk-recovery": {
       "name": "@wxyc/broken-fk-recovery",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -318,7 +318,7 @@
     "jobs/catalog-popularity-freetext-resolve": {
       "name": "@wxyc/catalog-popularity-freetext-resolve",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -334,7 +334,7 @@
     "jobs/concerts-artist-lml-resolver": {
       "name": "@wxyc/concerts-artist-lml-resolver",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -350,7 +350,7 @@
     "jobs/concerts-artist-resolver": {
       "name": "@wxyc/concerts-artist-resolver",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -365,7 +365,7 @@
     "jobs/concerts-genre-enrichment": {
       "name": "@wxyc/concerts-genre-enrichment",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -381,7 +381,7 @@
     "jobs/concerts-poster-enrichment": {
       "name": "@wxyc/concerts-poster-enrichment",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -397,7 +397,7 @@
     "jobs/concerts-similar-artists-enrichment": {
       "name": "@wxyc/concerts-similar-artists-enrichment",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -412,7 +412,7 @@
     "jobs/flowsheet-artwork-repair": {
       "name": "@wxyc/flowsheet-artwork-repair",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -429,7 +429,7 @@
     "jobs/flowsheet-dj-name-backfill": {
       "name": "@wxyc/flowsheet-dj-name-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -443,7 +443,7 @@
     "jobs/flowsheet-etl": {
       "name": "@wxyc/flowsheet-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -458,7 +458,7 @@
     "jobs/flowsheet-ghost-row-sweep": {
       "name": "@wxyc/flowsheet-ghost-row-sweep",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -473,7 +473,7 @@
     "jobs/flowsheet-linkage-audit-backfill": {
       "name": "@wxyc/flowsheet-linkage-audit-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -487,7 +487,7 @@
     "jobs/flowsheet-linked-reenrichment": {
       "name": "@wxyc/flowsheet-linked-reenrichment",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -504,7 +504,7 @@
     "jobs/flowsheet-metadata-backfill": {
       "name": "@wxyc/flowsheet-metadata-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -521,7 +521,7 @@
     "jobs/flowsheet-reenrichment": {
       "name": "@wxyc/flowsheet-reenrichment",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -538,7 +538,7 @@
     "jobs/legacy-dj-name-remediation": {
       "name": "@wxyc/legacy-dj-name-remediation",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -552,7 +552,7 @@
     "jobs/legacy-linkage-resolve": {
       "name": "@wxyc/legacy-linkage-resolve",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -567,7 +567,7 @@
     "jobs/legacy-mirror-reconcile": {
       "name": "@wxyc/legacy-mirror-reconcile",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -584,7 +584,7 @@
     "jobs/library-artist-name-backfill": {
       "name": "@wxyc/library-artist-name-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -598,7 +598,7 @@
     "jobs/library-artwork-url-backfill": {
       "name": "@wxyc/library-artwork-url-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -615,7 +615,7 @@
     "jobs/library-call-number-dedup": {
       "name": "@wxyc/library-call-number-dedup",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -629,7 +629,7 @@
     "jobs/library-canonical-entity-backfill": {
       "name": "@wxyc/library-canonical-entity-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0"
@@ -644,7 +644,7 @@
     "jobs/library-discogs-unavailable-recheck": {
       "name": "@wxyc/library-discogs-unavailable-recheck",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -660,7 +660,7 @@
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -674,7 +674,7 @@
     "jobs/library-identity-consumer": {
       "name": "@wxyc/library-identity-consumer",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -689,7 +689,7 @@
     "jobs/metadata-no-match-digest": {
       "name": "@wxyc/metadata-no-match-digest",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1106.0",
         "@sentry/node": "^10.69.0",
@@ -705,7 +705,7 @@
     "jobs/rotation-artist-backfill": {
       "name": "@wxyc/rotation-artist-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -721,7 +721,7 @@
     "jobs/rotation-etl": {
       "name": "@wxyc/rotation-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/database": "^1.0.0"
       },
@@ -735,7 +735,7 @@
     "jobs/rotation-lml-identity-backfill": {
       "name": "@wxyc/rotation-lml-identity-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -751,7 +751,7 @@
     "jobs/rotation-release-id-backfill": {
       "name": "@wxyc/rotation-release-id-backfill",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -766,12 +766,13 @@
     },
     "jobs/rotation-release-id-pollution-check": {
       "name": "@wxyc/rotation-release-id-pollution-check",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "PolyForm-Noncommercial-1.0.0"
     },
     "jobs/streaming-url-remediation": {
       "name": "@wxyc/streaming-url-remediation",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -787,7 +788,7 @@
     "jobs/streaming-url-upgrade": {
       "name": "@wxyc/streaming-url-upgrade",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -803,7 +804,7 @@
     "jobs/triangle-shows-etl": {
       "name": "@wxyc/triangle-shows-etl",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -818,7 +819,7 @@
     "jobs/va-apple-music-url-remediation": {
       "name": "@wxyc/va-apple-music-url-remediation",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
@@ -834,7 +835,7 @@
     "jobs/venue-events-scraper": {
       "name": "@wxyc/venue-events-scraper",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -14658,7 +14659,7 @@
     "shared/authentication": {
       "name": "@wxyc/authentication",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1106.0",
         "@sentry/node": "^10.69.0",
@@ -14677,7 +14678,7 @@
     "shared/database": {
       "name": "@wxyc/database",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "node-ssh": "^13.2.1",
@@ -14691,7 +14692,7 @@
     "shared/legacy-mirror": {
       "name": "@wxyc/legacy-mirror",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0"
@@ -14707,7 +14708,7 @@
     "shared/lml-client": {
       "name": "@wxyc/lml-client",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
         "@wxyc/shared": "^3.3.0"
@@ -14720,7 +14721,7 @@
     "shared/metadata": {
       "name": "@wxyc/metadata",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@wxyc/lml-client": "^1.0.0"
       },
@@ -14732,7 +14733,7 @@
     "shared/observability": {
       "name": "@wxyc/observability",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/core": "^10.69.0",
         "@sentry/node": "^10.69.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prepare": "husky || true"
   },
   "author": "AyBruno",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "workspaces": [
     "apps/*",
     "jobs/*",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Types and Middleware for Authentication in WXYC Services",
   "author": "Jackson Meade",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/shared/database/package.json
+++ b/shared/database/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Database Types and Drizzle Integration for DTOs on the WXYC Flowsheet backend",
   "author": "AyBruno",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/shared/legacy-mirror/package.json
+++ b/shared/legacy-mirror/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Shared tubafrenzy legacy-mirror client: HTTP show/entry create + map helpers and the rotation-match probe. One source of truth for the mirror payload shape, consumed by the Express app's live mirror middleware and the jobs/legacy-mirror-reconcile cron (BS#1707).",
   "author": "WXYC",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Shared HTTP client for the library-metadata-lookup (LML) service. One chokepoint for every WXYC backend caller (Express app + cron jobs).",
   "author": "WXYC",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/shared/metadata/package.json
+++ b/shared/metadata/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Deep module that normalizes LML lookup responses into a flat, snake_case metadata shape. Single source of truth for the helpers (filterSpacerGif, isSyntheticArtwork, cleanDiscogsBio, synthesizeSearchUrls) plus the composition (normalizeLookup). Consumed by apps/backend and the enrichment worker + 4 jobs that previously kept inline copies.",
   "author": "WXYC",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",

--- a/shared/observability/package.json
+++ b/shared/observability/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Shared Sentry transaction/span filter predicates (BS#2089). Single source of truth for dropping liveness-route transactions (/ok, /healthcheck) and Express middleware bookkeeping spans, consumed by apps/backend/instrument.ts and apps/auth/instrument.ts so both containers apply byte-identical filtering.",
   "author": "WXYC",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "exports": {
     ".": {
       "source": "./src/index.ts",


### PR DESCRIPTION
Adds the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0) (SPDX `PolyForm-Noncommercial-1.0.0`) as part of the org-wide relicensing. Wave 1 — the 17 repos with a sole copyright holder — landed first; this repo is in the wave that has outside contributors.

### What stays free

Named as permitted purposes in the license itself, with no need to ask:

- Personal study, research, experiment, hobby projects, private entertainment
- Educational institutions
- Charitable organizations and nonprofits — including other college and community radio stations
- Public research organizations, public safety and health organizations, and government institutions

The license grants this "regardless of the source of funding or obligations resulting from the funding," so grant- and university-funded use is covered.

### What changes

Commercial use requires a separate agreement. See `COMMERCIAL.md`.

### Attribution

The `Required Notice:` lines at the bottom of `LICENSE` must be passed along to anyone who receives any part of the software, which makes attribution a license condition rather than a convention.

### Prior releases

Prospective only. Versions already published under the previous license remain under it permanently, and existing copies keep the rights they were given.

### Notes for review

- The license body above the `---` is upstream PolyForm text, verbatim. Only the trailing notice block is repo-specific.
- PolyForm Noncommercial is source-available, not OSI-approved — deliberately so, since OSI approval requires permitting commercial use.

### Mechanical notes

All 53 workspace manifests move together, and `package-lock.json` is regenerated alongside them — npm records each local workspace's `license` in the lockfile, so changing the manifests alone would leave it stale. The regeneration touches license lines only; no dependency resolution changed.
