### PR TITLE
fix(library): repair the 11 residual U+FFFD mojibake rows from #863

### DIFF
--- a/scripts/audit/bs_replacement_char_phase4.sql
+++ b/scripts/audit/bs_replacement_char_phase4.sql
@@ -1,0 +1,227 @@
+-- V_BS_FFFD_P4: Phase 4 lossy-recovery U+FFFD mojibake migration for #2114.
+--
+-- Hand-applied operator script, NOT a Drizzle-tracked migration -- same
+-- posture as scripts/audit/bs_replacement_char_recovery.sql (Phase 1/2) and
+-- scripts/audit/bs_replacement_char_phase35.sql (Phase 3.5). docs/migrations.md
+-- calls migrations DDL-only; this is DML, so it lives here and is run via
+-- `psql -f` against prod RDS, the same as its two predecessors.
+--
+-- This is RESIDUE from the #863 recovery, surfaced by the first full run of
+-- the discogs-etl catalog-parity harness (discogs-etl#365) on 2026-08-12
+-- (WXYC/wiki#89). #863 proposed repairs by fuzzy-matching against
+-- LML/discogs-cache/mb-cache at >=0.80 confidence with human review; these
+-- 11 rows never cleared that gate ("mu-Ziq [mu-Ziq]" is an awkward fuzzy
+-- target). The parity harness instead reads the correct value straight out
+-- of tubafrenzy MySQL (dc1-mysql-01.kattare.com, database wxycmusic), so
+-- this is a direct substitution -- no matching step, no judgement call.
+--
+-- Only 2 distinct correct strings are involved, across 11 catalog rows
+-- (`legacy_release_id`, i.e. the tubafrenzy `LIBRARY_RELEASE.ID`):
+--
+--   1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776
+--     artist, corrupt:  <U+FFFD>-Ziq [mu-Ziq]
+--     artist, correct:  µ-Ziq [mu-Ziq]              (U+00B5 MICRO SIGN)
+--     tubafrenzy source: LIBRARY_CODE.ID=956 (CALL_LETTERS='Mu', CALL_NUMBERS=3)
+--
+--   50340
+--     title,  corrupt:  La B<U+FFFD>te
+--     title,  correct:  La Bête                     (U+00EA E WITH CIRCUMFLEX)
+--     tubafrenzy source: LIBRARY_RELEASE.ID=50340 (The Cripple Lillies, CR/140)
+--
+-- All ten µ-Ziq releases share ONE tubafrenzy LIBRARY_CODE, i.e. one Backend
+-- `artists` row. `artists.artist_name` is the source of truth for the
+-- denormalized `library.artist_name` copy: migration 0060's
+-- `cascade_library_artist_name` trigger fires `AFTER UPDATE OF artist_name
+-- ON wxyc_schema.artists` and pushes the new value onto every
+-- `library` row with a matching `artist_id`. So the first UPDATE below
+-- targets `artists.artist_name` directly and lets the trigger do the
+-- `library.artist_name` write for us. The second UPDATE re-targets
+-- `library.artist_name` directly, scoped to exactly the 10 catalog ids named
+-- in BS#2114, matched on (still-corrupt value AND legacy_release_id) -- a
+-- self-correcting no-op once the trigger has already fixed a row, and a
+-- safety net for any of the 10 rows whose `artist_id` linkage doesn't hold
+-- for some unrelated reason. Neither UPDATE fights the trigger: the trigger
+-- only fires on `artists` writes, and its own guard
+-- (`artist_name IS DISTINCT FROM NEW.artist_name`) makes it inert once the
+-- value already matches.
+--
+-- `artists.alphabetical_name` is deliberately NOT touched. Backend's
+-- `alphabetical_name` is sourced 1:1 from tubafrenzy's
+-- `LIBRARY_CODE.ALPHABETICAL_NAME` (see `toAlphabeticalName` in
+-- jobs/library-etl/job.ts). For LIBRARY_CODE.ID=956 that value is the plain-
+-- ASCII string `mu-Ziq` -- no non-ASCII byte to have been lossily replaced
+-- in the first place, so it cannot carry this corruption class. It is still
+-- included in the audit predicates below, per BS#2114's ask to check it, so
+-- a future reader can see that it was looked at and came back clean rather
+-- than simply omitted.
+--
+-- No live prod Backend database was available while writing this script, but
+-- dev_env/seed-clone.sql (a pg_dump --data-only snapshot derived from
+-- staging, which itself clones prod -- ~64,193 library rows) was loaded into
+-- the local dev Postgres and gave a real, if possibly-stale, measurement.
+-- Pre-amble counts measured against THAT CLONE on 2026-08-12, not live prod:
+--   artists.artist_name = '<U+FFFD>-Ziq [mu-Ziq]'                    -> 1 row  (id 656)
+--   library.artist_name = '<U+FFFD>-Ziq [mu-Ziq]' (10 named ids)     -> 10 rows
+--   library.album_title = 'La B<U+FFFD>te' (id 50340)                -> 1 row
+-- Running this script end-to-end against that clone (twice, to prove
+-- idempotency) drove all three counts to 0 and left every one of the 11
+-- targeted rows holding the tubafrenzy-verified correct value, with zero
+-- change to any other row. BS#2114 acceptance criterion 1 asks for the row
+-- count + affected ids to be recorded in the migration or its PR
+-- description: **the operator running this against live prod should paste
+-- the actual pre-amble output into the PR description**, since the clone can
+-- be somewhat stale relative to live prod (e.g. a very recent librarian edit
+-- wouldn't be reflected yet) -- treat the counts above as "true of the clone
+-- on 2026-08-12", not as a guarantee of what prod holds today.
+--
+-- The same clone surfaced two count mismatches worth recording rather than
+-- silently folding into this fix, both OUT OF SCOPE for BS#2114 (no
+-- tubafrenzy ground truth was pulled for them, and the ticket names exactly
+-- 11 rows):
+--   - `artists.artist_name` LIKE E'%�%' returned 3 in the clone, not 1:
+--     alongside the µ-Ziq row, `Beyonc<U+FFFD>` (id 22025) and
+--     `Damian Nisenson / Jean F<U+FFFD>lix Mailloux / Pierre Tanguay` (id
+--     23162) are also still corrupt. The #863 recovery
+--     (bs_replacement_char_recovery.sql) fixed both of those names on
+--     `library.artist_name` only -- it never touched the `artists` source of
+--     truth, so those two rows are a standing hazard: if `artists.artist_name`
+--     is ever written again for either row for an unrelated reason, migration
+--     0060's cascade trigger will push the still-corrupt value back onto
+--     every linked `library` row and silently UNDO the #863 fix. Worth its
+--     own follow-up ticket.
+--   - The rotation/flowsheet re-check the next section runs (BS#2114
+--     acceptance criterion 5) found 5 rows in the clone, all pre-existing
+--     residue from #863 Phase 3.5's deliberately-unrecovered bucket (no
+--     canonical was identifiable at the time): `rotation` ids 10789
+--     (Justice, album_title mangled to 3 replacement chars), 13703
+--     (`Acc<U+FFFD>sed`), 21149 (`N<U+FFFD>dia & Valentina`), 21335
+--     (`Civilistj<U+FFFD>vel! & Mayssa Jallad`), and 16683 (artist_name
+--     already fixed to "Amara Toure", but album_title still reads
+--     `Amare Tour<U+FFFD> 1973-1980` -- the #863 fix only matched the exact
+--     artist_name value, not this separate album_title occurrence). None of
+--     the 5 map to a `legacy_release_id` this ticket names.
+--
+-- Design is self-correcting / idempotent by construction: every UPDATE's
+-- WHERE clause matches on the corrupt value AND (for `library`) the specific
+-- `legacy_release_id`, so a row already fixed no longer matches and a
+-- re-run is a genuine no-op -- verified for real against the clone above,
+-- not just asserted; the post-amble re-verifies it on every run.
+--
+-- Not round-trippable: same posture as Phase 1/2/3.5. `ef bf bd` is the
+-- UTF-8 encoding of U+FFFD itself; the original byte was already destroyed
+-- upstream. This script substitutes the tubafrenzy-verified exact original,
+-- not a fuzzy/plausible reconstruction.
+--
+-- BS#2114 also asks to re-check wxyc_schema.rotation and wxyc_schema.flowsheet
+-- with the same U+FFFD predicate #863 used (this ticket only measured the
+-- catalog export, i.e. wxyc_schema.library). That predicate is included
+-- below as an INFORMATIONAL, non-fixing audit -- this script has no
+-- tubafrenzy-verified correct values for whatever it might find there. A
+-- non-zero count in that section needs either a follow-up ticket naming the
+-- counts, or a future phase of this same script family once ground truth is
+-- established.
+
+-- ===========================================================
+-- Pre-amble: targeted rows + their BEFORE counts (1 / 10 / 1 against the
+-- 2026-08-12 dev clone, see header -- re-run this against prod to get the
+-- real prod counts before COMMIT).
+-- ===========================================================
+SELECT '=== V_BS_FFFD_P4 pre-amble: rows targeted per (table, column) ===' AS section;
+
+SELECT 'artists' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.artists WHERE artist_name = '�-Ziq [mu-Ziq]') AS rows
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE legacy_release_id IN (1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776) AND artist_name = '�-Ziq [mu-Ziq]') AS rows
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'La B�te' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE legacy_release_id = 50340 AND album_title = 'La B�te') AS rows;
+
+-- Per-id detail so the 10 catalog ids named in BS#2114's table are visible
+-- individually, not just as an aggregate -- acceptance criterion 1.
+SELECT 'BEFORE — targeted catalog ids and current values' AS section;
+SELECT legacy_release_id, artist_name, album_title
+  FROM wxyc_schema.library
+ WHERE legacy_release_id IN (1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 50340, 63110, 69776)
+ ORDER BY legacy_release_id;
+
+-- ===========================================================
+-- Transactional UPDATE block.
+-- ===========================================================
+BEGIN;
+SET LOCAL statement_timeout = '30s';
+
+-- Source-of-truth fix: cascades to `library.artist_name` for every row with
+-- a matching `artist_id` via the 0060 trigger.
+UPDATE wxyc_schema.artists
+   SET artist_name = 'µ-Ziq [mu-Ziq]'
+ WHERE artist_name = '�-Ziq [mu-Ziq]';
+
+-- Self-correcting safety net for the 10 named catalog ids -- a no-op
+-- wherever the trigger above already fixed the row.
+UPDATE wxyc_schema.library
+   SET artist_name = 'µ-Ziq [mu-Ziq]'
+ WHERE legacy_release_id IN (1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776)
+   AND artist_name = '�-Ziq [mu-Ziq]';
+
+UPDATE wxyc_schema.library
+   SET album_title = 'La Bête'
+ WHERE legacy_release_id = 50340
+   AND album_title = 'La B�te';
+
+COMMIT;
+
+-- ===========================================================
+-- Post-amble verify: every targeted tuple should show residual=0.
+-- ===========================================================
+SELECT '=== V_BS_FFFD_P4 post-amble: residual count per row (expect 0) ===' AS section;
+
+SELECT 'artists' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.artists WHERE artist_name = '�-Ziq [mu-Ziq]') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE legacy_release_id IN (1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776) AND artist_name = '�-Ziq [mu-Ziq]') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'La B�te' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE legacy_release_id = 50340 AND album_title = 'La B�te') AS residual
+ORDER BY residual DESC, tbl, col;
+
+SELECT 'AFTER — targeted catalog ids and current values' AS section;
+SELECT legacy_release_id, artist_name, album_title
+  FROM wxyc_schema.library
+ WHERE legacy_release_id IN (1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 50340, 63110, 69776)
+ ORDER BY legacy_release_id;
+
+-- Desired end state per BS#2114: this returns 0 for wxyc_schema.library.
+SELECT 'AFTER — overall residual U+FFFD, wxyc_schema.library (desired end state: 0)' AS section;
+SELECT (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name LIKE E'%�%' OR album_title LIKE E'%�%') AS remaining;
+
+-- BS#2114 acceptance criterion 5: re-check rotation + flowsheet with the
+-- same predicate #863 used. INFORMATIONAL ONLY -- this script fixes nothing
+-- here, it only reports. A non-zero count needs a follow-up ticket (name the
+-- counts) or a future phase once ground truth for those rows is available.
+-- `artists.alphabetical_name` is included per the "check it" ask above; see
+-- the header comment for why it's expected to stay at 0 structurally.
+SELECT 'AFTER — informational residual U+FFFD, other tables/columns (not fixed by this script)' AS section;
+SELECT 'artists' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.artists WHERE artist_name LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'artists' AS tbl, 'alphabetical_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.artists WHERE alphabetical_name LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'library' AS tbl, 'label' AS col, (SELECT COUNT(*) FROM wxyc_schema.library WHERE label LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'rotation' AS tbl, 'record_label' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE record_label LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'record_label' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label LIKE E'%�%') AS remaining
+ORDER BY remaining DESC;
+
+-- Refresh planner stats on every UPDATEd table (BS#934). ANALYZE cannot run
+-- inside a transaction, so it lives here, outside any BEGIN/COMMIT. Only
+-- `artists` and `library` are UPDATEd by this script -- `rotation` and
+-- `flowsheet` above are read-only audits, not writes, so they don't need it.
+-- See docs/bulk-update-playbook.md for the full pattern.
+ANALYZE wxyc_schema.artists;
+ANALYZE wxyc_schema.library;

--- a/scripts/audit/bs_replacement_char_phase4.sql
+++ b/scripts/audit/bs_replacement_char_phase4.sql
@@ -81,14 +81,24 @@
 --   - `artists.artist_name` LIKE E'%�%' returned 3 in the clone, not 1:
 --     alongside the µ-Ziq row, `Beyonc<U+FFFD>` (id 22025) and
 --     `Damian Nisenson / Jean F<U+FFFD>lix Mailloux / Pierre Tanguay` (id
---     23162) are also still corrupt. The #863 recovery
---     (bs_replacement_char_recovery.sql) fixed both of those names on
---     `library.artist_name` only -- it never touched the `artists` source of
---     truth, so those two rows are a standing hazard: if `artists.artist_name`
---     is ever written again for either row for an unrelated reason, migration
---     0060's cascade trigger will push the still-corrupt value back onto
---     every linked `library` row and silently UNDO the #863 fix. Worth its
---     own follow-up ticket.
+--     23162) are also still corrupt -- and id 22025's `alphabetical_name` is
+--     corrupt too (`Beyonc<U+FFFD>`), so it is 3 corrupt values across 2 rows,
+--     not 2. The #863 recovery (bs_replacement_char_recovery.sql, lines
+--     126-127) fixed both of those names on `library.artist_name` only -- it
+--     never touched the `artists` source of truth, so those two rows are a
+--     standing hazard: if `artists.artist_name` is ever written again for
+--     either row for an unrelated reason, migration 0060's cascade trigger
+--     will push the still-corrupt value back onto every linked `library` row
+--     and silently UNDO the #863 fix. (`alphabetical_name` has no cascade --
+--     0060 fires only on `artist_name` -- so that third value is inert, but
+--     it is still what sorts and displays.) Worth its own follow-up ticket,
+--     which INHERITS THIS TICKET'S 2026-08-31 DEADLINE: tubafrenzy is the
+--     ground truth for those `artists` rows as much as for these, and #863's
+--     values for them came from curated fuzzy matching, not from tubafrenzy.
+--     They are deliberately not folded in here because BS#2114 names exactly
+--     11 rows and this script's whole warrant is "direct substitution from
+--     tubafrenzy, no judgement call" -- repairing them would need their own
+--     ground-truth pull.
 --   - The rotation/flowsheet re-check the next section runs (BS#2114
 --     acceptance criterion 5) found 5 rows in the clone, all pre-existing
 --     residue from #863 Phase 3.5's deliberately-unrecovered bucket (no
