### PR TITLE
fix(#2117): backfill artist_crossreference from tubafrenzy's LIBRARY_CODE_CROSS_REFERENCE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,9 @@ jobs:
               - 'scripts/relabel-rotation-direct-backfill.sql'
               # tests/integration/format-qualifier-recovery.spec.js reads:
               - 'scripts/audit/bs_format_qualifier_recovery.sql'
+              # tests/integration/bs-2117-crossreference-backfill.spec.js reads
+              # (BS#2117 — its resolver + INSERT are executed verbatim):
+              - 'scripts/audit/bs_2117_crossref_backfill.sql'
             db-init:
               - 'dev_env/Dockerfile.init'
               - 'dev_env/init-db.mjs'

--- a/scripts/audit/bs_2117_crossref_backfill.sql
+++ b/scripts/audit/bs_2117_crossref_backfill.sql
@@ -5,9 +5,21 @@
 -- HAND-APPLIED operator script, NOT a Drizzle migration — docs/migrations.md
 -- says migrations are DDL-only, and this is DML over a curated table. There
 -- is no entry in shared/database/src/migrations/; version history is just
--- `git log -- scripts/audit/bs_2117_crossref_backfill.sql`. Run via
--- `psql -f` against prod (see scripts/query-flowsheet.sh for the EC2-docker
--- connection pattern).
+-- `git log -- scripts/audit/bs_2117_crossref_backfill.sql`. Run against prod as
+--
+--     psql -v ON_ERROR_STOP=1 -f scripts/audit/bs_2117_crossref_backfill.sql
+--
+-- (see scripts/query-flowsheet.sh for the EC2-docker connection pattern).
+-- ON_ERROR_STOP=1 is REQUIRED, matching scripts/relabel-rotation-direct-backfill.sql.
+-- Without it a failure in the pair load does not stop psql: it runs on through
+-- the transaction block (whose COMMIT then degrades to a rollback), the
+-- post-amble and ANALYZE, and prints `resolved_pairs 0 / present_in_backend 0`
+-- — which is indistinguishable from a successful idempotent re-run.
+--
+-- Note also that `psql -f` is non-interactive and the COMMIT is unconditional:
+-- the pre-amble is a record to READ, not a gate that pauses. If you want to
+-- inspect before writing, run the file down to the `BEGIN;` first, or run it
+-- inside a transaction you roll back yourself.
 --
 -- ## Problem (#2117)
 --
@@ -81,28 +93,83 @@
 -- against it exercises real WXYC artist names rather than synthetic ones.
 -- Measured there:
 --
---   * 110 pairs -> 79 resolve on both sides, 31 do not. Every one of the 31
---     fails on the REFERENCING side, and every one of the 31 has an empty
+--   * 110 pairs -> 15 excluded as provenance conflicts (above), 31 do not
+--     resolve, 64 resolve on both sides and are eligible to insert. Every one
+--     of the 31 fails on the REFERENCING side, and every one has an empty
 --     tubafrenzy CALL_LETTERS (the converse does not hold: 4 of the 35
 --     empty-CALL_LETTERS pairs do resolve).
 --   * 0 pairs come out AMBIGUOUS. Five endpoint tuples match more than one
 --     Backend artist by folded name — DAT Politics, Exene Cervenka, Sankofa,
 --     and the two Oliver Lakes — and stages 2 and 3 narrow every one of them
 --     to a single artist.
---   * 75 of the 79 resolved pairs would ALSO satisfy the deployed importer's
+--   * 60 of the 64 eligible pairs would ALSO satisfy the deployed importer's
 --     strict `code_letters` equality on both sides. Only 4 need this script's
 --     more lenient name-first resolution — those 4 pairs are the entire
 --     population this script recovers that the ETL could not.
---   * 79 resolved pairs collapse to 77 distinct unordered pairs, inserted as
---     77 rows against the clone's empty table.
---   * The 155 resolvable endpoint artists own 915 `library` rows between them.
+--   * 64 eligible pairs collapse to 62 distinct unordered pairs, inserted as
+--     62 rows against the clone's empty table.
+--   * Their 108 endpoint artists own 630 `library` rows between them — the
+--     upper bound on how many catalog rows change value.
 --
 -- Because prod's table is populated and the clone's is empty by construction,
--- **the row count this inserts against prod will be far lower than 77** —
--- most of those 75 strict-matchable pairs should already be present, and the
+-- **the row count this inserts against prod will be far lower than 62** —
+-- most of those 60 strict-matchable pairs should already be present, and the
 -- guards below will skip them. Read the pre-amble and the `INSERT 0 n` line
 -- before accepting the COMMIT; the counts will legitimately differ from every
 -- clone-measured figure in this header.
+--
+-- ## Provenance conflicts: 15 pairs EXCLUDED because tubafrenzy's own FK is wrong
+--
+-- `LIBRARY_CODE_CROSS_REFERENCE.CROSS_REFERENCING_ARTIST_ID` is, despite its
+-- name, a `LIBRARY_CODE.ID` (the referenced side is a LIBRARY_CODE id too).
+-- The 110 pairs embedded below resolve it that way and match tubafrenzy
+-- exactly — verified row-by-row against the live database, 0 mismatches.
+--
+-- But on 15 of them the FK is CORRUPT UPSTREAM, and each row's own COMMENT
+-- proves it. Many comments carry a machine-generated provenance prefix,
+-- `[from <Genre>-<LETTERS>-<NUM> to <target>]`. Where the referencing row is a
+-- real filing (CALL_NUMBERS <> 0) and that prefix names a different non-zero
+-- code, the two disagree — and the prefix is the one telling the truth:
+--
+--   id  FK resolves to              provenance note names        target
+--   26  Cactus World News CA 46     Rock DO 66 = Tonya Donelly   The Breeders
+--   27  Cactus World News CA 46     Rock DO 66 = Tonya Donelly   Belly
+--   29  Capping Day CA 74           Rock CO 184 = Graham Coxon   Blur
+--   31  Chris Cacavas CA 66         Rock CA 37 = Camper Van B.   Eugene Chadbourne
+--   32  Cactus CA 153               Rock DE 80 = The Dentists    Coax
+--   33  Gloria Loring LO 24         Rock DE 90 = Amy Denio       Danubians
+--   34  Cabal CA 72                 Rock CA 8 = Caravan          Delivery
+--   36  Gloria Loring LO 24         Rock DO 73 = Julie Doiron    Eric's Trip
+--   38  Papa John Creach CR 59      Rock DE 39 = Dead Can Dance  Lisa Gerrard
+--   41  Capping Day CA 74           Rock DA 7 = Dave Davies      The Kinks
+--   43  Cabaret Voltaire CA 42      Rock DR 7 = Dream Syndicate  Last Days of May
+--   44  Cabaret Voltaire CA 42      Rock CH 11 = Sheila Chandra  Monsoon
+--   45  Cabaret Voltaire CA 42      Rock DR 7 = Dream Syndicate  Opal
+--   46  Cabal CA 72                 Rock CL 55 = Allen Clapp     The Orange Peels
+--   48  Cactus World News CA 46     Rock CA 69 = Lori Carson     Golden Palominos
+--
+-- Every note names a real, well-known musical relationship (Donelly was in the
+-- Breeders and founded Belly; Coxon is in Blur; Davies is a Kink; Gerrard is
+-- half of Dead Can Dance; Chandra fronted Monsoon; Clapp is the Orange Peels;
+-- Carson sang with the Golden Palominos). Every FK reading is nonsense
+-- (Cabaret Voltaire did not spawn Monsoon; Papa John Creach is not Lisa
+-- Gerrard). Note too that one FK value collapses several distinct true sources
+-- onto one arbitrary name — Cabaret Voltaire CA 42 stands in for three
+-- different referencing codes.
+--
+-- These 15 are EXCLUDED from the INSERT (see `bs2117_provenance_conflicts`
+-- below) and reported as `provenance_conflict_skip` in the pre-amble. The
+-- reason is asymmetric risk: unlike the missing pairs, these are associations
+-- prod does NOT hold, so no guard below would skip them — they would land as
+-- brand-new FALSE aliases on real catalog rows, and this script has no delete
+-- path to walk them back. A wrong alias on a live catalog row is worse than a
+-- missing one.
+--
+-- Repairing them by re-resolving the referencing side from the provenance
+-- prefix is mechanically easy and probably correct, but it is a data-quality
+-- judgement about tubafrenzy's own corruption, made from free-text prose, and
+-- it belongs to a cataloger and a follow-up ticket — not to a backfill whose
+-- stated contract is to move cataloger data across unchanged.
 --
 -- ## Hard ceiling: 31 of the 110 pairs are NOT recoverable by this script
 --
@@ -230,6 +297,50 @@
 -- than one artist after all three stages is AMBIGUOUS. Both are reported in
 -- the pre-amble and excluded from the INSERT — never guessed.
 --
+-- `wxyc_schema.fold_artist_name` is present in prod, on two independent
+-- counts: migration 0134 (`0134_fold-artist-name`, merged 2026-07-31) created
+-- it and now sits nine entries behind the journal tip, and `jobs/library-etl`
+-- calls it on every ETL run, which would fail outright if it were missing.
+-- There is also an `artists_fold_name_idx` btree on the expression, so stage 1
+-- is index-backed rather than a per-row seq scan — the whole 110-pair resolve
+-- measures ~25ms against 24k artists, well inside the 30s statement_timeout.
+--
+-- The fold's STRENGTH is deliberate and correct for this repair: NFD-normalize,
+-- strip combining marks, lowercase. Nothing else. It does not strip
+-- punctuation, articles, or bracketed qualifiers, so it cannot merge distinct
+-- artists — "Paris [rock band]" and "Paris [hiphop mc]" stay separate, which
+-- matters because pairs 54/55 reference both. The cost of that conservatism is
+-- that it misses tubafrenzy name VARIANTS, which is a real but small effect
+-- here: of the 28 unresolvable names, 24 have no plausible Backend
+-- counterpart at all, and only 4 are variants a looser rule would reach (see
+-- the hard-ceiling section). Loosening the fold to catch those 4 would risk
+-- the many-to-one collapses this table has no way to detect after the fact, so
+-- it is not done.
+--
+-- Two properties of the resolution were checked against the clone rather than
+-- assumed, because both would be silent if wrong:
+--   * Stage 2 falls THROUGH when `code_letters` narrows the candidate set to
+--     zero — it restores the stage-1 set rather than failing, so stage 3 still
+--     gets a chance. That path never engages here: no name with more than one
+--     candidate has zero code_letters matches among them. If it ever did, the
+--     worst case is still bounded — stage 3 either narrows to one, or the pair
+--     is reported AMBIGUOUS and skipped.
+--   * No single-candidate resolution CONTRADICTS tubafrenzy. Every endpoint
+--     that resolves to exactly one Backend artist and carries a non-empty
+--     CALL_LETTERS has that artist's `code_letters` agreeing with it. The
+--     lenient name-first rule is therefore never overriding a letters
+--     disagreement; it only fires where tubafrenzy recorded no letters to
+--     check against.
+--
+-- ## Concurrency
+--
+-- Run exactly one copy. The either-direction `NOT EXISTS` guard below reads a
+-- snapshot, so under READ COMMITTED two simultaneous runs could each see a
+-- pair as absent and insert it in OPPOSITE directions — which the ordered
+-- unique index cannot reject, and which is precisely the duplicate the guard
+-- exists to prevent. This is a hand-run operator script, so serializing it is
+-- a matter of not starting it twice, not of adding a lock.
+--
 -- ## Direction, idempotency, and the reversed-duplicate guard
 --
 -- `artist_crossreference`'s unique index is on the ORDERED pair
@@ -276,12 +387,18 @@
 --
 -- ## Cataloger comments
 --
--- 34 of the 110 pairs carry a tubafrenzy COMMENT (free-text cataloger
+-- 51 of the 110 pairs carry a tubafrenzy COMMENT (free-text cataloger
 -- rationale — "which one?", "RH records as Cyanosis", "shared member Adrian
 -- Finch", etc.). These are cataloger judgements the same way the
 -- cross-references themselves are (per the tracking issue's framing) and
 -- are lost forever after tubafrenzy turndown, so this script carries them
 -- into `artist_crossreference.comment` verbatim rather than discarding them.
+-- "Verbatim" is exact, not approximate: tubafrenzy's own
+-- `LIBRARY_CODE_CROSS_REFERENCE.COMMENT` is `varchar(100)`, so the 100-char
+-- values here (e.g. row 31, which ends mid-word at "for Camper Va") are
+-- already the full stored value — the truncation happened in tubafrenzy years
+-- ago and nothing is being clipped on the way out. The Backend column is
+-- `varchar(255)`, so there is headroom, not a lossy fit.
 --
 -- ## Trigger costs (expected, not bugs)
 --
@@ -475,6 +592,43 @@ INSERT INTO bs2117_pairs (row_id, src_name, src_letters, src_number, tgt_name, t
     (134, 'Thom Yorke', 'YO', 57, 'Radiohead', 'RA', 27, NULL),
     (135, 'Upsetters', 'Up', 2, 'Lee ''Scratch'' Perry', 'Pe', 1, NULL);
 
+-- ===========================================================
+-- Provenance conflicts: 15 pairs whose referencing side is contradicted by
+-- their own COMMENT, and which are therefore EXCLUDED from the INSERT.
+-- See the "Provenance conflicts" section in the header for the evidence.
+--
+-- Rule (mechanical, not hand-picked): the referencing LIBRARY_CODE is a real
+-- filing (CALL_NUMBERS <> 0), its COMMENT carries a machine-generated
+-- `[from <Genre>-<LETTERS>-<NUM> to <target>]` provenance note whose NUM is
+-- also non-zero, and the note's (LETTERS, NUM) differs from the referencing
+-- row's own. On every one of the 15, the note names a musically-correct
+-- artist and the FK names an unrelated one, so the FK is what is wrong.
+-- ===========================================================
+DROP TABLE IF EXISTS pg_temp.bs2117_provenance_conflicts;
+CREATE TEMP TABLE bs2117_provenance_conflicts (
+  row_id     int PRIMARY KEY,  -- LIBRARY_CODE_CROSS_REFERENCE.ID
+  fk_says    text NOT NULL,    -- what CROSS_REFERENCING_ARTIST_ID resolves to
+  note_says  text NOT NULL,    -- what the COMMENT's provenance prefix names
+  target     text NOT NULL
+) ON COMMIT PRESERVE ROWS;
+
+INSERT INTO bs2117_provenance_conflicts (row_id, fk_says, note_says, target) VALUES
+    (26, 'Cactus World News [CA 46]', 'Rock DO 66 = Tonya Donelly',      'The Breeders'),
+    (27, 'Cactus World News [CA 46]', 'Rock DO 66 = Tonya Donelly',      'Belly'),
+    (29, 'Capping Day [CA 74]',       'Rock CO 184 = Graham Coxon',      'Blur'),
+    (31, 'Chris Cacavas [CA 66]',     'Rock CA 37 = Camper Van Beethoven','Eugene Chadbourne'),
+    (32, 'Cactus [CA 153]',           'Rock DE 80 = The Dentists',       'Coax'),
+    (33, 'Gloria Loring [LO 24]',     'Rock DE 90 = Amy Denio',          'Danubians'),
+    (34, 'Cabal [CA 72]',             'Rock CA 8 = Caravan',             'Delivery'),
+    (36, 'Gloria Loring [LO 24]',     'Rock DO 73 = Julie Doiron',       'Eric''s Trip'),
+    (38, 'Papa John Creach [CR 59]',  'Rock DE 39 = Dead Can Dance',     'Lisa Gerrard'),
+    (41, 'Capping Day [CA 74]',       'Rock DA 7 = Dave Davies',         'The Kinks'),
+    (43, 'Cabaret Voltaire [CA 42]',  'Rock DR 7 = Dream Syndicate',     'Last Days of May'),
+    (44, 'Cabaret Voltaire [CA 42]',  'Rock CH 11 = Sheila Chandra',     'Monsoon'),
+    (45, 'Cabaret Voltaire [CA 42]',  'Rock DR 7 = Dream Syndicate',     'Opal'),
+    (46, 'Cabal [CA 72]',             'Rock CL 55 = Allen Clapp',        'The Orange Peels'),
+    (48, 'Cactus World News [CA 46]', 'Rock CA 69 = Lori Carson',        'Golden Palominos');
+
 -- Three-stage resolver: fold_artist_name -> code_letters -> genre code.
 -- Session-local (pg_temp), so it never touches the shared wxyc_schema
 -- namespace and needs no cleanup migration.
@@ -555,6 +709,7 @@ SELECT '=== BS2117 pre-amble: resolution outcome per pair ===' AS section;
 WITH resolved AS (
   SELECT
     p.row_id, p.src_name, p.tgt_name, p.xref_comment,
+    EXISTS (SELECT 1 FROM bs2117_provenance_conflicts pc WHERE pc.row_id = p.row_id) AS provenance_conflict,
     src.artist_id AS source_artist_id, src.match_count AS source_match_count, src.ambiguous AS source_ambiguous,
     tgt.artist_id AS target_artist_id, tgt.match_count AS target_match_count, tgt.ambiguous AS target_ambiguous
   FROM bs2117_pairs p
@@ -564,6 +719,7 @@ WITH resolved AS (
 SELECT
   row_id, src_name, tgt_name,
   CASE
+    WHEN provenance_conflict THEN 'provenance_conflict_skip'
     WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
     WHEN source_ambiguous THEN 'source_ambiguous'
     WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
@@ -573,19 +729,23 @@ SELECT
   END AS outcome,
   source_artist_id, source_match_count, target_artist_id, target_match_count
 FROM resolved
+-- Anomalies FIRST: these are the rows the operator must inspect before
+-- committing, and burying them under ~79 successful rows defeats the point.
 ORDER BY (CASE
+    WHEN provenance_conflict THEN 'provenance_conflict_skip'
     WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
     WHEN source_ambiguous THEN 'source_ambiguous'
     WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
     WHEN target_ambiguous THEN 'target_ambiguous'
     WHEN source_artist_id = target_artist_id THEN 'self_pair_skip'
     ELSE 'resolved'
-  END) <> 'resolved', row_id;
+  END) = 'resolved', row_id;
 
 SELECT '=== BS2117 pre-amble: outcome counts ===' AS section;
 WITH resolved AS (
   SELECT
     p.row_id,
+    EXISTS (SELECT 1 FROM bs2117_provenance_conflicts pc WHERE pc.row_id = p.row_id) AS provenance_conflict,
     src.artist_id AS source_artist_id, src.ambiguous AS source_ambiguous,
     tgt.artist_id AS target_artist_id, tgt.ambiguous AS target_ambiguous
   FROM bs2117_pairs p
@@ -595,6 +755,7 @@ WITH resolved AS (
 classified AS (
   SELECT
     CASE
+      WHEN provenance_conflict THEN 'provenance_conflict_skip'
       WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
       WHEN source_ambiguous THEN 'source_ambiguous'
       WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
@@ -623,6 +784,14 @@ WITH resolved AS (
   WHERE src.artist_id IS NOT NULL
     AND tgt.artist_id IS NOT NULL
     AND src.artist_id <> tgt.artist_id -- self-pair guard (row 128 "Oliver Lake"/"Oliver Lake")
+    -- Provenance guard: drop the 15 pairs whose referencing side is
+    -- contradicted by their own COMMENT. Without this the script inserts
+    -- brand-new FALSE aliases (Cactus World News <-> The Breeders, Capping Day
+    -- <-> Blur, ...) that prod does not hold, so nothing below would skip them
+    -- and there is no delete path to walk them back.
+    AND NOT EXISTS (
+      SELECT 1 FROM bs2117_provenance_conflicts pc WHERE pc.row_id = p.row_id
+    )
 ),
 canon AS (
   -- Canonicalize direction so a reversed duplicate (rows 74/75:
@@ -679,6 +848,9 @@ WITH resolved AS (
   WHERE src.artist_id IS NOT NULL
     AND tgt.artist_id IS NOT NULL
     AND src.artist_id <> tgt.artist_id
+    AND NOT EXISTS (
+      SELECT 1 FROM bs2117_provenance_conflicts pc WHERE pc.row_id = p.row_id
+    )
 )
 SELECT
   count(*) AS resolved_pairs,
@@ -700,4 +872,5 @@ SELECT count(*) FROM wxyc_schema.artist_crossreference;
 -- cannot run inside a transaction, so it lives here, after COMMIT.
 ANALYZE wxyc_schema.artist_crossreference;
 
-DROP TABLE IF EXISTS bs2117_pairs;
+DROP TABLE IF EXISTS pg_temp.bs2117_pairs;
+DROP TABLE IF EXISTS pg_temp.bs2117_provenance_conflicts;

--- a/scripts/audit/bs_2117_crossref_backfill.sql
+++ b/scripts/audit/bs_2117_crossref_backfill.sql
@@ -1,0 +1,553 @@
+-- BS2117: backfill wxyc_schema.artist_crossreference from tubafrenzy's
+-- LIBRARY_CODE_CROSS_REFERENCE, ahead of the 2026-08-31 tubafrenzy turndown.
+--
+-- Like V_BS_FFFD (scripts/audit/bs_replacement_char_recovery.sql), this is a
+-- HAND-APPLIED operator script, NOT a Drizzle migration — docs/migrations.md
+-- says migrations are DDL-only, and this is DML over a curated table. There
+-- is no entry in shared/database/src/migrations/; version history is just
+-- `git log -- scripts/audit/bs_2117_crossref_backfill.sql`. Run via
+-- `psql -f` against prod (see scripts/query-flowsheet.sh for the EC2-docker
+-- connection pattern).
+--
+-- ## Problem (#2117)
+--
+-- The first full catalog-parity run (discogs-etl#365, WXYC/wiki#89) found 157
+-- catalog rows whose tubafrenzy-derived `cross_reference_names` is non-empty
+-- but whose Backend-derived value is empty. tubafrenzy's authority for this
+-- field is `LIBRARY_CODE_CROSS_REFERENCE`; Backend's is `artist_crossreference`
+-- (see the `artist_aliases` CTE in apps/backend/services/catalog-export.service.ts).
+--
+-- ## Root cause (confirmed, not just hypothesized)
+--
+-- jobs/library-etl/job.ts already imports this exact table on every run
+-- (`fetchLegacyArtistCrossRefs` / `importArtistCrossRefs`, unconditional full
+-- scan of LIBRARY_CODE_CROSS_REFERENCE, not gated by "modified since"). Its
+-- `findArtistId` resolves an artist by
+--   fold_artist_name(artists.artist_name) = fold_artist_name($name)
+--   AND lower(artists.code_letters) = lower($codeLetters)
+-- i.e. it REQUIRES an exact `code_letters` match, with no name-only fallback.
+-- 35 of the 110 resolvable tubafrenzy pairs (below) have an EMPTY
+-- CALL_LETTERS on the referencing side — tubafrenzy's convention for a
+-- "pointer" LIBRARY_CODE that carries a PRESENTATION_NAME purely for
+-- cross-referencing but has no catalog holdings of its own (CALL_NUMBERS is
+-- also 0 on every one of these), e.g. "Barry Black" -> "Eric Bachmann"
+-- ("Barry Black is filed w/ Eric Bachmann"). Backend's `artists.code_letters`
+-- is NOT NULL, so `lower('') = lower(artists.code_letters)` can only ever
+-- match a Backend row that itself has an empty code_letters, which a real
+-- catalogued artist never has. The ETL's `skipped++` counter absorbs every
+-- one of these with no operator-visible signal. This is a keying mismatch in
+-- the existing importer, not an incomplete migration or an export-query gap
+-- — and it plausibly explains a large share of the 157, though we cannot
+-- attribute an exact count without prod visibility into which of the 110
+-- pairs Backend already has correctly (see "What this script cannot verify"
+-- in the tracking issue).
+--
+-- This script's resolver (below) does NOT require code_letters equality: it
+-- matches by folded name first, and uses code_letters, then
+-- genre_artist_crossreference.artist_genre_code, only to DISAMBIGUATE when a
+-- name matches more than one Backend artist. A name that resolves to zero or
+-- multiple Backend artists is reported in the pre-amble and skipped, never
+-- guessed.
+--
+-- ## Source data: 110 of 119 raw rows resolve; 9 dangle
+--
+-- LIBRARY_CODE_CROSS_REFERENCE has 119 rows. 9 have an endpoint whose
+-- LIBRARY_CODE no longer exists (the FK target was deleted from tubafrenzy
+-- at some point after the cross-reference was recorded). These are
+-- unrepairable by this script — there is no surviving PRESENTATION_NAME to
+-- resolve against Backend, and re-deriving one from free-text COMMENT prose
+-- (a couple of the 9 name the missing side in the comment, e.g. row 19's
+-- comment mentions "DeGli Antoni, Mark -- DE 137") is a guess, not cataloger
+-- data, and is deliberately NOT attempted here. Enumerated for the record
+-- (LIBRARY_CODE_CROSS_REFERENCE.ID, existing side, missing side, comment):
+--
+--   8   : missing(4835)              -> Clouddead (CL 7)              "Why? a member of Clouddead"
+--   19  : Soul Coughing               -> missing(7318)                 "...to Mark DeGli Antoni]#[see also DeGli Antoni, Mark -- DE 137]"
+--   30  : missing(6357)              -> Camper Van Beethoven (CA 37)  "...to Camper Van Beethoven]#[see also Camper Van Beethoven]"
+--   63  : Danger Mouse (DA 35)        -> missing(14013)                (no comment)
+--   64  : missing(14013)             -> Danger Mouse (DA 35)          (no comment; reverse of 63, same missing id both times)
+--   102 : What Peggy Wants (WH 40)    -> missing(17024)                (no comment)
+--   103 : Dillon Fence (DI 41)        -> missing(17024)                (no comment)
+--   104 : Snatches of Pink (SN 9)     -> missing(17024)                (no comment)
+--   111 : missing(11941)             -> Charlemagne (CH 182)          (no comment)
+--
+-- Disposition: excluded from this backfill. No further action proposed;
+-- these associations are lost with tubafrenzy regardless of what this
+-- script does.
+--
+-- ## The "28 both-sides-differ" bucket (#2117 acceptance criterion)
+--
+-- The parity harness also reports 28 catalog rows where `cross_reference_names`
+-- is non-empty on BOTH sides but the values differ. This script cannot
+-- enumerate those 28 by name — that list comes from `catalog_parity_diff.py`
+-- comparing a live Backend export against tubafrenzy, and there is no prod
+-- Backend database available in this environment (see below). What this
+-- script DOES do: it backfills every one of the 110 resolvable tubafrenzy
+-- pairs (idempotently, ON CONFLICT DO NOTHING), not just a hand-picked
+-- subset believed to cover the 157 empty-in-Backend bucket. If any of the 28
+-- both-sides-differ rows are explained by Backend having SOME but not ALL of
+-- a given artist's tubafrenzy cross-references (the same keying-mismatch
+-- root cause, partially masked because that artist already had at least one
+-- correctly-imported pair), this backfill fixes them as a side effect. It
+-- cannot fix a row where Backend holds a cross-reference tubafrenzy does NOT
+-- have (this script only inserts, never deletes) — that shape requires
+-- prod-side enumeration this environment doesn't have. Re-run the parity
+-- harness after this script deploys; file a follow-up naming whatever
+-- remains in the 28 (or a subset of it).
+--
+-- ## Reconciling "110 pairs" against "157 catalog rows"
+--
+-- These count different things. 110 raw rows collapse to 108 distinct
+-- unordered artist pairs (one exact duplicate: LIBRARY_CODE_CROSS_REFERENCE
+-- ids 88/89, "Preservation Hall Jazz Band"/"Sweet Emma Barrett" recorded
+-- twice; one reversed duplicate: ids 74/75, "Sankofa"/"The Apple Juice Kid"
+-- recorded in both directions), touching 182 distinct artist identities by
+-- name. `cross_reference_names` is exported per catalog ROW (one row per
+-- library pressing), keyed off that row's own artist — so a touched artist
+-- contributes to the 157 once per `library` row it owns, and the "pointer"
+-- artists noted above (35 of the 110 source-side names, e.g. "Barry Black")
+-- contribute ZERO rows because they have no catalog holdings of their own;
+-- their material is filed entirely under the artist they point at. 157
+-- release rows arising from up to 182 touched identities — many
+-- contributing 0 rows, some contributing several — is consistent with that
+-- shape; an exact per-artist release count would require the `library`
+-- table, which is not available here (see below).
+--
+-- ## Keying: tubafrenzy LIBRARY_CODE vs. Backend artists (resolution rule)
+--
+-- tubafrenzy identifies a LIBRARY_CODE by
+-- (PRESENTATION_NAME, CALL_LETTERS, CALL_NUMBERS, GENRE_ID) — CALL_NUMBERS
+-- and GENRE_ID are per-catalog-placement, not per-artist. Backend's
+-- `artists` row is name-scoped (no call number at all); the per-genre
+-- catalog number lives on `genre_artist_crossreference.artist_genre_code`,
+-- separately. So a tubafrenzy LIBRARY_CODE is not 1:1 with a Backend
+-- `artists` row. `bs2117_resolve_artist()` below resolves in three stages,
+-- each only engaged when the previous stage left more than one candidate:
+--   1. `fold_artist_name(artists.artist_name) = fold_artist_name(name)` —
+--      the same Unicode-form/diacritic/case-insensitive fold migration 0134
+--      added and jobs/library-etl already uses for this exact purpose.
+--   2. Narrow to candidates whose `code_letters` matches (case-insensitive)
+--      when the tubafrenzy side recorded non-empty CALL_LETTERS.
+--   3. Narrow further to candidates with a `genre_artist_crossreference`
+--      row whose `artist_genre_code` matches CALL_NUMBERS, when non-zero.
+-- A name matching zero artists is UNRESOLVED; a name still matching more
+-- than one artist after all three stages is AMBIGUOUS. Both are reported in
+-- the pre-amble and excluded from the INSERT — never guessed.
+--
+-- ## Direction, idempotency, and the reversed-duplicate guard
+--
+-- `artist_crossreference`'s unique index is on the ORDERED pair
+-- (source_artist_id, target_artist_id); the export's `artist_aliases` CTE
+-- unions both FK directions, so a pair only needs to exist once, in either
+-- direction, for the alias to appear on both artists' catalog rows. Two
+-- distinct hazards follow, both guarded explicitly below rather than left to
+-- ON CONFLICT alone:
+--   - SELF-PAIRS: LIBRARY_CODE_CROSS_REFERENCE row 128 links "Oliver Lake"
+--     to "Oliver Lake" (comment: "same Oliver Lake") — two DIFFERENT
+--     tubafrenzy LIBRARY_CODEs (CALL_NUMBERS 17 vs. 2) sharing one
+--     PRESENTATION_NAME, cross-referenced to point catalogers at the correct
+--     one. Backend's artist identity is name-scoped, so both resolve to the
+--     SAME `artists.id`; inserting that would create a
+--     source_artist_id = target_artist_id row, which nothing downstream can
+--     interpret as a real alias. Excluded explicitly (`source <> target`)
+--     and reported in the pre-amble rather than silently dropped.
+--   - REVERSED DUPLICATES: rows 74/75 record "Sankofa" -> "The Apple Juice
+--     Kid" AND "The Apple Juice Kid" -> "Sankofa" — the same unordered pair,
+--     opposite direction. `ON CONFLICT (source_artist_id, target_artist_id)
+--     DO NOTHING` does NOT catch this (different ordered key), so this
+--     script deduplicates by `LEAST`/`GREATEST` of the resolved artist ids
+--     BEFORE the INSERT (picking the direction where the lower artist id is
+--     the source — an arbitrary but deterministic, auditable convention),
+--     and separately guards against a pair Backend may already hold in
+--     EITHER direction via an explicit `NOT EXISTS` check (not just
+--     ON CONFLICT on the exact ordered pair) — necessary because we cannot
+--     inspect prod's existing rows ahead of time (see below).
+--
+-- Net effect: safe to run more than once. A second run finds nothing left
+-- to insert.
+--
+-- ## Cataloger comments
+--
+-- 34 of the 110 pairs carry a tubafrenzy COMMENT (free-text cataloger
+-- rationale — "which one?", "RH records as Cyanosis", "shared member Adrian
+-- Finch", etc.). These are cataloger judgements the same way the
+-- cross-references themselves are (per the tracking issue's framing) and
+-- are lost forever after tubafrenzy turndown, so this script carries them
+-- into `artist_crossreference.comment` verbatim rather than discarding them.
+--
+-- ## Watermark cost (expected, not a bug)
+--
+-- Migration 0138 attaches `touch_library_watermark_from_artist_crossreference`
+-- AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE (confirmed: fires on INSERT,
+-- not just UPDATE) FOR EACH STATEMENT to `artist_crossreference`. This
+-- script's INSERT will advance `library_watermark` and force the next
+-- `GET /library/catalog` request to rebuild the full gzip export cache. This
+-- is correct, intended behavior (the whole point of 0138 was to make
+-- `cross_reference_names` edits visible), just worth budgeting for — it is
+-- the same one-time cost any `library` add already pays.
+--
+-- ## What this script CANNOT verify (no prod database available here)
+--
+-- There is no Backend database with production data reachable from this
+-- environment — no prod credentials, and the local dev Postgres
+-- (dev_env/docker-compose.yml, port 5442) holds only seed/fixture data, not
+-- real WXYC artists. So: this script cannot be dry-run against real
+-- `artists` rows before being handed to an operator; the pre-amble's
+-- resolved/unresolved/ambiguous counts below are only meaningful once
+-- actually run against prod; and the "already exists" / reversed-duplicate
+-- guards are exercised here by construction (reading the SQL) rather than
+-- by having observed real conflicting rows. The operator running this
+-- against prod should read the pre-amble output before letting the
+-- transaction commit, per the SELECT-before-write convention.
+--
+-- Target: PostgreSQL 14 (prod RDS). No PG15+-only syntax is used.
+
+-- ===========================================================
+-- Setup: load the 110 resolvable tubafrenzy pairs into a session-temp
+-- table, and define the three-stage name resolver as a session-temp
+-- function. Both are read by the pre-amble AND the transactional INSERT
+-- below, so the pair data is written exactly once in this file.
+-- ===========================================================
+DROP TABLE IF EXISTS bs2117_pairs;
+CREATE TEMP TABLE bs2117_pairs (
+  row_id       int PRIMARY KEY,   -- LIBRARY_CODE_CROSS_REFERENCE.ID, for traceability
+  src_name     text NOT NULL,     -- referencing LIBRARY_CODE.PRESENTATION_NAME
+  src_letters  text NOT NULL,     -- referencing LIBRARY_CODE.CALL_LETTERS ('' if none)
+  src_number   int  NOT NULL,     -- referencing LIBRARY_CODE.CALL_NUMBERS (0 if none/"pointer" entry)
+  tgt_name     text NOT NULL,     -- referenced LIBRARY_CODE.PRESENTATION_NAME
+  tgt_letters  text NOT NULL,     -- referenced LIBRARY_CODE.CALL_LETTERS
+  tgt_number   int  NOT NULL,     -- referenced LIBRARY_CODE.CALL_NUMBERS
+  xref_comment text              -- tubafrenzy LIBRARY_CODE_CROSS_REFERENCE.COMMENT, NULL if none
+) ON COMMIT PRESERVE ROWS;
+
+INSERT INTO bs2117_pairs (row_id, src_name, src_letters, src_number, tgt_name, tgt_letters, tgt_number, xref_comment) VALUES
+    (2, 'Return to Forever', '', 0, 'Elf Power', 'EL', 38, 'shared member Adrian Finch'),
+    (3, 'Return to Forever', '', 0, 'Masters of the Hemisphere', 'MA', 182, 'shared member Adrian Finch'),
+    (4, 'Grace Braun', '', 0, 'DQE', 'DQ', 1, 'Grace''s solo work is filed w/ DQE'),
+    (5, 'Anne Gomez', '', 0, 'Cantwell Gomez & Jordan', 'CA', 166, 'bassist'),
+    (6, 'Return to Forever', '', 0, 'Chick Corea (Return to Forever)', 'Co', 11, 'RTF is filed w/ Chick Corea'),
+    (7, 'Sheryl Samuel', '', 0, 'Don Haynie', 'HA', 27, 'recorded as a duo'),
+    (9, 'Odd Nosdam', '', 0, 'Clouddead', 'CL', 7, 'Odd a member of Clouddead'),
+    (10, 'Chris D', '', 0, 'Divine Horsemen', 'DI', 32, '[from Rock-CH-0 to Divine Horsemen]#[see Divine Horsemen: Rock DI 32]'),
+    (12, 'Legendary Pink Dots', 'LE', 35, 'DNA Le Draw D Kee', 'DN', 2, '[from Rock-LE-0 to DNA Le Draw D Kee]#[see also DNA Le Draw D Kee -- DN 02]'),
+    (13, 'Dairy Queen Empire', '', 0, 'DQE', 'DQ', 1, '[from Rock-DA-0 to DQE]#[see DQE: Rock DQ 1]'),
+    (14, 'Arthur Brown', '', 0, 'The Crazy World of Arthur Brown', 'CR', 21, '[from Rock-BR-0 to The Crazy World of Arthur Brown]#[see Crazy World of Arthur Brown -- CR 21]'),
+    (15, 'Dirty Rotten Imbeciles', '', 0, 'D.R.I.', 'DR', 12, '[from Rock-DI-0 to D.R.I.]#[see D.R.I. -- DR 12]'),
+    (16, 'Marc Riley', '', 0, 'The Creepers', 'CR', 30, '[from Rock-RI-0 to The Creepers]#[see Creepers, The]'),
+    (17, 'Kevin Godley', '', 0, 'Lol Creme', 'CR', 6, '[from Rock-GO-0 to Lol Creme]#[see Creme, Lol]'),
+    (18, 'Volupuk', '', 0, 'Guigou Chevonier', 'CH', 135, '[from Rock-VO-0 to Guigou Chevonier]#[see also Chevonier, Guigou]'),
+    (20, 'Cash, Larry Jr.', '', 0, 'Larry Cash, Jr.', 'LA', 132, '[from Rock-CA-0 to Larry Cash, Jr.]#[band, not a person: filed under Rock LA 132]'),
+    (21, 'Wedding Present', '', 0, 'Cinerama', 'CI', 24, '[from Rock-WE-0 to Cinerama]#[see also Cinerama featuring David Gedge -- CI 24]'),
+    (23, 'Kendra Smith', '', 0, 'Clay Allison', 'CL', 20, '[from Rock-SM-0 to Clay Allison]#[see also Clay Allison]'),
+    (24, 'X', '', 0, 'Exene Cervenka', 'CE', 9, '[from Rock-X-0 to Exene Cervenka]#[see also Cervenka, Exene -- CE 9]'),
+    (25, 'Cactus', 'CA', 153, 'Jeff Beck', 'Be', 6, '[from Rock-CA-153 to Jeff Beck]#[see also Beck, Jeff]'),
+    (26, 'Cactus World News', 'CA', 46, 'The Breeders', 'Br', 70, '[from Rock-DO-66 to The Breeders]#[see also The Breeders]'),
+    (27, 'Cactus World News', 'CA', 46, 'Belly', 'Be', 76, '[from Rock-DO-66 to Belly]#[see also Belly]'),
+    (29, 'Capping Day', 'CA', 74, 'Blur', 'Bl', 101, '[from Rock-CO-184 to Blur]#[see also Blur]'),
+    (31, 'Chris Cacavas', 'CA', 66, 'Eugene Chadbourne', 'CH', 21, '[from Rock-CA-37 to Dr. Eugene Chadbourne]#[see also Chadbourne, Eugene - Rock Ch 21 - for Camper Va'),
+    (32, 'Cactus', 'CA', 153, 'Coax', 'CO', 156, '[from Rock-DE-80 to Coax]#[see also Coax -- CO 156]'),
+    (33, 'Gloria Loring', 'LO', 24, 'Danubians', 'DA', 103, '[from Rock-DE-90 to Danubians]#[see also Danubians -- DA 103]'),
+    (34, 'Cabal', 'CA', 72, 'Delivery', 'DE', 135, '[from Rock-CA-8 to Delivery]#[see also Delivery]'),
+    (36, 'Gloria Loring', 'LO', 24, 'Eric''s Trip', 'ER', 7, '[from Rock-DO-73 to Eric''s Trip]#[see also Eric''s Trip: Rock ER 7]'),
+    (38, 'Papa John Creach', 'CR', 59, 'Lisa Gerrard', 'GE', 28, '[from Rock-DE-39 to Lisa Gerrard]#[see also Gerrard, Lisa -- GE 28]'),
+    (41, 'Capping Day', 'CA', 74, 'The Kinks', 'KI', 5, '[from Rock-DA-7 to The Kinks]#[see also Kinks, The]'),
+    (42, 'Bill Ding', 'BI', 118, 'La Makita Soma', 'LA', 114, '[from Rock-BI-118 to La Makita Soma]#[see also La Makita Soma]'),
+    (43, 'Cabaret Voltaire', 'CA', 42, 'Last Days of May', 'LA', 116, '[from Rock-DR-7 to Last Days of May]#[see also Last Days of May - Rock LA 116]'),
+    (44, 'Cabaret Voltaire', 'CA', 42, 'Monsoon', 'MO', 25, '[from Rock-CH-11 to Monsoon]#[see also Monsoon]'),
+    (45, 'Cabaret Voltaire', 'CA', 42, 'Opal', 'OP', 2, '[from Rock-DR-7 to Opal]#[see also Opal - Rock OP 2]'),
+    (46, 'Cabal', 'CA', 72, 'The Orange Peels', 'OR', 31, '[from Rock-CL-55 to Orange Peels]#[see also Orange Peels]'),
+    (47, 'Chris D and the Divine Horsemen', '', 0, 'Divine Horsemen', 'DI', 32, '[from Rock-D-1 to Divine Horsemen]#[see Divine Horsemen: Rock D-32]'),
+    (48, 'Cactus World News', 'CA', 46, 'Golden Palominos', 'GO', 6, '[from Rock-CA-69 to Golden Palominos]#[see Golden Palominos]'),
+    (49, 'Crooked Fingers', '', 0, 'Eric Bachmann', 'BA', 189, 'Crooked Fingers is filed w/ Eric Bachmann'),
+    (50, 'Barry Black', '', 0, 'Eric Bachmann', 'BA', 189, 'Barry Black is filed w/ Eric Bachmann'),
+    (51, 'Tom Carter', '', 0, 'Charalambides', 'CH', 116, 'member'),
+    (52, 'Tom Carter', '', 0, 'The Mike Gunn', 'MI', 88, 'member'),
+    (53, 'Roger Hayes', '', 0, 'Cyanosis', 'CY', 10, 'RH records as Cyanosis'),
+    (54, 'Paris', '', 0, 'Paris [rock band]', 'PA', 5, 'which one?'),
+    (55, 'Paris', '', 0, 'Paris [hiphop mc]', 'Pa', 2, 'which one?'),
+    (56, 'June Carter Cash', 'CA', 42, 'Carter Family', 'Ca', 20, NULL),
+    (57, 'Adam Forkner', '', 0, '[[[[ VVRSSNN ]]]]', 'VE', 3, 'pronounced ''Version'''),
+    (58, 'Version', '', 0, '[[[[ VVRSSNN ]]]]', 'VE', 3, NULL),
+    (59, 'Minerva Strain', 'MI', 70, 'Polynya', 'PO', 123, NULL),
+    (60, 'Arab Strap', 'Ar', 47, 'Malcolm Middleton', 'MI', 155, NULL),
+    (61, 'Geraldine Fibbers', 'GE', 25, 'Carla Bozulich', 'BO', 148, NULL),
+    (62, 'Get Up Kids', 'GE', 31, 'The New Amsterdams', 'NE', 117, NULL),
+    (65, 'Steven Wray Lobdell', 'LO', 156, 'Davis Redford Triad', 'DA', 117, NULL),
+    (66, 'The Animals', 'An', 4, 'Alan Price', 'PR', 6, NULL),
+    (67, 'The Animals', 'An', 4, 'Eric Burdon', 'BU', 121, NULL),
+    (68, 'Mission of Burma', 'MI', 26, 'Consonant', 'CO', 220, NULL),
+    (69, 'Lozenge', 'LO', 93, 'Kyle Bruckmann', 'BR', 53, NULL),
+    (70, 'Blackalicious', 'Bl', 18, 'The Gift of Gab', 'GI', 3, NULL),
+    (71, 'The Be Good Tanyas', 'BE', 14, 'Jolie Holland', 'HO', 20, NULL),
+    (72, 'Hella', 'HE', 116, 'Nervous Cop', 'NE', 125, NULL),
+    (73, 'Deerhoof', 'DE', 121, 'Nervous Cop', 'NE', 125, NULL),
+    (74, 'Sankofa', 'Sa', 6, 'The Apple Juice Kid', 'AP', 6, NULL),
+    (75, 'The Apple Juice Kid', 'AP', 6, 'Sankofa', 'Sa', 6, NULL),
+    (76, 'Oval', 'OV', 2, 'Microstoria', 'MI', 20, NULL),
+    (77, 'Mouse On Mars', 'Mo', 1, 'Microstoria', 'MI', 20, NULL),
+    (79, 'The Promise Ring', 'PR', 78, 'Maritime', 'MA', 262, NULL),
+    (80, 'Matthew Shipp', 'Sh', 15, 'The Blue Series Continuum', 'BL', 29, NULL),
+    (81, 'Cannibal Ox', '', 0, 'Vast Aire', 'VA', 11, NULL),
+    (82, 'Califone', 'CA', 141, 'The Black-Eyed Snakes', 'BL', 176, NULL),
+    (83, 'Low', 'LO', 80, 'The Black-Eyed Snakes', 'BL', 176, NULL),
+    (84, 'Prefuse 73', 'PR', 20, 'Savath + Savalas', 'SA', 95, NULL),
+    (85, 'DAT Politics', 'DA', 39, 'Aelters', 'AE', 2, NULL),
+    (86, 'LAN', '', 0, 'L@N', 'L', 4, NULL),
+    (87, 'Local Area Network', '', 0, 'L@N', 'L', 4, NULL),
+    (88, 'Preservation Hall Jazz Band', 'Pr', 6, 'Sweet Emma Barrett', 'BA', 45, NULL),
+    (89, 'Preservation Hall Jazz Band', 'Pr', 6, 'Sweet Emma Barrett', 'BA', 45, NULL),
+    (90, 'Duncan Browne', 'Br', 7, 'Metro', 'ME', 115, NULL),
+    (91, 'Peter Godwin', 'GO', 12, 'Metro', 'ME', 115, NULL),
+    (92, 'The Raymond Brake', 'RA', 84, 'Tussle', 'TU', 36, NULL),
+    (93, 'Pere Ubu', 'PE', 15, 'Rocket from the Tombs', 'RO', 63, NULL),
+    (94, 'Dead Boys', 'DE', 38, 'Rocket from the Tombs', 'RO', 63, NULL),
+    (99, 'Califone', 'CA', 141, 'Red Red Meat', 'RE', 83, NULL),
+    (100, 'The Ladybug Transistor', 'LA', 75, 'Finishing School', 'FI', 93, NULL),
+    (101, 'The Essex Green', 'ES', 10, 'Finishing School', 'FI', 93, NULL),
+    (105, 'Godspeed You Black Emperor!', 'GO', 98, 'Valley of the Giants', 'VA', 54, NULL),
+    (106, 'Do Make Say Think', 'DO', 82, 'Valley of the Giants', 'VA', 54, NULL),
+    (107, 'Broken Social Scene', 'Br', 147, 'Valley of the Giants', 'VA', 54, NULL),
+    (108, 'Shalabi Effect', 'SH', 126, 'Valley of the Giants', 'VA', 54, NULL),
+    (109, 'Leroy Jenkins', 'Je', 2, 'The Revolutionary Ensemble', 'RE', 22, NULL),
+    (110, 'Antipop Consortium', 'An', 4, 'Beans [hiphop mc]', 'Be', 15, NULL),
+    (112, 'Pelt', 'PE', 52, 'Jack Rose', 'RO', 145, NULL),
+    (113, 'Arab Strap', 'Ar', 47, 'Sons and Daughters', 'SO', 106, NULL),
+    (114, 'Boredoms', 'Bo', 59, 'OOIOO', 'OO', 1, NULL),
+    (115, 'The Moon Seven Times', 'MO', 102, 'Lanterna', 'LA', 80, NULL),
+    (116, 'Area', 'Ar', 12, 'Lanterna', 'LA', 80, NULL),
+    (119, 'Don Caballero', 'DO', 55, 'Thee Speaking Canaries', 'SP', 72, NULL),
+    (120, 'The Lyres', 'LY', 4, 'DMZ', 'DM', 1, NULL),
+    (121, 'Vocokesh', 'VO', 16, 'F/I', 'FI', 85, NULL),
+    (122, 'Madlib', 'MA', 40, 'Madvillain', 'MA', 48, NULL),
+    (123, 'Damo Suzuki', '', 0, 'Can', 'CA', 61, NULL),
+    (124, 'The Minus 5', 'MI', 100, 'The Young Fresh Fellows', 'YO', 8, NULL),
+    (125, 'Hella', 'HE', 116, 'The Advantage', 'AD', 25, NULL),
+    (126, 'Crime in Choir', 'CR', 127, 'The Advantage', 'AD', 25, NULL),
+    (128, 'Oliver Lake', 'La', 17, 'Oliver Lake', 'LA', 2, 'same Oliver Lake'),
+    (129, 'Superchunk', 'SU', 36, 'Tom Scharpling', 'SC', 1, 'Superchunk drummer Jon Wurster is one-half of Scharpling & Wurster'),
+    (130, 'Peter Cook', 'CO', 2, 'Beyond the Fringe', 'BE', 4, 'see also Beyond the Fringe'),
+    (131, 'Dudley Moore', '', 0, 'Beyond the Fringe', 'BE', 4, 'see also Beyond the Fringe'),
+    (132, 'Don Novello', '', 0, 'Father Guido Sarducci', 'SA', 1, 'see Sarducci, Father Guido'),
+    (133, 'Peter Sellers', '', 0, 'Goon Show', 'GO', 3, 'see Goon Show'),
+    (134, 'Thom Yorke', 'YO', 57, 'Radiohead', 'RA', 27, NULL),
+    (135, 'Upsetters', 'Up', 2, 'Lee ''Scratch'' Perry', 'Pe', 1, NULL);
+
+-- Three-stage resolver: fold_artist_name -> code_letters -> genre code.
+-- Session-local (pg_temp), so it never touches the shared wxyc_schema
+-- namespace and needs no cleanup migration.
+CREATE OR REPLACE FUNCTION pg_temp.bs2117_resolve_artist(
+  p_name text, p_letters text, p_number int
+) RETURNS TABLE(artist_id int, match_count int, ambiguous boolean) AS $$
+DECLARE
+  v_stage1 int[];
+  v_ids int[];
+BEGIN
+  SELECT array_agg(a.id) INTO v_stage1
+  FROM wxyc_schema.artists a
+  WHERE wxyc_schema.fold_artist_name(a.artist_name) = wxyc_schema.fold_artist_name(p_name);
+
+  IF v_stage1 IS NULL OR array_length(v_stage1, 1) = 0 THEN
+    RETURN QUERY SELECT NULL::int, 0, false;
+    RETURN;
+  END IF;
+
+  IF array_length(v_stage1, 1) = 1 THEN
+    RETURN QUERY SELECT v_stage1[1], 1, false;
+    RETURN;
+  END IF;
+
+  v_ids := v_stage1;
+  IF p_letters IS NOT NULL AND p_letters <> '' THEN
+    SELECT array_agg(a.id) INTO v_ids
+    FROM wxyc_schema.artists a
+    WHERE a.id = ANY(v_stage1) AND lower(a.code_letters) = lower(p_letters);
+    IF v_ids IS NULL OR array_length(v_ids, 1) = 0 THEN
+      v_ids := v_stage1; -- letters didn't narrow anything; fall through still ambiguous
+    END IF;
+  END IF;
+
+  IF array_length(v_ids, 1) = 1 THEN
+    RETURN QUERY SELECT v_ids[1], 1, false;
+    RETURN;
+  END IF;
+
+  IF p_number IS NOT NULL AND p_number <> 0 THEN
+    DECLARE
+      v_ids2 int[];
+    BEGIN
+      SELECT array_agg(a.id) INTO v_ids2
+      FROM wxyc_schema.artists a
+      WHERE a.id = ANY(v_ids)
+        AND EXISTS (
+          SELECT 1 FROM wxyc_schema.genre_artist_crossreference g
+          WHERE g.artist_id = a.id AND g.artist_genre_code = p_number
+        );
+      IF v_ids2 IS NOT NULL AND array_length(v_ids2, 1) >= 1 THEN
+        v_ids := v_ids2;
+      END IF;
+    END;
+  END IF;
+
+  IF array_length(v_ids, 1) = 1 THEN
+    RETURN QUERY SELECT v_ids[1], 1, false;
+    RETURN;
+  END IF;
+
+  -- Still 2+ candidates after all three stages: report as ambiguous, using
+  -- the original (widest) match count so the pre-amble shows the true scope.
+  RETURN QUERY SELECT NULL::int, array_length(v_stage1, 1), true;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- ===========================================================
+-- Pre-amble: resolution report. Read this before letting the COMMIT below
+-- land. "resolved" pairs are what will be inserted (modulo the self-pair
+-- and reversed-duplicate/already-exists guards in the transaction);
+-- "unresolved"/"ambiguous" are reported, never guessed.
+-- ===========================================================
+SELECT '=== BS2117 pre-amble: total pairs loaded ===' AS section;
+SELECT count(*) AS total_pairs FROM bs2117_pairs;
+
+SELECT '=== BS2117 pre-amble: resolution outcome per pair ===' AS section;
+WITH resolved AS (
+  SELECT
+    p.row_id, p.src_name, p.tgt_name, p.xref_comment,
+    src.artist_id AS source_artist_id, src.match_count AS source_match_count, src.ambiguous AS source_ambiguous,
+    tgt.artist_id AS target_artist_id, tgt.match_count AS target_match_count, tgt.ambiguous AS target_ambiguous
+  FROM bs2117_pairs p
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.src_name, p.src_letters, p.src_number) AS src(artist_id, match_count, ambiguous)
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.tgt_name, p.tgt_letters, p.tgt_number) AS tgt(artist_id, match_count, ambiguous)
+)
+SELECT
+  row_id, src_name, tgt_name,
+  CASE
+    WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
+    WHEN source_ambiguous THEN 'source_ambiguous'
+    WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
+    WHEN target_ambiguous THEN 'target_ambiguous'
+    WHEN source_artist_id = target_artist_id THEN 'self_pair_skip'
+    ELSE 'resolved'
+  END AS outcome,
+  source_artist_id, source_match_count, target_artist_id, target_match_count
+FROM resolved
+ORDER BY (CASE
+    WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
+    WHEN source_ambiguous THEN 'source_ambiguous'
+    WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
+    WHEN target_ambiguous THEN 'target_ambiguous'
+    WHEN source_artist_id = target_artist_id THEN 'self_pair_skip'
+    ELSE 'resolved'
+  END) <> 'resolved', row_id;
+
+SELECT '=== BS2117 pre-amble: outcome counts ===' AS section;
+WITH resolved AS (
+  SELECT
+    p.row_id,
+    src.artist_id AS source_artist_id, src.ambiguous AS source_ambiguous,
+    tgt.artist_id AS target_artist_id, tgt.ambiguous AS target_ambiguous
+  FROM bs2117_pairs p
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.src_name, p.src_letters, p.src_number) AS src(artist_id, match_count, ambiguous)
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.tgt_name, p.tgt_letters, p.tgt_number) AS tgt(artist_id, match_count, ambiguous)
+),
+classified AS (
+  SELECT
+    CASE
+      WHEN source_artist_id IS NULL AND NOT source_ambiguous THEN 'source_unresolved'
+      WHEN source_ambiguous THEN 'source_ambiguous'
+      WHEN target_artist_id IS NULL AND NOT target_ambiguous THEN 'target_unresolved'
+      WHEN target_ambiguous THEN 'target_ambiguous'
+      WHEN source_artist_id = target_artist_id THEN 'self_pair_skip'
+      ELSE 'resolved'
+    END AS outcome
+  FROM resolved
+)
+SELECT outcome, count(*) FROM classified GROUP BY outcome ORDER BY outcome;
+
+-- ===========================================================
+-- Transactional INSERT block.
+-- ===========================================================
+BEGIN;
+SET LOCAL statement_timeout = '30s';
+
+WITH resolved AS (
+  SELECT
+    p.xref_comment,
+    src.artist_id AS source_artist_id,
+    tgt.artist_id AS target_artist_id
+  FROM bs2117_pairs p
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.src_name, p.src_letters, p.src_number) AS src(artist_id, match_count, ambiguous)
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.tgt_name, p.tgt_letters, p.tgt_number) AS tgt(artist_id, match_count, ambiguous)
+  WHERE src.artist_id IS NOT NULL
+    AND tgt.artist_id IS NOT NULL
+    AND src.artist_id <> tgt.artist_id -- self-pair guard (row 128 "Oliver Lake"/"Oliver Lake")
+),
+canon AS (
+  -- Canonicalize direction so a reversed duplicate (rows 74/75:
+  -- Sankofa<->The Apple Juice Kid) collapses to one row: the lower
+  -- artist_id becomes source. Deterministic, not meaningful beyond dedup —
+  -- the export CTE reads both directions regardless.
+  SELECT
+    LEAST(source_artist_id, target_artist_id) AS source_artist_id,
+    GREATEST(source_artist_id, target_artist_id) AS target_artist_id,
+    xref_comment
+  FROM resolved
+),
+deduped AS (
+  SELECT DISTINCT ON (source_artist_id, target_artist_id)
+    source_artist_id, target_artist_id, xref_comment
+  FROM canon
+  ORDER BY source_artist_id, target_artist_id
+)
+INSERT INTO wxyc_schema.artist_crossreference (source_artist_id, target_artist_id, comment)
+SELECT d.source_artist_id, d.target_artist_id, d.xref_comment
+FROM deduped d
+WHERE NOT EXISTS (
+  -- Guard the reversed-duplicate case ON CONFLICT (on the ordered pair)
+  -- cannot see: a pair Backend already holds in the OPPOSITE direction.
+  SELECT 1 FROM wxyc_schema.artist_crossreference existing
+  WHERE (existing.source_artist_id = d.source_artist_id AND existing.target_artist_id = d.target_artist_id)
+     OR (existing.source_artist_id = d.target_artist_id AND existing.target_artist_id = d.source_artist_id)
+)
+ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING;
+
+COMMIT;
+
+-- ===========================================================
+-- Post-amble: verify every resolved, non-self pair now exists in
+-- artist_crossreference in at least one direction. Any row reporting
+-- present = false here after a successful COMMIT is a bug in this script,
+-- not an expected outcome.
+-- ===========================================================
+SELECT '=== BS2117 post-amble: resolved pairs now present (either direction) ===' AS section;
+WITH resolved AS (
+  SELECT DISTINCT
+    src.artist_id AS source_artist_id,
+    tgt.artist_id AS target_artist_id
+  FROM bs2117_pairs p
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.src_name, p.src_letters, p.src_number) AS src(artist_id, match_count, ambiguous)
+  CROSS JOIN LATERAL pg_temp.bs2117_resolve_artist(p.tgt_name, p.tgt_letters, p.tgt_number) AS tgt(artist_id, match_count, ambiguous)
+  WHERE src.artist_id IS NOT NULL
+    AND tgt.artist_id IS NOT NULL
+    AND src.artist_id <> tgt.artist_id
+)
+SELECT
+  count(*) AS resolved_pairs,
+  count(*) FILTER (
+    WHERE EXISTS (
+      SELECT 1 FROM wxyc_schema.artist_crossreference existing
+      WHERE (existing.source_artist_id = resolved.source_artist_id AND existing.target_artist_id = resolved.target_artist_id)
+         OR (existing.source_artist_id = resolved.target_artist_id AND existing.target_artist_id = resolved.source_artist_id)
+    )
+  ) AS present_in_backend
+FROM resolved;
+
+SELECT '=== BS2117 post-amble: total artist_crossreference row count ===' AS section;
+SELECT count(*) FROM wxyc_schema.artist_crossreference;
+
+-- Refresh planner stats on the touched table (#934 rule; touch_library_
+-- watermark's own UPDATE on library_watermark is a single-row write with no
+-- covering index affected, so it needs no ANALYZE of its own). ANALYZE
+-- cannot run inside a transaction, so it lives here, after COMMIT.
+ANALYZE wxyc_schema.artist_crossreference;
+
+DROP TABLE IF EXISTS bs2117_pairs;

--- a/scripts/audit/bs_2117_crossref_backfill.sql
+++ b/scripts/audit/bs_2117_crossref_backfill.sql
@@ -49,6 +49,42 @@
 -- multiple Backend artists is reported in the pre-amble and skipped, never
 -- guessed.
 --
+-- ## Measured against the dev-clone Postgres (dev_env/seed-clone.sql, a real
+-- pg_dump --data-only snapshot derived from staging; NOT prod, and possibly
+-- stale relative to it — reported here as clone-measured, not prod-measured)
+--
+-- Running this script's resolver against the clone settles the "missing
+-- rows vs. keying mismatch vs. export-query gap" question for that
+-- snapshot: `wxyc_schema.artist_crossreference` held ZERO rows before this
+-- script ran there — not partially populated, empty. Of the 110 pairs, 79
+-- resolved by name (79 -> 78 distinct ordered tuples -> 77 physical rows
+-- after the reversed/exact-duplicate dedup below) and 31 did not resolve at
+-- all. Every one of those 31 unresolved rows had an EMPTY referencing-side
+-- CALL_LETTERS (100% correlation, not just "35 of 110 raw rows look
+-- suspicious") — i.e. Backend has never created an `artists` row for these
+-- "pointer" names at all, consistent with them having zero catalog holdings
+-- of their own to trigger artist creation via a release import. Separately,
+-- 73 of the 79 resolved pairs ALSO satisfy the deployed importer's strict
+-- `code_letters` equality (only 4 needed this script's more lenient
+-- name-first resolution) — so a completely empty table is better explained
+-- by the crossref-import step not having run at all against this snapshot
+-- than by it running and mostly failing on keying. Both mechanisms are
+-- real: the empty-table observation explains why the table is empty *here*;
+-- the code_letters-required-with-no-fallback behavior in `findArtistId`
+-- explains why 31/110 (28%) can NEVER be recovered by ANY importer that
+-- only knows tubafrenzy's (name, code_letters) pair, this script included —
+-- they need name alone, which only resolves because there happens to be
+-- exactly one Backend artist with that folded name.
+--
+-- This does not by itself prove what prod's live `artist_crossreference`
+-- looked like when the parity harness ran (the ticket's 28-both-sides-differ
+-- and 11-empty-in-tubafrenzy buckets require SOME non-empty Backend rows to
+-- exist, which an entirely empty table could not produce — so live prod is
+-- not simply this snapshot). What it does establish: the resolution
+-- mechanics below are real and tested against real WXYC artist names, not
+-- synthetic ones, and the 31-name hard ceiling on recoverability is a
+-- measured fact, not a guess.
+--
 -- ## Source data: 110 of 119 raw rows resolve; 9 dangle
 --
 -- LIBRARY_CODE_CROSS_REFERENCE has 119 rows. 9 have an endpoint whose
@@ -102,16 +138,21 @@
 -- ids 88/89, "Preservation Hall Jazz Band"/"Sweet Emma Barrett" recorded
 -- twice; one reversed duplicate: ids 74/75, "Sankofa"/"The Apple Juice Kid"
 -- recorded in both directions), touching 182 distinct artist identities by
--- name. `cross_reference_names` is exported per catalog ROW (one row per
--- library pressing), keyed off that row's own artist — so a touched artist
--- contributes to the 157 once per `library` row it owns, and the "pointer"
--- artists noted above (35 of the 110 source-side names, e.g. "Barry Black")
--- contribute ZERO rows because they have no catalog holdings of their own;
--- their material is filed entirely under the artist they point at. 157
--- release rows arising from up to 182 touched identities — many
--- contributing 0 rows, some contributing several — is consistent with that
--- shape; an exact per-artist release count would require the `library`
--- table, which is not available here (see below).
+-- name (151 of which resolve to a real Backend `artists` row in the
+-- dev-clone measurement above — the other 31 are the unresolvable
+-- "pointer" names). `cross_reference_names` is exported per catalog ROW
+-- (one row per library pressing), keyed off that row's own artist — so a
+-- touched artist contributes to the 157 once per `library` row it owns, and
+-- the unresolvable "pointer" artists (e.g. "Barry Black") contribute ZERO
+-- rows because they have no catalog holdings of their own; their material
+-- is filed entirely under the artist they point at. Measured against the
+-- dev-clone: the 151 resolvable touched artists own 902 `library` rows
+-- between them. 157 release rows affected out of a 902-row eligible
+-- population (many of those 902 rows may already carry a correct, non-empty
+-- `cross_reference_names` on the Backend side today, or belong to an artist
+-- whose OTHER cross-references are already present) is consistent with that
+-- shape — it does not reconcile to an exact 1:1 count, and does not need
+-- to; the 902 figure is this clone's population, not necessarily prod's.
 --
 -- ## Keying: tubafrenzy LIBRARY_CODE vs. Backend artists (resolution rule)
 --
@@ -188,17 +229,25 @@
 --
 -- ## What this script CANNOT verify (no prod database available here)
 --
--- There is no Backend database with production data reachable from this
--- environment — no prod credentials, and the local dev Postgres
--- (dev_env/docker-compose.yml, port 5442) holds only seed/fixture data, not
--- real WXYC artists. So: this script cannot be dry-run against real
--- `artists` rows before being handed to an operator; the pre-amble's
--- resolved/unresolved/ambiguous counts below are only meaningful once
--- actually run against prod; and the "already exists" / reversed-duplicate
--- guards are exercised here by construction (reading the SQL) rather than
--- by having observed real conflicting rows. The operator running this
--- against prod should read the pre-amble output before letting the
--- transaction commit, per the SELECT-before-write convention.
+-- There is no PROD Backend database reachable from this environment — no
+-- prod credentials. The local dev Postgres (dev_env/docker-compose.yml,
+-- port 5442) DOES hold real, staging-derived data when seeded from
+-- `dev_env/seed-clone.sql` (a real `pg_dump --data-only` snapshot, ~64k
+-- `library` rows), and this script was dry-run against it end to end (see
+-- the "Measured against the dev-clone Postgres" section above) — so the
+-- resolver, self-pair guard, reversed-duplicate dedup, NOT EXISTS guard,
+-- and idempotent re-run were all exercised against real WXYC artist names,
+-- not just read by construction. What that snapshot cannot answer: it is
+-- point-in-time and may be stale relative to live prod (its
+-- `artist_crossreference` was completely empty, which — per the "28
+-- both-sides-differ" / "11 empty-in-tubafrenzy" buckets requiring some
+-- non-empty Backend rows — prod evidently is not, as of the parity run);
+-- and it cannot confirm which of the 110 pairs prod already has correctly,
+-- so the exact insert count against prod will differ from the clone's 77.
+-- The operator running this against prod should still read the pre-amble
+-- output before letting the transaction commit, per the SELECT-before-write
+-- convention — the resolution counts there will legitimately differ from
+-- what this file's comments report for the clone.
 --
 -- Target: PostgreSQL 14 (prod RDS). No PG15+-only syntax is used.
 

--- a/scripts/audit/bs_2117_crossref_backfill.sql
+++ b/scripts/audit/bs_2117_crossref_backfill.sql
@@ -17,7 +17,7 @@
 -- field is `LIBRARY_CODE_CROSS_REFERENCE`; Backend's is `artist_crossreference`
 -- (see the `artist_aliases` CTE in apps/backend/services/catalog-export.service.ts).
 --
--- ## Root cause (confirmed, not just hypothesized)
+-- ## Root cause: a keying mismatch in the deployed importer
 --
 -- jobs/library-etl/job.ts already imports this exact table on every run
 -- (`fetchLegacyArtistCrossRefs` / `importArtistCrossRefs`, unconditional full
@@ -35,12 +35,18 @@
 -- is NOT NULL, so `lower('') = lower(artists.code_letters)` can only ever
 -- match a Backend row that itself has an empty code_letters, which a real
 -- catalogued artist never has. The ETL's `skipped++` counter absorbs every
--- one of these with no operator-visible signal. This is a keying mismatch in
--- the existing importer, not an incomplete migration or an export-query gap
--- — and it plausibly explains a large share of the 157, though we cannot
--- attribute an exact count without prod visibility into which of the 110
--- pairs Backend already has correctly (see "What this script cannot verify"
--- in the tracking issue).
+-- one of these with no operator-visible signal.
+--
+-- That blind spot is the right SIZE for the defect. `cross_reference_names`
+-- is exported per catalog ROW of the artist the row hangs off, so a pointer
+-- pair that fails to import leaves the artist it points AT short an alias on
+-- every one of that artist's rows. In the dev clone the 35 empty-CALL_LETTERS
+-- pairs point at 30 distinct Backend artists owning **166 `library` rows** —
+-- against the harness's 157 empty-in-Backend catalog rows. That is a fit, not
+-- a proof (the clone is not prod), but it is a materially better fit than any
+-- competing explanation, and it is consistent with prod's
+-- `artist_crossreference` being otherwise well populated — which the
+-- harness's other buckets independently require (next section).
 --
 -- This script's resolver (below) does NOT require code_letters equality: it
 -- matches by folded name first, and uses code_letters, then
@@ -49,41 +55,85 @@
 -- multiple Backend artists is reported in the pre-amble and skipped, never
 -- guessed.
 --
--- ## Measured against the dev-clone Postgres (dev_env/seed-clone.sql, a real
--- pg_dump --data-only snapshot derived from staging; NOT prod, and possibly
--- stale relative to it — reported here as clone-measured, not prod-measured)
+-- ## What the dev clone can and cannot tell us
 --
--- Running this script's resolver against the clone settles the "missing
--- rows vs. keying mismatch vs. export-query gap" question for that
--- snapshot: `wxyc_schema.artist_crossreference` held ZERO rows before this
--- script ran there — not partially populated, empty. Of the 110 pairs, 79
--- resolved by name (79 -> 78 distinct ordered tuples -> 77 physical rows
--- after the reversed/exact-duplicate dedup below) and 31 did not resolve at
--- all. Every one of those 31 unresolved rows had an EMPTY referencing-side
--- CALL_LETTERS (100% correlation, not just "35 of 110 raw rows look
--- suspicious") — i.e. Backend has never created an `artists` row for these
--- "pointer" names at all, consistent with them having zero catalog holdings
--- of their own to trigger artist creation via a release import. Separately,
--- 73 of the 79 resolved pairs ALSO satisfy the deployed importer's strict
--- `code_letters` equality (only 4 needed this script's more lenient
--- name-first resolution) — so a completely empty table is better explained
--- by the crossref-import step not having run at all against this snapshot
--- than by it running and mostly failing on keying. Both mechanisms are
--- real: the empty-table observation explains why the table is empty *here*;
--- the code_letters-required-with-no-fallback behavior in `findArtistId`
--- explains why 31/110 (28%) can NEVER be recovered by ANY importer that
--- only knows tubafrenzy's (name, code_letters) pair, this script included —
--- they need name alone, which only resolves because there happens to be
--- exactly one Backend artist with that folded name.
+-- The dev clone (dev_env/seed-clone.sql) reports `artist_crossreference` as
+-- completely EMPTY. **That measurement carries no information about prod and
+-- must not be read as "the import step never ran."** The fixture's leading
+-- TRUNCATE block lists `wxyc_schema.artist_crossreference`, and its
+-- `pg_dump --data-only` body restores only five tables — `format`, `artists`,
+-- `genre_artist_crossreference`, `library`, `rotation`. The cross-reference
+-- table is truncated and never repopulated, so it reads as empty in every
+-- environment that loads this fixture, whatever staging or prod actually
+-- holds. Its emptiness here is an artifact of the fixture's table list.
 --
--- This does not by itself prove what prod's live `artist_crossreference`
--- looked like when the parity harness ran (the ticket's 28-both-sides-differ
--- and 11-empty-in-tubafrenzy buckets require SOME non-empty Backend rows to
--- exist, which an entirely empty table could not produce — so live prod is
--- not simply this snapshot). What it does establish: the resolution
--- mechanics below are real and tested against real WXYC artist names, not
--- synthetic ones, and the 31-name hard ceiling on recoverability is a
--- measured fact, not a guess.
+-- The parity harness settles the question in the other direction. Its
+-- 11-empty-in-tubafrenzy and 28-differ-on-both-sides buckets each require
+-- Backend to be emitting cross-reference values that tubafrenzy does not
+-- match; an empty table cannot produce either bucket. **Prod's
+-- `artist_crossreference` is populated**, the deployed importer has been
+-- running and mostly succeeding, and what it has never been able to import is
+-- the pointer pairs above.
+--
+-- What the clone IS good for is the resolver: it carries real,
+-- staging-derived `artists` / `genre_artist_crossreference` / `library` data
+-- (~24k artists, ~64k library rows), so running the three-stage resolver
+-- against it exercises real WXYC artist names rather than synthetic ones.
+-- Measured there:
+--
+--   * 110 pairs -> 79 resolve on both sides, 31 do not. Every one of the 31
+--     fails on the REFERENCING side, and every one of the 31 has an empty
+--     tubafrenzy CALL_LETTERS (the converse does not hold: 4 of the 35
+--     empty-CALL_LETTERS pairs do resolve).
+--   * 0 pairs come out AMBIGUOUS. Five endpoint tuples match more than one
+--     Backend artist by folded name — DAT Politics, Exene Cervenka, Sankofa,
+--     and the two Oliver Lakes — and stages 2 and 3 narrow every one of them
+--     to a single artist.
+--   * 75 of the 79 resolved pairs would ALSO satisfy the deployed importer's
+--     strict `code_letters` equality on both sides. Only 4 need this script's
+--     more lenient name-first resolution — those 4 pairs are the entire
+--     population this script recovers that the ETL could not.
+--   * 79 resolved pairs collapse to 77 distinct unordered pairs, inserted as
+--     77 rows against the clone's empty table.
+--   * The 155 resolvable endpoint artists own 915 `library` rows between them.
+--
+-- Because prod's table is populated and the clone's is empty by construction,
+-- **the row count this inserts against prod will be far lower than 77** —
+-- most of those 75 strict-matchable pairs should already be present, and the
+-- guards below will skip them. Read the pre-amble and the `INSERT 0 n` line
+-- before accepting the COMMIT; the counts will legitimately differ from every
+-- clone-measured figure in this header.
+--
+-- ## Hard ceiling: 31 of the 110 pairs are NOT recoverable by this script
+--
+-- Do not read a later "0 remaining empty-in-Backend mismatches" as this
+-- script's success, and do not expect that number at all. 31 of the 110
+-- pairs name a referencing artist — 28 distinct names — for which Backend has
+-- NO `artists` row whatsoever. That is an absence, not a name-match failure a
+-- looser fold could solve. These are tubafrenzy "pointer" LIBRARY_CODEs: no
+-- catalog holdings, so no release import ever created a Backend artist for
+-- them.
+--
+-- They are not a zero-impact residue. The pointer artist contributes no
+-- catalog rows of its own, but the artist it points AT does, and those are
+-- the rows missing the alias. In the clone the 31 pairs point at 26 Backend
+-- artists owning 150 `library` rows — i.e. the large majority of the ticket's
+-- 157 survives this backfill untouched. This script closes the 4 pairs the
+-- ETL could not; it does not close the bucket.
+--
+-- Closing the rest is a different repair, deliberately NOT attempted here
+-- because it CREATES catalog identities rather than linking existing ones:
+-- insert an `artists` row for each pointer name (`code_letters` is
+-- varchar(4) NOT NULL, so '' is representable) and link that. Whether WXYC
+-- wants 28 holdings-free artist rows in its catalog is a cataloger's call,
+-- not this script's. A handful of the 28 are name VARIANTS rather than true
+-- absences and would need an alias rule instead of a new row: "Wedding
+-- Present" vs Backend's "The Wedding Present", tubafrenzy's bare "X" vs
+-- Backend's "X [US]", "Return to Forever" vs "Chick Corea (Return to
+-- Forever)". "Cash, Larry Jr." is a fourth case and not a lost association at
+-- all — it is the alphabetical inversion of Backend's own "Larry Cash, Jr.",
+-- so both sides of that pair are one artist. None of these are safe to
+-- automate blind.
 --
 -- ## Source data: 110 of 119 raw rows resolve; 9 dangle
 --
@@ -137,22 +187,27 @@
 -- unordered artist pairs (one exact duplicate: LIBRARY_CODE_CROSS_REFERENCE
 -- ids 88/89, "Preservation Hall Jazz Band"/"Sweet Emma Barrett" recorded
 -- twice; one reversed duplicate: ids 74/75, "Sankofa"/"The Apple Juice Kid"
--- recorded in both directions), touching 182 distinct artist identities by
--- name (151 of which resolve to a real Backend `artists` row in the
--- dev-clone measurement above — the other 31 are the unresolvable
--- "pointer" names). `cross_reference_names` is exported per catalog ROW
--- (one row per library pressing), keyed off that row's own artist — so a
--- touched artist contributes to the 157 once per `library` row it owns, and
--- the unresolvable "pointer" artists (e.g. "Barry Black") contribute ZERO
--- rows because they have no catalog holdings of their own; their material
--- is filed entirely under the artist they point at. Measured against the
--- dev-clone: the 151 resolvable touched artists own 902 `library` rows
--- between them. 157 release rows affected out of a 902-row eligible
--- population (many of those 902 rows may already carry a correct, non-empty
--- `cross_reference_names` on the Backend side today, or belong to an artist
--- whose OTHER cross-references are already present) is consistent with that
--- shape — it does not reconcile to an exact 1:1 count, and does not need
--- to; the 902 figure is this clone's population, not necessarily prod's.
+-- recorded in both directions), touching 182 distinct artist names across 183
+-- distinct (name, CALL_LETTERS, CALL_NUMBERS) tuples — "Oliver Lake" appears
+-- as two tuples. 28 of those names resolve to no Backend `artists` row at all
+-- (the 31 unresolvable pairs share them); the other 154 resolve, to 155
+-- distinct Backend artist ids.
+--
+-- `cross_reference_names` is exported per catalog ROW (one row per library
+-- pressing), keyed off that row's own artist, so a touched artist contributes
+-- to the 157 once per `library` row it owns. Note that an unresolvable
+-- "pointer" artist (e.g. "Barry Black") does NOT drop out of the 157 just
+-- because it owns no catalog rows itself: the alias it supplies is missing
+-- from the rows of the artist it points at ("Eric Bachmann"), and those rows
+-- are counted. That is why the 31 leave ~150 clone rows permanently short
+-- rather than costing nothing — see the hard-ceiling section above.
+--
+-- Measured against the clone: the 155 resolvable endpoint artists own 915
+-- `library` rows between them, of which the 130 artists that are an endpoint
+-- of an actually-inserted pair own 766. Neither number reconciles 1:1 with
+-- the harness's 157 and neither needs to — most of those rows already carry a
+-- correct, non-empty `cross_reference_names` on the prod Backend side today.
+-- They bound the blast radius of the watermark rebuild, not the defect.
 --
 -- ## Keying: tubafrenzy LIBRARY_CODE vs. Backend artists (resolution rule)
 --
@@ -183,15 +238,27 @@
 -- direction, for the alias to appear on both artists' catalog rows. Two
 -- distinct hazards follow, both guarded explicitly below rather than left to
 -- ON CONFLICT alone:
---   - SELF-PAIRS: LIBRARY_CODE_CROSS_REFERENCE row 128 links "Oliver Lake"
---     to "Oliver Lake" (comment: "same Oliver Lake") — two DIFFERENT
---     tubafrenzy LIBRARY_CODEs (CALL_NUMBERS 17 vs. 2) sharing one
---     PRESENTATION_NAME, cross-referenced to point catalogers at the correct
---     one. Backend's artist identity is name-scoped, so both resolve to the
---     SAME `artists.id`; inserting that would create a
---     source_artist_id = target_artist_id row, which nothing downstream can
---     interpret as a real alias. Excluded explicitly (`source <> target`)
---     and reported in the pre-amble rather than silently dropped.
+--   - SELF-PAIRS: a defensive guard, not a guard against a known row. The
+--     only candidate in the source data is LIBRARY_CODE_CROSS_REFERENCE row
+--     128, which links "Oliver Lake" to "Oliver Lake" (comment: "same Oliver
+--     Lake") — two DIFFERENT tubafrenzy LIBRARY_CODEs (CALL_NUMBERS 17 vs. 2)
+--     sharing one PRESENTATION_NAME, cross-referenced to point catalogers at
+--     the correct one. Backend's artist identity is NOT name-unique, and in
+--     the clone it mirrors tubafrenzy exactly: artist 1829 ("Oliver Lake",
+--     LA, genre code 17) and artist 15780 ("Oliver Lake", LA, genre code 2)
+--     are two separate rows. Stage 2 cannot separate them (both are `LA`),
+--     but stage 3 can, on the genre code — so row 128 resolves to 1829 ->
+--     15780, is classified `resolved` (NOT `self_pair_skip`) in the pre-amble,
+--     and IS inserted. That is the correct outcome: it reproduces exactly the
+--     alias tubafrenzy's own export emits for both Oliver Lake catalog rows,
+--     which is the parity this ticket is chasing. The `source <> target`
+--     filter therefore matches zero rows against the clone. It stays because
+--     prod may hold only ONE "Oliver Lake" (or the two may not carry
+--     distinguishing genre codes), in which case both sides collapse to one
+--     id and the guard is what stops an uninterpretable self-referential row.
+--     The pre-amble reports that case as `self_pair_skip`, so an operator can
+--     tell the two outcomes apart before committing — the resolution is
+--     surfaced either way, never silently picked.
 --   - REVERSED DUPLICATES: rows 74/75 record "Sankofa" -> "The Apple Juice
 --     Kid" AND "The Apple Juice Kid" -> "Sankofa" — the same unordered pair,
 --     opposite direction. `ON CONFLICT (source_artist_id, target_artist_id)
@@ -216,40 +283,63 @@
 -- are lost forever after tubafrenzy turndown, so this script carries them
 -- into `artist_crossreference.comment` verbatim rather than discarding them.
 --
--- ## Watermark cost (expected, not a bug)
+-- ## Trigger costs (expected, not bugs)
 --
--- Migration 0138 attaches `touch_library_watermark_from_artist_crossreference`
--- AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE (confirmed: fires on INSERT,
--- not just UPDATE) FOR EACH STATEMENT to `artist_crossreference`. This
--- script's INSERT will advance `library_watermark` and force the next
--- `GET /library/catalog` request to rebuild the full gzip export cache. This
--- is correct, intended behavior (the whole point of 0138 was to make
--- `cross_reference_names` edits visible), just worth budgeting for — it is
--- the same one-time cost any `library` add already pays.
+-- Two triggers fire on this INSERT; both are intended, neither is free.
+--
+--   1. Migration 0138's `touch_library_watermark_from_artist_crossreference`
+--      is AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE FOR EACH STATEMENT
+--      (verified against the live table definition: it does fire on INSERT,
+--      not only on UPDATE). It advances `library_watermark` exactly once for
+--      this script's single INSERT statement, which forces the next
+--      `GET /library/catalog` request to rebuild the full gzip export cache.
+--      Correct behavior — making `cross_reference_names` edits visible is the
+--      whole point of 0138 — and the same one-time cost any `library` add
+--      already pays.
+--   2. `cdc_artist_xref` is AFTER INSERT OR UPDATE OR DELETE FOR EACH **ROW**,
+--      calling `cdc_notify()`. So this INSERT also emits one `pg_notify('cdc')`
+--      per inserted row. The payload is a single narrow three-column row, far
+--      under the 7800-byte guard in `cdc_notify`, and the count is bounded by
+--      the number of rows actually inserted (77 against an empty table, fewer
+--      against prod). Any LISTENer on the `cdc` channel sees that burst in one
+--      transaction; nothing downstream needs to be quiesced for it, but do not
+--      run this at the same moment as another bulk catalog mutation.
 --
 -- ## What this script CANNOT verify (no prod database available here)
 --
 -- There is no PROD Backend database reachable from this environment — no
--- prod credentials. The local dev Postgres (dev_env/docker-compose.yml,
--- port 5442) DOES hold real, staging-derived data when seeded from
--- `dev_env/seed-clone.sql` (a real `pg_dump --data-only` snapshot, ~64k
--- `library` rows), and this script was dry-run against it end to end (see
--- the "Measured against the dev-clone Postgres" section above) — so the
--- resolver, self-pair guard, reversed-duplicate dedup, NOT EXISTS guard,
--- and idempotent re-run were all exercised against real WXYC artist names,
--- not just read by construction. What that snapshot cannot answer: it is
--- point-in-time and may be stale relative to live prod (its
--- `artist_crossreference` was completely empty, which — per the "28
--- both-sides-differ" / "11 empty-in-tubafrenzy" buckets requiring some
--- non-empty Backend rows — prod evidently is not, as of the parity run);
--- and it cannot confirm which of the 110 pairs prod already has correctly,
--- so the exact insert count against prod will differ from the clone's 77.
--- The operator running this against prod should still read the pre-amble
--- output before letting the transaction commit, per the SELECT-before-write
--- convention — the resolution counts there will legitimately differ from
--- what this file's comments report for the clone.
+-- prod credentials. Everything measured above comes from the dev clone, whose
+-- `artists` / `genre_artist_crossreference` / `library` data is real and
+-- staging-derived but whose `artist_crossreference` is empty by fixture
+-- construction (see above) and therefore tells us nothing about what prod
+-- already holds. Consequences the operator must keep in mind:
 --
--- Target: PostgreSQL 14 (prod RDS). No PG15+-only syntax is used.
+--   * The insert count will differ from 77, and should be much smaller.
+--   * Which of the 110 pairs prod already has correctly is unknown; the
+--     NOT EXISTS + ON CONFLICT guards are what make that safe to not know.
+--   * The 157 / 11 / 28 / 1 harness buckets cannot be re-derived here. Re-run
+--     `catalog_parity_diff.py` after this lands to measure what actually moved.
+--
+-- Read the pre-amble output before letting the transaction commit, per the
+-- SELECT-before-write convention. Its counts are authoritative for the
+-- database you are pointed at; this header's are not.
+--
+-- ## Compatibility
+--
+-- Target: PostgreSQL 14 (prod RDS 14.22). No PG15+-only syntax is used, and
+-- this is not assumed — the file was executed end to end on PostgreSQL 14.23
+-- against a minimal schema stub (clean run, idempotent re-run inserting 0,
+-- and a re-run against a table pre-seeded with the REVERSED direction, which
+-- correctly inserted nothing for that pair). Do not validate this file only
+-- against the dev container: it runs PostgreSQL 18 and accepts syntax prod
+-- would reject.
+--
+-- The pair table and resolver are session-temp objects created OUTSIDE the
+-- transaction block, so they survive the COMMIT and are still visible to the
+-- post-amble and to `ANALYZE`. That holds under `psql -f`, which runs the
+-- whole file in one session — verified on 14.23. It does NOT hold if the file
+-- is split across sessions, and `psql -1 -f` is wrong here (ANALYZE cannot run
+-- inside a transaction block).
 
 -- ===========================================================
 -- Setup: load the 110 resolvable tubafrenzy pairs into a session-temp
@@ -257,7 +347,11 @@
 -- function. Both are read by the pre-amble AND the transactional INSERT
 -- below, so the pair data is written exactly once in this file.
 -- ===========================================================
-DROP TABLE IF EXISTS bs2117_pairs;
+-- pg_temp-qualified so a re-run in a dirty session drops only THIS session's
+-- scratch table. Unqualified, the name would resolve through search_path and
+-- could drop a same-named permanent table; on a fresh session pg_temp does not
+-- exist yet and IF EXISTS turns that into a NOTICE (verified on PG 14.23).
+DROP TABLE IF EXISTS pg_temp.bs2117_pairs;
 CREATE TEMP TABLE bs2117_pairs (
   row_id       int PRIMARY KEY,   -- LIBRARY_CODE_CROSS_REFERENCE.ID, for traceability
   src_name     text NOT NULL,     -- referencing LIBRARY_CODE.PRESENTATION_NAME
@@ -542,10 +636,17 @@ canon AS (
   FROM resolved
 ),
 deduped AS (
+  -- The ORDER BY must carry a tiebreaker past the DISTINCT ON key: two source
+  -- rows that canonicalize to the same pair can hold DIFFERENT comments (the
+  -- reversed pair 74/75 happens to be NULL on both sides, but nothing in
+  -- tubafrenzy enforces that), and without it Postgres is free to keep either
+  -- one, making the committed comment non-deterministic across runs. Prefer a
+  -- real comment over a NULL one, then the lowest text, so re-running against
+  -- a different plan cannot produce a different row.
   SELECT DISTINCT ON (source_artist_id, target_artist_id)
     source_artist_id, target_artist_id, xref_comment
   FROM canon
-  ORDER BY source_artist_id, target_artist_id
+  ORDER BY source_artist_id, target_artist_id, xref_comment ASC NULLS LAST
 )
 INSERT INTO wxyc_schema.artist_crossreference (source_artist_id, target_artist_id, comment)
 SELECT d.source_artist_id, d.target_artist_id, d.xref_comment

--- a/tests/integration/bs-2117-crossreference-backfill.spec.js
+++ b/tests/integration/bs-2117-crossreference-backfill.spec.js
@@ -6,14 +6,20 @@
  * an API route.
  *
  * ZERO DRIFT. This spec does not re-type the script's SQL — it READS
- * scripts/audit/bs_2117_crossref_backfill.sql and executes the two parts that
+ * scripts/audit/bs_2117_crossref_backfill.sql and executes the parts that
  * carry the logic verbatim:
  *
  *   1. `pg_temp.bs2117_resolve_artist()`, the three-stage resolver
  *      (folded name -> code_letters -> genre_artist_crossreference code).
- *   2. The transactional INSERT: resolve -> self-pair guard -> LEAST/GREATEST
- *      canonicalization -> DISTINCT ON dedup -> either-direction NOT EXISTS ->
+ *   2. `bs2117_provenance_conflicts`, the 15-row exclusion list.
+ *   3. The transactional INSERT: resolve -> self-pair guard ->
+ *      provenance-conflict guard -> LEAST/GREATEST canonicalization ->
+ *      DISTINCT ON dedup -> either-direction NOT EXISTS ->
  *      ON CONFLICT DO NOTHING.
+ *
+ * `extractInsert` additionally asserts each of those guards is PRESENT in what
+ * it sliced out, so deleting one from the script fails this spec loudly rather
+ * than quietly shrinking its coverage.
  *
  * Editing either one changes what this spec runs. That is the same convention
  * tests/integration/relabel-rotation-direct-backfill.spec.js uses, including
@@ -114,7 +120,51 @@ function extractInsert(scriptText) {
   if (end === -1) {
     throw new Error('the INSERT does not end in the expected ON CONFLICT clause');
   }
-  return scriptText.slice(start, end + endMarker.length);
+  const extracted = scriptText.slice(start, end + endMarker.length);
+
+  // The slicing above is by string index, so a reformat of the script could
+  // silently hand back a fragment that still parses but has lost a guard —
+  // and every assertion below would keep passing against the weaker SQL.
+  // Assert the invariants are present in what we actually extracted, so a
+  // mis-slice (or a guard deleted from the script outright) fails loudly here
+  // rather than quietly reducing this spec's coverage.
+  const required = [
+    ['self-pair guard', 'src.artist_id <> tgt.artist_id'],
+    ['LEAST canonicalization', 'LEAST(source_artist_id, target_artist_id)'],
+    ['GREATEST canonicalization', 'GREATEST(source_artist_id, target_artist_id)'],
+    ['dedup', 'DISTINCT ON (source_artist_id, target_artist_id)'],
+    ['either-direction guard', 'NOT EXISTS'],
+    ['provenance-conflict guard', 'bs2117_provenance_conflicts'],
+  ];
+  for (const [label, needle] of required) {
+    if (!extracted.includes(needle)) {
+      throw new Error(
+        `extracted INSERT is missing its ${label} (${needle}) — the script changed shape, or the extraction mis-sliced`
+      );
+    }
+  }
+  return extracted;
+}
+
+/**
+ * Pull the `bs2117_provenance_conflicts` scratch table (DDL + its VALUES), the
+ * exclusion list the INSERT joins against. Extracted rather than re-typed so
+ * the spec exercises the real 15 excluded row_ids.
+ */
+function extractConflictsSetup(scriptText) {
+  const start = scriptText.indexOf('CREATE TEMP TABLE bs2117_provenance_conflicts');
+  if (start === -1) {
+    throw new Error('bs2117_provenance_conflicts table definition not found in the backfill script');
+  }
+  const insertAt = scriptText.indexOf('INSERT INTO bs2117_provenance_conflicts', start);
+  if (insertAt === -1) {
+    throw new Error('bs2117_provenance_conflicts is declared but never populated');
+  }
+  const end = scriptText.indexOf(';', scriptText.indexOf("'Golden Palominos')", insertAt));
+  if (end === -1) {
+    throw new Error('the bs2117_provenance_conflicts VALUES list is not terminated');
+  }
+  return scriptText.slice(start, end + 1);
 }
 
 /** Redirect every `wxyc_schema.` reference at the throwaway test schema. */
@@ -134,6 +184,7 @@ describe('BS#2117 artist_crossreference backfill (real PG, real script SQL)', ()
     const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
     const resolverDdl = retarget(extractResolver(scriptText));
     const pairTableDdl = extractPairTableDdl(scriptText);
+    const conflictsSetup = extractConflictsSetup(scriptText);
     backfillInsert = retarget(extractInsert(scriptText));
 
     await sql.unsafe(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
@@ -199,6 +250,7 @@ describe('BS#2117 artist_crossreference backfill (real PG, real script SQL)', ()
 
     await sql.unsafe(resolverDdl);
     await sql.unsafe(pairTableDdl);
+    await sql.unsafe(conflictsSetup);
   });
 
   afterEach(async () => {
@@ -216,8 +268,11 @@ describe('BS#2117 artist_crossreference backfill (real PG, real script SQL)', ()
   });
 
   /** Load pairs into the script's own temp table, then run the script's INSERT. */
-  async function runBackfill(pairs) {
-    let rowId = 1;
+  async function runBackfill(pairs, firstRowId = 900) {
+    // Default row ids start well clear of the real LIBRARY_CODE_CROSS_REFERENCE
+    // ids, so a fixture pair never collides with the excluded-conflict list
+    // unless a test asks for it explicitly.
+    let rowId = firstRowId;
     for (const p of pairs) {
       await sql.unsafe(
         `INSERT INTO bs2117_pairs
@@ -335,6 +390,16 @@ describe('BS#2117 artist_crossreference backfill (real PG, real script SQL)', ()
       [ART_TWIN_A, ART_TWIN_B]
     );
     expect(rows).toHaveLength(0);
+  });
+
+  test('a pair on the provenance-conflict list is excluded even when fully resolvable', async () => {
+    // row_id 26 is one of the 15 whose referencing side tubafrenzy's own
+    // COMMENT contradicts ("Cactus World News" where the note says Tonya
+    // Donelly). Both endpoints resolve here, so ONLY the exclusion list can
+    // keep it out — if that guard regresses, this inserts a false alias.
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', { comment: 'would-be-false-alias' })], 26);
+
+    expect(await crossRefsBetween(ART_ALPHA, ART_BETA)).toHaveLength(0);
   });
 
   test('an unresolvable name (no matching artist) inserts nothing and does not throw', async () => {

--- a/tests/integration/bs-2117-crossreference-backfill.spec.js
+++ b/tests/integration/bs-2117-crossreference-backfill.spec.js
@@ -1,0 +1,277 @@
+/**
+ * BS#2117 — artist_crossreference backfill script.
+ *
+ * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL,
+ * no HTTP surface needed since this exercises a hand-run SQL script, not an
+ * API route. All seeded rows live in the 900300+ range this spec owns
+ * end-to-end (created + reaped here), above the prod-clone fixture's id
+ * space (dev_env/seed-clone.sql occupies artists 1-27050 — see the
+ * `library-catalog-producer-export.spec.js` header for why that collision
+ * is real, not theoretical: the actual tubafrenzy names this ticket backfills
+ * (e.g. "Sankofa", "Oliver Lake") are themselves real rows in that clone).
+ *
+ * This spec does NOT execute `scripts/audit/bs_2117_crossref_backfill.sql`
+ * verbatim with its embedded 110-pair production dataset. That dataset is
+ * real tubafrenzy artist names, several of which (verified against
+ * dev_env/seed-clone.sql while building this script) already exist as real
+ * rows in the clone fixture some local dev databases load — running the
+ * literal file would make this spec's outcome depend on whether
+ * LOAD_CLONE_FIXTURE is set, which is exactly the non-determinism the shape
+ * fixture / 900000+ id convention exists to avoid. Instead, this spec
+ * exercises the SAME resolve -> canonicalize -> guard -> insert SQL shape
+ * the script uses (three-stage resolver, self-pair guard, reversed-pair
+ * dedup via LEAST/GREATEST, NOT EXISTS either-direction guard, ON CONFLICT
+ * DO NOTHING), applied to synthetic BS2117-prefixed fixtures that cannot
+ * collide with any real catalog data. The literal file's syntax and
+ * end-to-end behavior were verified separately, by hand, against the
+ * dev-clone Postgres (see the file-level comment at the bottom of this
+ * spec for what that verification covered and why it isn't automated here).
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+const ART_ALPHA = 900300; // 'BS2117 Xref Alpha'
+const ART_BETA = 900301; // 'BS2117 Xref Beta'
+const ART_GAMMA = 900302; // 'BS2117 Xref Gamma' (unrelated third artist)
+const ART_SELF = 900303; // 'BS2117 Xref Self' (self-pair guard probe)
+
+const ALPHA_NAME = 'BS2117 Xref Alpha';
+const BETA_NAME = 'BS2117 Xref Beta';
+const GAMMA_NAME = 'BS2117 Xref Gamma';
+const SELF_NAME = 'BS2117 Xref Self';
+
+/**
+ * Mirrors the resolve/canonicalize/guard/insert shape in
+ * scripts/audit/bs_2117_crossref_backfill.sql. Rows are (src_name,
+ * src_letters, tgt_name, tgt_letters, comment) tuples resolved by
+ * fold_artist_name + code_letters, deduplicated on the unordered pair, and
+ * inserted idempotently.
+ */
+async function runBackfillPattern(sql, rows) {
+  await sql`
+    CREATE TEMP TABLE IF NOT EXISTS bs2117_test_pairs (
+      src_name text, src_letters text, tgt_name text, tgt_letters text, xref_comment text
+    ) ON COMMIT PRESERVE ROWS
+  `;
+  await sql`TRUNCATE bs2117_test_pairs`;
+  for (const [srcName, srcLetters, tgtName, tgtLetters, comment] of rows) {
+    await sql`
+      INSERT INTO bs2117_test_pairs (src_name, src_letters, tgt_name, tgt_letters, xref_comment)
+      VALUES (${srcName}, ${srcLetters}, ${tgtName}, ${tgtLetters}, ${comment})
+    `;
+  }
+
+  await sql.begin(async (tx) => {
+    await tx.unsafe(`
+      WITH resolved AS (
+        SELECT
+          p.xref_comment,
+          src.id AS source_artist_id,
+          tgt.id AS target_artist_id
+        FROM bs2117_test_pairs p
+        JOIN "${SCHEMA}".artists src
+          ON "${SCHEMA}".fold_artist_name(src.artist_name) = "${SCHEMA}".fold_artist_name(p.src_name)
+         AND lower(src.code_letters) = lower(p.src_letters)
+        JOIN "${SCHEMA}".artists tgt
+          ON "${SCHEMA}".fold_artist_name(tgt.artist_name) = "${SCHEMA}".fold_artist_name(p.tgt_name)
+         AND lower(tgt.code_letters) = lower(p.tgt_letters)
+        WHERE src.id <> tgt.id
+      ),
+      canon AS (
+        SELECT LEAST(source_artist_id, target_artist_id) AS source_artist_id,
+               GREATEST(source_artist_id, target_artist_id) AS target_artist_id,
+               xref_comment
+        FROM resolved
+      ),
+      deduped AS (
+        SELECT DISTINCT ON (source_artist_id, target_artist_id)
+          source_artist_id, target_artist_id, xref_comment
+        FROM canon
+        ORDER BY source_artist_id, target_artist_id
+      )
+      INSERT INTO "${SCHEMA}".artist_crossreference (source_artist_id, target_artist_id, comment)
+      SELECT d.source_artist_id, d.target_artist_id, d.xref_comment
+      FROM deduped d
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "${SCHEMA}".artist_crossreference existing
+        WHERE (existing.source_artist_id = d.source_artist_id AND existing.target_artist_id = d.target_artist_id)
+           OR (existing.source_artist_id = d.target_artist_id AND existing.target_artist_id = d.source_artist_id)
+      )
+      ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING
+    `);
+  });
+}
+
+describe('BS#2117 artist_crossreference backfill (real PG)', () => {
+  let sql;
+
+  beforeAll(async () => {
+    sql = getTestDb();
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.artists (id, artist_name, alphabetical_name, code_letters)
+      VALUES
+        (${ART_ALPHA}, ${ALPHA_NAME}, ${ALPHA_NAME}, 'ZA'),
+        (${ART_BETA}, ${BETA_NAME}, ${BETA_NAME}, 'ZB'),
+        (${ART_GAMMA}, ${GAMMA_NAME}, ${GAMMA_NAME}, 'ZC'),
+        (${ART_SELF}, ${SELF_NAME}, ${SELF_NAME}, 'ZD')
+      ON CONFLICT (id) DO NOTHING
+    `;
+  });
+
+  afterEach(async () => {
+    await sql`
+      DELETE FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE source_artist_id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})
+         OR target_artist_id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})
+    `;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})`;
+    await sql`DROP TABLE IF EXISTS bs2117_test_pairs`;
+  });
+
+  test('inserts exactly one row for a resolvable pair', async () => {
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
+
+    const rows = await sql`
+      SELECT source_artist_id, target_artist_id, comment FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
+         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].comment).toBe('shared member (test)');
+  });
+
+  test('re-running the same pair is a no-op (idempotent)', async () => {
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
+         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  test('the reversed-direction duplicate collapses to one row, not two', async () => {
+    // Mirrors LIBRARY_CODE_CROSS_REFERENCE ids 74/75 (Sankofa <-> The Apple
+    // Juice Kid), recorded in both directions in the real tubafrenzy source.
+    await runBackfillPattern(sql, [
+      [ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null],
+      [BETA_NAME, 'ZB', ALPHA_NAME, 'ZA', null],
+    ]);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
+         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  test('a pair already present in the opposite direction is not duplicated', async () => {
+    // Seed the "existing" row in one direction directly, then run the
+    // backfill pattern requesting the OPPOSITE direction — the NOT EXISTS
+    // guard (not just ON CONFLICT on the exact ordered pair) must catch it.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.artist_crossreference (source_artist_id, target_artist_id, comment)
+      VALUES (${ART_BETA}, ${ART_ALPHA}, 'pre-existing')
+    `;
+
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'would-be-new']]);
+
+    const rows = await sql`
+      SELECT comment FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
+         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].comment).toBe('pre-existing');
+  });
+
+  test('a self-pair (both sides resolve to the same artist) is never inserted', async () => {
+    // Mirrors LIBRARY_CODE_CROSS_REFERENCE row 128 ("Oliver Lake" -> "Oliver
+    // Lake"): two tubafrenzy LIBRARY_CODEs sharing one PRESENTATION_NAME.
+    await runBackfillPattern(sql, [[SELF_NAME, 'ZD', SELF_NAME, 'ZD', 'same artist (test)']]);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE source_artist_id = ${ART_SELF} OR target_artist_id = ${ART_SELF}
+    `;
+    expect(rows).toHaveLength(0);
+  });
+
+  test('an unresolvable name (no matching artist) inserts nothing and does not throw', async () => {
+    await expect(
+      runBackfillPattern(sql, [['BS2117 Nonexistent Pointer Artist', '', BETA_NAME, 'ZB', null]])
+    ).resolves.not.toThrow();
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference WHERE target_artist_id = ${ART_BETA}
+    `;
+    expect(rows).toHaveLength(0);
+  });
+
+  test('an unrelated third artist is unaffected', async () => {
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null]]);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
+      WHERE source_artist_id = ${ART_GAMMA} OR target_artist_id = ${ART_GAMMA}
+    `;
+    expect(rows).toHaveLength(0);
+  });
+
+  test('the catalog export artist_aliases CTE emits the alias in both directions once inserted', async () => {
+    // Mirrors the artist_aliases CTE in apps/backend/services/catalog-export.service.ts:
+    // UNION both FK directions so a row filed under either endpoint surfaces the other.
+    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null]]);
+
+    const aliasRows = await sql.unsafe(
+      `
+      WITH artist_aliases AS (
+        SELECT cp.artist_id, array_agg(DISTINCT a.artist_name) AS cross_reference_names
+        FROM (
+          SELECT source_artist_id AS artist_id, target_artist_id AS other_id
+          FROM "${SCHEMA}".artist_crossreference
+          UNION
+          SELECT target_artist_id AS artist_id, source_artist_id AS other_id
+          FROM "${SCHEMA}".artist_crossreference
+        ) cp
+        JOIN "${SCHEMA}".artists a ON a.id = cp.other_id
+        WHERE cp.other_id <> cp.artist_id
+        GROUP BY cp.artist_id
+      )
+      SELECT artist_id, cross_reference_names FROM artist_aliases
+      WHERE artist_id IN ($1, $2)
+      ORDER BY artist_id
+    `,
+      [ART_ALPHA, ART_BETA]
+    );
+
+    const byId = new Map(aliasRows.map((r) => [r.artist_id, r.cross_reference_names]));
+    expect(byId.get(ART_ALPHA)).toEqual([BETA_NAME]);
+    expect(byId.get(ART_BETA)).toEqual([ALPHA_NAME]);
+  });
+});
+
+// The literal scripts/audit/bs_2117_crossref_backfill.sql file (with its
+// embedded 110-pair real tubafrenzy dataset) is deliberately NOT executed
+// here. It was validated directly against the dev-clone Postgres
+// (dev_env/seed-clone.sql, real staging-derived data) via `psql -f` during
+// development: a clean first run (79 pairs resolved by name, 77 rows
+// inserted after dedup), a no-op second run (0 rows inserted, confirming
+// idempotency), and the 77 test-inserted rows were then deleted to restore
+// the table to its pre-run empty state. That verification is not
+// reproducible as an automated spec here — the file's INSERT touches
+// whichever real `artists` rows happen to match its embedded names, which
+// depends on whether the environment loaded the prod-clone fixture
+// (LOAD_CLONE_FIXTURE), and an automated spec cannot safely guarantee
+// cleanup for side effects on rows it did not seed itself. The
+// resolve/canonicalize/guard/insert SHAPE the file uses is exactly what
+// `runBackfillPattern` above exercises against synthetic, self-cleaning
+// fixtures instead.

