### PR TITLE
Disposition the four #2118 sites the sub-issue PRs left, and consolidate the show-scoped idiom

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -25,6 +25,8 @@ import {
   resolveDjDisplayName,
   resolveShowDjName,
   showDjNameOverride,
+  lastLoggedShowEntryOrderBy,
+  lastLoggedShowEntryOrderBySql,
 } from '@wxyc/database';
 import { ALBUM_METADATA_PROJECTION, suppressMislabeledStreamingUrls } from '../utils/album-metadata-projection.js';
 import { getUpcomingShowsMapsCached } from './concerts.service.js';
@@ -610,8 +612,34 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
   return raw.map(transformToIFSEntry);
 };
 
+/**
+ * Entries whose `flowsheet.id` falls in `[startId, endId]`, newest id first.
+ *
+ * AN ID WINDOW IS NOT A TIME WINDOW, AND STOPPED APPROXIMATING ONE (BS#2118,
+ * explicitly accepted). The `start_id`/`end_id` contract is literally an id
+ * range — that is the wire shape, not an implementation detail — so unlike
+ * `getEntriesByPage` above this function is NOT re-scoped to `add_time`;
+ * doing so would answer a different question than the one it was asked.
+ *
+ * What changed is the informal reading a caller could previously get away
+ * with. While every insert was a live one, ids advanced with wall-clock time,
+ * so an id window was a usable stand-in for a time window and the controller
+ * markets this as the "genuine deep-history pull" path. A historical insert
+ * (backfill, gap import, repair) breaks that correspondence permanently and
+ * in both directions: the imported rows take head-era ids, so they are
+ * unreachable through any id window covering the era they actually aired in,
+ * and they interleave into head-era windows where they did not air. #2119's
+ * April cohort is exactly this — those 403 rows answer to head-era ids, not
+ * April ones.
+ *
+ * For a genuine time window, use `GET /flowsheet/range` /
+ * `getEntriesInTimeWindow` below, which windows on `add_time` and was built
+ * (BS#2062) for that question. This function stays id-shaped for the callers
+ * that genuinely want ids.
+ */
 export const getEntriesByRange = async (startId: number, endId: number): Promise<IFSEntry[]> => {
-  // play_order is per-show after #693; id is globally monotonic across shows.
+  // play_order is per-show after #693; id is globally monotonic across shows
+  // in INSERTION order (see the header — not airtime order).
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
@@ -1237,7 +1265,10 @@ export const isLatestEntryShowEnd = async (showId: number): Promise<boolean> => 
     .select({ entry_type: flowsheet.entry_type })
     .from(flowsheet)
     .where(eq(flowsheet.show_id, showId))
-    .orderBy(desc(flowsheet.id))
+    // `id DESC` — see `lastLoggedShowEntryOrderBy` (@wxyc/database) for the
+    // shared rationale this and its two siblings (site 7 below, site 8 in
+    // jobs/legacy-mirror-reconcile) now hold in one place.
+    .orderBy(...lastLoggedShowEntryOrderBy())
     .limit(1);
   return latest?.entry_type === 'show_end';
 };