@@ -96,10 +106,16 @@
 --     (Justice, album_title mangled to 3 replacement chars), 13703
 --     (`Acc<U+FFFD>sed`), 21149 (`N<U+FFFD>dia & Valentina`), 21335
 --     (`Civilistj<U+FFFD>vel! & Mayssa Jallad`), and 16683 (artist_name
---     already fixed to "Amara Toure", but album_title still reads
---     `Amare Tour<U+FFFD> 1973-1980` -- the #863 fix only matched the exact
---     artist_name value, not this separate album_title occurrence). None of
---     the 5 map to a `legacy_release_id` this ticket names.
+--     already fixed to "Amara Toure" by Phase 2, but album_title still reads
+--     `Amare Tour<U+FFFD> 1973-1980`). All five appear in
+--     audit/bs_replacement_char_phase35.csv with an EMPTY curated-canonical
+--     column, which is what "deliberately unrecovered" means there: the two
+--     rotation rows that DID get a curated value in that CSV (Midnight Zone,
+--     GER<U+FFFD>USCHMANUFAKTUR) are the two Phase 3.5 actually repaired.
+--     16683's album_title was not an oversight either -- it was curated and
+--     dropped, its auto-proposal ("Used Songs (1973-1980)", confidence 0.38)
+--     being plainly wrong. None of the 5 map to a `legacy_release_id` this
+--     ticket names.
 --
 -- Design is self-correcting / idempotent by construction: every UPDATE's
 -- WHERE clause matches on the corrupt value AND (for `library`) the specific
