### PR TITLE
fix(playlist): order /playlists/recentEntries by add_time, not the id PK (BS#2132)

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -438,6 +438,12 @@ function toBaseEntry(row: RecentRow): BaseEntry {
     // tubafrenzy's own GLOBAL_ORDER_ID numbering (show*1000+seq), which no
     // longer exists once tubafrenzy is decommissioned; consumers only rely
     // on chronOrderID for ordering/dedup, not on its numeric scheme.
+    //
+    // BS#2132 caveat: "globally monotonic" above means insert-order
+    // monotonic, not chronological — the file-header comment explains why
+    // those diverge for a historical insert. chronOrderID stays id-derived
+    // here deliberately; whether to change it is a decision tracked on the
+    // parent, #2118, not made by this comment or this PR.
     chronOrderID: row.id,
     hour: computeHourMs(row),
     timeCreated: row.add_time.getTime(),
@@ -459,11 +465,20 @@ function toBaseEntry(row: RecentRow): BaseEntry {
  * on the v=2 path, no offset), so reordering is a bounded backward scan
  * served by the existing single-column `flowsheet_add_time_idx`
  * (`schema.ts`) plus an incremental sort over timestamp ties — no new index.
- * Note `add_time` defaults to `now()` (`transaction_timestamp()`) and the
- * tubafrenzy webhook writes it from tubafrenzy's own clock
- * (`apps/backend/routes/internal.route.ts`), so cross-host clock skew is a
- * (sub-second, in practice) source of ordering difference from the old
- * id-only order even for purely live traffic.
+ * Two `add_time` semantics worth knowing when reasoning about ordering here.
+ * The primary one: the tubafrenzy webhook (`apps/backend/routes/internal.route.ts`)
+ * writes `add_time` from `entry.startTime` — tubafrenzy's own EVENT time for
+ * the entry, not a clock reading taken at delivery — so a first delivery
+ * tubafrenzy logged late (a missed track from earlier in the show, a
+ * corrected past show) lands with an `add_time` that diverges from its id
+ * rank by however late it was logged, unbounded, not sub-second. That
+ * divergence is exactly the historical-insert case this reorder exists to
+ * handle. The `ON CONFLICT` path anchors `add_time` to the first INSERT, so
+ * later webhook redeliveries never move it. Secondary and genuinely
+ * sub-second: `add_time` defaults to `now()` (`transaction_timestamp()`) for
+ * BS-originated rows, so cross-host clock skew between BS and a webhook
+ * sender is a minor additional source of ordering difference from the old
+ * id-only order, distinct from the webhook case above.
  */
 async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
   return db

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -9,13 +9,23 @@
  * Backend-Service's own Postgres `flowsheet` table.
  *
  * Query shape: the most recent MAX_ENTRIES (200) flowsheet rows (any
- * entry_type, ordered by flowsheet.id DESC — the same "most recent"
- * convention `flowsheet.service.ts`'s `getEntriesByPage` uses, since
- * flowsheet.id is globally monotonic across shows) are grouped into
+ * entry_type, ordered by flowsheet.add_time DESC with flowsheet.id DESC as
+ * the tie-break for rows sharing a timestamp) are grouped into
  * playcuts/talksets/breakpoints exactly as the old SSE-fed in-memory store
  * was. Playcuts are then sliced to the caller's requested `n`; talksets and
  * breakpoints are returned in full (unsliced) — matching the pre-Phase-3
  * behavior byte-for-byte at the GroupedResponse shape level.
+ *
+ * BS#2132: this used to order by flowsheet.id DESC alone, on the theory that
+ * flowsheet.id is globally monotonic across shows (the same convention
+ * `flowsheet.service.ts`'s `getEntriesByPage` still uses — see BS#2118/#2133
+ * for that sibling site). That theory only holds while every insert is a
+ * live one; a historical insert (backfill, import, repair) receives the
+ * highest ids in the table and would sort as the newest content. Ordering by
+ * add_time first fixes that for this endpoint. This does not change
+ * `chronOrderID` (see `toBaseEntry` below) — the wire-level ordering key
+ * consumers re-sort by is a separate, deliberately-deferred decision tracked
+ * on BS#2118.
  *
  * entry_type -> tubafrenzy wire vocabulary mapping (see PR description for
  * the full rationale): 'track' -> playcut; 'talkset' | 'dj_join' |
@@ -436,10 +446,24 @@ function toBaseEntry(row: RecentRow): BaseEntry {
 
 /**
  * Fetch the most recent `limit` flowsheet rows (any entry_type, ordered by
- * flowsheet.id DESC), with the FK-lane rotation_bin joined in. Shared by both
- * the v=2 grouped path (`getRecentEntries`, limit = MAX_ENTRIES) and the v=1
- * flat path (`getRecentEntriesFlat`, limit = the caller's n). The fallback
- * rotation lane runs separately, post-classification (BS#1862).
+ * flowsheet.add_time DESC with flowsheet.id DESC as the tie-break), with the
+ * FK-lane rotation_bin joined in. Shared by both the v=2 grouped path
+ * (`getRecentEntries`, limit = MAX_ENTRIES) and the v=1 flat path
+ * (`getRecentEntriesFlat`, limit = the caller's n). The fallback rotation
+ * lane runs separately, post-classification (BS#1862).
+ *
+ * BS#2132: previously ordered by flowsheet.id DESC alone. flowsheet.id is a
+ * serial PK, not a chronological key, so a historical insert (backfill,
+ * import, repair) would receive the highest ids in the table and sort as the
+ * newest content. This is a top-N query (`.limit(limit)`, MAX_ENTRIES = 200
+ * on the v=2 path, no offset), so reordering is a bounded backward scan
+ * served by the existing single-column `flowsheet_add_time_idx`
+ * (`schema.ts`) plus an incremental sort over timestamp ties — no new index.
+ * Note `add_time` defaults to `now()` (`transaction_timestamp()`) and the
+ * tubafrenzy webhook writes it from tubafrenzy's own clock
+ * (`apps/backend/routes/internal.route.ts`), so cross-host clock skew is a
+ * (sub-second, in practice) source of ordering difference from the old
+ * id-only order even for purely live traffic.
  */
 async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
   return db
@@ -465,7 +489,7 @@ async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
     })
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .orderBy(desc(flowsheet.id))
+    .orderBy(desc(flowsheet.add_time), desc(flowsheet.id))
     .limit(limit);
 }
 

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -1276,6 +1276,16 @@ export const flowsheet = wxyc_schema.table(
     // The 8-day ceiling in the contract is what makes that trade safe: it
     // bounds the sorted set to ~3k rows, so the cheaper index wins on a table
     // whose index bloat is a tracked concern (epic #1058).
+    //
+    // Second consumer, BS#2132: `fetchRecentRows` (playlist-proxy.service.ts)
+    // also orders `desc(add_time), desc(id)`, serving `GET
+    // /playlists/recentEntries`. Different bound than the range read above —
+    // LIMIT 200, no WHERE clause at all — so the single-column-vs-composite
+    // trade-off has to be re-weighed against this workload too, not just the
+    // 8-day range one. Re-validated against prod on 2026-08-13 at that LIMIT:
+    // `Index Scan Backward` on this index plus an `Incremental Sort` of 7
+    // full-sort groups / 29 kB, 0.9 ms warm — single-column still wins here.
+    // A future change to this index's shape should check both consumers.
     index('flowsheet_add_time_idx').on(table.add_time),
     index('flowsheet_search_doc_idx').using('gin', sql`${table.search_doc}`),
     // BS#1012 (Epic D / D5). Functional partial index that supports the

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -20,10 +20,11 @@
  * and drift; see flowsheet-upcoming-show-support.spec.js for the same
  * rationale). fetchRecentRows orders by `add_time DESC, id DESC` (BS#2132 —
  * previously `id DESC` alone, which let a historical `add_time` silently
- * ride in on the id PK), so every fixture row below either takes the
- * `add_time` DEFAULT (`now()`, sorting first same as before) or, if it sets
- * `add_time` explicitly (the breakpoint row), computes it relative to "now"
- * rather than a hard-coded date — see that fixture's own comment.
+ * ride in on the id PK), so EVERY fixture row below — including the
+ * breakpoint, which used to set `add_time` explicitly to a hard-coded past
+ * date — takes the `add_time` DEFAULT (`now()`). See the breakpoint
+ * fixture's own comment for why even a small, JS-computed backdating
+ * still isn't safe here.
  */
 
 const postgres = require('postgres');
