### PR TITLE
fix(auth): check the email disable switch before SES config validation

### DIFF
--- a/shared/authentication/src/email.ts
+++ b/shared/authentication/src/email.ts
@@ -136,16 +136,19 @@ function getConfigurationSetName(): string | undefined {
 }
 
 /**
- * SES has a 200-message/month quota. `EMAIL_ENABLED` gates the actual
- * `client.send()` call so test/CI runs (which repeatedly exercise the
+ * SES has a 200-message/month quota. `EMAIL_ENABLED` gates the entire send
+ * path — a disabled environment needs NO SES configuration at all (no
+ * `SES_FROM_EMAIL`, no AWS credentials); the senders no-op before any config
+ * validation runs — so test/CI runs (which repeatedly exercise the
  * password-reset / verification / OTP flows) never burn that quota.
  * Defaults to enabled (production behavior) when unset. `scripts/ci-env.sh`
  * does NOT set this var -- test/CI environments set `EMAIL_ENABLED=false`
- * explicitly in two other places: `tests/setup/unit.setup.ts` (the jest
- * unit-test-runner process itself) and, for the separately-spawned auth/
+ * explicitly in these places: `tests/setup/unit.setup.ts` (the jest
+ * unit-test-runner process itself); for the separately-spawned auth/
  * backend servers the integration suite talks to over HTTP, on
  * `dev_env/docker-compose.yml`'s `auth` service (CI profile, hardcoded) and
- * `.github/workflows/test.yml`'s Integration-Tests "Start services" step.
+ * `.github/workflows/test.yml`'s Integration-Tests "Start services" step;
+ * and dj-site's E2E workflow Backend `.env` (BS#1999).
  */
 export function isEmailSendingEnabled(): boolean {
   const raw = process.env.EMAIL_ENABLED;
@@ -160,6 +163,17 @@ export function isEmailSendingEnabled(): boolean {
  * Send a transactional email using the unified email system
  */
 export async function sendEmail(email: WXYCEmail): Promise<void> {
+  // The disable switch must run before any SES config validation: an
+  // environment that deliberately disables email (E2E, local dev) sets
+  // EMAIL_ENABLED=false without SES vars, and must get a clean no-op rather
+  // than a config throw. With the checks in the other order, BS#1969's
+  // awaited invite send surfaced the throw as emailSent:false on every
+  // provision, failing dj-site's admin E2E suite (BS#1999). Enabled but
+  // misconfigured still throws below — that misconfiguration must stay loud.
+  if (!isEmailSendingEnabled()) {
+    return;
+  }
+
   const from = process.env.SES_FROM_EMAIL;
   if (!from) {
     throw new Error('Missing AWS SES configuration: SES_FROM_EMAIL');
@@ -183,10 +197,6 @@ export async function sendEmail(email: WXYCEmail): Promise<void> {
     },
     ConfigurationSetName: getConfigurationSetName(),
   });
-
-  if (!isEmailSendingEnabled()) {
-    return;
-  }
 
   const client = getSesClient();
   await client.send(command);
@@ -252,6 +262,12 @@ export const buildOTPEmailHtml = ({ title, intro, otp, footer }: OTPEmailTemplat
 `.trim();
 
 export const sendOTPEmail = async ({ to, otp, type }: OTPEmailInput) => {
+  // Same ordering constraint as sendEmail: the disable switch short-circuits
+  // before SES config validation so email-less environments no-op cleanly.
+  if (!isEmailSendingEnabled()) {
+    return;
+  }
+
   const from = process.env.SES_FROM_EMAIL;
   if (!from) {
     throw new Error('Missing AWS SES configuration: SES_FROM_EMAIL');
@@ -292,10 +308,6 @@ export const sendOTPEmail = async ({ to, otp, type }: OTPEmailInput) => {
     },
     ConfigurationSetName: getConfigurationSetName(),
   });
-
-  if (!isEmailSendingEnabled()) {
-    return;
-  }
 
   const client = getSesClient();
   await client.send(command);

--- a/tests/unit/authentication/email-otp.test.ts
+++ b/tests/unit/authentication/email-otp.test.ts
@@ -156,5 +156,22 @@ describe('Email OTP', () => {
 
       delete process.env.EMAIL_ENABLED;
     });
+
+    it('resolves as a clean no-op when EMAIL_ENABLED=false and SES is entirely unconfigured (BS#1999)', async () => {
+      // The disable switch must short-circuit BEFORE the SES_FROM_EMAIL
+      // validation — a deliberately email-less environment sets
+      // EMAIL_ENABLED=false without any SES vars and must get the documented
+      // no-op, not a config throw.
+      process.env.EMAIL_ENABLED = 'false';
+      const originalFrom = process.env.SES_FROM_EMAIL;
+      delete process.env.SES_FROM_EMAIL;
+
+      await expect(sendOTPEmail({ to: 'dj@wxyc.org', otp: '123456', type: 'sign-in' })).resolves.toBeUndefined();
+
+      expect(mockSend).not.toHaveBeenCalled();
+
+      process.env.SES_FROM_EMAIL = originalFrom;
+      delete process.env.EMAIL_ENABLED;
+    });
   });
 });

--- a/tests/unit/services/email.test.ts
+++ b/tests/unit/services/email.test.ts
@@ -251,6 +251,30 @@ describe('EMAIL_ENABLED gating', () => {
     const emailModule = await import('../../../shared/authentication/src/email');
     expect(emailModule.isEmailSendingEnabled()).toBe(false);
   });
+
+  it('resolves as a clean no-op when EMAIL_ENABLED=false and SES is entirely unconfigured (BS#1999)', async () => {
+    // The disable switch must short-circuit BEFORE any SES config validation:
+    // a deliberately email-less environment (dj-site E2E, local dev) sets
+    // EMAIL_ENABLED=false without SES vars, and a config throw there is what
+    // turned BS#1969's awaited invite send into emailSent:false on every
+    // provision — failing dj-site's entire admin E2E suite.
+    process.env.EMAIL_ENABLED = 'false';
+    delete process.env.SES_FROM_EMAIL;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_REGION;
+    const emailModule = await import('../../../shared/authentication/src/email');
+
+    await expect(
+      emailModule.sendEmail({
+        type: 'accountSetup',
+        to: 'newdj@test.wxyc.org',
+        url: 'https://example.com/setup',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
 });
 
 // Test cases for new user detection logic (to be used in auth.definition)


### PR DESCRIPTION
## Problem

The two senders in `shared/authentication/src/email.ts` validate SES configuration before consulting the `EMAIL_ENABLED` disable switch: `sendEmail` throws `Missing AWS SES configuration: SES_FROM_EMAIL` (and `sendOTPEmail` likewise) before ever reaching `if (!isEmailSendingEnabled()) return;`. An environment that deliberately disables email and therefore sets no SES vars gets a config throw instead of the documented no-op.

That ordering was latent for as long as every caller fire-and-forgot the send. #1969's `createAndSendAccountSetupInvite` awaits the send and reports honestly, so in dj-site's E2E environment — no SES vars, `EMAIL_ENABLED` unset — every `provisionUser` began returning `emailSent: false`. dj-site's roster UI renders that as a **warning** toast instead of the success toast, and every admin spec provisions its target account through the roster and asserts the success toast first (`rosterPage.createAccount(...)` → `expectSuccessToast()`), so the entire admin suite failed at its create-account setup step. That is the mechanism behind #1999 / WXYC/dj-site#1088 — the recorded failing assertion is the **no-text-filter** success-toast locator, i.e. the create step, not the later role-change toast.

## The fix

Hoist the `isEmailSendingEnabled()` early-return above all SES config reads in both `sendEmail` and `sendOTPEmail`. This is the ordering the `metadata-no-match-digest` job's self-contained sender already uses (its unit test pins "disabled is a clean no-op even when `SES_FROM_EMAIL` is missing" — this PR brings `shared/authentication` in line with that sibling). The `isEmailSendingEnabled` doc now states the contract: **a disabled environment needs no SES configuration at all.**

Deliberately unchanged:

- **Enabled but misconfigured still throws loudly.** Production (where `EMAIL_ENABLED` is unset → enabled) behaves byte-identically; the existing throw tests in both files run with `EMAIL_ENABLED='true'` and still pass.
- **#1969's behavior is fully preserved** — long-lived account-setup token, awaited observable send, Sentry captures. Nothing in `account-setup.ts`, `auth.definition.ts`, or `provision-user.ts` is touched. This is the repair #1999 asked for, not a revert.

## Regression coverage

Two new unit tests (the Backend-level tests that would have caught this): with `EMAIL_ENABLED=false` and SES **entirely unconfigured** — no `SES_FROM_EMAIL`, no AWS creds — `sendEmail` and `sendOTPEmail` resolve cleanly and never touch the SES client. The E2E-environment half of the outage (dj-site's generated Backend `.env` never declared `EMAIL_ENABLED=false`, unlike every other Backend test environment) is fixed by the paired dj-site PR, which also unpins `BACKEND_PINNED_REF` back to `main` per #1999's acceptance criteria.

Verification per #1999's reproduce-before-fix constraint: dj-site E2E dispatched from the paired branch with `backend_ref=fix/1999-email-enabled-check-order`, pin line confirmed in the job log — **success, 4/4 shards** ([run 31714993252](https://github.com/WXYC/dj-site/actions/runs/31714993252)); job log line: `Using Backend-Service ref: fix/1999-email-enabled-check-order`.

## Related

- #1999 — the root-cause ticket (closed manually once dj-site is unpinned and green on `main`; its remaining acceptance criteria live downstream)
- #1969 — the feature whose honest error reporting surfaced this
- WXYC/dj-site#1088 — the merge-gate outage; WXYC/dj-site#1089 — the emergency pin this unblocks removing
- Paired PR: dj-site branch `fix/1088-e2e-email-enabled-unpin` (PR opens after this merges, so its own gate run proves the unpinned float)