@@ -111,6 +127,38 @@
 -- UTF-8 encoding of U+FFFD itself; the original byte was already destroyed
 -- upstream. This script substitutes the tubafrenzy-verified exact original,
 -- not a fuzzy/plausible reconstruction.
+--
+-- Unicode normalization: DELIBERATELY NOT APPLIED, unlike Phase 2/3.5, which
+-- NFC-normalised and stripped zero-width chars before write. That step was
+-- right there and wrong here, because the provenance is different. Phase 2/3.5
+-- injected strings assembled by a matcher from LML/Discogs/MusicBrainz, which
+-- can arrive in arbitrary Unicode form; NFC gave those a canonical shape for
+-- Lucene/trgm tokenization. Phase 4's two strings are copied from tubafrenzy,
+-- and BS#2114's acceptance criterion is that the catalog-parity harness
+-- reports 0 mismatches -- and that harness compares BYTE-EXACT
+-- (scripts/catalog_parity_diff.py::_normalize strips surrounding whitespace
+-- and collapses NULL/''/'NULL', and explicitly applies "no case folding, no
+-- accent folding"). Normalizing on write would therefore be the one thing
+-- that could REINTRODUCE a parity mismatch, if tubafrenzy ever held a
+-- non-NFC form. It is moot for these two values in any case -- both are
+-- already NFC-stable and carry no zero-width characters:
+--   µ-Ziq [mu-Ziq]  = c2 b5 2d 5a 69 71 20 5b 6d 75 2d 5a 69 71 5d
+--   La Bête         = 4c 61 20 42 c3 aa 74 65
+-- Both byte sequences were read back out of a tubafrenzy-sourced library.db
+-- and match these literals exactly, for all 10 ids and for 50340.
+--
+-- The `µ` is U+00B5 MICRO SIGN (c2 b5), NOT U+03BC GREEK SMALL LETTER MU
+-- (ce bc). This distinction is load-bearing and easy to lose in an editor.
+-- NFC and NFD both leave U+00B5 alone (it has only a COMPATIBILITY
+-- decomposition), so every normalization this codebase actually performs is
+-- a no-op on it: `normalize(..., NFD)` inside migration 0134's
+-- `fold_artist_name`, migration 0092's `normalize_artist_name`, and the
+-- `.normalize('NFC')` on the artist create path all preserve it. NFKC/NFKD
+-- WOULD fold it to U+03BC and break parity -- the two NFKC call sites in this
+-- repo (jobs/flowsheet-metadata-backfill/lookup-cache.ts and
+-- jobs/streaming-url-upgrade/orchestrate.ts) are in-memory lookup keys only
+-- and never write a folded string back to any column, so no live write path
+-- can convert this value. If one is ever added, this row breaks first.
 --
 -- BS#2114 also asks to re-check wxyc_schema.rotation and wxyc_schema.flowsheet
 -- with the same U+FFFD predicate #863 used (this ticket only measured the
@@ -194,8 +242,12 @@ SELECT (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name LIKE E'%�%'
 -- same predicate #863 used. INFORMATIONAL ONLY -- this script fixes nothing
 -- here, it only reports. A non-zero count needs a follow-up ticket (name the
 -- counts) or a future phase once ground truth for those rows is available.
--- `artists.alphabetical_name` is included per the "check it" ask above; see
--- the header comment for why it's expected to stay at 0 structurally.
+-- `artists.alphabetical_name` is included per the "check it" ask above. Do NOT
+-- expect 0 here: the µ-Ziq row's own `alphabetical_name` is the plain-ASCII
+-- `mu-Ziq` and cannot carry this corruption class (see header), but the table
+-- as a whole is not clean -- id 22025's `alphabetical_name` is `Beyonc<U+FFFD>`,
+-- the third corrupt value in the out-of-scope group described in the header.
+-- Expected against the 2026-08-12 clone: artist_name 2, alphabetical_name 1.
 SELECT 'AFTER — informational residual U+FFFD, other tables/columns (not fixed by this script)' AS section;
 SELECT 'artists' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.artists WHERE artist_name LIKE E'%�%') AS remaining
 UNION ALL

--- a/scripts/audit/bs_replacement_char_phase4.sql
+++ b/scripts/audit/bs_replacement_char_phase4.sql
@@ -211,10 +211,16 @@ SET client_encoding TO 'UTF8';
 -- Pre-amble: targeted rows + their BEFORE counts (1 / 10 / 1 against the
 -- 2026-08-12 dev clone, see header).
 --
--- To eyeball prod's real counts before anything is written, run ONLY this
--- section first -- e.g. `sed -n '/Pre-amble/,/Transactional/p'` -- since the
--- whole file executes non-interactively under `psql -f` and offers no pause
--- between the pre-amble and COMMIT at which an operator could abort.
+-- To eyeball prod's real counts before anything is written, run everything
+-- ahead of the transaction on its own first:
+--
+--   awk '/^BEGIN;/{exit} {print}' scripts/audit/bs_replacement_char_phase4.sql \
+--     | psql "$DATABASE_URL"
+--
+-- That is read-only (session guards + the two audit SELECTs) and stops before
+-- the first write. Worth doing, because the whole file executes
+-- non-interactively under `psql -f` and offers no pause between the pre-amble
+-- and COMMIT at which an operator could inspect and abort.
 -- ===========================================================
 SELECT '=== V_BS_FFFD_P4 pre-amble: rows targeted per (table, column) ===' AS section;
 

--- a/scripts/audit/bs_replacement_char_phase4.sql
+++ b/scripts/audit/bs_replacement_char_phase4.sql
@@ -91,7 +91,25 @@
 --     will push the still-corrupt value back onto every linked `library` row
 --     and silently UNDO the #863 fix. (`alphabetical_name` has no cascade --
 --     0060 fires only on `artist_name` -- so that third value is inert, but
---     it is still what sorts and displays.) Worth its own follow-up ticket,
+--     it is still what sorts and displays.)
+--
+--     Two further arming conditions, neither of which needs a write to
+--     `artists` at all, because catalog-export.service.ts reads
+--     `artists.artist_name` on two paths of its own: (a) its
+--     `cross_reference_names` aggregate reads that column DIRECTLY with no
+--     `library` fallback, so merely inserting an `artist_crossreference` row
+--     touching 22025 or 23162 would publish the corrupt name into another
+--     release's export; (b) its `artist_name` is
+--     `COALESCE(library.artist_name, artists.artist_name)`, so any `library`
+--     row that ever holds a NULL `artist_name` (the column is nullable --
+--     schema.ts "Nullable until A.2") falls through to the corrupt value.
+--     BOTH ARE UNARMED IN THE 2026-08-12 CLONE, measured not assumed:
+--     `artist_crossreference` has 0 rows referencing either artist, and
+--     `library.artist_name IS NULL` is 0 across the whole table. So the
+--     export is clean TODAY and this stays a latent hazard rather than a
+--     live parity failure -- but the surface is wider than "someone writes
+--     to `artists`", and any of the three triggers fires it silently.
+--     Worth its own follow-up ticket,
 --     which INHERITS THIS TICKET'S 2026-08-31 DEADLINE: tubafrenzy is the
 --     ground truth for those `artists` rows as much as for these, and #863's
 --     values for them came from curated fuzzy matching, not from tubafrenzy.