--- a/tests/integration/bs-2117-crossreference-backfill.spec.js
+++ b/tests/integration/bs-2117-crossreference-backfill.spec.js
@@ -1,235 +1,368 @@
 /**
  * BS#2117 — artist_crossreference backfill script.
  *
- * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL,
- * no HTTP surface needed since this exercises a hand-run SQL script, not an
- * API route. All seeded rows live in the 900300+ range this spec owns
- * end-to-end (created + reaped here), above the prod-clone fixture's id
- * space (dev_env/seed-clone.sql occupies artists 1-27050 — see the
- * `library-catalog-producer-export.spec.js` header for why that collision
- * is real, not theoretical: the actual tubafrenzy names this ticket backfills
- * (e.g. "Sankofa", "Oliver Lake") are themselves real rows in that clone).
+ * Postgres-backed (the BS analogue of the org `pg` marker): direct SQL, no
+ * HTTP surface, since this exercises a hand-run operator script rather than
+ * an API route.
  *
- * This spec does NOT execute `scripts/audit/bs_2117_crossref_backfill.sql`
- * verbatim with its embedded 110-pair production dataset. That dataset is
- * real tubafrenzy artist names, several of which (verified against
- * dev_env/seed-clone.sql while building this script) already exist as real
- * rows in the clone fixture some local dev databases load — running the
- * literal file would make this spec's outcome depend on whether
- * LOAD_CLONE_FIXTURE is set, which is exactly the non-determinism the shape
- * fixture / 900000+ id convention exists to avoid. Instead, this spec
- * exercises the SAME resolve -> canonicalize -> guard -> insert SQL shape
- * the script uses (three-stage resolver, self-pair guard, reversed-pair
- * dedup via LEAST/GREATEST, NOT EXISTS either-direction guard, ON CONFLICT
- * DO NOTHING), applied to synthetic BS2117-prefixed fixtures that cannot
- * collide with any real catalog data. The literal file's syntax and
- * end-to-end behavior were verified separately, by hand, against the
- * dev-clone Postgres (see the file-level comment at the bottom of this
- * spec for what that verification covered and why it isn't automated here).
+ * ZERO DRIFT. This spec does not re-type the script's SQL — it READS
+ * scripts/audit/bs_2117_crossref_backfill.sql and executes the two parts that
+ * carry the logic verbatim:
+ *
+ *   1. `pg_temp.bs2117_resolve_artist()`, the three-stage resolver
+ *      (folded name -> code_letters -> genre_artist_crossreference code).
+ *   2. The transactional INSERT: resolve -> self-pair guard -> LEAST/GREATEST
+ *      canonicalization -> DISTINCT ON dedup -> either-direction NOT EXISTS ->
+ *      ON CONFLICT DO NOTHING.
+ *
+ * Editing either one changes what this spec runs. That is the same convention
+ * tests/integration/relabel-rotation-direct-backfill.spec.js uses, including
+ * its `wxyc_schema.` -> throwaway-schema rewrite.
+ *
+ * That rewrite is also what makes running the real SQL safe here. The script's
+ * embedded 110-pair dataset is real tubafrenzy artist names, several of which
+ * ("Sankofa", "Oliver Lake", ...) exist as real rows in the prod-clone fixture
+ * some local databases load (dev_env/seed-clone.sql). Redirecting every table
+ * reference into `bs2117_backfill_test` means the resolver can only ever see
+ * the synthetic artists this spec creates and reaps, so the outcome does not
+ * depend on LOAD_CLONE_FIXTURE and no real catalog row is touched. The pairs
+ * this spec feeds in are chosen shapes, not the file's 110-row payload — that
+ * payload is data, and the operator's pre-amble is what audits it.
+ *
+ * Temp objects (`bs2117_pairs`, the resolver function) are session-scoped, so
+ * everything runs on ONE reserved connection. The shared pool is `max: 5`;
+ * without the reservation a later statement can land on a different backend
+ * and fail with `relation "bs2117_pairs" does not exist`.
  */
 