@@ -1280,13 +1311,22 @@ export const isLatestEntryShowEnd = async (showId: number): Promise<boolean> => 
  * detector still reports the show, so nothing is lost by failing quietly here.
  */
 export const closeShowFromTerminalShowEndMarker = async (showId: number): Promise<number> => {
-  // Newest flowsheet row of this show, by insertion order — `id DESC`, not
-  // `play_order DESC`, matching `isLatestEntryShowEnd` above (changeOrder
-  // renumbers play_order; marker rows are never reordered).
+  // Last row LOGGED for this show — `id DESC`, in lockstep with
+  // `isLatestEntryShowEnd` above (BS#2118 sites 5 and 7). The shared
+  // rationale for the key, and what accepting it exposes, lives once in
+  // `lastLoggedShowEntryOrderBy` (@wxyc/database) rather than in four
+  // near-identical copies.
+  //
+  // THE LOCKSTEP IS LOAD-BEARING HERE SPECIFICALLY. This statement re-reads
+  // the marker-type check atomically with its own write precisely so there is
+  // no TOCTOU against the caller's separate `isLatestEntryShowEnd` read (see
+  // the header above), and that guarantee holds only while both sides sort by
+  // the same key. Change one and you must change the other in the same
+  // commit — which is what the shared helper now makes hard to get wrong.
   const newestAddTime = sql`(SELECT ${flowsheet.add_time} FROM ${flowsheet}
-      WHERE ${flowsheet.show_id} = ${showId} ORDER BY ${flowsheet.id} DESC LIMIT 1)`;
+      WHERE ${flowsheet.show_id} = ${showId} ORDER BY ${lastLoggedShowEntryOrderBySql()} LIMIT 1)`;
   const newestEntryType = sql`(SELECT ${flowsheet.entry_type} FROM ${flowsheet}
-      WHERE ${flowsheet.show_id} = ${showId} ORDER BY ${flowsheet.id} DESC LIMIT 1)`;
+      WHERE ${flowsheet.show_id} = ${showId} ORDER BY ${lastLoggedShowEntryOrderBySql()} LIMIT 1)`;
 
   try {
     const closed = await db

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -17,15 +17,18 @@
  * behavior byte-for-byte at the GroupedResponse shape level.
  *
  * BS#2132: this used to order by flowsheet.id DESC alone, on the theory that
- * flowsheet.id is globally monotonic across shows (the same convention
- * `flowsheet.service.ts`'s `getEntriesByPage` still uses — see BS#2118/#2133
- * for that sibling site). That theory only holds while every insert is a
- * live one; a historical insert (backfill, import, repair) receives the
- * highest ids in the table and would sort as the newest content. Ordering by
- * add_time first fixes that for this endpoint. This does not change
- * `chronOrderID` (see `toBaseEntry` below) — the wire-level ordering key
- * consumers re-sort by is a separate, deliberately-deferred decision tracked
- * on BS#2118.
+ * flowsheet.id is globally monotonic across shows. That theory only holds
+ * while every insert is a live one; a historical insert (backfill, import,
+ * repair) receives the highest ids in the table and would sort as the newest
+ * content. Ordering by add_time first fixes that for this endpoint.
+ * `flowsheet.service.ts`'s `getEntriesByPage` moved off the same convention
+ * for the same reason (BS#2133) — both now sort `add_time DESC, id DESC`.
+ *
+ * This does not change `chronOrderID` (see `toBaseEntry` below). BS#2132
+ * deferred that call to the parent issue; BS#2118 has since MADE it —
+ * `chronOrderID` stays id-derived, and the decision record above
+ * `toBaseEntry` carries the reasoning plus the operator constraint it
+ * assumes in exchange. It is no longer an open question.
  *
  * entry_type -> tubafrenzy wire vocabulary mapping (see PR description for
  * the full rationale): 'track' -> playcut; 'talkset' | 'dj_join' |
@@ -428,22 +431,95 @@ function computeHourMs(row: RecentRow): number {
   return Math.floor(startMs / HOUR_MS) * HOUR_MS;
 }
 
+/**
+ * `chronOrderID` decision record (BS#2118 site 3) — the decision BS#2132
+ * deferred to the parent issue.
+ *
+ * DECISION: LEFT `id`-DERIVED. `chronOrderID: row.id` below, and its two
+ * siblings at the v=2 grouped `GroupedPlaycut.chronOrderID` and the v=1 flat
+ * `FlatEntry.chronOrderID`, are unchanged. This is the conservative option
+ * — no wire-contract change, no coordinated iOS/Android release — but it is
+ * defensible ONLY together with the operator constraint at the bottom of
+ * this comment. Read that constraint as the actual mitigation.
+ *
+ * WHY THE BLAST RADIUS IS SMALLER THAN IT LOOKS. iOS already derives its own
+ * chronological order on the v2 path and never consults this field there:
+ * `FlowsheetConverter.chronOrderID(showID:playOrder:id:)` (`wxyc-ios-64`,
+ * `Shared/Playlist/Sources/Playlist/V2/FlowsheetConverter.swift`) computes
+ * `(show_id << 32) | play_order`, falling back to `id` only when `show_id`
+ * is nil. An imported row carries its real (chronological) `show_id`, so
+ * `/v2/flowsheet` sorts it correctly with no backend change at all. That
+ * leaves `/playlists/recentEntries` — this file — as the only surface where
+ * `chronOrderID` is both `id`-derived AND consumed for client-side
+ * re-sorting (`PlaylistService.swift`, `PlaycutHistoryStore.swift`).
+ *
+ * WHY BS#2132's REORDER ALREADY COVERS THE COHORT THAT PROMPTED THIS.
+ * `fetchRecentRows` now orders by `add_time DESC, id DESC`, so a months-old
+ * historical row never enters the 200-row payload — 200 entries is roughly
+ * 15 hours of airplay at ~325 entries/day. A row that never ships cannot be
+ * mis-sorted by this field.
+ *
+ * THE RESIDUAL THAT REORDER DOES NOT COVER, and the case this decision is
+ * actually answered against: a row inserted out of order but RECENT ENOUGH
+ * to fall inside that window. Such a row is simultaneously (a) inside the
+ * chronologically-ordered top-200, so the payload contains it, and (b) still
+ * highest-id, so `chronOrderID = id` sorts it to the HEAD of the client's
+ * re-sorted timeline — defeating BS#2132's reorder for this endpoint
+ * specifically. It is also inside BS#2131's 24 h SSE age guard, so the same
+ * row broadcasts on `liveFs`.
+ *
+ * THAT RESIDUAL IS REACHABLE IN ROUTINE OPERATION, NOT ONLY BY A PLANNED
+ * IMPORT — which is what makes this decision load-bearing rather than
+ * theoretical. The tubafrenzy webhook (`apps/backend/routes/internal.route.ts`)
+ * writes `add_time` from `entry.startTime`, tubafrenzy's EVENT clock, for
+ * rows that carry a non-zero one. So an ordinary late-logged delivery — a DJ
+ * entering a track well after it played, a delivery the webhook retried —
+ * lands with the highest `id` in the table and an `add_time` still inside the
+ * ~15 h window. It survives BS#2132's filter and iOS sorts it to the head as
+ * now-playing. This is true on `main` today, with no import running. The
+ * divergence is bounded only by tubafrenzy delivery lag (minutes to days),
+ * not by anything sub-second.
+ *
+ * #1543's tubafrenzy-turndown "re-run this job at last-write" plan is the
+ * planned instance of the same shape, importing rows that aired HOURS rather
+ * than months earlier. Answering against these cases rather than against the
+ * since-cold April cohort is what makes "leave it id-derived" a decision
+ * instead of a default: against April alone, changing it and leaving it look
+ * equally safe, which is exactly what made this read as lower-stakes than it
+ * is.
+ *
+ * See also #2143, which tracks the related hazard that a FUTURE `add_time`
+ * pins this endpoint's window and freezes `X-Last-Modified` — the same
+ * event-clock mechanism, in the opposite temporal direction.
+ *
+ * OPERATOR CONSTRAINT (the mitigation this decision buys instead of a code
+ * change): any historical import, backfill, repair, or last-write re-run
+ * that writes `flowsheet` MUST run outside this endpoint's live window — or
+ * be paced so its rows are older than ~15 h by the time the 200-row window
+ * would otherwise include them. `LIVE_FS_INSERT_MAX_AGE_HOURS`
+ * (`metadata-broadcast.ts`, BS#2131) is the nearest existing knob for the
+ * analogous SSE-side residual, but it does NOT govern this endpoint.
+ * Nothing in this codebase enforces the constraint for
+ * `/playlists/recentEntries`; a future implementer of the #1543 re-run must
+ * honor it independently. If that proves hard to honor operationally, the
+ * next step is to make `chronOrderID` `add_time`-derived here — a
+ * coordinated iOS/Android change — not to relitigate this silently.
+ */
 function toBaseEntry(row: RecentRow): BaseEntry {
   return {
     id: row.id,
     // flowsheet.id is globally monotonic across shows (see
     // flowsheet.service.ts's getEntriesByRange / getEntriesByShow comments),
     // making it the natural analog of tubafrenzy's chronOrderID — a stable,
-    // strictly-increasing chronological order key. Not a reconstruction of
-    // tubafrenzy's own GLOBAL_ORDER_ID numbering (show*1000+seq), which no
-    // longer exists once tubafrenzy is decommissioned; consumers only rely
-    // on chronOrderID for ordering/dedup, not on its numeric scheme.
+    // strictly-increasing INSERTION-order key. It is NOT a chronological
+    // key: a historical insert takes the highest id while carrying an old
+    // `add_time` (BS#2118). Not a reconstruction of tubafrenzy's own
+    // GLOBAL_ORDER_ID numbering (show*1000+seq), which no longer exists once
+    // tubafrenzy is decommissioned; consumers only rely on chronOrderID for
+    // ordering/dedup, not on its numeric scheme.
     //
-    // BS#2132 caveat: "globally monotonic" above means insert-order
-    // monotonic, not chronological — the file-header comment explains why
-    // those diverge for a historical insert. chronOrderID stays id-derived
-    // here deliberately; whether to change it is a decision tracked on the
-    // parent, #2118, not made by this comment or this PR.
+    // Stays id-derived deliberately — see the decision record above this
+    // function for the reasoning and the operator constraint it assumes.
     chronOrderID: row.id,
     hour: computeHourMs(row),
     timeCreated: row.add_time.getTime(),

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -54,7 +54,16 @@
  */
 
 import { and, asc, eq, exists, gt, isNotNull, isNull, lt, notExists, notInArray, or, sql } from 'drizzle-orm';
-import { db, flowsheet, shows, user, type FSEntry, type Show, type User } from '@wxyc/database';
+import {
+  db,
+  flowsheet,
+  lastLoggedShowEntryOrderBySql,
+  shows,
+  user,
+  type FSEntry,
+  type Show,
+  type User,
+} from '@wxyc/database';
 
 export type LogLevel = 'info' | 'warn' | 'error';
 
@@ -793,12 +802,30 @@ const staleCeiling = (staleAfterHours: number) => sql`now() - (interval '1 hour'
 const latestShowId = sql`(SELECT max(s2.id) FROM ${shows} s2)`;
 
 /**
- * Newest flowsheet row of the outer `shows` row, by insertion order.
+ * Last row LOGGED for the outer `shows` row (BS#2118 site 8).
  *
- * `ORDER BY id DESC`, not `play_order DESC` — matching
- * `flowsheet_service.isLatestEntryShowEnd`: `changeOrder` renumbers
- * `play_order` for track reordering, but marker rows are never reordered and
- * the serial PK is an unambiguous "newest".
+ * `id DESC`, via the shared `lastLoggedShowEntryOrderBySql` helper
+ * (@wxyc/database) that also serves `flowsheet_service`'s
+ * `isLatestEntryShowEnd` (site 5) and `closeShowFromTerminalShowEndMarker`
+ * (site 7). The rationale for the key — why not `play_order`, why not
+ * `add_time` even though the page reads moved, and what accepting `id DESC`
+ * exposes — lives once in that helper's doc comment. This comment previously
+ * asserted "the serial PK is an unambiguous 'newest'", which was the exact
+ * claim BS#2118 disproved.
+ *
+ * WHAT THAT ACCEPTANCE COSTS THIS DETECTOR SPECIFICALLY: a historical insert
+ * (backfill, gap import, repair) into a still-open show takes the highest id
+ * and flips `newestEntryType` away from `'show_end'` — disabling the
+ * sign-off escape hatch in `selectStaleOpenShows` below, so this job can no
+ * longer report the exact state it exists to catch (a dropped `show_end`
+ * delivery with `end_time` still NULL). `newestEntryAt` degrades the same
+ * way: it reports the import's row rather than the show's real last
+ * activity, and that is the value an operator reads as `last_entry_at`.
+ *
+ * Not reached by #2119's April cohort — those 18 shows are closed, and this
+ * detector selects only `end_time IS NULL`. Reachable by any import landing
+ * while a show is open; the #1543 last-write re-run is the concrete
+ * candidate, and the operator constraint is to run it outside a live window.
  *
  * Written with an explicit `fe` alias and an explicitly table-qualified outer
  * reference (`${shows}.id`) rather than the bare `${flowsheet.col}` /
@@ -812,10 +839,10 @@ const latestShowId = sql`(SELECT max(s2.id) FROM ${shows} s2)`;
  * outer column makes the correlation unambiguous in either context.
  */
 const newestEntryType = sql<string | null>`(SELECT fe.entry_type FROM ${flowsheet} fe
-    WHERE fe.show_id = ${shows}.id ORDER BY fe.id DESC LIMIT 1)`;
+    WHERE fe.show_id = ${shows}.id ORDER BY ${lastLoggedShowEntryOrderBySql('fe')} LIMIT 1)`;
 
 const newestEntryAt = sql<Date | null>`(SELECT fe.add_time FROM ${flowsheet} fe
-    WHERE fe.show_id = ${shows}.id ORDER BY fe.id DESC LIMIT 1)`;
+    WHERE fe.show_id = ${shows}.id ORDER BY ${lastLoggedShowEntryOrderBySql('fe')} LIMIT 1)`;
 
 /**
  * Detector selection: `end_time IS NULL`, no activity since the cutoff, inside

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -18,3 +18,4 @@ export * from './album-resolve.js';
 export * from './freetext-enumerate.js';
 export * from './int-array-literal.js';
 export * from './dj-name.js';
+export * from './last-logged-show-entry.js';

--- a/shared/database/src/last-logged-show-entry.ts
+++ b/shared/database/src/last-logged-show-entry.ts
@@ -1,0 +1,148 @@
+/**
+ * "The last row we LOGGED for this show" — the show-scoped
+ * `WHERE show_id = ? ORDER BY id DESC LIMIT 1` idiom, factored into one
+ * place (BS#2118 sites 5/7/8).
+ *
+ * Named for insertion order on purpose. The four copies this replaces were
+ * each commented as finding the "newest" entry, and BS#2118 exists because
+ * that word was read as *chronological* when the query only ever delivered
+ * *insertion* order. `lastLogged` is the semantics these callers actually
+ * want and actually get.
+ *
+ * CALL SITES (all preserved byte-identically — this is a pure consolidation,
+ * not a behavior change):
+ *   - `apps/backend/services/flowsheet.service.ts`'s `isLatestEntryShowEnd`
+ *     (BS#2118 site 5) — query-builder `.orderBy(...)`. Uses
+ *     {@link lastLoggedShowEntryOrderBy}.
+ *   - `apps/backend/services/flowsheet.service.ts`'s
+ *     `closeShowFromTerminalShowEndMarker` (site 7) — two raw-`sql`
+ *     correlated subqueries in an UPDATE...WHERE context, where an unaliased
+ *     `${flowsheet.column}` renders fully-qualified. Uses
+ *     {@link lastLoggedShowEntryOrderBySql} with no alias.
+ *   - `jobs/legacy-mirror-reconcile/orchestrate.ts`'s `selectStaleOpenShows`
+ *     (site 8) — the same raw-`sql` shape but inside a `.select({...})`
+ *     PROJECTION, where an unaliased interpolation renders BARE and can
+ *     self-correlate against the subquery's own `flowsheet` scope instead of
+ *     the outer table. Uses {@link lastLoggedShowEntryOrderBySql} with an
+ *     explicit alias (`'fe'` there).
+ *
+ * Lives in `@wxyc/database`, not `apps/backend`, because
+ * `jobs/legacy-mirror-reconcile` is a separate npm workspace whose Dockerfile
+ * copies only its own directory plus this package — an `apps/backend` import
+ * fails that build stage. Same shape as the `concerts-recompute.ts` (BS#1763)
+ * and `album-resolve.ts` (BS#1829) extractions.
+ *
+ * ── WHY `id DESC` AND NOT `play_order DESC` ──
+ *
+ * `changeOrder` renumbers `play_order` for track reordering within a show.
+ * These callers must answer "what did we log last", not "what does the DJ
+ * currently want listed last". Marker rows are never reordered, so the two
+ * agree for the marker question in practice — but only `id` is stable under
+ * a reorder. Contrast `getEntriesByShow` (`flowsheet.service.ts`), where
+ * `play_order` IS the right primary key because that query renders the DJ's
+ * chosen order.
+ *
+ * ── WHY `id DESC` AND NOT `add_time DESC`, EVEN THOUGH THE PAGE READS MOVED ──
+ *
+ * BS#2118 established that `flowsheet.id` is insertion order, not airtime
+ * order: a historical insert (backfill, gap import, repair) takes the highest
+ * id in the table while carrying an `add_time` from whenever it actually
+ * aired. BS#2132 and BS#2133 moved `/playlists/recentEntries` and
+ * `getEntriesByPage` to `(add_time DESC, id DESC)` for exactly that reason.
+ *
+ * These three call sites deliberately did NOT move, and the difference is not
+ * inconsistency — it is the different question they ask. The page reads are
+ * display surfaces that want AIRTIME. These are control-flow gates that ask
+ * "is this show's last row the sign-off marker?", and for that question
+ * insertion order is not an approximation of the right answer, it IS the
+ * right answer: the marker is written last, so it holds the highest id by
+ * construction.
+ *
+ * Switching them to `add_time` would trade a rare failure for a likelier one.
+ * Per `getEntriesByPage`'s clock-mixing comment, the tubafrenzy webhook
+ * (`apps/backend/routes/internal.route.ts`) writes `add_time` from
+ * `entry.startTime` — tubafrenzy's EVENT clock — for rows that carry a
+ * non-zero one, which per the BS#351 gap-import findings is `show_start` /
+ * `show_end` markers; ordinary track rows have `startTime = 0` and fall
+ * through to `new Date()`, Backend's DELIVERY clock. So markers and tracks in
+ * the same show can be timestamped from two different clocks whose divergence
+ * is unbounded (tubafrenzy delivery lag), not sub-second. On a lag exceeding
+ * the gap between a show's final track and its sign-off, the TRACK carries
+ * the later `add_time` and would sort above the marker — these gates would
+ * then misfire on ordinary network lag rather than on a historical import.
+ *
+ * WHAT THAT ACCEPTS. Each caller inherits the false premise BS#2118 named: a
+ * historical insert into a show DOES take the highest id and DOES make these
+ * queries report it as the last-logged row. The per-site consequences and why
+ * each is bounded are documented at the call sites (site 5 is gated by
+ * `joinShow`'s own `end_time` short-circuit; site 7 is bounded by
+ * `WHERE end_time IS NULL` to "never closes", never "closes wrong"; site 8
+ * loses its sign-off escape hatch for the affected show). This is an accepted
+ * exposure with a documented operator constraint — historical imports run
+ * outside a live window — not an unnoticed one.
+ *
+ * If a future caller genuinely needs "the row that aired most recently",
+ * that is a different query: order by `add_time` with `id` as its own
+ * tie-break (`add_time` defaults to `now()` = `transaction_timestamp()`, so
+ * rows written by one statement share it), and it should NOT reuse these
+ * helpers.
+ */
+import { desc, sql, type SQL } from 'drizzle-orm';
+import { flowsheet } from './schema.js';
+
+/**
+ * Query-builder ORDER BY terms for "last row logged for this show".
+ * Spread into a drizzle `.orderBy(...)`:
+ * `.orderBy(...lastLoggedShowEntryOrderBy())`.
+ *
+ * A function rather than a module-level constant so the `desc(...)` call is
+ * deferred to call time, keeping this module side-effect-free at import —
+ * which matters because `tests/mocks/database.mock.ts` auto-mocks
+ * `drizzle-orm` for some unit suites and not others.
+ */
+export function lastLoggedShowEntryOrderBy(): readonly [SQL] {
+  return [desc(flowsheet.id)];
+}
+
+/**
+ * Reject anything that isn't a plain unquoted SQL identifier before it
+ * reaches {@link sql.raw}.
+ *
+ * `sql.raw` concatenates rather than parameterizes, and this module is
+ * exported from `@wxyc/database` to every workspace, so `alias` is a public
+ * raw-SQL sink. Today's only caller passes the literal `'fe'`, so there is
+ * nothing live to exploit; the guard is what keeps that true for the next
+ * caller, and ESLint's `security/detect-*` rules do not see through the
+ * `sql.raw` indirection to flag it.
+ */
+function assertSafeSqlIdentifier(alias: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
+    throw new Error(
+      `lastLoggedShowEntryOrderBySql: unsafe SQL alias ${JSON.stringify(alias)} — ` +
+        `expected a plain unquoted identifier (letters, digits, underscores; not starting with a digit).`
+    );
+  }
+}
+
+/**
+ * Raw-SQL ORDER BY tail for a correlated subquery selecting a show's
+ * last-logged row — `id DESC`, matching {@link lastLoggedShowEntryOrderBy}.
+ *
+ * With no `alias`, interpolates the real `flowsheet` column object, which
+ * renders fully-qualified in a WHERE-clause context (site 7's shape).
+ *
+ * With `alias`, emits an alias-qualified bare identifier (`<alias>.id DESC`)
+ * instead — required inside a `.select({...})` projection subquery, where an
+ * unaliased `${flowsheet.id}` renders BARE and Postgres resolves it against
+ * the subquery's own scope rather than the caller's intended outer table
+ * (site 8's self-correlation hazard; see that call site's comment). The
+ * caller must alias `flowsheet` to the same string in its own FROM clause —
+ * this builds only the ORDER BY tail, not the FROM.
+ */
+export function lastLoggedShowEntryOrderBySql(alias?: string): SQL {
+  if (alias) {
+    assertSafeSqlIdentifier(alias);
+    return sql`${sql.raw(alias)}.id DESC`;
+  }
+  return sql`${flowsheet.id} DESC`;
+}

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { desc, sql } from 'drizzle-orm';
 
 type MockQueryChain = {
   select: jest.Mock;
@@ -530,6 +531,23 @@ export { intArrayLiteral } from '../../shared/database/src/int-array-literal.js'
 // precisely the drift the extraction exists to prevent. The job tests assert
 // their resolver AGAINST `resolveShowDjName`, so it must be the real one.
 export { resolveDjDisplayName, showDjNameOverride, resolveShowDjName } from '../../shared/database/src/dj-name.js';
+
+// Stubs of shared/database/src/last-logged-show-entry.ts (BS#2118 sites
+// 5/7/8). NOT re-exported from source, unlike the pure dj-name chain above:
+// the real module closes over the REAL `flowsheet` schema object, while
+// consumers' assertions here compare against the MOCK `flowsheet` defined in
+// this file, so a source re-export would make every shape-pin compare two
+// different column objects. These stubs mirror the real implementations
+// exactly, over the mock's own table object.
+//
+// The real module's behavior — including that it renders byte-identically to
+// the hand-written fragments it replaced, and that it rejects an unsafe
+// alias — is covered against SOURCE in
+// tests/unit/database/last-logged-show-entry.test.ts, which unmocks
+// drizzle-orm and imports the module directly.
+export const lastLoggedShowEntryOrderBy = (): readonly [unknown] => [desc(flowsheet.id)];
+export const lastLoggedShowEntryOrderBySql = (alias?: string): unknown =>
+  alias ? sql`${sql.raw(alias)}.id DESC` : sql`${flowsheet.id} DESC`;
 
 // Re-export the pure `RawPair` TYPE from source (type-only — erased at
 // compile time, no runtime import, so it can't pull in the module's `db`

--- a/tests/unit/database/last-logged-show-entry.test.ts
+++ b/tests/unit/database/last-logged-show-entry.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for shared/database/src/last-logged-show-entry.ts (BS#2118
+ * sites 5/7/8).
+ *
+ * Pure SQL-fragment module — no DB client — so these render the real
+ * fragments through drizzle's own `PgDialect` and assert on the genuine SQL
+ * text, mirroring `tests/unit/utils/sql-like.test.ts` and
+ * `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts`
+ * (both chosen over a call-shape mock for the same reason: a mock can pin
+ * that `orderBy` was called, not what it was called WITH).
+ *
+ * The consolidation this module performs is a PURE REFACTOR — it must emit
+ * exactly what the four hand-written copies emitted. The byte-equality tests
+ * below are the guard on that claim, since a silent change to any of these
+ * fragments would alter which row three control-flow gates consider a show's
+ * last-logged entry.
+ */
+jest.unmock('drizzle-orm');
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { desc, sql } from 'drizzle-orm';
+import { flowsheet } from '../../../shared/database/src/schema';
+import {
+  lastLoggedShowEntryOrderBy,
+  lastLoggedShowEntryOrderBySql,
+} from '../../../shared/database/src/last-logged-show-entry';
+
+const dialect = new PgDialect();
+const render = (fragment: Parameters<PgDialect['sqlToQuery']>[0]): string => dialect.sqlToQuery(fragment).sql;
+
+describe('lastLoggedShowEntryOrderBy (query-builder form, BS#2118 site 5)', () => {
+  it('orders by id DESC — insertion order, deliberately not add_time', () => {
+    const [term] = lastLoggedShowEntryOrderBy();
+    const text = render(term);
+    expect(text).toContain('"id" desc');
+    // The whole point of the accepted decision: this must NOT sort by airtime.
+    expect(text).not.toContain('add_time');
+  });
+
+  it('emits exactly one ORDER BY term (no tie-break needed — id is unique)', () => {
+    expect(lastLoggedShowEntryOrderBy()).toHaveLength(1);
+  });
+
+  it('renders byte-identically to the hand-written desc(flowsheet.id) it replaced', () => {
+    const [term] = lastLoggedShowEntryOrderBy();
+    expect(render(term)).toBe(render(desc(flowsheet.id)));
+  });
+});
+
+describe('lastLoggedShowEntryOrderBySql (raw-SQL form, BS#2118 sites 7 and 8)', () => {
+  it("renders byte-identically to site 7's hand-written unaliased fragment", () => {
+    // Site 7 (closeShowFromTerminalShowEndMarker) interpolated the column
+    // object inside an UPDATE...WHERE, where it renders fully-qualified.
+    expect(render(lastLoggedShowEntryOrderBySql())).toBe(render(sql`${flowsheet.id} DESC`));
+  });
+
+  it("renders byte-identically to site 8's hand-written aliased fragment", () => {
+    // Site 8 (selectStaleOpenShows) hand-wrote `fe.id DESC` inside a
+    // .select({...}) projection, where a bare interpolation would
+    // self-correlate against the subquery's own flowsheet scope.
+    expect(render(lastLoggedShowEntryOrderBySql('fe'))).toBe(render(sql`${sql.raw('fe')}.id DESC`));
+  });
+
+  it('never emits an unqualified/fully-qualified column when an alias is requested', () => {
+    const text = render(lastLoggedShowEntryOrderBySql('fe'));
+    expect(text).toContain('fe.id DESC');
+    // Falling back to the table-qualified form is the self-correlation bug
+    // documented at orchestrate.ts's newestEntryType.
+    expect(text).not.toContain('"flowsheet"."id"');
+  });
+
+  it('sorts by id, never add_time, in either form', () => {
+    expect(render(lastLoggedShowEntryOrderBySql())).not.toContain('add_time');
+    expect(render(lastLoggedShowEntryOrderBySql('fe'))).not.toContain('add_time');
+  });
+
+  // The alias reaches `sql.raw`, which concatenates rather than
+  // parameterizes, on a function exported from @wxyc/database to every
+  // workspace. No live caller passes anything but 'fe'; the guard is what
+  // keeps that safe for the next one.
+  it.each([
+    ['a quote-and-comment injection', 'fe"; DROP TABLE flowsheet; --'],
+    ['a whitespace-separated clause', 'fe, (SELECT 1)'],
+    ['a leading digit', '1fe'],
+    ['a hyphen', 'fe-alias'],
+  ])('rejects %s rather than interpolating it', (_label, alias) => {
+    expect(() => lastLoggedShowEntryOrderBySql(alias)).toThrow(/unsafe SQL alias/);
+  });
+
+  it.each(['fe', 'f', 'flowsheet_entry', '_fe', 'fe2'])('accepts the plain identifier %p', (alias) => {
+    expect(() => lastLoggedShowEntryOrderBySql(alias)).not.toThrow();
+  });
+
+  // An empty string is falsy, so it takes the unaliased branch rather than
+  // reaching the guard. Safe either way (nothing is interpolated), but pinned
+  // so the fall-through is documented behavior rather than an assumed one.
+  it('falls through to the unaliased form on an empty-string alias', () => {
+    expect(render(lastLoggedShowEntryOrderBySql(''))).toBe(render(sql`${flowsheet.id} DESC`));
+  });
+});

--- a/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts
@@ -87,11 +87,16 @@ jest.unmock('drizzle-orm');
 
 jest.mock('@wxyc/database', () => {
   const realSchema = jest.requireActual('../../../../shared/database/src/schema');
+  // The REAL last-logged-show-entry helper (BS#2118 site 8), not a stub: this
+  // file exists to render genuine SQL text, so the ORDER BY fragment under
+  // test must be the one production emits. It is a pure module over the same
+  // real schema object above, so it composes here without pulling in `db`.
+  const realOrderBy = jest.requireActual('../../../../shared/database/src/last-logged-show-entry');
   const chain: Record<string, jest.Mock> = {};
   for (const method of ['select', 'from', 'where', 'orderBy']) {
     chain[method] = jest.fn().mockReturnValue(chain);
   }
-  return { ...realSchema, db: chain };
+  return { ...realSchema, ...realOrderBy, db: chain };
 });
 
 import { PgDialect } from 'drizzle-orm/pg-core';


### PR DESCRIPTION
Rebased onto `main` and reduced to the delta, per the [status comment](https://github.com/WXYC/Backend-Service/pull/2144#issuecomment-5284152369). #2131, #2132, and #2133 merged while this branch was open; everything they shipped is dropped here rather than relitigated. What remains is the four sites those PRs did not reach, plus #2118's last open decision.

**No behavior changes.** Every query in this diff emits the SQL it emitted before — the consolidation is a pure refactor, pinned byte-for-byte by unit tests.

## What's here

| Site | Disposition |
|---|---|
| 7 — `closeShowFromTerminalShowEndMarker` | **Explicitly accepted** at `id DESC`, in lockstep with site 5 |
| 8 — `selectStaleOpenShows` (`jobs/legacy-mirror-reconcile`) | **Explicitly accepted**; its "the serial PK is an unambiguous 'newest'" claim removed |
| 3 — `chronOrderID` | **Decision recorded**: stays id-derived, with the operator constraint that decision assumes |
| — `getEntriesByRange` | **Explicitly accepted**: its `start_id`/`end_id` contract genuinely *is* an id range |
| — the show-scoped idiom | Four near-identical copies → one `lastLoggedShowEntryOrderBy` helper in `@wxyc/database` |

## Why sites 5/7/8 keep `id DESC` instead of moving to `add_time`

This is the substantive call, and it inverts what this PR originally proposed. #2133's clock-mixing finding is the reason: the tubafrenzy webhook stamps `show_start`/`show_end` markers with tubafrenzy's **event** clock (non-zero `startTime`), while ordinary track rows have `startTime = 0` and fall through to Backend's **delivery** clock.

All three sites are control-flow gates asking one question: *is this show's last row the sign-off marker?* For that question insertion order isn't an approximation of the right answer — it **is** the right answer, because the marker is written last by construction. Moving them to `add_time` would mean that on any delivery lag exceeding the gap between a show's final track and its sign-off, the track carries the later `add_time` and sorts above the marker — so these gates would misfire on ordinary network lag instead of on a historical import. That trades a rare failure for a likelier one.

The page reads that moved to `add_time` want **airtime**; these want **what we logged last**. The divergence is the point, not an inconsistency — and it's now stated once, in the helper, rather than implied four times.

## The helper

Named `lastLoggedShowEntryOrderBy`, not `newest*`, on purpose: the four copies it replaces each said "newest", and this whole issue exists because that word got read as chronological when the query only ever delivered insertion order. It lives in `@wxyc/database` rather than `apps/backend` because `jobs/legacy-mirror-reconcile` is a separate workspace whose Dockerfile can't reach the app.

Because a silent change to these fragments would alter which row three gates treat as a show's last entry, the tests assert each emitted fragment is byte-identical to the hand-written one it replaced. The raw-SQL alias parameter is an exported `sql.raw` sink, so it validates its identifier — no live caller passes anything but `'fe'`, and the guard is what keeps that true for the next one.

## `chronOrderID` — the decision, not a deferral

Stays id-derived. iOS already derives its own order on the v2 path (`FlowsheetConverter.chronOrderID` packs `show_id`/`play_order`), and #2132's reorder keeps a months-old cohort out of the 200-row payload, so the blast radius is the legacy `recentEntries` view alone.

The residual is a row inserted out of order yet recent enough to stay inside the window — and per the review note, **that's reachable in routine operation, not just via #1543**. Because the webhook writes event time, an ordinary late-logged delivery takes the highest `id` with an `add_time` still inside the window, survives the reorder, and sorts to the head as now-playing. That's true on `main` today with no import running. So the mitigation is an operator constraint — historical imports and re-runs land outside the live window — which nothing enforces automatically. It's written where the next implementer of the #1543 re-run will find it, and cross-references #2143 as the same mechanism in the opposite temporal direction.

## Dropped from the earlier version of this PR

- Sites 1, 2, 4 and the site 5/6 docstrings — all on `main`.
- **Migration 0146 and the composite index.** The prod probe on #2133 (2.6M rows, db.t3.micro) measured offset 50,000 at 11,739 ms against this branch's 8.92 ms on 600k synthetic rows — a cache-resident harness that can't reproduce the cliff between offsets 20,000 and 30,000. `main`'s one-line `MAX_OFFSET` reduction was already measured as sufficient, and it also closes the pre-existing 4,447 ms-vs-5 s-timeout exposure the index approach left untouched. Not re-proposing it without a prod measurement.
- The "both sub-second in practice" caveat — wrong about the dominant mechanism, and corrected on `main`.
- The `playlist-recent-entries.spec.js` fixture change — the version on `main` (`0a29125c`, taking the `add_time` DEFAULT) is the one that survives CI's 103 serial suites.

## Verification

`typecheck`, `lint` (0 errors), `format:check` clean; `jobs/legacy-mirror-reconcile` typechecked directly since the root typecheck doesn't cover `jobs/**`. Full unit suite: 432 suites / 7251 tests green.

Closes #2118
