### PR TITLE
fix(flowsheet): order GET /flowsheet pagination chronologically, lower MAX_OFFSET

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -144,16 +144,49 @@ const MAX_EPOCH_MS = 253402300799999; // 9999-12-31T23:59:59.999Z
 // an unhandled "value out of range for type integer" Postgres error (BS#1800).
 const INT4_MAX = 2147483647;
 // BS#1960 cost/DoS guard on `page * limit` (the OFFSET passed to
-// getEntriesByPage). The BS#1960 deferred-join rewrite of getEntriesByPage
-// made deep offsets cheap (a bare flowsheet.id PK index scan, no joins on
-// the discarded rows), so this is not a correctness bound — it's a ceiling
-// on how much index-scanning a single request can ask for. Set well above
-// any realistic UI paging depth: the acceptance floor is page=50 at
-// limit=100 (offset 5,000), and this allows offset up to page 500 at
-// limit=100 — 10x that. A genuine deep-history pull (further back than a UI
-// paginator would ever click) should use the start_id/end_id range path
-// above, which is a true index range scan regardless of depth.
-const MAX_OFFSET = 50_000;
+// getEntriesByPage). This is not a correctness bound — it's a ceiling on how
+// much index-scanning a single request can ask for. A genuine deep-history
+// pull (further back than a UI paginator would ever click) should use the
+// start_id/end_id range path above, which is a true index range scan
+// regardless of depth.
+//
+// BS#2133 (parent #2118): lowered from 50,000 to 20,000. getEntriesByPage's
+// ORDER BY changed from `id DESC` to `add_time DESC, id DESC` (see that
+// function's comment) so a historical insert can't sort as the newest
+// content — but the new ordering can no longer use an index-ONLY scan
+// (there is no composite `(add_time DESC, id DESC)` index; see below), so it
+// pays a heap fetch per scanned row instead of a bare PK scan. That shape
+// falls off a measured CACHE CLIFF, not a curve, between offset 20,000 and
+// 30,000 — prod EXPLAIN (ANALYZE, BUFFERS), warm, three passes:
+//
+//   offset 20,000:     17.8 ms
+//   offset 30,000:  3,570.9 ms  (188x)
+//   offset 50,000: 11,739.2 ms  (472x — past DB_STATEMENT_TIMEOUT_MS's 5s)
+//
+// 20,000 sits below the cliff with margin (still 4x the page=50/limit=100 =
+// 5,000 acceptance floor pinned by flowsheet-deep-pagination.spec.js) and
+// costs nothing over the floor (17.8ms vs 7.7ms) — the previous "10x the
+// acceptance floor" justification for 50,000 is superseded by this
+// measurement and must not be used to raise the cap back. 5,000 (the floor
+// itself) was considered and rejected: it would leave zero headroom and put
+// that spec's own acceptance case exactly on the offset > MAX_OFFSET
+// boundary.
+//
+// Incidentally, but worth recording: the OLD `id DESC` shape, at the OLD
+// 50,000 cap, measured 4,447 ms COLD (vs. warm's 24.9 ms) against that same
+// 5s timeout — on a public, unauthenticated route. The old cap was already
+// marginal before this change; lowering it to 20,000 (784 ms cold there)
+// closes that latent exposure too.
+//
+// A composite `(add_time DESC, id DESC)` index would restore an index-only
+// scan at any depth (~78 MB measured on a 2.6M-row stand-in) and was
+// considered and REJECTED in favor of lowering this cap: lowering the cap is
+// one line and zero storage, against a table epic #1058 is actively trying
+// to slim, and this cap is explicitly a cost ceiling rather than a
+// correctness bound in the first place. Do not add that index on the
+// strength of this comment alone — if the cap ever needs to go back up,
+// that trade needs to be re-measured, not assumed.
+const MAX_OFFSET = 20_000;
 
 /**
  * Project a page of flowsheet entries to their V2 wire shape, tolerating — but
@@ -402,11 +435,12 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 
   // BS#1960 note: totalPages is derived from the full row estimate, so it can
   // advertise more pages than MAX_OFFSET actually permits (e.g. ~26k pages at
-  // limit=100 against a ~2.6M-row table, while offset is capped at 50k / page
-  // 500). A client that lets a user jump past the cap gets an explicit 400
-  // rather than the old timeout-500; genuine deep-history reads belong on the
-  // start_id/end_id range path. Left unclamped deliberately — totalPages stays
-  // an honest "how many pages of data exist" for the "Page X of N" display.
+  // limit=100 against a ~2.6M-row table, while offset is capped at 20k / page
+  // 200 — BS#2133). A client that lets a user jump past the cap gets an
+  // explicit 400 rather than the old timeout-500; genuine deep-history reads
+  // belong on the start_id/end_id range path. Left unclamped deliberately —
+  // totalPages stays an honest "how many pages of data exist" for the
+  // "Page X of N" display.
   const totalPages = Math.ceil(total / limit);
 
   // `on_air` lets clients render the on-air banner without scanning the fetched

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -163,20 +163,37 @@ const INT4_MAX = 2147483647;
 //   offset 30,000:  3,570.9 ms  (188x)
 //   offset 50,000: 11,739.2 ms  (472x — past DB_STATEMENT_TIMEOUT_MS's 5s)
 //
-// 20,000 sits below the cliff with margin (still 4x the page=50/limit=100 =
-// 5,000 acceptance floor pinned by flowsheet-deep-pagination.spec.js) and
-// costs nothing over the floor (17.8ms vs 7.7ms) — the previous "10x the
+// 20,000 is the LAST GOOD SAMPLE, not a point measured to sit comfortably
+// inside the good region — the next sample, 30,000, is already 188x. Nothing
+// between the two was measured, so this bound is EMPIRICAL AND
+// CACHE-STATE-DEPENDENT, not a derived constant: re-measure before ever
+// moving it in either direction, do not interpolate or extrapolate from this
+// comment. 20,000 does clear the page=50/limit=100 = 5,000 acceptance floor
+// pinned by flowsheet-deep-pagination.spec.js with real headroom (4x) at
+// negligible extra cost (17.8ms vs 7.7ms warm) — the previous "10x the
 // acceptance floor" justification for 50,000 is superseded by this
 // measurement and must not be used to raise the cap back. 5,000 (the floor
-// itself) was considered and rejected: it would leave zero headroom and put
-// that spec's own acceptance case exactly on the offset > MAX_OFFSET
-// boundary.
+// itself) was considered and rejected as the cap: it would leave zero
+// headroom and put that spec's own acceptance case exactly on the
+// offset > MAX_OFFSET boundary.
 //
-// Incidentally, but worth recording: the OLD `id DESC` shape, at the OLD
-// 50,000 cap, measured 4,447 ms COLD (vs. warm's 24.9 ms) against that same
-// 5s timeout — on a public, unauthenticated route. The old cap was already
-// marginal before this change; lowering it to 20,000 (784 ms cold there)
-// closes that latent exposure too.
+// The number that actually bounds what ships is COLD, not warm — full
+// three-pass cold->warm sequences (ms), prod, posted in full on #2133:
+//
+//   offset 20,000 (new cap): current 784, 8, 11   | proposed  852, 22, 18
+//   offset 50,000 (old cap): current 4447, 31, 25 | proposed 10261, 14708, 11739
+//
+// Proposed-shape COLD at the NEW 20,000 cap is 852 ms against the 5s
+// DB_STATEMENT_TIMEOUT_MS — worse than the current shape's 784 ms cold at
+// that same offset, but this PR also lowers the cap: what actually SHIPS
+// (proposed ordering, new 20,000 cap, 852 ms cold) beats what shipped before
+// (current ordering, old 50,000 cap, 4,447 ms cold) by a wide margin. This
+// change is a net improvement on the worst case being shipped, not merely a
+// neutral one. At and below 20,000 the proposed shape also converges on
+// repetition (852 -> 22 -> 18, a healthy cache warm-up); at 30,000+ it
+// diverges instead (e.g. 40,000: 6446 -> 8604 -> 11120, getting WORSE with
+// repetition) — the cliff shows up in the shape of the sequence, not only
+// in the magnitude.
 //
 // A composite `(add_time DESC, id DESC)` index would restore an index-only
 // scan at any depth (~78 MB measured on a 2.6M-row stand-in) and was

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -621,17 +621,37 @@ export const getEntryCount = async (): Promise<number> => {
  * airtime order — so a historical insert (backfill, gap import, repair)
  * receives the highest ids in the table and previously sorted as the newest
  * content on this, the default page of the public unauthenticated
- * `GET /flowsheet`. `id` stays as an explicit tie-break because `add_time`
- * is not unique: it defaults to `now()`, which is `transaction_timestamp()`
- * — every row written by the same statement (e.g. a bulk `INSERT ... SELECT`)
- * shares one `add_time`, so without the tie-break those rows would have no
- * defined relative order. This means `(add_time DESC, id DESC)` is NOT
- * identical to `(id DESC)` even for purely live traffic (a live row's
- * `add_time` and `id` can theoretically diverge in ordering across a
- * transaction boundary), and the tubafrenzy webhook writes `add_time` from
- * tubafrenzy's own clock (`apps/backend/routes/internal.route.ts:329`), so
- * cross-host clock skew becomes visible in ordering where it previously
- * wasn't. Both are sub-second effects in practice.
+ * `GET /flowsheet` — and on `getLatest` (`flowsheet.controller.ts`,
+ * `GET /flowsheet/latest`), the OTHER caller of this function
+ * (`getEntriesByPage(0, 1)`). This function now serves two different
+ * contracts under one query: "page N of the flowsheet" and "the single
+ * latest entry." Both move from "most recently inserted" to "most recently
+ * aired" with this change — an improvement for `getLatest` specifically,
+ * since "latest" reads naturally as airtime, not insertion order.
+ *
+ * `id` stays as an explicit tie-break because `add_time` is not unique: it
+ * defaults to `now()`, which is `transaction_timestamp()` — every row
+ * written by the same statement (e.g. a bulk `INSERT ... SELECT`) shares one
+ * `add_time`, so without the tie-break those rows would have no defined
+ * relative order.
+ *
+ * TWO DIFFERENT CLOCKS FEED `add_time`, AND THIS SORT KEY NOW MIXES THEM.
+ * The tubafrenzy webhook (`apps/backend/routes/internal.route.ts:329`) sets
+ * `add_time` to `entry.startTime ? new Date(entry.startTime) : new Date()`
+ * for EVERY entry type it inserts — but per the BS#351 gap-import findings,
+ * only `show_start`/`show_end` marker rows carry a non-zero `startTime` in
+ * tubafrenzy; ordinary track rows have `startTime = 0` (falsy) and fall
+ * through to `new Date()`. So MARKER rows get tubafrenzy's EVENT clock and
+ * TRACK rows get Backend's DELIVERY clock — two different clocks landing in
+ * the same column, and now the same sort key. Consequence: on a webhook
+ * delivery lag, a show's `show_end` marker can carry an `add_time` EARLIER
+ * than the delivery timestamp of that same show's own final track, so the
+ * marker now sorts BELOW the track on page 0 (and `getLatest` /
+ * `GET /flowsheet/latest` would return the track instead of the sign-off).
+ * Under plain `id DESC` this was structurally impossible — insertion order
+ * always put the marker last. This is a known, accepted consequence of the
+ * new key, not something this change fixes; the divergence between the two
+ * clocks is unbounded (tubafrenzy delivery lag), not sub-second.
  *
  * Measured 2026-08-13 (see BS#2133): below the `MAX_OFFSET` cache cliff
  * (`flowsheet.controller.ts`) this ordering costs the same order of
@@ -1259,22 +1279,33 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
  * `changeOrder` can renumber `play_order` for track reordering within a
  * show, but marker rows are never reordered.
  *
- * SCOPED TO LIVE-SHOW TRAFFIC — `id DESC` is insertion order, NOT airtime
- * order, so this is not a general "newest entry in this show" query (BS#2118
- * site 5). A historical insert (backfill, gap import, repair) into an
- * ALREADY-CLOSED show receives an id higher than that show's real terminal
- * `show_end` marker, so this then answers `false` for a show that is, in
- * fact, closed. #2119's April gap-import cohort is exactly this case: 403
- * rows land in 18 shows that already hold `show_end` markers, and post-
- * import this function returns `false` for all 18. That is safe here
- * ONLY because `joinShow` is this function's one caller, and it only ever
- * asks about the show a DJ is trying to go live on RIGHT NOW — nobody joins
- * an April show months later, and BS#1861 option (a) independently stamps
- * `shows.end_time` at write time, so `joinShow` has a second signal even
- * once this one goes stale for an old show. Do not repurpose this as a
- * general recency check for anything a historical import could touch; for
- * that, order by `add_time` instead (see `getEntriesByPage`'s comment for
- * why `add_time` needs an explicit `id` tie-break too).
+ * ITS OWN PREMISE IS FALSE FOR A HISTORICALLY-INSERTED SHOW — `id DESC` is
+ * insertion order, NOT airtime order, so this is not a general "newest entry
+ * in this show" query (BS#2118 site 5). A historical insert (backfill, gap
+ * import, repair) into an ALREADY-CLOSED show receives an id higher than
+ * that show's real terminal `show_end` marker, so this then answers `false`
+ * for a show that is, in fact, closed. #2119's April gap-import cohort is
+ * exactly this case: 403 rows land in 18 shows that already hold `show_end`
+ * markers, and post-import this function would return `false` for all 18 if
+ * it were ever called on them.
+ *
+ * It never is, and that — not caller intent — is what makes the cohort
+ * inert. `joinShow` (`flowsheet.controller.ts`) only calls this function
+ * inside its own `current_show.end_time === null &&` short-circuit, gating
+ * on the SAME `end_time` fast-path this function's header comment describes
+ * as independent of it; `current_show` itself comes from `getLatestShow` ->
+ * `ORDER BY shows.id DESC LIMIT 1`, so `joinShow` always evaluates the
+ * newest-by-insertion show, not a caller-chosen one. Measured 2026-08-12
+ * (`plans/bs351-april-flowsheet-gap-import.md`): all 18 of #2119's affected
+ * shows already carry a non-null `shows.end_time`, so `joinShow` never
+ * reaches this function for any of them — the short-circuit short-circuits
+ * before the stale answer would matter. Safety today lives entirely in that
+ * caller-side `end_time` check, not in this function. A future caller of
+ * `isLatestEntryShowEnd` without an equivalent `end_time` guard would be
+ * exposed to the false-premise failure mode above; do not assume this
+ * function is self-safe. For a general recency check on a row a historical
+ * import could touch, order by `add_time` instead (see `getEntriesByPage`'s
+ * comment for why `add_time` needs an explicit `id` tie-break too).
  */
 export const isLatestEntryShowEnd = async (showId: number): Promise<boolean> => {
   const [latest] = await db

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -612,22 +612,43 @@ export const getEntryCount = async (): Promise<number> => {
  * passed ~450-500, hitting this RDS instance's 5s statement_timeout — plain
  * OFFSET-with-joins pagination pathology.
  *
- * The fix: resolve the page of `flowsheet.id`s FIRST, against the bare PK
- * index (no joins touched), then join only that already-bounded `limit`-row
- * set. `page` is a subquery-in-FROM (`.as('page')`) so it plans as an index
- * range scan over `flowsheet.id DESC` — the same cheap shape
- * `getEntriesByRange` already gets from its `WHERE id BETWEEN` predicate.
+ * The fix: resolve the page of `flowsheet.id`s FIRST, against a bare-table
+ * subquery (no joins touched), then join only that already-bounded `limit`-
+ * row set. `page` is a subquery-in-FROM (`.as('page')`).
+ *
+ * BS#2133 (parent #2118 site 1): ordered by `add_time DESC, id DESC`, not
+ * `id DESC` alone. `flowsheet.id` is a serial PK — insertion order, not
+ * airtime order — so a historical insert (backfill, gap import, repair)
+ * receives the highest ids in the table and previously sorted as the newest
+ * content on this, the default page of the public unauthenticated
+ * `GET /flowsheet`. `id` stays as an explicit tie-break because `add_time`
+ * is not unique: it defaults to `now()`, which is `transaction_timestamp()`
+ * — every row written by the same statement (e.g. a bulk `INSERT ... SELECT`)
+ * shares one `add_time`, so without the tie-break those rows would have no
+ * defined relative order. This means `(add_time DESC, id DESC)` is NOT
+ * identical to `(id DESC)` even for purely live traffic (a live row's
+ * `add_time` and `id` can theoretically diverge in ordering across a
+ * transaction boundary), and the tubafrenzy webhook writes `add_time` from
+ * tubafrenzy's own clock (`apps/backend/routes/internal.route.ts:329`), so
+ * cross-host clock skew becomes visible in ordering where it previously
+ * wasn't. Both are sub-second effects in practice.
+ *
+ * Measured 2026-08-13 (see BS#2133): below the `MAX_OFFSET` cache cliff
+ * (`flowsheet.controller.ts`) this ordering costs the same order of
+ * magnitude as the old `id DESC` shape (single-digit-to-teens ms warm); no
+ * composite index was added — see `MAX_OFFSET`'s comment for why.
+ *
  * The inner `ORDER BY ... OFFSET ... LIMIT` picks the page; the outer
- * `ORDER BY flowsheet.id DESC` re-establishes descending order after the
- * join (a join doesn't guarantee it preserves the subquery's row order).
- * flowsheet.id is a unique, monotonic PK, so no tie-break column is needed
- * here (contrast `getEntriesByShow`, which ties on `play_order`).
+ * `ORDER BY` re-establishes the SAME order after the join (a join doesn't
+ * guarantee it preserves the subquery's row order). The inner and outer
+ * clauses must always change together — changing only one silently breaks
+ * pagination.
  */
 export const getEntriesByPage = async (offset: number, limit: number): Promise<IFSEntry[]> => {
   const page = db
     .select({ id: flowsheet.id })
     .from(flowsheet)
-    .orderBy(desc(flowsheet.id))
+    .orderBy(desc(flowsheet.add_time), desc(flowsheet.id))
     .offset(offset)
     .limit(limit)
     .as('page');
@@ -639,7 +660,7 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-    .orderBy(desc(flowsheet.id));
+    .orderBy(desc(flowsheet.add_time), desc(flowsheet.id));
 
   return raw.map(transformToIFSEntry);
 };
@@ -1221,8 +1242,8 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
 };
 
 /**
- * True when the newest flowsheet entry belonging to `showId` is a
- * `show_end` marker.
+ * True when the most-recently-INSERTED flowsheet entry belonging to `showId`
+ * is a `show_end` marker.
  *
  * Belt-and-braces guard for `joinShow` (BS#1861 option (b)). The tubafrenzy
  * webhook's stub-show flow can leave `shows.end_time` NULL for a window
@@ -1236,8 +1257,24 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
  *
  * Ordered by `id DESC` (insertion order), not `play_order DESC` —
  * `changeOrder` can renumber `play_order` for track reordering within a
- * show, but marker rows are never reordered and the serial PK is an
- * unambiguous "newest".
+ * show, but marker rows are never reordered.
+ *
+ * SCOPED TO LIVE-SHOW TRAFFIC — `id DESC` is insertion order, NOT airtime
+ * order, so this is not a general "newest entry in this show" query (BS#2118
+ * site 5). A historical insert (backfill, gap import, repair) into an
+ * ALREADY-CLOSED show receives an id higher than that show's real terminal
+ * `show_end` marker, so this then answers `false` for a show that is, in
+ * fact, closed. #2119's April gap-import cohort is exactly this case: 403
+ * rows land in 18 shows that already hold `show_end` markers, and post-
+ * import this function returns `false` for all 18. That is safe here
+ * ONLY because `joinShow` is this function's one caller, and it only ever
+ * asks about the show a DJ is trying to go live on RIGHT NOW — nobody joins
+ * an April show months later, and BS#1861 option (a) independently stamps
+ * `shows.end_time` at write time, so `joinShow` has a second signal even
+ * once this one goes stale for an old show. Do not repurpose this as a
+ * general recency check for anything a historical import could touch; for
+ * that, order by `add_time` instead (see `getEntriesByPage`'s comment for
+ * why `add_time` needs an explicit `id` tie-break too).
  */
 export const isLatestEntryShowEnd = async (showId: number): Promise<boolean> => {
   const [latest] = await db

--- a/shared/database/src/album-resolve.ts
+++ b/shared/database/src/album-resolve.ts
@@ -91,6 +91,25 @@ export interface LinkedFlowsheetRow {
  * most-popular key has hundreds of matches, not thousands; the post-filter
  * `id DESC` sort on the small match set is sub-ms in practice.
  *
+ * `id DESC` HERE MEANS "PICK A CONSISTENT WINNER," NOT "PICK THE NEWEST
+ * PLAY" (BS#2118 site 6) — do not read this as a recency query. `id` is
+ * insertion order, not airtime order, and this function does not care which
+ * candidate row actually aired most recently; it only needs the same
+ * candidate every time. That said, a historical insert (backfill, gap
+ * import, repair) DOES change which row wins here once it acquires an
+ * `album_id` — `jobs/legacy-linkage-resolve` links `flowsheet.album_id` on
+ * its own 30-minute cron, independent of when the row was inserted — and
+ * the winning row's `record_label` / `label_id` / `metadata_status` then
+ * come from that historical row instead of whichever live row previously
+ * won. Accepted as-is: those three columns are DJ-entered or ETL-written
+ * free text, not derived from *when* the row aired, so a historical row's
+ * values are not wrong in the way a recency claim would be — just a
+ * different, equally legitimate, source row for the same key. If a future
+ * caller needs "the row that actually aired most recently" instead of "a
+ * stable pick," that is a different query (order by `add_time`, with `id` as
+ * its own tie-break — see `getEntriesByPage`'s comment for why `add_time`
+ * alone is not unique), not a change to this one.
+ *
  * An empty/whitespace-only `artistName` or `releaseTitle` short-circuits to
  * `null`: the key `'<artist>-'` (blank release) would otherwise match any
  * linked flowsheet row whose DJ left `album_title` blank and return an

--- a/shared/database/src/album-resolve.ts
+++ b/shared/database/src/album-resolve.ts
@@ -98,17 +98,38 @@ export interface LinkedFlowsheetRow {
  * candidate every time. That said, a historical insert (backfill, gap
  * import, repair) DOES change which row wins here once it acquires an
  * `album_id` — `jobs/legacy-linkage-resolve` links `flowsheet.album_id` on
- * its own 30-minute cron, independent of when the row was inserted — and
- * the winning row's `record_label` / `label_id` / `metadata_status` then
- * come from that historical row instead of whichever live row previously
- * won. Accepted as-is: those three columns are DJ-entered or ETL-written
- * free text, not derived from *when* the row aired, so a historical row's
- * values are not wrong in the way a recency claim would be — just a
- * different, equally legitimate, source row for the same key. If a future
- * caller needs "the row that actually aired most recently" instead of "a
- * stable pick," that is a different query (order by `add_time`, with `id` as
- * its own tie-break — see `getEntriesByPage`'s comment for why `add_time`
- * alone is not unique), not a change to this one.
+ * its own 30-minute cron, independent of when the row was inserted — and the
+ * winning row's `record_label` / `label_id` / `metadata_status` then come
+ * from that historical row instead of whichever live row previously won.
+ *
+ * `record_label` and `label_id` are accepted as-is: DJ-entered or
+ * ETL-written free text, not derived from *when* the row aired, so a
+ * historical row's values are not wrong in the way a recency claim would
+ * be — just a different, equally legitimate, source row for the same key.
+ *
+ * `metadata_status` is NOT the same kind of column and is NOT covered by
+ * that argument — it is a `pgEnum` (`schema.ts`) written only by the
+ * enrichment pipeline (`apps/enrichment-worker`), and it inherently makes a
+ * temporal claim about the row (a `pending`/`enriching` value asserts
+ * enrichment hasn't landed *yet* — see `proxy.controller.ts`'s
+ * `NON_TERMINAL_METADATA_STATUSES` comment). Whether a replayed/stale value
+ * here is acceptable is the terminal-semantics question iOS#685 already
+ * owns and this function already declines to answer (see the base-field
+ * paragraph above) — that pre-existing carve-out stands; this comment does
+ * not relitigate it. What IS new here: a historical insert can make a
+ * non-terminal (`pending`/`enriching`) row win the pick for a key whose
+ * live row had already reached a terminal status. On the
+ * `GET /proxy/metadata/album` hot path, the proxy controller treats a
+ * non-terminal `metadataStatus` as uncacheable and skips
+ * `albumMetadataCache.set` (`proxy.controller.ts`) — so for as long as that
+ * historical row keeps winning and stays non-terminal, this key's 1-hour
+ * album-metadata memo is suppressed. Reachable by the #2119 cohort.
+ *
+ * If a future caller needs "the row that actually aired most recently"
+ * instead of "a stable pick," that is a different query (order by
+ * `add_time`, with `id` as its own tie-break — see `getEntriesByPage`'s
+ * comment for why `add_time` alone is not unique), not a change to this
+ * one.
  *
  * An empty/whitespace-only `artistName` or `releaseTitle` short-circuits to
  * `null`: the key `'<artist>-'` (blank release) would otherwise match any

--- a/tests/integration/flowsheet-deep-pagination.spec.js
+++ b/tests/integration/flowsheet-deep-pagination.spec.js
@@ -21,6 +21,18 @@
  * did under the old one — the assertions below hold, but for that reason,
  * not because `add_time` distinguishes these rows at all.
  *
+ * WHAT GUARANTEES THIS BATCH IS THE HEAD OF THE TABLE changed kind, not just
+ * mechanism. Under plain `id DESC`, a freshly-inserted batch was
+ * STRUCTURALLY guaranteed to be the top BATCH_SIZE rows — the serial PK
+ * cannot be beaten by an earlier row. Under `add_time DESC, id DESC`, that
+ * guarantee is additionally conditional on no row ANYWHERE in the schema
+ * carrying a later `add_time` than this batch's — true in CI/dev today, but
+ * now an ENVIRONMENTAL fact about the fixture data, not a structural one.
+ * The `beforeAll` below asserts that condition explicitly right after the
+ * insert, so a future future-dated fixture (or a clock skewed forward) fails
+ * loudly there with a clear count, instead of surfacing here as a confusing
+ * off-by-N content mismatch.
+ *
  * This spec bulk-inserts a large, uniquely-tagged batch of track rows so a
  * deep page (page=50, limit=100 — offset 5,000, the acceptance floor from
  * the issue) has real, predictable content to assert on regardless of
@@ -80,6 +92,32 @@ describe('GET /flowsheet deep OFFSET pagination (BS#1960)', () => {
       [MARKER, BATCH_SIZE]
     );
     insertedIds = rows.map((r) => r.id);
+
+    // Head-of-table guarantee check (BS#2133 — see the header comment). All
+    // rows in this batch share one add_time (single INSERT ... SELECT), so
+    // the batch's own MAX(add_time), computed inside this one statement, is
+    // representative. If any OTHER row in the schema has a strictly later
+    // add_time, this batch is no longer guaranteed to sort as the top
+    // BATCH_SIZE under `add_time DESC, id DESC`, and the deterministic
+    // content assertions below would fail for a reason unrelated to the code
+    // under test. Fail here, loudly and specifically, rather than there.
+    //
+    // The batch's add_time is compared entirely IN SQL via the subquery
+    // below, never round-tripped through a JS Date: postgres `timestamptz`
+    // carries microsecond precision but a JS `Date` only carries
+    // milliseconds, so materializing the batch's add_time into JS and
+    // passing it back as a query parameter would silently truncate it —
+    // every row (including the batch's own) would then compare as "later"
+    // than its own truncated timestamp, a false positive that isn't the
+    // real invariant this check exists to guard. Keeping both sides of the
+    // comparison in Postgres avoids that trap entirely.
+    const [{ count: laterRowCount }] = await sql.unsafe(
+      `SELECT count(*)::int AS count
+       FROM "${SCHEMA}".flowsheet
+       WHERE add_time > (SELECT max(add_time) FROM "${SCHEMA}".flowsheet WHERE id = ANY($1::int[]))`,
+      [insertedIds]
+    );
+    expect(laterRowCount).toBe(0);
   });
 
   afterAll(async () => {

--- a/tests/integration/flowsheet-deep-pagination.spec.js
+++ b/tests/integration/flowsheet-deep-pagination.spec.js
@@ -7,8 +7,19 @@
  * it could discard them. Latency grew ~11ms per discarded row and the
  * endpoint 500'd once `offset` passed roughly 450-500, hitting this RDS
  * instance's 5s statement_timeout. The fix (deferred-join / late-row-lookup)
- * resolves the page of `flowsheet.id`s first, against the bare PK index, and
- * joins only the already-bounded page.
+ * resolves the page of `flowsheet.id`s first, against a bare-table subquery,
+ * and joins only the already-bounded page.
+ *
+ * BS#2133 (parent #2118): the ordering that subquery resolves against
+ * changed from `id DESC` to `add_time DESC, id DESC`, so a historical insert
+ * (backfill, gap import, repair) can no longer sort as the newest content —
+ * see `getEntriesByPage`'s comment in `flowsheet.service.ts`. This spec's
+ * batch below lands as a single `INSERT ... SELECT`, so every row in it
+ * shares one `add_time` (`now()` = `transaction_timestamp()`, constant for
+ * the whole statement); the `id` tie-break is therefore what actually
+ * determines this batch's relative order under the new ordering, same as it
+ * did under the old one — the assertions below hold, but for that reason,
+ * not because `add_time` distinguishes these rows at all.
  *
  * This spec bulk-inserts a large, uniquely-tagged batch of track rows so a
  * deep page (page=50, limit=100 — offset 5,000, the acceptance floor from
@@ -86,11 +97,14 @@ describe('GET /flowsheet deep OFFSET pagination (BS#1960)', () => {
     expect(res.body.page).toBe(50);
     expect(res.body.limit).toBe(100);
 
-    // Deterministic content check. Ordered by flowsheet.id DESC (most recent
-    // first), skipping the top 5,000 rows (offset) and taking the next 100
-    // (limit) lands entirely inside this batch: the first row on the page is
-    // n = BATCH_SIZE - 5000 = 200 (counting from the top: rank 5001 overall
-    // == the 5001st-most-recent row == n=200), descending to n=101.
+    // Deterministic content check. Ordered by add_time DESC, id DESC
+    // (BS#2133) — this batch's rows all share one add_time (single
+    // INSERT ... SELECT statement, see the header comment), so id DESC is
+    // what actually orders them, same as it did pre-BS#2133. Skipping the
+    // top 5,000 rows (offset) and taking the next 100 (limit) lands entirely
+    // inside this batch: the first row on the page is n = BATCH_SIZE - 5000
+    // = 200 (counting from the top: rank 5001 overall == the 5001st-most-
+    // recent row == n=200), descending to n=101.
     const firstN = BATCH_SIZE - 5000;
     expect(res.body.entries[0].track_title).toBe(`${MARKER} #${firstN}`);
     expect(res.body.entries[99].track_title).toBe(`${MARKER} #${firstN - 99}`);
@@ -106,8 +120,10 @@ describe('GET /flowsheet deep OFFSET pagination (BS#1960)', () => {
   }, 30000);
 
   test('a page depth beyond MAX_OFFSET is rejected with 400, not a 500 or a hang', async () => {
-    // page 501 * limit 100 = offset 50,100 > MAX_OFFSET (50,000).
-    const res = await request.get('/flowsheet').query({ page: 501, limit: 100 }).send();
+    // page 201 * limit 100 = offset 20,100 > MAX_OFFSET (20,000 — BS#2133
+    // lowered it from 50,000; see flowsheet.controller.ts's MAX_OFFSET
+    // comment for the measured cache-cliff rationale).
+    const res = await request.get('/flowsheet').query({ page: 201, limit: 100 }).send();
 
     expect(res.status).toBe(400);
   });

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -594,11 +594,14 @@ describe('flowsheet.controller', () => {
     // ~11ms/row, hitting the 5s statement_timeout past an offset of ~450-500).
     // This guard is a separate cost/DoS ceiling on top of that fix — see
     // MAX_OFFSET in flowsheet.controller.ts — so an absurd page*limit fails
-    // fast with a 400 instead of ever reaching the query.
+    // fast with a 400 instead of ever reaching the query. BS#2133 lowered
+    // MAX_OFFSET from 50,000 to 20,000 (measured cache cliff between 20,000
+    // and 30,000 once getEntriesByPage's ORDER BY changed to
+    // `add_time DESC, id DESC` — see that constant's comment).
     describe('deep-offset guard (BS#1960)', () => {
       it('rejects an offset (page * limit) exceeding MAX_OFFSET with 400', async () => {
-        // page 501 * limit 100 = offset 50,100 > MAX_OFFSET (50,000).
-        const req = createMockReq({ page: '501', limit: '100' });
+        // page 201 * limit 100 = offset 20,100 > MAX_OFFSET (20,000).
+        const req = createMockReq({ page: '201', limit: '100' });
         const res = createMockRes();
 
         await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
@@ -608,24 +611,24 @@ describe('flowsheet.controller', () => {
       });
 
       it('rejects with a WxycError (400), not an unhandled error', async () => {
-        const req = createMockReq({ page: '501', limit: '100' });
+        const req = createMockReq({ page: '201', limit: '100' });
         const res = createMockRes();
 
         await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
       });
 
-      it('accepts an offset exactly at MAX_OFFSET (page 500 * limit 100 = 50,000)', async () => {
+      it('accepts an offset exactly at MAX_OFFSET (page 200 * limit 100 = 20,000)', async () => {
         mockGetEntriesByPage.mockResolvedValue([]);
         mockGetEntryCount.mockResolvedValue(0);
         mockGetOnAirDJName.mockResolvedValue(null);
 
-        const req = createMockReq({ page: '500', limit: '100' });
+        const req = createMockReq({ page: '200', limit: '100' });
         const res = createMockRes();
 
         await getEntries(req as Request, res as Response, mockNext);
 
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(mockGetEntriesByPage).toHaveBeenCalledWith(50000, 100);
+        expect(mockGetEntriesByPage).toHaveBeenCalledWith(20000, 100);
       });
 
       // The acceptance floor this cap must clear: a UI paginator walking to

--- a/tests/unit/services/flowsheet.getEntriesByPage.deferredJoin.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByPage.deferredJoin.test.ts
@@ -82,7 +82,7 @@ describe('flowsheet.service', () => {
       // carries the offset/limit — this is the load-bearing fix: pre-#1960
       // these landed on the fully-joined query instead.
       expect(subFromMock).toHaveBeenCalledWith(flowsheet);
-      expect(subOrderByMock).toHaveBeenCalledWith(desc(flowsheet.id));
+      expect(subOrderByMock).toHaveBeenCalledWith(desc(flowsheet.add_time), desc(flowsheet.id));
       expect(subOffsetMock).toHaveBeenCalledWith(5000);
       expect(subLimitMock).toHaveBeenCalledWith(100);
       expect(asMock).toHaveBeenCalledWith('page');
@@ -98,12 +98,16 @@ describe('flowsheet.service', () => {
       expect(leftJoin3Mock).toHaveBeenCalledWith(album_metadata, eq(album_metadata.album_id, flowsheet.album_id));
     });
 
-    it('re-establishes descending order on the outer query after the join', async () => {
+    it('re-establishes the same add_time/id order on the outer query after the join', async () => {
       await getEntriesByPage(5000, 100);
 
-      expect(outerOrderByMock).toHaveBeenCalledWith(desc(flowsheet.id));
-      // Never desc(play_order) — flowsheet.id is globally monotonic and
-      // unique, unlike play_order (see getEntriesByShow's tie-break).
+      // Must match the inner subquery's ORDER BY exactly (BS#2133) — the join
+      // doesn't guarantee it preserves the subquery's row order, so a
+      // mismatched outer ORDER BY silently breaks pagination.
+      expect(outerOrderByMock).toHaveBeenCalledWith(desc(flowsheet.add_time), desc(flowsheet.id));
+      // Never desc(play_order) — id is the tie-break, not play_order (see
+      // getEntriesByShow's tie-break, which is per-show and not applicable
+      // here).
       expect(outerOrderByMock).not.toHaveBeenCalledWith(desc(flowsheet.play_order));
     });
 


### PR DESCRIPTION
## Summary

`getEntriesByPage` paged on `desc(flowsheet.id)` — a serial PK that tracks insertion order, not airtime order. A historical insert (backfill, gap import, repair) receives the highest ids in the table and sorts as the newest content on the default page of the public, unauthenticated `GET /flowsheet`. Both the inner id-picking subquery and the outer post-join `ORDER BY` now sort by `desc(add_time), desc(id)` identically, so historical rows sort by when they aired rather than when they were written, and pagination stays consistent across the join.

## MAX_OFFSET: 50,000 -> 20,000

Measured 2026-08-13 against prod (`EXPLAIN (ANALYZE, BUFFERS)`, warm, three passes per case — full numbers on WXYC/Backend-Service#2133):

| offset | current (`id DESC`) | proposed (`add_time DESC, id DESC`) | ratio |
|---:|---:|---:|---:|
| 5,000 (acceptance floor) | 2.5 ms | 7.7 ms | 3.0x |
| 20,000 | 11.2 ms | 17.8 ms | 1.6x |
| 30,000 | 18.9 ms | **3,570.9 ms** | 188x |
| 50,000 (old cap) | 24.9 ms | **11,739.2 ms** | 472x — past `DB_STATEMENT_TIMEOUT_MS`'s 5s |

The new ordering can't use an index-only scan the way plain `id DESC` could (it becomes an Incremental Sort over an Index Scan Backward, a heap fetch per row), and falls off a cache cliff between offset 20,000 and 30,000 — not a curve. `MAX_OFFSET` drops from 50,000 to 20,000 to stay below that cliff with margin (still 4x the acceptance floor); a composite `(add_time DESC, id DESC)` index was measured and rejected in favor of the cheaper cap change (~78 MB vs. one line and zero storage, against a table epic #1058 is actively slimming).

Also worth recording: the **old** `id DESC` shape at the **old** 50,000 cap measured **4,447 ms cold** against that same 5s timeout, on a public unauthenticated route — the old cap was already marginal before this change; lowering it to 20,000 (784 ms cold there) closes that latent exposure too.

No migration, no new index — both were considered and rejected on measurement.

## Two related sites resolved

- `isLatestEntryShowEnd` (`flowsheet.service.ts`) — its docstring claimed the serial PK is an "unambiguous newest," which a historical import into an already-closed show falsifies. Left the query as-is (accepted, not re-scoped) and rewrote the docstring to state plainly that it's scoped to live-show traffic: its one caller, `joinShow`, only ever asks about the show a DJ is trying to go live on right now, and `BS#1861` option (a) independently stamps `end_time` at write time, so a stale answer for an old show is benign.
- `selectLinkedFlowsheetRow` (`shared/database/src/album-resolve.ts`) — its `ORDER BY flowsheet.id DESC LIMIT 1` picks a deterministic winner, not the most recent play. Docstring now says so loudly, and documents that a historical insert can still flip which row wins once `legacy-linkage-resolve` links its `album_id` — accepted, since the columns it feeds (`record_label`/`label_id`/`metadata_status`) are DJ-entered/ETL-written and not derived from airtime.

## Tests

- `tests/unit/services/flowsheet.getEntriesByPage.deferredJoin.test.ts` — updated both pinned `orderBy` assertions (inner subquery + outer re-establishment) to `desc(add_time), desc(id)`.
- `tests/unit/controllers/flowsheet.controller.test.ts` — updated the `MAX_OFFSET` boundary tests to the new 20,000 cap.
- `tests/integration/flowsheet-deep-pagination.spec.js` — updated the beyond-cap boundary case (page 201 -> offset 20,100) and the ordering rationale in prose. Ran it against a live instance of this branch: its 5,200-row batch lands in a single `INSERT ... SELECT`, so every row shares one `add_time`, and `id` is still what determines relative order under the new scheme — verified rather than assumed, both tests pass.

Closes #2133

Parent: #2118