@@ -170,9 +188,33 @@
 -- established.
 
 -- ===========================================================
+-- Session guards. Both matter more here than in a typical script because
+-- EVERY predicate below is exact-byte string equality.
+--
+-- client_encoding: if the operator's psql session resolves to a non-UTF8
+-- client encoding (it is locale-derived, so this is environmental, not a
+-- typo), the server reinterprets this file's UTF-8 bytes, every predicate
+-- matches zero rows, and the pre-amble reports 0 / 0 / 0 -- which reads as
+-- "already repaired" rather than "matched nothing". Declaring it makes that
+-- failure impossible instead of silent.
+--
+-- ON_ERROR_STOP: without it, an error inside the transaction leaves psql
+-- issuing the remaining commands into an aborted transaction, COMMIT
+-- degrades to ROLLBACK, and psql still exits 0 -- a repair that reports
+-- success and changed nothing. (`\` lines are dropped by the test's
+-- statement extractor, so this does not affect what the spec verifies.)
+-- ===========================================================
+\set ON_ERROR_STOP on
+SET client_encoding TO 'UTF8';
+
+-- ===========================================================
 -- Pre-amble: targeted rows + their BEFORE counts (1 / 10 / 1 against the
--- 2026-08-12 dev clone, see header -- re-run this against prod to get the
--- real prod counts before COMMIT).
+-- 2026-08-12 dev clone, see header).
+--
+-- To eyeball prod's real counts before anything is written, run ONLY this
+-- section first -- e.g. `sed -n '/Pre-amble/,/Transactional/p'` -- since the
+-- whole file executes non-interactively under `psql -f` and offers no pause
+-- between the pre-amble and COMMIT at which an operator could abort.
 -- ===========================================================
 SELECT '=== V_BS_FFFD_P4 pre-amble: rows targeted per (table, column) ===' AS section;
 
@@ -195,6 +237,27 @@ SELECT legacy_release_id, artist_name, album_title
 -- ===========================================================
 BEGIN;
 SET LOCAL statement_timeout = '30s';
+
+-- Blast-radius guard. The `artists` write below is bounded by the corrupt
+-- string, not by `id = 656`, and its 0060 cascade then rewrites every
+-- `library` row under whatever `artists` rows it hit. That is safe only while
+-- the corrupt string identifies exactly one `artists` row -- true of the
+-- 2026-08-12 clone, but a fact about the data, not a property of the
+-- statement. If prod has since gained a second row carrying the identical
+-- corrupt name (a duplicate from a DJ pasting the mojibake, say), the
+-- unguarded form would rename it too and cascade across its library rows,
+-- well outside the 11 BS#2114 names. Abort loudly instead.
+--
+-- The threshold is "> 1", not "<> 1", so a re-run -- where the count is
+-- legitimately 0 -- stays the genuine no-op the header promises.
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT COUNT(*) INTO n FROM wxyc_schema.artists WHERE artist_name = '�-Ziq [mu-Ziq]';
+  IF n > 1 THEN
+    RAISE EXCEPTION 'BS#2114 guard: expected at most 1 corrupt artists row, found %. Resolve the duplicates before proceeding.', n;
+  END IF;
+END $$;
 
 -- Source-of-truth fix: cascades to `library.artist_name` for every row with
 -- a matching `artist_id` via the 0060 trigger.
@@ -268,6 +331,20 @@ UNION ALL
 SELECT 'flowsheet' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title LIKE E'%�%') AS remaining
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'record_label' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label LIKE E'%�%') AS remaining
+UNION ALL
+-- `compilation_track_artist` is NOT part of #863's scan set, but it belongs
+-- in this sweep: the parity harness compares CTA as its own multiset
+-- (catalog_parity_diff.py CTA_COLUMNS = library_release_id, artist_name,
+-- track_title), and CTA is populated by jobs/library-etl and
+-- jobs/library-identity-consumer -- the same lossy legacy path that produced
+-- everything else here. Omitting it would let this script report "clean"
+-- while the harness kept failing on rows it never looked at. 0 in the
+-- 2026-08-12 clone; included so that stays true by measurement, not
+-- assumption. (Distinct from BS#1996, which tracks a different corruption
+-- class in this table: double-encoded CP1252, not U+FFFD.)
+SELECT 'compilation_track_artist' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS remaining
+UNION ALL
+SELECT 'compilation_track_artist' AS tbl, 'track_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS remaining
 ORDER BY remaining DESC;
 
 -- Refresh planner stats on every UPDATEd table (BS#934). ANALYZE cannot run

--- a/tests/integration/bs-replacement-char-phase4.spec.js
+++ b/tests/integration/bs-replacement-char-phase4.spec.js
@@ -15,6 +15,14 @@
  *  - a row that merely shares bytes with the corrupt strings (same 0xEA byte as the
  *    corrupt "La B�te", or the same "-Ziq [mu-Ziq]" suffix under a different artist)
  *    is left untouched -- the match is on the full corrupt string, not a substring;
+ *  - a row holding the EXACT corrupt string at a `legacy_release_id` the ticket does
+ *    NOT name is left untouched. This is the pin that makes "and only those" mean
+ *    something: with only near-miss decoys, the exact-string predicate alone spares
+ *    them and the `legacy_release_id IN (...)` scoping is never exercised -- dropping
+ *    that scoping entirely (widening either UPDATE into a table-wide rewrite) still
+ *    passed every assertion. An exact-string, out-of-scope row is the only decoy that
+ *    fails when the scoping is removed, so it is what actually bounds the blast
+ *    radius of the operator script against a future well-meaning edit;
  *  - a second run is a genuine no-op (0 rows affected) once the first has landed,
  *    proving the self-correcting / idempotent design the script's header claims;
  *  - the `artists` UPDATE and the `library` safety-net UPDATE don't double-count or
@@ -159,6 +167,13 @@ describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
       INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
       VALUES (999999, ${'�ther-Ziq [mu-Ziq]'}, 'unrelated')
     `;
+    // The scoping decoy: the EXACT corrupt string, at an id BS#2114 does not name.
+    // Only `legacy_release_id IN (...)` keeps the UPDATE off this row, so this is the
+    // assertion that fails if that scoping is ever widened or dropped.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+      VALUES (900001, ${CORRUPT_ARTIST}, 'out of ticket scope')
+    `;
 
     await runScript();
 
@@ -168,6 +183,8 @@ describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
     }
     const untouched = await libraryRow(999999);
     expect(untouched.artist_name).toBe('�ther-Ziq [mu-Ziq]');
+    const outOfScope = await libraryRow(900001);
+    expect(outOfScope.artist_name).toBe(CORRUPT_ARTIST);
   });
 
   test('fixes library.album_title for catalog id 50340, and only that id', async () => {
@@ -179,6 +196,11 @@ describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
       INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
       VALUES (888888, 'Some Artist', ${'La Forêt'})
     `;
+    // The scoping decoy, as above: the EXACT corrupt title at an unnamed id.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+      VALUES (900002, 'Some Other Artist', ${CORRUPT_TITLE})
+    `;
 
     await runScript();
 
@@ -186,6 +208,8 @@ describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
     expect(fixed.album_title).toBe(CORRECT_TITLE);
     const untouched = await libraryRow(888888);
     expect(untouched.album_title).toBe('La Forêt');
+    const outOfScope = await libraryRow(900002);
+    expect(outOfScope.album_title).toBe(CORRUPT_TITLE);
   });
 
   test('the U+FFFD predicate returns 0 across artist_name/album_title after the run', async () => {

--- a/tests/integration/bs-replacement-char-phase4.spec.js
+++ b/tests/integration/bs-replacement-char-phase4.spec.js
@@ -1,0 +1,236 @@
+/**
+ * Re-run + correctness pin for scripts/audit/bs_replacement_char_phase4.sql (BS#2114).
+ *
+ * The Phase 4 script repairs 11 rows of residual U+FFFD mojibake left behind by the
+ * #863 recovery: the `µ-Ziq [mu-Ziq]` artist name (10 catalog ids, denormalized from
+ * one `artists` row per migration 0060's cascade) and the `La Bête` album title (1
+ * catalog id). These tests execute the REAL UPDATE statements extracted from the
+ * script file (schema-substituted into a throwaway schema, same technique as
+ * relabel-rotation-direct-backfill.spec.js) so there is zero drift between the
+ * artifact under test and what prod actually runs.
+ *
+ * What's pinned:
+ *  - the artist fix touches every one of the 10 named catalog ids, and only those;
+ *  - the title fix touches catalog id 50340, and only that id;
+ *  - a row that merely shares bytes with the corrupt strings (same 0xEA byte as the
+ *    corrupt "La B�te", or the same "-Ziq [mu-Ziq]" suffix under a different artist)
+ *    is left untouched -- the match is on the full corrupt string, not a substring;
+ *  - a second run is a genuine no-op (0 rows affected) once the first has landed,
+ *    proving the self-correcting / idempotent design the script's header claims;
+ *  - the `artists` UPDATE and the `library` safety-net UPDATE don't double-count or
+ *    conflict with each other -- both are exercised because the throwaway schema
+ *    does not recreate migration 0060's cascade trigger, so this test is the only
+ *    place the `library` safety-net UPDATE's own correctness is actually verified
+ *    (in prod the trigger would normally do that half of the work first).
+ *
+ * The throwaway tables use plain `text` columns rather than the production
+ * `varchar(128)` -- irrelevant to the string-equality UPDATE logic under test.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getTestDb } = require('../utils/db');
+
+const TEST_SCHEMA = 'bs2114_mojibake_test';
+const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_replacement_char_phase4.sql');
+
+const CORRUPT_ARTIST = '�-Ziq [mu-Ziq]';
+const CORRECT_ARTIST = 'µ-Ziq [mu-Ziq]'; // µ-Ziq [mu-Ziq]
+const CORRUPT_TITLE = 'La B�te';
+const CORRECT_TITLE = 'La Bête'; // La Bête
+
+const TARGET_ARTIST_IDS = [1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776];
+const TARGET_TITLE_ID = 50340;
+
+/**
+ * Pull the real UPDATE statements out of the operator script and retarget them at
+ * the throwaway schema. Same hazards guarded against as
+ * relabel-rotation-direct-backfill.spec.js's extractor:
+ *   - psql meta (`\`) lines are dropped and both full-line and trailing inline `--`
+ *     comments are stripped, so a `;` inside a comment (the header prose describes
+ *     "the first UPDATE below" etc.) can't be mistaken for a statement boundary;
+ *   - requires EXACTLY THREE UPDATEs. If a future edit adds, removes, or reorders
+ *     one, this throws instead of silently validating a different statement set
+ *     than the one prod runs.
+ */
+function extractUpdates(scriptText, targetSchema) {
+  const sqlOnly = scriptText
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('\\'))
+    .map((line) => {
+      const comment = line.indexOf('--');
+      return comment === -1 ? line : line.slice(0, comment);
+    })
+    .join('\n');
+  const matches = sqlOnly.match(/UPDATE[\s\S]*?;/gi) ?? [];
+  if (matches.length !== 3) {
+    throw new Error(`expected exactly 3 UPDATEs in bs_replacement_char_phase4.sql, found ${matches.length}`);
+  }
+  return matches.map((m) => m.replace(/wxyc_schema\./g, `${targetSchema}.`));
+}
+
+describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
+  let sql;
+  let updates;
+
+  beforeAll(async () => {
+    sql = getTestDb();
+    const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    updates = extractUpdates(scriptText, TEST_SCHEMA);
+
+    await sql.unsafe(`CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}`);
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS ${TEST_SCHEMA}.artists (
+        id serial PRIMARY KEY,
+        artist_name text NOT NULL
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS ${TEST_SCHEMA}.library (
+        id serial PRIMARY KEY,
+        legacy_release_id integer NOT NULL,
+        artist_name text,
+        album_title text
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await sql.unsafe(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(`TRUNCATE ${TEST_SCHEMA}.artists, ${TEST_SCHEMA}.library RESTART IDENTITY`);
+  });
+
+  async function runScript() {
+    let totalAffected = 0;
+    for (const stmt of updates) {
+      const result = await sql.unsafe(stmt);
+      totalAffected += result.count;
+    }
+    return totalAffected;
+  }
+
+  async function seedTargetRows() {
+    // The source-of-truth artists row, still corrupt.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.artists (artist_name) VALUES (${CORRUPT_ARTIST})
+    `;
+    // The 10 named catalog ids, denormalized copies also still corrupt -- no cascade
+    // trigger exists in this throwaway schema, so these rows are independent of the
+    // artists row above until the script's second UPDATE fixes them directly.
+    for (const id of TARGET_ARTIST_IDS) {
+      await sql`
+        INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+        VALUES (${id}, ${CORRUPT_ARTIST}, 'some other album')
+      `;
+    }
+    // The one title-corrupt catalog id.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+      VALUES (${TARGET_TITLE_ID}, 'The Cripple Lillies', ${CORRUPT_TITLE})
+    `;
+  }
+
+  async function libraryRow(legacyReleaseId) {
+    const rows = await sql`
+      SELECT artist_name, album_title FROM ${sql(TEST_SCHEMA)}.library WHERE legacy_release_id = ${legacyReleaseId}
+    `;
+    return rows[0];
+  }
+
+  test('fixes the artists source-of-truth row', async () => {
+    await seedTargetRows();
+
+    await runScript();
+
+    const rows = await sql`SELECT artist_name FROM ${sql(TEST_SCHEMA)}.artists`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].artist_name).toBe(CORRECT_ARTIST);
+  });
+
+  test('fixes library.artist_name for every one of the 10 named catalog ids, and only those', async () => {
+    await seedTargetRows();
+    // A neighbor row sharing the "-Ziq [mu-Ziq]" suffix under a DIFFERENT corrupt
+    // prefix, at an id NOT in the target list -- must not be touched by a loose match.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+      VALUES (999999, ${'�ther-Ziq [mu-Ziq]'}, 'unrelated')
+    `;
+
+    await runScript();
+
+    for (const id of TARGET_ARTIST_IDS) {
+      const row = await libraryRow(id);
+      expect(row.artist_name).toBe(CORRECT_ARTIST);
+    }
+    const untouched = await libraryRow(999999);
+    expect(untouched.artist_name).toBe('�ther-Ziq [mu-Ziq]');
+  });
+
+  test('fixes library.album_title for catalog id 50340, and only that id', async () => {
+    await seedTargetRows();
+    // A neighbor row with the same 0xEA ("ê") byte in a clean, already-correct
+    // title -- proves the match is on the full corrupt string, not a fuzzy/byte
+    // match that could clobber an unrelated accented title.
+    await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id, artist_name, album_title)
+      VALUES (888888, 'Some Artist', ${'La Forêt'})
+    `;
+
+    await runScript();
+
+    const fixed = await libraryRow(TARGET_TITLE_ID);
+    expect(fixed.album_title).toBe(CORRECT_TITLE);
+    const untouched = await libraryRow(888888);
+    expect(untouched.album_title).toBe('La Forêt');
+  });
+
+  test('the U+FFFD predicate returns 0 across artist_name/album_title after the run', async () => {
+    await seedTargetRows();
+
+    await runScript();
+
+    const [{ remaining }] = await sql`
+      SELECT COUNT(*)::int AS remaining
+      FROM ${sql(TEST_SCHEMA)}.library
+      WHERE artist_name LIKE '%' || chr(65533) || '%' OR album_title LIKE '%' || chr(65533) || '%'
+    `;
+    expect(remaining).toBe(0);
+    const [{ artistsRemaining }] = await sql`
+      SELECT COUNT(*)::int AS "artistsRemaining"
+      FROM ${sql(TEST_SCHEMA)}.artists
+      WHERE artist_name LIKE '%' || chr(65533) || '%'
+    `;
+    expect(artistsRemaining).toBe(0);
+  });
+
+  test('a second run is a genuine no-op once the first has landed', async () => {
+    await seedTargetRows();
+    const firstRunAffected = await runScript();
+    expect(firstRunAffected).toBeGreaterThan(0);
+
+    const secondRunAffected = await runScript();
+
+    expect(secondRunAffected).toBe(0);
+    // Values are still correct, not reverted or double-mangled.
+    const rows = await sql`SELECT artist_name FROM ${sql(TEST_SCHEMA)}.artists`;
+    expect(rows[0].artist_name).toBe(CORRECT_ARTIST);
+    const titleRow = await libraryRow(TARGET_TITLE_ID);
+    expect(titleRow.album_title).toBe(CORRECT_TITLE);
+  });
+
+  test('is a no-op against rows that were never corrupt in the first place', async () => {
+    // No seed at all -- simulates the state after tubafrenzy turndown, or a clean
+    // dev database. The script must not error and must not manufacture rows.
+    const affected = await runScript();
+
+    expect(affected).toBe(0);
+    const artistCount = await sql`SELECT COUNT(*)::int AS n FROM ${sql(TEST_SCHEMA)}.artists`;
+    expect(artistCount[0].n).toBe(0);
+    const libraryCount = await sql`SELECT COUNT(*)::int AS n FROM ${sql(TEST_SCHEMA)}.library`;
+    expect(libraryCount[0].n).toBe(0);
+  });
+});

--- a/tests/integration/bs-replacement-char-phase4.spec.js
+++ b/tests/integration/bs-replacement-char-phase4.spec.js
@@ -42,10 +42,15 @@ const { getTestDb } = require('../utils/db');
 const TEST_SCHEMA = 'bs2114_mojibake_test';
 const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_replacement_char_phase4.sql');
 
+// Written as escapes, not raw literals, so the expectations cannot drift with the
+// script under a transform that rewrites both files at once (a repo-wide NFKC pass,
+// a paste through a normalizing editor). A raw 'µ' on both sides would keep the
+// suite green while prod wrote U+03BC. `scriptUsesTheRightCodepoints` below closes
+// the other half by asserting the bytes actually present in the script text.
 const CORRUPT_ARTIST = '�-Ziq [mu-Ziq]';
-const CORRECT_ARTIST = 'µ-Ziq [mu-Ziq]'; // µ-Ziq [mu-Ziq]
+const CORRECT_ARTIST = 'µ-Ziq [mu-Ziq]'; // µ-Ziq [mu-Ziq], U+00B5 MICRO SIGN
 const CORRUPT_TITLE = 'La B�te';
-const CORRECT_TITLE = 'La Bête'; // La Bête
+const CORRECT_TITLE = 'La Bête'; // La Bête, U+00EA E WITH CIRCUMFLEX
 
 const TARGET_ARTIST_IDS = [1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776];
 const TARGET_TITLE_ID = 50340;
@@ -148,6 +153,26 @@ describe('bs_replacement_char_phase4 mojibake repair (BS#2114)', () => {
     `;
     return rows[0];
   }