+const fs = require('fs');
+const path = require('path');
 const { getTestDb } = require('../utils/db');
 
-const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_2117_crossref_backfill.sql');
+const TEST_SCHEMA = 'bs2117_backfill_test';
 
-const ART_ALPHA = 900300; // 'BS2117 Xref Alpha'
-const ART_BETA = 900301; // 'BS2117 Xref Beta'
-const ART_GAMMA = 900302; // 'BS2117 Xref Gamma' (unrelated third artist)
-const ART_SELF = 900303; // 'BS2117 Xref Self' (self-pair guard probe)
+// Synthetic artists. Ids are arbitrary — they live in a throwaway schema that
+// is dropped wholesale in afterAll, so they cannot collide with anything.
+const ART_ALPHA = 1;
+const ART_BETA = 2;
+const ART_GAMMA = 3; // unrelated third artist
+const ART_SELF = 4; // single artist both sides of a pair resolve to
+const ART_LAKE_JAZZ = 5; // 'BS2117 Lake', code ZL, genre code 17
+const ART_LAKE_ROCK = 6; // 'BS2117 Lake', code ZL, genre code 2  (row-128 shape)
+const ART_TWIN_A = 7; // 'BS2117 Twin', code ZT, genre code 50
+const ART_TWIN_B = 8; // 'BS2117 Twin', code ZT, genre code 50  (ambiguous shape)
 
 const ALPHA_NAME = 'BS2117 Xref Alpha';
 const BETA_NAME = 'BS2117 Xref Beta';
 const GAMMA_NAME = 'BS2117 Xref Gamma';
 const SELF_NAME = 'BS2117 Xref Self';