@@ -116,9 +117,9 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   const flowsheetIds = [];
   const libraryIds = [PRESS_CD, PRESS_LP, BRANCHA_LIB_ID, BRANCHC_LIB_ID, ENRICHED_LIB_ID];
   const rotationIds = [];
-  // Set by beforeAll and read by the breakpoint-hour assertion below — see
-  // the breakpointRow fixture comment for why this must be computed relative
-  // to "now" rather than hard-coded (BS#2132).
+  // Set by beforeAll from the INSERT's own RETURNING radio_hour (never
+  // recomputed in JS) and read by the breakpoint-hour assertion below —
+  // see the breakpointRow fixture comment for why (BS#2132).
   let breakpointHourMs;
 
   beforeAll(async () => {
@@ -341,31 +342,45 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // backdated add_time (this used to be a hard-coded 2026-07-28 literal)
     // silently falls out of the top-N window as soon as it ages past
     // whatever else lands in the table, exactly the id-DESC-reliance bug
-    // BS#2132 fixed. Compute it relative to "now" instead — and NOT floored
-    // to a real calendar hour boundary: an earlier version of this fixture
-    // did that (current/previous hour, floored) and a real `ci:testmock`
-    // --runInBand run proved it insufficiently fresh — many sibling
-    // integration specs insert their own flowsheet rows on the `add_time`
-    // DEFAULT (`now()`) during the SAME run, so a row backdated by tens of
-    // minutes routinely loses to 200 fresher ones and the breakpoint drops
-    // out of the window entirely. radio_hour here is instead just a few
-    // seconds in the past (comfortably inside the window, and never
-    // future — see BS#2118 for why a future add_time is its own hazard);
-    // add_time sits ~48s before that, mirroring the original
-    // 19:59:12-vs-20:00:00 relationship this fixture exists to exercise.
-    // This still validates "radio_hour wins over floor(add_time)": since
-    // radio_hour is (virtually) never exactly on an hour boundary,
-    // floor(add_time) always lands an hour (or more) earlier than the raw
-    // radio_hour value, so the two remain distinguishable regardless of
-    // calendar alignment.
-    breakpointHourMs = Date.now() - 10_000;
-    const breakpointHour = new Date(breakpointHourMs);
-    const breakpointAddTime = new Date(breakpointHourMs - 48_000);
+    // BS#2132 fixed. Sibling integration specs insert their own flowsheet
+    // rows on the add_time DEFAULT (now()) throughout the same --runInBand
+    // run, so this row has to compete with a genuinely large, run-to-run-
+    // variable population for a place in the 200-row window.
+    //
+    // Two earlier attempts tried to out-run that population by backdating
+    // add_time by a shrinking margin (first to a real calendar hour
+    // boundary — up to an hour stale — then to ~58s stale, computed in
+    // JS). Both were proven flaky against real CI, not just locally: any
+    // nonzero backdating is a race against however many sibling rows
+    // land in that window during the run, which is nondeterministic run
+    // to run. Worse, both computed the margin from the TEST RUNNER's
+    // clock (`Date.now()`) while every sibling row's `now()` DEFAULT is
+    // timestamped by the DATABASE container's clock — a second, compounding
+    // source of drift on top of the shrinking margin itself.
+    //
+    // The actual fix: don't set add_time at all. Omitted from the INSERT,
+    // it takes the DEFAULT `now()` — the same column, the same DATABASE
+    // clock, the same freshness as every sibling row in this file. It
+    // cannot lose the window on its own; if it ever does, every other row
+    // in this fixture loses it too, which fails for an honest reason
+    // instead of a timing coincidence. radio_hour is computed in the same
+    // SQL statement, on the same clock, as the literal next hour boundary:
+    // `date_trunc('hour', now()) + interval '1 hour'` — the "upcoming top
+    // of hour" a breakpoint logged ~1 minute early carries in production.
+    // A future radio_hour is harmless here: the SQL ordering only ever
+    // reads add_time, never radio_hour (a pure display value —
+    // computeHourMs — not a sort/filter key). floor(add_time) is
+    // necessarily the CURRENT top of hour while radio_hour is the NEXT
+    // one, so they always differ by exactly one hour and remain
+    // distinguishable regardless of exactly when in the hour this runs.
+    // RETURNING radio_hour makes the row itself the source of truth for
+    // the assertion below, rather than recomputing it a second time.
     const breakpointRow = await sql`
-      INSERT INTO ${sql(SCHEMA)}.flowsheet (entry_type, play_order, add_time, radio_hour, message)
-      VALUES ('breakpoint', 91605, ${breakpointAddTime}, ${breakpointHour}, 'BREAKPOINT')
-      RETURNING id
+      INSERT INTO ${sql(SCHEMA)}.flowsheet (entry_type, play_order, radio_hour, message)
+      VALUES ('breakpoint', 91605, date_trunc('hour', now()) + interval '1 hour', 'BREAKPOINT')
+      RETURNING id, radio_hour
     `;
+    breakpointHourMs = breakpointRow[0].radio_hour.getTime();
 
     const showStartRow = await sql`
       INSERT INTO ${sql(SCHEMA)}.flowsheet (entry_type, play_order, dj_name)

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -18,9 +18,12 @@
  *
  * Fresh rows only (no fixed-id assumptions — local dev DB volumes persist
  * and drift; see flowsheet-upcoming-show-support.spec.js for the same
- * rationale). flowsheet.id is a serial PK, so freshly-inserted probe rows
- * always sort first under `ORDER BY id DESC`, independent of whatever else
- * is in the table.
+ * rationale). fetchRecentRows orders by `add_time DESC, id DESC` (BS#2132 —
+ * previously `id DESC` alone, which let a historical `add_time` silently
+ * ride in on the id PK), so every fixture row below either takes the
+ * `add_time` DEFAULT (`now()`, sorting first same as before) or, if it sets
+ * `add_time` explicitly (the breakpoint row), computes it relative to "now"
+ * rather than a hard-coded date — see that fixture's own comment.
  */
 
 const postgres = require('postgres');
@@ -113,6 +116,10 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
   const flowsheetIds = [];
   const libraryIds = [PRESS_CD, PRESS_LP, BRANCHA_LIB_ID, BRANCHC_LIB_ID, ENRICHED_LIB_ID];
   const rotationIds = [];
+  // Set by beforeAll and read by the breakpoint-hour assertion below — see
+  // the breakpointRow fixture comment for why this must be computed relative
+  // to "now" rather than hard-coded (BS#2132).
+  let breakpointHourMs;
 
   beforeAll(async () => {
     sql = makeSql();
@@ -328,9 +335,35 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
 
     // Breakpoint logged ~1 minute before the top of the hour: radio_hour
     // must win over flooring add_time (BS#1448/#1449).
+    //
+    // BS#2132: fetchRecentRows now orders by add_time DESC (not the
+    // flowsheet.id PK), so this row MUST stay recent — an absolute
+    // backdated add_time (this used to be a hard-coded 2026-07-28 literal)
+    // silently falls out of the top-N window as soon as it ages past
+    // whatever else lands in the table, exactly the id-DESC-reliance bug
+    // BS#2132 fixed. Compute it relative to "now" instead — and NOT floored
+    // to a real calendar hour boundary: an earlier version of this fixture
+    // did that (current/previous hour, floored) and a real `ci:testmock`
+    // --runInBand run proved it insufficiently fresh — many sibling
+    // integration specs insert their own flowsheet rows on the `add_time`
+    // DEFAULT (`now()`) during the SAME run, so a row backdated by tens of
+    // minutes routinely loses to 200 fresher ones and the breakpoint drops
+    // out of the window entirely. radio_hour here is instead just a few
+    // seconds in the past (comfortably inside the window, and never
+    // future — see BS#2118 for why a future add_time is its own hazard);
+    // add_time sits ~48s before that, mirroring the original
+    // 19:59:12-vs-20:00:00 relationship this fixture exists to exercise.
+    // This still validates "radio_hour wins over floor(add_time)": since
+    // radio_hour is (virtually) never exactly on an hour boundary,
+    // floor(add_time) always lands an hour (or more) earlier than the raw
+    // radio_hour value, so the two remain distinguishable regardless of
+    // calendar alignment.
+    breakpointHourMs = Date.now() - 10_000;
+    const breakpointHour = new Date(breakpointHourMs);
+    const breakpointAddTime = new Date(breakpointHourMs - 48_000);
     const breakpointRow = await sql`
       INSERT INTO ${sql(SCHEMA)}.flowsheet (entry_type, play_order, add_time, radio_hour, message)
-      VALUES ('breakpoint', 91605, '2026-07-28 19:59:12+00', '2026-07-28 20:00:00+00', 'BREAKPOINT')
+      VALUES ('breakpoint', 91605, ${breakpointAddTime}, ${breakpointHour}, 'BREAKPOINT')
       RETURNING id
     `;
 
@@ -472,7 +505,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
 
     const breakpointEntry = res.body.breakpoints.find((b) => b.id === flowsheetIds[5]);
     expect(breakpointEntry).toBeDefined();
-    expect(breakpointEntry.hour).toBe(new Date('2026-07-28T20:00:00.000Z').getTime());
+    expect(breakpointEntry.hour).toBe(breakpointHourMs);
   });
 
   test('v=2 defaults to <=50 playcuts and returns the grouped object', async () => {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -184,10 +184,14 @@ jest.mock('@wxyc/database', () => ({
 // siblings below — the ordering test at "queries the most recent MAX_ENTRIES
 // (200) rows ordered by ..." needs to assert the actual orderBy() column
 // arguments (BS#2132), and the real desc() applied to the mocked `flowsheet`
-// column stand-ins (plain strings — see the '@wxyc/database' mock below)
-// produces a deep-equal-comparable SQL wrapper each call, the same pattern
-// `flowsheet.getEntriesByShow.ordering.test.ts` uses for its own
-// `desc(flowsheet.play_order)` / `desc(flowsheet.id)` assertions.
+// column stand-ins (plain strings — see the '@wxyc/database' mock above)
+// produces a deep-equal-comparable SQL wrapper each call. That's the same
+// assertion trick `flowsheet.getEntriesByShow.ordering.test.ts` relies on
+// for its own `desc(flowsheet.play_order)` / `desc(flowsheet.id)`
+// assertions — though that file doesn't mock drizzle-orm at all; it imports
+// the real `desc` directly. This file already mocks the rest of
+// drizzle-orm's exports for other tests, so it uses `jest.requireActual`
+// here to pull in only the real `desc`, leaving those other mocks alone.
 jest.mock('drizzle-orm', () => {
   const actual = jest.requireActual<typeof import('drizzle-orm')>('drizzle-orm');
   return {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -180,15 +180,26 @@ jest.mock('@wxyc/database', () => ({
   },
 }));
 
-jest.mock('drizzle-orm', () => ({
-  sql: Object.assign(jest.fn(), { raw: jest.fn(), join: jest.fn() }),
-  inArray: jest.fn(),
-  isNotNull: jest.fn(),
-  and: jest.fn(),
-  eq: jest.fn(),
-  desc: jest.fn(),
-  asc: jest.fn(),
-}));
+// `desc` is the real drizzle-orm implementation, not a bare jest.fn() like its
+// siblings below — the ordering test at "queries the most recent MAX_ENTRIES
+// (200) rows ordered by ..." needs to assert the actual orderBy() column
+// arguments (BS#2132), and the real desc() applied to the mocked `flowsheet`
+// column stand-ins (plain strings — see the '@wxyc/database' mock below)
+// produces a deep-equal-comparable SQL wrapper each call, the same pattern
+// `flowsheet.getEntriesByShow.ordering.test.ts` uses for its own
+// `desc(flowsheet.play_order)` / `desc(flowsheet.id)` assertions.
+jest.mock('drizzle-orm', () => {
+  const actual = jest.requireActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return {
+    sql: Object.assign(jest.fn(), { raw: jest.fn(), join: jest.fn() }),
+    inArray: jest.fn(),
+    isNotNull: jest.fn(),
+    and: jest.fn(),
+    eq: jest.fn(),
+    desc: actual.desc,
+    asc: jest.fn(),
+  };
+});
 
 // BS#2103: the v=2 grouped path reuses `/flowsheet`'s feed-assembly attaches
 // for `upcoming_show` / `critic_reviews` rather than re-deriving the match
@@ -227,6 +238,8 @@ import {
   getRecentEntriesFlat,
   lastModifiedFromTimestamps,
 } from '../../../apps/backend/services/playlist-proxy.service';
+import { desc } from 'drizzle-orm';
+import { flowsheet } from '@wxyc/database';
 
 // --- Fixtures: representative WXYC data ---
 // (see the org CLAUDE.md "Example Music Data" section for the canonical pool)
@@ -450,10 +463,15 @@ describe('playlist-proxy.service', () => {
       expect(result.breakpoints).toHaveLength(1);
     });
 
-    it('queries the most recent MAX_ENTRIES (200) rows ordered by flowsheet.id DESC', async () => {
+    it('queries the most recent MAX_ENTRIES (200) rows ordered by flowsheet.add_time DESC, flowsheet.id DESC', async () => {
       await getRecentEntries(50);
 
-      expect(mockOrderBy).toHaveBeenCalled();
+      // BS#2132: flowsheet.id is a serial PK, not a chronological key — any
+      // historical insert (backfill, import, repair) receives the highest
+      // ids in the table and would sort as newest under an id-only order.
+      // add_time is the primary sort key, with id retained only as the
+      // tie-break for rows sharing a timestamp.
+      expect(mockOrderBy).toHaveBeenCalledWith(desc(flowsheet.add_time), desc(flowsheet.id));
       expect(mockLimit).toHaveBeenCalledWith(200);
     });
   });
@@ -473,7 +491,7 @@ describe('playlist-proxy.service', () => {
       expect(result.breakpoints).toHaveLength(1);
     });
 
-    it('keeps the most recent playcuts first (rows already arrive DESC by id)', async () => {
+    it('keeps the most recent playcuts first (rows already arrive DESC by add_time, id)', async () => {
       mockLimit.mockResolvedValue([jessicaPrattRow, juanaMolinaRow]);
 
       const result = await getRecentEntries(1);


### PR DESCRIPTION
Closes #2132. Parent: #2118 (site 2 of six).

## Problem

`fetchRecentRows` in `apps/backend/services/playlist-proxy.service.ts` ordered `desc(flowsheet.id)`. `flowsheet.id` is a serial PK, so any historical insert (backfill, import, repair) receives the highest ids in the table and sorts as the newest content. This query is shared by v2 `getRecentEntries` and v1 `getRecentEntriesFlat`, i.e. it serves `/playlists/recentEntries` and therefore the entire iOS/Android fleet through the tf#620 bridge. #2119 (the BS#351 April gap import) is the first insert that would falsify it.

## Change

`.orderBy(desc(flowsheet.id))` -> `.orderBy(desc(flowsheet.add_time), desc(flowsheet.id))`. `add_time` is the primary sort key; `id` is retained only as the tie-break for rows sharing a timestamp.

This is a top-N query (`.limit(MAX_ENTRIES)` = 200, no offset), so reordering is a bounded backward scan served by the existing single-column `flowsheet_add_time_idx`. **No migration, no new index** — matches the issue's scope exactly.

Updated the two doc comments that described the old id-only order (file header + the `fetchRecentRows` doc comment). The `fetchRecentRows` comment now also explains the two mechanisms that make `add_time` diverge from `id` order: primarily, the tubafrenzy webhook (`apps/backend/routes/internal.route.ts`) writes `add_time` from `entry.startTime` — tubafrenzy's own event time for the entry, not a delivery-time clock reading — so a first delivery that tubafrenzy logged late (a missed track, a corrected past show) diverges from its id rank by however late it was logged, unbounded, and the `ON CONFLICT` path anchors `add_time` to that first INSERT so later redeliveries never move it; secondarily, and only sub-second, `add_time` defaults to `now()` for BS-originated rows, so cross-host clock skew is a minor additional source of difference from the old id-only order.

Two more comment-only touches, no behavior change: `toBaseEntry`'s existing comment (byte-identical code, `chronOrderID: row.id` untouched) now points out that its "globally monotonic ... chronological order key" framing is insert-order, not chronological, per the file header above it, and that the `chronOrderID` decision itself lives on #2118. And `shared/database/src/schema.ts`'s `flowsheet_add_time_idx` comment, which previously justified staying single-column purely against `/flowsheet/range`'s 8-day-bounded workload, now names `fetchRecentRows` as a second consumer with its own LIMIT-200/no-WHERE bound, citing a prod re-validation at that limit: `Index Scan Backward` + `Incremental Sort` of 7 full-sort groups / 29 kB, 0.9 ms warm.

## chronOrderID is deliberately untouched

`playlist-proxy.service.ts` still sets `chronOrderID: row.id`. Ordering the SQL changes *which* rows are in the payload but not how iOS/Android re-sort them within it (`PlaylistService.swift:783`, `PlaycutHistoryStore.swift:363` re-sort client-side on `(chronOrderID, id)`). That residual — whether to change `chronOrderID` itself — is explicitly out of scope here and is tracked as a decision on the parent, #2118. This PR does not touch it.

## Tests

Both tests the issue named at `tests/unit/services/playlist-proxy.service.test.ts` were updated, not deleted:

- The test titled "ordered by flowsheet.id DESC" (previously only asserting `toHaveBeenCalled()`) is retitled to "ordered by flowsheet.add_time DESC, flowsheet.id DESC" and now asserts the actual `orderBy()` column arguments: `expect(mockOrderBy).toHaveBeenCalledWith(desc(flowsheet.add_time), desc(flowsheet.id))`. To make that assertion possible, the test file's `drizzle-orm` mock now uses the *real* `desc()` implementation for just that one export (previously a bare `jest.fn()`, via `jest.requireActual` since the file's other drizzle-orm exports stay mocked) — the real `desc()` applied to the mocked `flowsheet` column stand-ins (plain strings) produces a deep-equal-comparable SQL wrapper each call, the same assertion trick `flowsheet.getEntriesByShow.ordering.test.ts` relies on (that file doesn't mock drizzle-orm at all, it imports the real `desc` directly — simpler because it has no other drizzle-orm export to keep mocked). Verified this tightened assertion actually fails against the pre-change `.orderBy(desc(flowsheet.id))` code (red before green).
- The test with the "rows already arrive DESC by id" comment is updated to "rows already arrive DESC by add_time, id".

The BS#2103 wire-golden test (`playlist-proxy-wire-golden.test.ts`) does not pin ordering and is unaffected (verified green).

**Integration fixture fix (CI caught this, not local unit tests):** `tests/integration/playlist-recent-entries.spec.js`'s breakpoint fixture hard-coded an absolute, now-stale `add_time` ('2026-07-28 19:59:12+00'). Under the old `id DESC` order it still sorted first regardless of age; under the new `add_time DESC` order it correctly aged out of the top-200 window and the breakpoint assertions started failing. This is the ordering fix working as designed, not a defect in it — the fixture was relying on id-ordering to make a deliberately-backdated row appear recent.

Fixed by computing the fixture's `add_time`/`radio_hour` pair relative to `Date.now()` instead of a fixed date, and deriving the hour assertion from the same computed value. First pass floored to a real calendar hour boundary (current/previous hour) per the obvious reading of "recent" — a local `ci:testmock` run against the real, `--runInBand` integration suite proved that insufficiently fresh: many sibling specs insert their own flowsheet rows on the `add_time` DEFAULT (`now()`) during the same run, so a row backdated by up to an hour lost to 200 fresher ones and the breakpoint dropped out of the window entirely (confirmed: `breakpoints: []`, not just wrong-hour). Landed instead on `radio_hour` = ~10s in the past (never future) with `add_time` ~48s before that, matching the freshness of every other fixture row in the file while still exercising "`radio_hour` wins over `floor(add_time)`" (BS#1448/#1449) correctly, since a non-hour-aligned `radio_hour` and `floor(add_time)` are guaranteed to differ. Re-ran the full local integration suite against this fix — green, including this spec. Checked the rest of the file and the one other playlist-adjacent integration spec (`playlist-proxy-artwork-tiebreak.spec.js`, which doesn't touch this endpoint) for the same pattern — no other fixture in scope sets an absolute `add_time`.

## Verification

- `npm run typecheck && npm run lint && npm run format:check && npm run test:unit` pass locally (full suite: 428 suites / 7101 tests green).
- `npm run ci:testmock` (Docker-isolated mirror of CI) run locally, including a full local integration-suite pass, after the fixture fix.

## EXPLAIN (ANALYZE, BUFFERS)

Done — see [this comment](https://github.com/WXYC/Backend-Service/pull/2140#issuecomment-5283159942) for the prod run at `n=50`: `Index Scan Backward using flowsheet_add_time_idx` + `Incremental Sort`, 0.9 ms warm vs. 0.5 ms for the old shape, no sequential scan.