+
+  test('the script writes U+00B5 MICRO SIGN and U+00EA, not their lookalikes', () => {
+    // The one fact this whole repair rests on: the bytes the script SETs have to be
+    // the bytes tubafrenzy holds, because BS#2114's acceptance criterion is a
+    // byte-exact parity comparison. U+00B5 MICRO SIGN and U+03BC GREEK SMALL LETTER
+    // MU are visually identical in most fonts, and NFKC/NFKD fold the former onto
+    // the latter -- so this is exactly the kind of difference that survives review
+    // and dies in prod. Asserted against the script TEXT rather than the extracted
+    // statements so it holds regardless of how the UPDATEs are shaped.
+    const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    const artistSet = scriptText.match(/SET artist_name = '(.+?)'/);
+    const titleSet = scriptText.match(/SET album_title = '(.+?)'/);
+    expect(artistSet).not.toBeNull();
+    expect(titleSet).not.toBeNull();
+    expect(Buffer.from(artistSet[1], 'utf8').toString('hex')).toBe('c2b52d5a6971205b6d752d5a69715d');
+    expect(Buffer.from(titleSet[1], 'utf8').toString('hex')).toBe('4c612042c3aa7465');
+    // And the replacement must not itself contain a replacement character.
+    expect(artistSet[1]).not.toContain('�');
+    expect(titleSet[1]).not.toContain('�');
+  });
 
   test('fixes the artists source-of-truth row', async () => {
     await seedTargetRows();


### PR DESCRIPTION
Closes #2114.

Repairs the eleven residual U+FFFD rows the #863 recovery left behind, which the first full run of the [catalog-parity harness](https://github.com/WXYC/discogs-etl/issues/365) surfaced on 2026-08-12. Only two distinct strings are involved: `µ-Ziq [mu-Ziq]` across ten catalog ids, and `La Bête` on one.

Delivered as an operator-run script (`scripts/audit/bs_replacement_char_phase4.sql`) rather than a Drizzle migration, matching its two predecessors `bs_replacement_char_recovery.sql` (Phase 1/2) and `bs_replacement_char_phase35.sql` (Phase 3.5). `docs/migrations.md` keeps migrations DDL-only; this is DML.

## What it does

The ten µ-Ziq catalog rows all descend from one `artists` row, so the script fixes `artists.artist_name` — the source of truth — and lets migration 0060's `cascade_library_artist_name` trigger push the corrected value onto the linked `library` rows. A second, id-scoped UPDATE on `library.artist_name` is a self-correcting safety net for any row whose `artist_id` linkage doesn't hold. A third fixes `library.album_title` for `legacy_release_id` 50340.

`ANALYZE` runs on both written tables, outside any transaction, per #934.

Three things make it fail closed rather than silently succeed, which matters because every predicate is exact-byte string matching:

- `SET client_encoding TO 'UTF8'`. Client encoding is locale-derived, so a non-UTF8 session is environmental rather than a typo. Under one, the server reinterprets this file's UTF-8 bytes, every predicate matches zero rows, and the pre-amble reports `0 / 0 / 0` — which reads as "already repaired" rather than "matched nothing".
- `\set ON_ERROR_STOP on`. Without it, an error inside the transaction leaves psql feeding the remaining commands into an aborted transaction, `COMMIT` degrades to `ROLLBACK`, and psql still exits 0.
- A blast-radius guard before the writes. The `artists` UPDATE is bounded by the corrupt string, not by `id = 656`, so its safety rests on that string identifying exactly one row — a fact about the data, not a property of the statement. The guard aborts if it finds more than one. The threshold is `> 1` rather than `<> 1` so a re-run, where 0 is correct, stays a genuine no-op.

Verified: with a duplicate `artists` row injected, the run aborts, psql exits 3, and all eleven rows stay corrupt. The happy path exits 0.

## Pre-migration audit

Measured against `dev_env/seed-clone.sql`, a prod-shaped staging clone (~64,193 library rows), on 2026-08-12. The operator should paste the live prod pre-amble output into this PR before merging, since the clone can lag a recent librarian edit.

| Table | Column | Rows |
|---|---|---|
| `artists` | `artist_name` | 1 (id 656) |
| `library` | `artist_name` | 10 (the ten named `legacy_release_id`s) |
| `library` | `album_title` | 1 (`legacy_release_id` 50340) |

Affected `legacy_release_id`s: 1977, 1978, 1979, 1980, 1981, 1982, 1983, 37529, 63110, 69776 (artist) and 50340 (title).

## Correctness of the substituted values

The correct bytes were read back out of a tubafrenzy-sourced `library.db` and compared against the literals in the script:

- `µ-Ziq [mu-Ziq]` = `c2 b5 2d 5a 69 71 20 5b 6d 75 2d 5a 69 71 5d` — identical for all ten ids
- `La Bête` = `4c 61 20 42 c3 aa 74 65` — identical for id 50340

The `µ` is **U+00B5 MICRO SIGN**, not U+03BC GREEK SMALL LETTER MU. The distinction is load-bearing and easy to lose in an editor, so the script says so and a test fails if it is ever swapped.

Unlike Phase 2/3.5, this script deliberately does **not** NFC-normalize before writing. Those phases injected strings assembled by a fuzzy matcher from LML/Discogs/MusicBrainz, which can arrive in arbitrary Unicode form. These two come from tubafrenzy and are graded by a harness that compares byte-exact (`catalog_parity_diff.py::_normalize` strips surrounding whitespace and collapses `NULL`/`''`/`'NULL'`, and applies no case or accent folding), so normalizing on write is the one transform that could reintroduce a mismatch. It is moot for these two values — both are already NFC-stable and carry no zero-width characters — but the reasoning is now recorded in the file rather than left implicit.

U+00B5 survives every normalization this codebase actually performs: NFD in migration 0134's `fold_artist_name` and migration 0092's `normalize_artist_name`, and the `.normalize('NFC')` on the artist create path, all leave it alone, since it has only a compatibility decomposition. NFKC/NFKD would fold it to U+03BC; the repo's two NFKC call sites (`jobs/flowsheet-metadata-backfill/lookup-cache.ts`, `jobs/streaming-url-upgrade/orchestrate.ts`) build in-memory lookup keys and never write a folded string back to a column.

## Verification

Run against **PostgreSQL 14.23** with migration 0060's cascade trigger installed — prod RDS is 14.22, while the dev container is 18 and accepts syntax prod rejects:

- first pass `UPDATE 1 / UPDATE 0 / UPDATE 1` (the `library` safety net correctly reports 0, the trigger having already fixed all ten rows in the same transaction)
- second pass `UPDATE 0 / UPDATE 0 / UPDATE 0` — a genuine no-op
- all three residual predicates land on 0; `wxyc_schema.library` U+FFFD count reaches 0
- adjacent corrupt rows and clean accented rows (`La Forêt`) untouched

`tests/integration/bs-replacement-char-phase4.spec.js` extracts the script's real UPDATE statements and runs them against a throwaway schema, the technique `relabel-rotation-direct-backfill.spec.js` established, so there is no drift between the artifact under test and what prod runs. The extractor requires exactly three UPDATEs and throws if a future edit adds or removes one.

Mutation-tested, since a passing suite proves nothing on its own:

| Mutation | Failing tests | Was |
|---|---|---|
| U+03BC substituted for U+00B5 in the script | 4 | 3 |
| U+03BC substituted in the script **and** the test in lockstep | 1 | 0 |
| one target id dropped from the `IN` list | 2 | 2 |
| artist UPDATE loses its `legacy_release_id` scoping | 1 | 0 |
| title UPDATE loses its `legacy_release_id` scoping | 1 | 0 |

Three of these originally caught nothing.

Both decoy rows used near-miss strings, which the exact-string predicate spares on its own, so the `legacy_release_id` scoping was never exercised and either UPDATE could be widened into a table-wide rewrite undetected. Each test now also seeds a row carrying the *exact* corrupt string at an id the ticket does not name — the only decoy shape that fails when the scoping goes.

The expected values were also raw literals in both files, so any transform touching both at once — a repo-wide NFKC pass, a paste through a normalizing editor — would swap U+00B5 for U+03BC in the script *and* in the assertion, leaving the suite green while prod wrote the wrong byte. A test now asserts the hex actually present in the script text (`c2b5...` / `4c612042c3aa7465`), which is the fact the whole repair rests on.

## Blast radius

The `artists` UPDATE matches on the corrupt string rather than by id. That string is unique to row 656 in the clone, and the row is the only `artists` row whose name ends `-Ziq [mu-Ziq]`. The 0060 trigger then reaches exactly the rows with `artist_id = 656` — 10 in the clone, precisely the set #2114 names. If prod has since gained an eleventh µ-Ziq release, the cascade corrects it too, which is the desired behavior rather than overreach. The two `library` UPDATEs are additionally id-scoped and cannot exceed the ticket's set.

## Out of scope, found while verifying

Both were confirmed directly against the clone, and neither is folded in here — #2114 names exactly eleven rows, and this script's warrant is "direct substitution from tubafrenzy, no judgement call". They are recorded in the script header.

**`artists` rows #863 never repaired (latent hazard).** `artists.artist_name` is still corrupt for id 22025 (`Beyonc<U+FFFD>`) and id 23162 (`Damian Nisenson / Jean F<U+FFFD>lix Mailloux / Pierre Tanguay`); id 22025's `alphabetical_name` is corrupt too, so it is three values across two rows. #863 fixed both names on `library.artist_name` only (`bs_replacement_char_recovery.sql` lines 126-127) and never touched the source of truth.

Three separate things arm it, not one. The 0060 cascade means **any** future write to either `artists.artist_name`, for any unrelated reason, pushes the corrupt value back onto every linked `library` row and silently undoes the #863 fix. Beyond that, `catalog-export.service.ts` reads `artists.artist_name` on two paths of its own: `cross_reference_names` aggregates it **directly**, with no `library` fallback, so merely inserting an `artist_crossreference` row touching either artist would publish the corrupt name into another release's export; and the exported `artist_name` is `COALESCE(library.artist_name, artists.artist_name)`, which falls through to the corrupt value for any `library` row holding a NULL `artist_name` (the column is nullable).

All three are **unarmed today, measured rather than assumed**: `artist_crossreference` has 0 rows referencing either artist, and `library.artist_name IS NULL` is 0 across the whole table. So the catalog export is clean now and this remains latent rather than a live parity failure. It still needs a follow-up ticket, and that ticket inherits #2114's **2026-08-31 turndown deadline**: tubafrenzy is the ground truth for those rows as much as for these, and #863's values for them came from curated fuzzy matching rather than from tubafrenzy.

**Rotation residue (pre-existing, correctly left alone).** The acceptance-criterion re-check finds 5 `rotation` rows and 0 in `flowsheet`. It now also covers `compilation_track_artist`, which is outside #863's scan set but which the parity harness compares as its own multiset and which `jobs/library-etl` populates from the same lossy legacy path — omitting it would have let this script report "clean" while the harness kept failing on rows nobody looked at. It is 0 in the clone; that is now measured rather than assumed. (Distinct from #1996, which tracks double-encoded CP1252 in the same table — a different corruption class.) The five rotation ids are 10789, 13703, 16683, 21149, 21335. All five appear in `audit/bs_replacement_char_phase35.csv` with an empty curated-canonical column, which is what "deliberately unrecovered" means there — the two rotation rows that *did* get a curated value are the two Phase 3.5 repaired. Id 16683 was not an oversight either: its album_title was curated and dropped, its auto-proposal (`Used Songs (1973-1980)`, confidence 0.38) being plainly wrong. None map to a `legacy_release_id` this ticket names.