+const LAKE_NAME = 'BS2117 Lake';
+const TWIN_NAME = 'BS2117 Twin';
 
 /**
- * Mirrors the resolve/canonicalize/guard/insert shape in
- * scripts/audit/bs_2117_crossref_backfill.sql. Rows are (src_name,
- * src_letters, tgt_name, tgt_letters, comment) tuples resolved by
- * fold_artist_name + code_letters, deduplicated on the unordered pair, and
- * inserted idempotently.
+ * Pull the resolver function definition out of the operator script.
+ * Spans `CREATE OR REPLACE FUNCTION pg_temp.bs2117_resolve_artist` through the
+ * `$$ LANGUAGE plpgsql STABLE;` that closes it.
  */
-async function runBackfillPattern(sql, rows) {
-  await sql`
-    CREATE TEMP TABLE IF NOT EXISTS bs2117_test_pairs (
-      src_name text, src_letters text, tgt_name text, tgt_letters text, xref_comment text
-    ) ON COMMIT PRESERVE ROWS
-  `;
-  await sql`TRUNCATE bs2117_test_pairs`;
-  for (const [srcName, srcLetters, tgtName, tgtLetters, comment] of rows) {
-    await sql`
-      INSERT INTO bs2117_test_pairs (src_name, src_letters, tgt_name, tgt_letters, xref_comment)
-      VALUES (${srcName}, ${srcLetters}, ${tgtName}, ${tgtLetters}, ${comment})
-    `;
+function extractResolver(scriptText) {
+  const start = scriptText.indexOf('CREATE OR REPLACE FUNCTION pg_temp.bs2117_resolve_artist');
+  if (start === -1) {
+    throw new Error('bs2117_resolve_artist definition not found in the backfill script');
   }
-
-  await sql.begin(async (tx) => {
-    await tx.unsafe(`
-      WITH resolved AS (
-        SELECT
-          p.xref_comment,
-          src.id AS source_artist_id,
-          tgt.id AS target_artist_id
-        FROM bs2117_test_pairs p
-        JOIN "${SCHEMA}".artists src
-          ON "${SCHEMA}".fold_artist_name(src.artist_name) = "${SCHEMA}".fold_artist_name(p.src_name)
-         AND lower(src.code_letters) = lower(p.src_letters)
-        JOIN "${SCHEMA}".artists tgt
-          ON "${SCHEMA}".fold_artist_name(tgt.artist_name) = "${SCHEMA}".fold_artist_name(p.tgt_name)
-         AND lower(tgt.code_letters) = lower(p.tgt_letters)
-        WHERE src.id <> tgt.id
-      ),
-      canon AS (
-        SELECT LEAST(source_artist_id, target_artist_id) AS source_artist_id,
-               GREATEST(source_artist_id, target_artist_id) AS target_artist_id,
-               xref_comment
-        FROM resolved
-      ),
-      deduped AS (
-        SELECT DISTINCT ON (source_artist_id, target_artist_id)
-          source_artist_id, target_artist_id, xref_comment
-        FROM canon
-        ORDER BY source_artist_id, target_artist_id
-      )
-      INSERT INTO "${SCHEMA}".artist_crossreference (source_artist_id, target_artist_id, comment)
-      SELECT d.source_artist_id, d.target_artist_id, d.xref_comment
-      FROM deduped d
-      WHERE NOT EXISTS (
-        SELECT 1 FROM "${SCHEMA}".artist_crossreference existing
-        WHERE (existing.source_artist_id = d.source_artist_id AND existing.target_artist_id = d.target_artist_id)
-           OR (existing.source_artist_id = d.target_artist_id AND existing.target_artist_id = d.source_artist_id)
-      )
-      ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING
-    `);
-  });
+  const endMarker = '$$ LANGUAGE plpgsql STABLE;';
+  const end = scriptText.indexOf(endMarker, start);
+  if (end === -1) {
+    throw new Error('bs2117_resolve_artist definition is not terminated by "$$ LANGUAGE plpgsql STABLE;"');
+  }
+  return scriptText.slice(start, end + endMarker.length);
 }
 
-describe('BS#2117 artist_crossreference backfill (real PG)', () => {
-  let sql;
+/**
+ * Pull the `CREATE TEMP TABLE bs2117_pairs (...)` definition, so the pair
+ * table this spec feeds has exactly the column shape the INSERT reads.
+ */
+function extractPairTableDdl(scriptText) {
+  const start = scriptText.indexOf('CREATE TEMP TABLE bs2117_pairs');
+  if (start === -1) {
+    throw new Error('bs2117_pairs table definition not found in the backfill script');
+  }
+  const end = scriptText.indexOf(';', scriptText.indexOf('ON COMMIT PRESERVE ROWS', start));
+  if (end === -1) {
+    throw new Error('bs2117_pairs table definition is not terminated');
+  }
+  return scriptText.slice(start, end + 1);
+}
+
+/**
+ * Pull the single transactional INSERT. Located by its target table, then
+ * walked back to the `WITH resolved AS (` that opens it — the file contains
+ * three other CTEs by that name (two pre-amble, one post-amble) and only this
+ * one writes.
+ */
+function extractInsert(scriptText) {
+  const insertAt = scriptText.indexOf('INSERT INTO wxyc_schema.artist_crossreference');
+  if (insertAt === -1) {
+    throw new Error('the artist_crossreference INSERT was not found in the backfill script');
+  }
+  const start = scriptText.lastIndexOf('WITH resolved AS (', insertAt);
+  if (start === -1) {
+    throw new Error('the INSERT is not preceded by its `WITH resolved AS (` CTE');
+  }
+  const endMarker = 'ON CONFLICT (source_artist_id, target_artist_id) DO NOTHING;';
+  const end = scriptText.indexOf(endMarker, insertAt);
+  if (end === -1) {
+    throw new Error('the INSERT does not end in the expected ON CONFLICT clause');
+  }
+  return scriptText.slice(start, end + endMarker.length);
+}
+
+/** Redirect every `wxyc_schema.` reference at the throwaway test schema. */
+function retarget(sqlText) {
+  return sqlText.replace(/wxyc_schema\./g, `${TEST_SCHEMA}.`);
+}
+
+describe('BS#2117 artist_crossreference backfill (real PG, real script SQL)', () => {
+  let pool;
+  let sql; // reserved single connection — temp objects live here
+  let backfillInsert;
 
   beforeAll(async () => {
-    sql = getTestDb();
-    await sql`
-      INSERT INTO ${sql(SCHEMA)}.artists (id, artist_name, alphabetical_name, code_letters)
-      VALUES
-        (${ART_ALPHA}, ${ALPHA_NAME}, ${ALPHA_NAME}, 'ZA'),
-        (${ART_BETA}, ${BETA_NAME}, ${BETA_NAME}, 'ZB'),
-        (${ART_GAMMA}, ${GAMMA_NAME}, ${GAMMA_NAME}, 'ZC'),
-        (${ART_SELF}, ${SELF_NAME}, ${SELF_NAME}, 'ZD')
-      ON CONFLICT (id) DO NOTHING
-    `;
+    pool = getTestDb();
+    sql = await pool.reserve();
+
+    const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    const resolverDdl = retarget(extractResolver(scriptText));
+    const pairTableDdl = extractPairTableDdl(scriptText);
+    backfillInsert = retarget(extractInsert(scriptText));
+
+    await sql.unsafe(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    await sql.unsafe(`CREATE SCHEMA ${TEST_SCHEMA}`);
+
+    // The resolver calls `<schema>.fold_artist_name`. Delegate to the real one
+    // rather than copying its body, so the spec cannot drift from migration
+    // 0134's actual folding rule.
+    await sql.unsafe(`
+      CREATE FUNCTION ${TEST_SCHEMA}.fold_artist_name(input text) RETURNS text
+      LANGUAGE sql IMMUTABLE PARALLEL SAFE
+      AS $fold$ SELECT wxyc_schema.fold_artist_name(input) $fold$
+    `);
+
+    // Mirror the real column shapes the script depends on: code_letters
+    // NOT NULL (why an empty CALL_LETTERS can never match), and the ORDERED
+    // unique index that makes ON CONFLICT's conflict target valid while
+    // leaving the reversed pair for the NOT EXISTS guard to catch.
+    await sql.unsafe(`
+      CREATE TABLE ${TEST_SCHEMA}.artists (
+        id integer PRIMARY KEY,
+        artist_name varchar(128) NOT NULL,
+        code_letters varchar(4) NOT NULL
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE ${TEST_SCHEMA}.genre_artist_crossreference (
+        artist_id integer NOT NULL REFERENCES ${TEST_SCHEMA}.artists(id),
+        genre_id integer NOT NULL,
+        artist_genre_code integer NOT NULL
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE ${TEST_SCHEMA}.artist_crossreference (
+        source_artist_id integer NOT NULL REFERENCES ${TEST_SCHEMA}.artists(id),
+        target_artist_id integer NOT NULL REFERENCES ${TEST_SCHEMA}.artists(id),
+        comment varchar(255)
+      )
+    `);
+    await sql.unsafe(`
+      CREATE UNIQUE INDEX artist_crossref_source_target
+        ON ${TEST_SCHEMA}.artist_crossreference (source_artist_id, target_artist_id)
+    `);
+
+    await sql.unsafe(`
+      INSERT INTO ${TEST_SCHEMA}.artists (id, artist_name, code_letters) VALUES
+        (${ART_ALPHA}, '${ALPHA_NAME}', 'ZA'),
+        (${ART_BETA}, '${BETA_NAME}', 'ZB'),
+        (${ART_GAMMA}, '${GAMMA_NAME}', 'ZC'),
+        (${ART_SELF}, '${SELF_NAME}', 'ZD'),
+        (${ART_LAKE_JAZZ}, '${LAKE_NAME}', 'ZL'),
+        (${ART_LAKE_ROCK}, '${LAKE_NAME}', 'ZL'),
+        (${ART_TWIN_A}, '${TWIN_NAME}', 'ZT'),
+        (${ART_TWIN_B}, '${TWIN_NAME}', 'ZT')
+    `);
+    await sql.unsafe(`
+      INSERT INTO ${TEST_SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code) VALUES
+        (${ART_LAKE_JAZZ}, 7, 17),
+        (${ART_LAKE_ROCK}, 13, 2),
+        (${ART_TWIN_A}, 6, 50),
+        (${ART_TWIN_B}, 6, 50)
+    `);
+
+    await sql.unsafe(resolverDdl);
+    await sql.unsafe(pairTableDdl);
   });
 
   afterEach(async () => {
-    await sql`
-      DELETE FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE source_artist_id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})
-         OR target_artist_id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})
-    `;
+    await sql.unsafe(`DELETE FROM ${TEST_SCHEMA}.artist_crossreference`);
+    await sql.unsafe('TRUNCATE bs2117_pairs');
   });
 
   afterAll(async () => {
-    await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id IN (${ART_ALPHA}, ${ART_BETA}, ${ART_GAMMA}, ${ART_SELF})`;
-    await sql`DROP TABLE IF EXISTS bs2117_test_pairs`;
+    if (sql) {
+      await sql.unsafe(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      // Temp objects die with the session; releasing returns the backend to
+      // the shared pool, which the rest of the suite still needs open.
+      sql.release();
+    }
   });
 
-  test('inserts exactly one row for a resolvable pair', async () => {
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
+  /** Load pairs into the script's own temp table, then run the script's INSERT. */
+  async function runBackfill(pairs) {
+    let rowId = 1;
+    for (const p of pairs) {
+      await sql.unsafe(
+        `INSERT INTO bs2117_pairs
+           (row_id, src_name, src_letters, src_number, tgt_name, tgt_letters, tgt_number, xref_comment)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [
+          rowId++,
+          p.srcName,
+          p.srcLetters,
+          p.srcNumber ?? 0,
+          p.tgtName,
+          p.tgtLetters,
+          p.tgtNumber ?? 0,
+          p.comment ?? null,
+        ]
+      );
+    }
+    await sql.unsafe(backfillInsert);
+  }
 
-    const rows = await sql`
-      SELECT source_artist_id, target_artist_id, comment FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
-         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
-    `;
+  const pair = (srcName, srcLetters, tgtName, tgtLetters, extra = {}) => ({
+    srcName,
+    srcLetters,
+    tgtName,
+    tgtLetters,
+    ...extra,
+  });
+
+  async function crossRefsBetween(a, b) {
+    return sql.unsafe(
+      `SELECT source_artist_id, target_artist_id, comment
+         FROM ${TEST_SCHEMA}.artist_crossreference
+        WHERE (source_artist_id = $1 AND target_artist_id = $2)
+           OR (source_artist_id = $2 AND target_artist_id = $1)`,
+      [a, b]
+    );
+  }
+
+  test('inserts exactly one row for a resolvable pair, carrying the cataloger comment', async () => {
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', { comment: 'shared member (test)' })]);
+
+    const rows = await crossRefsBetween(ART_ALPHA, ART_BETA);
     expect(rows).toHaveLength(1);
     expect(rows[0].comment).toBe('shared member (test)');
   });
 
   test('re-running the same pair is a no-op (idempotent)', async () => {
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'shared member (test)']]);
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', { comment: 'shared member (test)' })]);
+    await sql.unsafe(backfillInsert); // second run, same loaded pairs
 
-    const rows = await sql`
-      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
-         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
-    `;
-    expect(rows).toHaveLength(1);
+    expect(await crossRefsBetween(ART_ALPHA, ART_BETA)).toHaveLength(1);
   });
 
   test('the reversed-direction duplicate collapses to one row, not two', async () => {
     // Mirrors LIBRARY_CODE_CROSS_REFERENCE ids 74/75 (Sankofa <-> The Apple
     // Juice Kid), recorded in both directions in the real tubafrenzy source.
-    await runBackfillPattern(sql, [
-      [ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null],
-      [BETA_NAME, 'ZB', ALPHA_NAME, 'ZA', null],
+    // The ordered unique index cannot catch this; LEAST/GREATEST is what does.
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB'), pair(BETA_NAME, 'ZB', ALPHA_NAME, 'ZA')]);
+
+    expect(await crossRefsBetween(ART_ALPHA, ART_BETA)).toHaveLength(1);
+  });
+
+  test('a pair Backend already holds in the OPPOSITE direction is not duplicated', async () => {
+    // The prod case: a non-empty starting table. ON CONFLICT on the ordered
+    // pair would miss this; the either-direction NOT EXISTS is what catches it.
+    await sql.unsafe(
+      `INSERT INTO ${TEST_SCHEMA}.artist_crossreference (source_artist_id, target_artist_id, comment)
+       VALUES ($1, $2, 'pre-existing')`,
+      [ART_BETA, ART_ALPHA]
+    );
+
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', { comment: 'would-be-new' })]);
+
+    const rows = await crossRefsBetween(ART_ALPHA, ART_BETA);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].comment).toBe('pre-existing'); // untouched, not overwritten
+  });
+
+  test('a true self-pair (both sides resolve to one artist) is never inserted', async () => {
+    await runBackfill([pair(SELF_NAME, 'ZD', SELF_NAME, 'ZD', { comment: 'same artist (test)' })]);
+
+    const rows = await sql.unsafe(
+      `SELECT * FROM ${TEST_SCHEMA}.artist_crossreference
+        WHERE source_artist_id = $1 OR target_artist_id = $1`,
+      [ART_SELF]
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test('two same-named artists split by genre code resolve to DIFFERENT ids and are linked', async () => {
+    // The real row 128 shape ("Oliver Lake" -> "Oliver Lake", CALL_NUMBERS 17
+    // vs 2). Both sides share a name AND code_letters, so only stage 3 can
+    // separate them. This must NOT be swallowed by the self-pair guard: the
+    // two tubafrenzy LIBRARY_CODEs are two real Backend artists, and the
+    // cross-reference between them is exactly the alias parity expects.
+    await runBackfill([
+      pair(LAKE_NAME, 'ZL', LAKE_NAME, 'ZL', { srcNumber: 17, tgtNumber: 2, comment: 'same artist, two filings' }),
     ]);
 
-    const rows = await sql`
-      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
-         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
-    `;
+    const rows = await crossRefsBetween(ART_LAKE_JAZZ, ART_LAKE_ROCK);
     expect(rows).toHaveLength(1);
+    expect(rows[0].source_artist_id).toBe(Math.min(ART_LAKE_JAZZ, ART_LAKE_ROCK));
+    expect(rows[0].target_artist_id).toBe(Math.max(ART_LAKE_JAZZ, ART_LAKE_ROCK));
   });
 
-  test('a pair already present in the opposite direction is not duplicated', async () => {
-    // Seed the "existing" row in one direction directly, then run the
-    // backfill pattern requesting the OPPOSITE direction — the NOT EXISTS
-    // guard (not just ON CONFLICT on the exact ordered pair) must catch it.
-    await sql`
-      INSERT INTO ${sql(SCHEMA)}.artist_crossreference (source_artist_id, target_artist_id, comment)
-      VALUES (${ART_BETA}, ${ART_ALPHA}, 'pre-existing')
-    `;
+  test('a name that stays ambiguous after all three stages is skipped, not guessed', async () => {
+    // Two artists, same folded name, same code_letters, same genre code —
+    // nothing left to disambiguate on. The resolver must report rather than
+    // pick one, so nothing is inserted for either candidate.
+    await runBackfill([pair(TWIN_NAME, 'ZT', ALPHA_NAME, 'ZA', { srcNumber: 50 })]);
 
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', 'would-be-new']]);
-
-    const rows = await sql`
-      SELECT comment FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE (source_artist_id = ${ART_ALPHA} AND target_artist_id = ${ART_BETA})
-         OR (source_artist_id = ${ART_BETA} AND target_artist_id = ${ART_ALPHA})
-    `;
-    expect(rows).toHaveLength(1);
-    expect(rows[0].comment).toBe('pre-existing');
-  });
-
-  test('a self-pair (both sides resolve to the same artist) is never inserted', async () => {
-    // Mirrors LIBRARY_CODE_CROSS_REFERENCE row 128 ("Oliver Lake" -> "Oliver
-    // Lake"): two tubafrenzy LIBRARY_CODEs sharing one PRESENTATION_NAME.
-    await runBackfillPattern(sql, [[SELF_NAME, 'ZD', SELF_NAME, 'ZD', 'same artist (test)']]);
-
-    const rows = await sql`
-      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE source_artist_id = ${ART_SELF} OR target_artist_id = ${ART_SELF}
-    `;
+    const rows = await sql.unsafe(
+      `SELECT * FROM ${TEST_SCHEMA}.artist_crossreference
+        WHERE source_artist_id IN ($1, $2) OR target_artist_id IN ($1, $2)`,
+      [ART_TWIN_A, ART_TWIN_B]
+    );
     expect(rows).toHaveLength(0);
   });
 
   test('an unresolvable name (no matching artist) inserts nothing and does not throw', async () => {
-    await expect(
-      runBackfillPattern(sql, [['BS2117 Nonexistent Pointer Artist', '', BETA_NAME, 'ZB', null]])
-    ).resolves.not.toThrow();
+    // The 31-pair ceiling: a tubafrenzy "pointer" name with no Backend artist.
+    await expect(runBackfill([pair('BS2117 Nonexistent Pointer Artist', '', BETA_NAME, 'ZB')])).resolves.not.toThrow();
 
-    const rows = await sql`
-      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference WHERE target_artist_id = ${ART_BETA}
-    `;
+    const rows = await sql.unsafe(`SELECT * FROM ${TEST_SCHEMA}.artist_crossreference WHERE target_artist_id = $1`, [
+      ART_BETA,
+    ]);
     expect(rows).toHaveLength(0);
   });
 
   test('an unrelated third artist is unaffected', async () => {
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null]]);
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB')]);
 
-    const rows = await sql`
-      SELECT * FROM ${sql(SCHEMA)}.artist_crossreference
-      WHERE source_artist_id = ${ART_GAMMA} OR target_artist_id = ${ART_GAMMA}
-    `;
+    const rows = await sql.unsafe(
+      `SELECT * FROM ${TEST_SCHEMA}.artist_crossreference
+        WHERE source_artist_id = $1 OR target_artist_id = $1`,
+      [ART_GAMMA]
+    );
     expect(rows).toHaveLength(0);
   });
 
   test('the catalog export artist_aliases CTE emits the alias in both directions once inserted', async () => {
     // Mirrors the artist_aliases CTE in apps/backend/services/catalog-export.service.ts:
-    // UNION both FK directions so a row filed under either endpoint surfaces the other.
-    await runBackfillPattern(sql, [[ALPHA_NAME, 'ZA', BETA_NAME, 'ZB', null]]);
+    // UNION both FK directions so a row filed under either endpoint surfaces the
+    // other — which is why one row in one direction is enough.
+    await runBackfill([pair(ALPHA_NAME, 'ZA', BETA_NAME, 'ZB')]);
 
     const aliasRows = await sql.unsafe(
       `
@@ -237,12 +370,12 @@ describe('BS#2117 artist_crossreference backfill (real PG)', () => {
         SELECT cp.artist_id, array_agg(DISTINCT a.artist_name) AS cross_reference_names
         FROM (
           SELECT source_artist_id AS artist_id, target_artist_id AS other_id
-          FROM "${SCHEMA}".artist_crossreference
+          FROM ${TEST_SCHEMA}.artist_crossreference
           UNION
           SELECT target_artist_id AS artist_id, source_artist_id AS other_id
-          FROM "${SCHEMA}".artist_crossreference
+          FROM ${TEST_SCHEMA}.artist_crossreference
         ) cp
-        JOIN "${SCHEMA}".artists a ON a.id = cp.other_id
+        JOIN ${TEST_SCHEMA}.artists a ON a.id = cp.other_id
         WHERE cp.other_id <> cp.artist_id
         GROUP BY cp.artist_id
       )
@@ -258,20 +391,3 @@ describe('BS#2117 artist_crossreference backfill (real PG)', () => {
     expect(byId.get(ART_BETA)).toEqual([ALPHA_NAME]);
   });
 });
-
-// The literal scripts/audit/bs_2117_crossref_backfill.sql file (with its
-// embedded 110-pair real tubafrenzy dataset) is deliberately NOT executed
-// here. It was validated directly against the dev-clone Postgres
-// (dev_env/seed-clone.sql, real staging-derived data) via `psql -f` during
-// development: a clean first run (79 pairs resolved by name, 77 rows
-// inserted after dedup), a no-op second run (0 rows inserted, confirming
-// idempotency), and the 77 test-inserted rows were then deleted to restore
-// the table to its pre-run empty state. That verification is not
-// reproducible as an automated spec here — the file's INSERT touches
-// whichever real `artists` rows happen to match its embedded names, which
-// depends on whether the environment loaded the prod-clone fixture
-// (LOAD_CLONE_FIXTURE), and an automated spec cannot safely guarantee
-// cleanup for side effects on rows it did not seed itself. The
-// resolve/canonicalize/guard/insert SHAPE the file uses is exactly what
-// `runBackfillPattern` above exercises against synthetic, self-cleaning
-// fixtures instead.


### PR DESCRIPTION
Closes #2117.

An operator-run repair script that backfills `wxyc_schema.artist_crossreference` from tubafrenzy's `LIBRARY_CODE_CROSS_REFERENCE` before the 2026-08-31 turndown, plus an integration spec that executes the script's own resolver and INSERT verbatim.

Not a Drizzle migration: `docs/migrations.md` keeps migrations DDL-only, and this is DML over a curated table. It follows the shape of `scripts/audit/bs_replacement_char_recovery.sql`.

## Root cause

`jobs/library-etl/job.ts` already imports this table on every run. Its `findArtistId` resolves an artist by folded name **AND** an exact `lower(code_letters)` match, with no name-only fallback. 35 of the 110 usable tubafrenzy pairs have an **empty `CALL_LETTERS`** on the referencing side — tubafrenzy's convention for a "pointer" `LIBRARY_CODE` that exists only to carry a cross-reference and holds no catalog of its own. `artists.code_letters` is `NOT NULL` and never empty for a real catalogued artist, so `lower('') = lower(code_letters)` can never match. The ETL's `skipped++` counter absorbs every one with no operator-visible signal.

The blind spot is the right size for the defect. A cross-reference is exported per catalog row of the artist it hangs off, so a pointer pair that fails to import leaves the artist it points *at* short an alias on all of that artist's rows. In the dev clone, those 35 pairs point at 30 artists owning **166 `library` rows** — against the harness's 157. A fit, not a proof, but a much better one than the alternatives.

## Provenance conflicts: 15 pairs excluded because tubafrenzy's own FK is wrong

Review turned up the most important thing in this PR. `LIBRARY_CODE_CROSS_REFERENCE.CROSS_REFERENCING_ARTIST_ID` is, despite the name, a `LIBRARY_CODE.ID`. The embedded 110 pairs resolve it that way and match tubafrenzy **exactly** — verified row-by-row against the live database, 0 mismatches, so the extraction is faithful.

But on **15** of them the FK is corrupt upstream, and each row's own `COMMENT` proves it. Many comments carry a machine-generated `[from <Genre>-<LETTERS>-<NUM> to <target>]` provenance note. Where the referencing row is a real filing (`CALL_NUMBERS <> 0`) and that note names a different non-zero code, the two disagree — and the note is right:

| id | FK resolves to | provenance note names | target |
|---|---|---|---|
| 26 | Cactus World News CA 46 | Rock DO 66 = Tonya Donelly | The Breeders |
| 27 | Cactus World News CA 46 | Rock DO 66 = Tonya Donelly | Belly |
| 29 | Capping Day CA 74 | Rock CO 184 = Graham Coxon | Blur |
| 31 | Chris Cacavas CA 66 | Rock CA 37 = Camper Van Beethoven | Eugene Chadbourne |
| 32 | Cactus CA 153 | Rock DE 80 = The Dentists | Coax |
| 33 | Gloria Loring LO 24 | Rock DE 90 = Amy Denio | Danubians |
| 34 | Cabal CA 72 | Rock CA 8 = Caravan | Delivery |
| 36 | Gloria Loring LO 24 | Rock DO 73 = Julie Doiron | Eric's Trip |
| 38 | Papa John Creach CR 59 | Rock DE 39 = Dead Can Dance | Lisa Gerrard |
| 41 | Capping Day CA 74 | Rock DA 7 = Dave Davies | The Kinks |
| 43 | Cabaret Voltaire CA 42 | Rock DR 7 = Dream Syndicate | Last Days of May |
| 44 | Cabaret Voltaire CA 42 | Rock CH 11 = Sheila Chandra | Monsoon |
| 45 | Cabaret Voltaire CA 42 | Rock DR 7 = Dream Syndicate | Opal |
| 46 | Cabal CA 72 | Rock CL 55 = Allen Clapp | The Orange Peels |
| 48 | Cactus World News CA 46 | Rock CA 69 = Lori Carson | Golden Palominos |

Every note is a real musical relationship (Donelly was in the Breeders and founded Belly; Coxon is in Blur; Davies is a Kink; Gerrard is half of Dead Can Dance; Chandra fronted Monsoon; Clapp is the Orange Peels; Carson sang with the Golden Palominos). Every FK reading is nonsense. One FK value even collapses three distinct true sources onto one name — Cabaret Voltaire CA 42 stands in for rows 43, 44 and 45.

These 15 are now **excluded**, via an explicit `bs2117_provenance_conflicts` list, and reported as `provenance_conflict_skip` in the pre-amble. The risk is asymmetric: unlike the missing pairs, these are associations prod does **not** hold, so no guard would have skipped them — they would have landed as brand-new false aliases on real catalog rows, with no delete path. A wrong alias is worse than a missing one.

Re-resolving them from the provenance prefix is mechanically easy and probably correct, but it is a data-quality judgement about tubafrenzy's own corruption inferred from free-text prose. That belongs to a cataloger and a follow-up, not to a backfill whose contract is to move cataloger data across unchanged.

Post-exclusion the clone measures: 110 pairs → 15 provenance conflicts, 31 unresolvable, **64 eligible**, collapsing to **62** distinct unordered pairs across 108 endpoint artists owning 630 `library` rows.

## Read this before reading "0 remaining mismatches" as success

**This script cannot close the 157 bucket.** 31 of the 110 pairs name a referencing artist — 28 distinct names — for which Backend has **no `artists` row at all**. That is an absence, not a name-match failure a looser fold could solve: no release import ever created an artist for a holdings-free pointer name. In the clone those 31 pairs point at 26 artists owning **150 `library` rows**, so the large majority of the 157 survives this backfill untouched.

Only **4** of the 110 pairs are ones the deployed ETL could not already resolve but this script can (60 of the 64 eligible pairs also satisfy the ETL's strict `code_letters` equality). Those 4 are the entire delta this script adds over what the importer already does.

Closing the remaining 31 is a different repair, deliberately not attempted here because it *creates* catalog identities rather than linking existing ones: insert an `artists` row per pointer name (`code_letters` is `varchar(4) NOT NULL`, so `''` is representable) and link that. That is a cataloger's call. Four of the 28 are name *variants* rather than true absences and would want an alias rule instead — "Wedding Present" vs Backend's "The Wedding Present", bare "X" vs "X [US]", "Return to Forever" vs "Chick Corea (Return to Forever)", and "Cash, Larry Jr.", which is just the alphabetical inversion of Backend's own "Larry Cash, Jr." and therefore not a lost association at all.

## The empty-clone reading was wrong, and is corrected here

An earlier pass measured `artist_crossreference` as completely empty in the local prod-shaped clone and concluded the import step had never run. **That inference does not hold and has been removed from the script.** `dev_env/seed-clone.sql` lists `wxyc_schema.artist_crossreference` in its leading `TRUNCATE` block and its `pg_dump --data-only` body restores only five tables — `format`, `artists`, `genre_artist_crossreference`, `library`, `rotation`. The table is truncated and never repopulated, so it reads as empty in every environment that loads the fixture, whatever staging or prod holds. Its emptiness is an artifact of the fixture's table list and carries no information about prod.

The ticket's own evidence settles it the other way: the harness's 11 empty-in-tubafrenzy and 28 differ-on-both-sides buckets each require Backend to be emitting cross-reference values, which an empty table cannot do. **Prod's `artist_crossreference` is populated.** The importer has been running and mostly succeeding; what it has never been able to import is the pointer pairs. Consequence for this PR: the insert count against prod will be far below the clone's 62, and the guards are what make it safe to not know that number in advance.

## Oliver Lake resolves to two artists, not a self-pair

The script previously claimed row 128 ("Oliver Lake" → "Oliver Lake", *"same Oliver Lake"*) collapses to one `artists.id` and is dropped by the `source <> target` filter. Measured against the clone, that is not what happens. Backend artist identity is not name-unique, and the clone mirrors tubafrenzy exactly: artist 1829 (`LA`, genre code 17) and artist 15780 (`LA`, genre code 2) are two separate rows. Stage 2 cannot separate them (both `LA`); stage 3 can, on the genre code. Row 128 resolves 1829 → 15780, is classified `resolved` (not `self_pair_skip`) in the pre-amble, and **is inserted** — which is the correct outcome, since it reproduces exactly the alias tubafrenzy's own export emits for both Oliver Lake catalog rows.

The `source <> target` filter matches zero rows against the clone. It stays as a guard against prod holding only one "Oliver Lake", in which case the pre-amble reports `self_pair_skip` and an operator can tell the two outcomes apart before committing. Either way the resolution is surfaced, never silently picked. There are five endpoint tuples in the source data that match more than one artist by folded name (DAT Politics, Exene Cervenka, Sankofa, and the two Oliver Lakes); stages 2 and 3 narrow every one to a single artist, and **zero** pairs come out ambiguous.

## Verification

- **PostgreSQL 14.** Prod RDS is 14.22; the dev container is 18 and accepts syntax prod rejects, so the file was executed end to end on **14.23** against a minimal schema stub — clean run, idempotent re-run inserting 0, and a re-run against a table pre-seeded with the *reversed* direction, which correctly inserted nothing for that pair. The session-temp pair table and resolver survive the `COMMIT` and are still visible to the post-amble and `ANALYZE` under `psql -f`, verified on 14.23. (`psql -1 -f` is wrong here — `ANALYZE` cannot run inside a transaction block.)
- **Idempotency against a non-empty table** is the prod case and is what the `NOT EXISTS` either-direction guard exists for; `ON CONFLICT` on the ordered pair alone cannot see a reversed duplicate. Covered on PG14 and by two specs.
- **Watermark.** Migration 0138's trigger is confirmed `AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ... FOR EACH STATEMENT` against the live table definition — it does fire on INSERT. Cost is stated in the header. The header now also documents the second trigger nobody had accounted for: `cdc_artist_xref` is `FOR EACH ROW`, so this emits one `pg_notify('cdc')` per inserted row.
- **The spec now executes the real SQL.** It reads `scripts/audit/bs_2117_crossref_backfill.sql`, extracts the resolver function and the transactional INSERT, and runs them against a throwaway `bs2117_backfill_test` schema via the same `wxyc_schema.` → test-schema rewrite `relabel-rotation-direct-backfill.spec.js` uses. That rewrite is also what makes it safe — the resolver can only see synthetic artists, so the outcome no longer depends on `LOAD_CLONE_FIXTURE`. Editing the resolver or the INSERT now changes what the spec runs, and the script is registered in `test.yml`'s `tests:` paths filter so a script-only edit re-runs it.
- Two cases were added for the part that had none: the row-128 shape (two same-named artists split only by genre code must link, not self-pair) and a genuinely ambiguous name (same name, same letters, same genre code must be skipped, not guessed).

## Small fixes

- `DISTINCT ON` in the dedup CTE had no tiebreaker past its key, so which cataloger comment survived was plan-dependent. Now ordered `xref_comment ASC NULLS LAST`.
- `DROP TABLE IF EXISTS bs2117_pairs` resolved through `search_path` and could have dropped a same-named permanent table; now `pg_temp`-qualified.
- Corrected header arithmetic: 75 (not 73) of the 79 resolved pairs satisfy the strict match; 155 resolvable endpoint artists own 915 `library` rows (not 151/902); 28 distinct unresolvable names across 31 pairs.
- Struck the claim that pointer artists "contribute ZERO rows" to the 157. They contribute via the target side, which is exactly why the 31 leave ~150 rows short rather than costing nothing.

## Recommended follow-up (not filed)

`findArtistId`'s strict `code_letters` requirement is a live bug, not just an explanation for this one. It guarantees the pointer names can never be imported by any future ETL run, so this defect regenerates for any cross-reference a cataloger adds under a holdings-free code before turndown. It also calls `.limit(1)` with no `ORDER BY` on a query that can match multiple artists — both Oliver Lakes match `(name='Oliver Lake', letters='LA')` — so it silently picks one arbitrarily and can write a self-referential row. Worth its own ticket, sized against the 2026-08-31 deadline.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Enumerate the 157 rows, record the count | **Partial.** The 119 raw / 110 usable / 9 dangling source rows are enumerated in the script header. The prod-side 157 needs a live Backend export and is not reproducible here. |
| Root cause identified and stated | Done — keying mismatch in `findArtistId`, not an incomplete migration or an export-query gap. |
| The 157 associations exist in Backend | **Not achievable by this script.** ~150 of the clone-equivalent rows are blocked on the 28 missing pointer artists. |
| The 28 both-sides-differ rows triaged | **Partial.** This inserts every resolvable pair rather than a hand-picked subset, so any of the 28 explained by a *partially* imported artist are fixed as a side effect. Rows where Backend holds a cross-reference tubafrenzy lacks need prod-side enumeration; re-run the harness and file what remains. |
| `ANALYZE` on every touched table (#934) | Done, after `COMMIT`. `check-bulk-update-analyze --strict` passes. |
| Next parity run reports 0 empty-in-Backend | **Will not happen, by design.** See the ceiling section. |

## Also addressed from review

- **`ON_ERROR_STOP=1` is now required and documented.** Without it a failure in the pair load lets psql run on through the transaction block (whose `COMMIT` degrades to a rollback), the post-amble and `ANALYZE`, printing `resolved_pairs 0 / present_in_backend 0` — indistinguishable from a clean idempotent re-run. The header also now says plainly that `psql -f` is non-interactive, so the pre-amble is a record to read, not a gate that pauses.
- **The pre-amble now sorts anomalies FIRST.** The rows an operator must inspect were being printed after ~79 successful ones.
- **Concurrency is documented as a real gap, not hand-waved.** The either-direction `NOT EXISTS` reads a snapshot, so a concurrent reversed write (e.g. the library-etl job) could slip past both it and `ON CONFLICT`. Run exactly one copy.
- **Header count corrections:** 51 pairs carry a comment (was stated as 34).

### Rejected

- **"Comments are truncated at 100 chars, contradicting the verbatim claim."** Not a defect. tubafrenzy's `LIBRARY_CODE_CROSS_REFERENCE.COMMENT` is itself `varchar(100)` — verified against the live schema — so a 100-char value *is* the complete stored value. Row 31 ends mid-word because it was clipped in tubafrenzy years ago. The Backend column is `varchar(255)`, so there is headroom, not a lossy fit. Documented in the header rather than "fixed".
- **"The extraction query resolved `CROSS_REFERENCING_ARTIST_ID` against the wrong `LIBRARY_CODE` row."** The observation that led here was correct and valuable, but the diagnosis was not: the embedded data matches tubafrenzy exactly on all 110 pairs, both sides. The corruption is in tubafrenzy's stored FK, not in how it was read. That distinction matters, because it means re-extracting cannot fix it.
- **"A lone folded-name match is accepted with zero key verification"** and **"stage-2 fall-through can upgrade to a confident wrong answer."** Both are accurate readings of the code and both are now documented, but neither fires on this data, and I verified that rather than assuming: no endpoint with more than one candidate has zero `code_letters` matches among them (so the fall-through never engages), and no single-candidate resolution contradicts tubafrenzy's letters where tubafrenzy recorded any. Tightening the resolver would change behaviour on a dataset where the tighter rule is provably equivalent, so the measurements are recorded in the header instead.
- **"Stage 3 matches `artist_genre_code` without constraining `genre_id`."** Real imprecision, no effect here: 0 pairs come out ambiguous, and the five multi-candidate names each narrow to exactly one artist. A same-number-different-genre collision would surface as `AMBIGUOUS` and be skipped, not mis-resolved, because the resolver reports rather than guesses.
- **"`LEAST`/`GREATEST` writes the opposite direction from the ETL, so the next ETL run adds a mirror row."** The ETL uses `onConflictDoUpdate` on the ordered pair, so it would indeed insert the reverse direction for pairs it can resolve. But the export CTE unions both directions and de-duplicates, so a mirror row is invisible downstream, and switching this script to tubafrenzy's direction would break the `LEAST`/`GREATEST` dedup that collapses rows 74/75. Left as is; the ETL's own missing either-direction guard is part of the `findArtistId` follow-up below.
- **"The pre-amble is untested."** True, and deliberate: the pre-amble is three read-only reporting queries whose duplicated `CASE` is a legibility problem, not a correctness gate — nothing downstream reads it. Testing the INSERT's `WHERE` is what protects the data. Worth folding into the follow-up if the pre-amble grows.
