### PR TITLE
fix(flowsheet): bound flowsheet.add_time against a future upstream startTime (BS#2143)

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -1,7 +1,17 @@
 import { Router } from 'express';
 import * as Sentry from '@sentry/node';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
-import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
+import {
+  db,
+  flowsheet,
+  shows,
+  rotation,
+  library,
+  truncate,
+  user,
+  epochMsToDate,
+  isBeyondFutureTolerance,
+} from '@wxyc/database';
 import { getAlbumIdByLegacyId } from '../services/library.service.js';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import {
@@ -34,6 +44,19 @@ const MARKER_ENTRY_TYPES: ReadonlySet<BackendEntryType> = new Set<BackendEntryTy
 // Materialized once for `inArray(...)` in the sibling-marker heal below — avoids
 // re-spreading the Set into an array on every webhook delivery.
 const MARKER_ENTRY_TYPE_LIST: BackendEntryType[] = [...MARKER_ENTRY_TYPES];
+
+// Stable Sentry grouping key for the BS#2143 future-`startTime` clamp below.
+// One issue for the whole class of event, not one per legacy_entry_id or per
+// delivery — a persistently-fast tubafrenzy clock would otherwise fire this
+// on every webhook delivery and, without a shared fingerprint, mint a fresh
+// issue (or at least a noisy one) per entry. Mirrors the CDC dispatcher's
+// `OVERSIZED_FINGERPRINT`/`ERROR_FINGERPRINT` convention
+// (apps/backend/services/cdc/dispatcher.ts): the per-occurrence detail
+// (legacy_entry_id, rejected value, how far ahead) still goes out on every
+// event via `tags`/`extra`, so nothing is lost — only the issue count is
+// capped, which is what keeps an alert threshold meaningful under sustained
+// skew instead of paging on issue-count churn.
+const FUTURE_START_TIME_FINGERPRINT = ['webhook-future-add-time'];
 
 export const internal_route = Router();
 
@@ -323,10 +346,97 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const breakpointRadioHour = resolveRadioHour(entryType, entry.radioHour ?? null);
 
       // Shared by the row's `add_time` and, for `show_end` markers, the
-      // `shows.end_time` fast-path below — one clock reading per delivery
-      // so the two never drift apart by the few ms between two `new Date()`
-      // calls when `entry.startTime` is absent.
-      const markerTimestamp = entry.startTime ? new Date(entry.startTime) : new Date();
+      // `shows.end_time` fast-path below (and, transitively, by
+      // `closeShowFromTerminalShowEndMarker` in flowsheet.service.ts, which
+      // re-reads THIS row's own `add_time` later) — one clock reading per
+      // delivery so all of those never drift apart by the few ms between two
+      // separate `new Date()` calls. `now` is read exactly once, below,
+      // whether or not it ends up being used.
+      //
+      // BS#2143: two defects fixed in the same expression that used to be
+      // `entry.startTime ? new Date(entry.startTime) : new Date()`.
+      //
+      // (a) No finite/NaN guard. The webhook body is untyped
+      //     (`req.body ?? {}`, validated only on `action`/`entry.id`), so a
+      //     non-numeric truthy `entry.startTime` (a string, an object) made
+      //     `new Date(...)` an Invalid Date and the Drizzle insert below
+      //     threw, 500-ing the whole delivery. `resolveRadioHour` six lines
+      //     up already routes through `epochMsToDate` "so a garbage payload
+      //     can't write an Invalid Date" — `markerTimestamp` was the one
+      //     timestamp in this handler that never got that treatment. Fixed
+      //     by routing `entry.startTime` through the same `epochMsToDate`
+      //     (null/0/NaN/non-finite → null; 0 is tubafrenzy's "not set"
+      //     sentinel, which the old bare-falsy check already depended on).
+      //
+      // (b) No upper bound. A tubafrenzy host with a fast clock (or a bad
+      //     manual entry) could pin `add_time` in the future. Before #2132
+      //     that was self-healing — `fetchRecentRows` sorted `ORDER BY id
+      //     DESC` and the row aged out after ~200 more inserts. Since #2132
+      //     switched to `ORDER BY add_time DESC, id DESC`
+      //     (playlist-proxy.service.ts `fetchRecentRows`), a future row
+      //     sorts first and NEVER ages out — it permanently pins the head of
+      //     `/playlists/recentEntries` (the whole legacy iOS/Android fleet)
+      //     and permanently freezes `X-Last-Modified`
+      //     (`lastModifiedFromTimestamps` is `Math.max(...add_time)`,
+      //     playlist.controller.ts). It also permanently pins the ONE-row
+      //     `GET /flowsheet/latest` read (`getEntriesByPage(0, 1)`,
+      //     flowsheet.service.ts / flowsheet.controller.ts), which sorts the
+      //     same way — not named in BS#2143's issue body, but the same root
+      //     cause and in scope for this fix.
+      //
+      //     Decision, made explicitly per the BS#2143 acceptance criterion:
+      //     CLAMP a beyond-tolerance `startTime` to the delivery clock,
+      //     don't reject it. This is a live flowsheet; dropping or 500-ing a
+      //     DJ's entry over a clock-skew problem on tubafrenzy's end is worse
+      //     than storing a slightly-wrong `add_time`. Contrast with
+      //     `resolveEntryTimestamp` (jobs/flowsheet-etl/transform.ts), the
+      //     ETL twin that reads the same upstream fields: that job
+      //     back-fills HISTORICAL rows, so clamping there would stamp a
+      //     months-old row with the import's wall clock and pin it exactly
+      //     where this fix exists to prevent pinning — it falls through to
+      //     the next candidate timestamp instead. Same bound
+      //     (`FUTURE_TIMESTAMP_TOLERANCE_MS`), deliberately different
+      //     handling per site; see that function's doc comment for the
+      //     reverse cross-reference.
+      //
+      //     Deliberately NOT a read-side `add_time <= now()` predicate on
+      //     `fetchRecentRows`/`getEntriesByPage` — that would make a
+      //     legitimately-live entry invisible for as long as an upstream
+      //     clock runs fast, and a live flowsheet silently lagging the DJ is
+      //     a worse failure than the one being fixed (BS#2143 acceptance
+      //     criterion).
+      //
+      //     No env var for the tolerance — see `FUTURE_TIMESTAMP_TOLERANCE_MS`'s
+      //     doc comment in `shared/database/src/legacy/etl-utils.ts` for why.
+      //
+      //     A clamp is surfaced to Sentry (grouped under one stable
+      //     fingerprint — see `FUTURE_START_TIME_FINGERPRINT` above) so a
+      //     genuinely misconfigured tubafrenzy clock gets diagnosed instead
+      //     of silently absorbed.
+      const parsedStartTime = epochMsToDate(entry.startTime ?? null);
+      const now = new Date();
+      let markerTimestamp: Date;
+      if (parsedStartTime === null) {
+        markerTimestamp = now;
+      } else if (isBeyondFutureTolerance(parsedStartTime, now)) {
+        Sentry.captureMessage(
+          '[webhook] flowsheet entry startTime beyond future tolerance — clamped to delivery clock',
+          {
+            level: 'warning',
+            tags: { subsystem: 'flowsheet-webhook' },
+            extra: {
+              legacy_entry_id: entry.id,
+              rejected_start_time_raw: entry.startTime,
+              rejected_start_time_iso: parsedStartTime.toISOString(),
+              ahead_ms: parsedStartTime.getTime() - now.getTime(),
+            },
+            fingerprint: FUTURE_START_TIME_FINGERPRINT,
+          }
+        );
+        markerTimestamp = now;
+      } else {
+        markerTimestamp = parsedStartTime;
+      }
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -405,6 +515,11 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
         // We never overwrite a non-NULL stored value with NULL — that
         // would regress a row the live path or a prior delivery already
         // resolved.
+        //
+        // BS#2143: `add_time` is confirmed absent from this refresh set (see
+        // the anchoring note above) — the conflict-UPDATE path never rewrites
+        // it, so it can't inherit a bad `markerTimestamp` from a redelivery
+        // either. Nothing to bound here.
         const refresh: Record<string, unknown> = {
           artist_name: artistName,
           album_title: albumTitle,
@@ -467,6 +582,14 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // dj_name-at-write-time precedent on these same marker rows): never
       // rewrite a value an earlier delivery of this same `show_end` — or a
       // deliberate one-shot ETL run — already repaired.
+      //
+      // BS#2143: `markerTimestamp` is bounded (see its computation above)
+      // before it ever reaches here, so this fast-path's `end_time` inherits
+      // the same future-timestamp clamp as `add_time` for free — a future
+      // `shows.end_time` would otherwise be a SECOND permanently-poisoned
+      // column, since both this write and `closeShowFromTerminalShowEndMarker`
+      // (flowsheet.service.ts) only ever fire under `WHERE end_time IS NULL`,
+      // so nothing downstream ever corrects a bad value once it lands.
       if (entryType === 'show_end' && showId !== null) {
         await db
           .update(shows)

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -58,6 +58,13 @@ const MARKER_ENTRY_TYPE_LIST: BackendEntryType[] = [...MARKER_ENTRY_TYPES];
 // skew instead of paging on issue-count churn.
 const FUTURE_START_TIME_FINGERPRINT = ['webhook-future-add-time'];
 
+// Sibling grouping key for the "startTime present but unparseable" arm below.
+// Separate from the clamp's fingerprint because the two are different upstream
+// defects with different fixes — a fast clock vs. a payload/serializer change —
+// and collapsing them into one issue would let a serializer regression hide
+// inside an ongoing clock-skew issue.
+const UNPARSEABLE_START_TIME_FINGERPRINT = ['webhook-unparseable-start-time'];
+
 export const internal_route = Router();
 
 /**
@@ -413,10 +420,39 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       //     fingerprint — see `FUTURE_START_TIME_FINGERPRINT` above) so a
       //     genuinely misconfigured tubafrenzy clock gets diagnosed instead
       //     of silently absorbed.
+      //
+      // The `null` arm splits in two, because (a)'s fix would otherwise trade
+      // a loud failure for a silent one. `epochMsToDate` returns null for BOTH
+      // "absent" (`null`/`undefined`/`0` — the overwhelmingly common case,
+      // every ordinary track row) and "present but unparseable" (a string, an
+      // object, a non-finite number — always an upstream defect). Before this
+      // change the second class produced an Invalid Date and a 500: wrong, but
+      // impossible to miss. Collapsing both into a silent fall-back to `now`
+      // would mean that if tubafrenzy ever changed its JSON serializer to ship
+      // `startTime` as a string (Jackson's long-as-string is a common config),
+      // EVERY `show_start`/`show_end` marker would quietly lose its event
+      // timestamp — and `shows.end_time`, which nothing downstream corrects
+      // (both writers gate on `WHERE end_time IS NULL`), would silently become
+      // the delivery time with zero telemetry. So: "absent" stays silent,
+      // "present but unparseable" alerts. The truthiness test is deliberately
+      // the same one the pre-BS#2143 expression used to define "absent", so
+      // the set of values that stay silent is unchanged.
       const parsedStartTime = epochMsToDate(entry.startTime ?? null);
       const now = new Date();
       let markerTimestamp: Date;
       if (parsedStartTime === null) {
+        if (entry.startTime) {
+          Sentry.captureMessage('[webhook] flowsheet entry startTime present but unparseable — using delivery clock', {
+            level: 'warning',
+            tags: { subsystem: 'flowsheet-webhook' },
+            extra: {
+              legacy_entry_id: entry.id,
+              unparseable_start_time_raw: entry.startTime,
+              unparseable_start_time_type: typeof entry.startTime,
+            },
+            fingerprint: UNPARSEABLE_START_TIME_FINGERPRINT,
+          });
+        }
         markerTimestamp = now;
       } else if (isBeyondFutureTolerance(parsedStartTime, now)) {
         Sentry.captureMessage(

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -563,12 +563,16 @@ export const getEntryCount = async (): Promise<number> => {
  * relative order.
  *
  * TWO DIFFERENT CLOCKS FEED `add_time`, AND THIS SORT KEY NOW MIXES THEM.
- * The tubafrenzy webhook (`apps/backend/routes/internal.route.ts:329`) sets
- * `add_time` to `entry.startTime ? new Date(entry.startTime) : new Date()`
- * for EVERY entry type it inserts — but per the BS#351 gap-import findings,
- * only `show_start`/`show_end` marker rows carry a non-zero `startTime` in
- * tubafrenzy; ordinary track rows have `startTime = 0` (falsy) and fall
- * through to `new Date()`. So MARKER rows get tubafrenzy's EVENT clock and
+ * The tubafrenzy webhook (`markerTimestamp` in
+ * `apps/backend/routes/internal.route.ts` — see that assignment's own doc
+ * comment) sets `add_time` from `entry.startTime` when that field parses to
+ * a usable timestamp no more than `FUTURE_TIMESTAMP_TOLERANCE_MS` ahead of
+ * the delivery clock (BS#2143), and from the delivery clock itself
+ * otherwise, for EVERY entry type it inserts — but per the BS#351
+ * gap-import findings, only `show_start`/`show_end` marker rows carry a
+ * non-zero `startTime` in tubafrenzy; ordinary track rows have
+ * `startTime = 0` (tubafrenzy's "not set" sentinel) and fall through to the
+ * delivery clock. So MARKER rows get tubafrenzy's EVENT clock and
  * TRACK rows get Backend's DELIVERY clock — two different clocks landing in
  * the same column, and now the same sort key. Consequence: on a webhook
  * delivery lag, a show's `show_end` marker can carry an `add_time` EARLIER

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -6,7 +6,7 @@
  */
 
 // Import shared utilities for local use and re-export so existing imports continue to work
-import { epochMsToDate as _epochMsToDate, truncate as _truncate } from '@wxyc/database';
+import { epochMsToDate as _epochMsToDate, truncate as _truncate, isBeyondFutureTolerance } from '@wxyc/database';
 export const epochMsToDate = _epochMsToDate;
 export const truncate = _truncate;
 
@@ -123,13 +123,49 @@ export const parseMySQLDatetime = (datetime: string | null): Date | null => {
  * Resolve the best available timestamp for a FLOWSHEET_ENTRY_PROD row.
  * Prefers START_TIME (epoch ms), falls back to TIME_CREATED, then TIME_LAST_MODIFIED.
  * Most track entries have START_TIME = 0, so the fallback is essential.
+ *
+ * BS#2143: a candidate that resolves to a Date more than
+ * `FUTURE_TIMESTAMP_TOLERANCE_MS` ahead of `now` is treated exactly like a
+ * null/0 candidate — skipped in favour of the next one in the preference
+ * chain. If every candidate is beyond tolerance (or absent), this returns
+ * `null`, same as it always has for an unresolvable row; every caller
+ * (`jobs/flowsheet-etl/job.ts` `importEntries`/`runIncremental`,
+ * `jobs/flowsheet-april-gap-import/build-row.ts` `buildInsertRow`,
+ * `jobs/flowsheet-april-gap-import/orchestrate.ts` `discoverCandidates`)
+ * already `continue`s or returns `null` on a null result, so this introduces
+ * no new failure mode at any call site — a future-dated candidate just joins
+ * the existing "couldn't resolve a timestamp" bucket.
+ *
+ * Deliberately FALLS THROUGH rather than CLAMPING (contrast with the webhook
+ * receiver's `markerTimestamp` in apps/backend/routes/internal.route.ts,
+ * which clamps to the delivery clock — see that assignment's doc comment for
+ * the full webhook-side reasoning and the cross-reference back to here).
+ * This function feeds two importers
+ * (`jobs/flowsheet-etl`, `jobs/flowsheet-april-gap-import`) that legitimately
+ * write HISTORICAL rows, sometimes months old. Clamping a bad `startTime` to
+ * the import's wall clock would stamp a months-old row with `now()` and land
+ * it at the head of exactly the three `add_time DESC`-sorted windows BS#2143
+ * exists to protect (`fetchRecentRows`, `X-Last-Modified`,
+ * `getEntriesByPage`/`GET /flowsheet/latest`) — converting a rare upstream
+ * defect into a guaranteed self-inflicted one on every import. Falling
+ * through to the next real (non-future) candidate timestamp avoids that
+ * entirely, at the cost of occasionally landing on a slightly-stale
+ * TIME_CREATED/TIME_LAST_MODIFIED instead of a bogus START_TIME — an
+ * acceptable trade for an importer, unacceptable for a live write.
  */
 export const resolveEntryTimestamp = (
   startTime: number | null,
   timeCreated: number | null,
-  timeLastModified: number | null
+  timeLastModified: number | null,
+  now: Date = new Date()
 ): Date | null => {
-  return epochMsToDate(startTime) ?? epochMsToDate(timeCreated) ?? epochMsToDate(timeLastModified);
+  const candidates = [epochMsToDate(startTime), epochMsToDate(timeCreated), epochMsToDate(timeLastModified)];
+  for (const candidate of candidates) {
+    if (candidate !== null && !isBeyondFutureTolerance(candidate, now)) {
+      return candidate;
+    }
+  }
+  return null;
 };
 
 /**

--- a/shared/database/src/legacy/etl-utils.ts
+++ b/shared/database/src/legacy/etl-utils.ts
@@ -43,6 +43,47 @@ export const epochMsToDate = (epochMs: number | null): Date | null => {
 };
 
 /**
+ * How far into the future an upstream (tubafrenzy) timestamp may legitimately
+ * drift before it's treated as bad data rather than ordinary clock skew
+ * (BS#2143). 5 minutes comfortably covers NTP-class drift between the
+ * tubafrenzy host and this service without being wide enough to mask a
+ * genuinely misconfigured clock.
+ *
+ * A plain constant, not an env var. The past-side sibling,
+ * `LIVE_FS_INSERT_MAX_AGE_HOURS`
+ * (apps/backend/services/metadata-broadcast/metadata-broadcast.ts), is
+ * env-gated because it's a kill switch — an operator may need to widen or
+ * disable that broadcast filter in production without a deploy. This bound
+ * has no analogous "turn it off" case (clamping a future timestamp to now is
+ * always the right call), so an env var would buy nothing but a
+ * docs/env-vars.md entry.
+ */
+export const FUTURE_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+
+/**
+ * True when `date` is more than `FUTURE_TIMESTAMP_TOLERANCE_MS` ahead of
+ * `now`. Pure predicate — `now` is injectable so callers (and their tests)
+ * don't depend on wall-clock timing. `date === null` is never "beyond
+ * tolerance" (there's nothing to flag).
+ *
+ * Deliberately NOT folded into `epochMsToDate` above (BS#2143). That
+ * converter also produces `radio_hour`, and a breakpoint's `radio_hour` is
+ * LEGITIMATELY in the near future — tubafrenzy logs a breakpoint marker
+ * roughly a minute before the top-of-hour it marks (see `resolveRadioHour`'s
+ * doc comment in jobs/flowsheet-etl/transform.ts, BS#1449). Clamping inside
+ * the shared converter would silently shift every breakpoint hour backward
+ * and reintroduce the exact bug BS#1449 fixed. Callers that need a future
+ * bound (the webhook's `markerTimestamp` / `add_time`, and
+ * `resolveEntryTimestamp` in jobs/flowsheet-etl/transform.ts) apply this
+ * predicate themselves, after conversion, only to the fields that actually
+ * need it — never inside `epochMsToDate` itself.
+ */
+export const isBeyondFutureTolerance = (date: Date | null, now: Date = new Date()): boolean => {
+  if (date === null) return false;
+  return date.getTime() - now.getTime() > FUTURE_TIMESTAMP_TOLERANCE_MS;
+};
+
+/**
  * Truncate a string to a max length, returning null if empty.
  * Matches the VARCHAR limits in the schema (128 for names, 250 for messages).
  *

--- a/shared/database/src/legacy/etl-utils.ts
+++ b/shared/database/src/legacy/etl-utils.ts
@@ -77,6 +77,19 @@ export const FUTURE_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
  * `resolveEntryTimestamp` in jobs/flowsheet-etl/transform.ts) apply this
  * predicate themselves, after conversion, only to the fields that actually
  * need it — never inside `epochMsToDate` itself.
+ *
+ * Note the precise scope of that argument: it rules out the bound living in
+ * the SHARED CONVERTER, not the bound ever being applied to `radio_hour`. The
+ * 5-minute tolerance comfortably exceeds the ~1-minute legitimate lead
+ * BS#1449 relies on, so a per-call-site bound on `radio_hour` would be
+ * coherent — it is simply out of scope for BS#2143, which is about the
+ * `add_time` sort key. `radio_hour` is left unbounded here as a known,
+ * deliberate gap: a skewed upstream clock can still write a breakpoint hour
+ * that hasn't happened, which `computeHourMs`
+ * (apps/backend/services/playlist-proxy.service.ts) passes through verbatim
+ * to the mobile clients. That's cosmetic (it pins no window and freezes no
+ * header), and the 2026-08-13 production sweep found zero
+ * `radio_hour > now()` rows — but it is unfixed, not disproven.
  */
 export const isBeyondFutureTolerance = (date: Date | null, now: Date = new Date()): boolean => {
   if (date === null) return false;

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -427,6 +427,17 @@ export const epochMsToDate = (epochMs: number | null): Date | null => {
   return Number.isNaN(date.getTime()) ? null : date;
 };
 
+// BS#2143 future-timestamp bound. Mirrors
+// shared/database/src/legacy/etl-utils.ts verbatim — kept in sync by hand
+// like the rest of this file's "pure ETL utility functions" section; see
+// tests/unit/database/etl-utils.test.ts for the real-module test that pins
+// the actual implementation these callers depend on at runtime.
+export const FUTURE_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+export const isBeyondFutureTolerance = (date: Date | null, now: Date = new Date()): boolean => {
+  if (date === null) return false;
+  return date.getTime() - now.getTime() > FUTURE_TIMESTAMP_TOLERANCE_MS;
+};
+
 // BS#1090: truncate on codepoint boundaries (Array.from), not UTF-16 code
 // units (String.prototype.slice) — mirrors the real fix in
 // shared/database/src/legacy/etl-utils.ts so this mock doesn't drift back

--- a/tests/unit/database/etl-utils.test.ts
+++ b/tests/unit/database/etl-utils.test.ts
@@ -14,7 +14,11 @@ import { epochMsToDate, truncate, parseTabRow, toNullable } from '@wxyc/database
 jest.mock('../../../shared/database/src/client.js', () => jest.requireActual('../../mocks/database.mock'), {
   virtual: true,
 });
-import { truncate as truncateReal } from '../../../shared/database/src/legacy/etl-utils';
+import {
+  truncate as truncateReal,
+  isBeyondFutureTolerance as isBeyondFutureToleranceReal,
+  FUTURE_TIMESTAMP_TOLERANCE_MS as FUTURE_TIMESTAMP_TOLERANCE_MS_REAL,
+} from '../../../shared/database/src/legacy/etl-utils';
 
 describe('epochMsToDate', () => {
   it('converts valid epoch ms to Date', () => {
@@ -37,6 +41,68 @@ describe('epochMsToDate', () => {
 
   it('returns null for Infinity', () => {
     expect(epochMsToDate(Infinity)).toBeNull();
+  });
+
+  // BS#2143: pins the guard that keeps `radio_hour` correct. A breakpoint's
+  // `radio_hour` is legitimately up to ~a minute in the future (BS#1449), so
+  // `epochMsToDate` — the converter `radio_hour` goes through — must NEVER
+  // clamp a future date. The future-tolerance bound lives in the separate
+  // `isBeyondFutureTolerance` predicate instead; this test fails if someone
+  // "simplifies" by folding that clamp into this converter.
+  it('returns a far-future date unchanged (no future clamp in the converter itself)', () => {
+    const farFutureMs = Date.now() + 365 * 24 * 60 * 60 * 1000; // ~1 year ahead
+    const date = epochMsToDate(farFutureMs);
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getTime()).toBe(farFutureMs);
+  });
+});
+
+/**
+ * BS#2143. `isBeyondFutureTolerance` is the shared predicate bounding
+ * `flowsheet.add_time` at write time (the webhook's `markerTimestamp` in
+ * apps/backend/routes/internal.route.ts and `resolveEntryTimestamp` in
+ * jobs/flowsheet-etl/transform.ts). Imported from the real module (not the
+ * `@wxyc/database` top-of-file import, which resolves to
+ * tests/mocks/database.mock.ts's hand-maintained copy) so this test pins the
+ * actual production implementation, mirroring the `truncate`/`truncateReal`
+ * split above.
+ */
+describe('isBeyondFutureTolerance (real implementation)', () => {
+  const now = new Date('2026-08-13T18:00:00.000Z');
+
+  it('is false for a date exactly at the tolerance boundary', () => {
+    const atBoundary = new Date(now.getTime() + FUTURE_TIMESTAMP_TOLERANCE_MS_REAL);
+    expect(isBeyondFutureToleranceReal(atBoundary, now)).toBe(false);
+  });
+
+  it('is false for a date 1ms inside the tolerance boundary', () => {
+    const justInside = new Date(now.getTime() + FUTURE_TIMESTAMP_TOLERANCE_MS_REAL - 1);
+    expect(isBeyondFutureToleranceReal(justInside, now)).toBe(false);
+  });
+
+  it('is true for a date 1ms beyond the tolerance boundary', () => {
+    const justOutside = new Date(now.getTime() + FUTURE_TIMESTAMP_TOLERANCE_MS_REAL + 1);
+    expect(isBeyondFutureToleranceReal(justOutside, now)).toBe(true);
+  });
+
+  it('is false for a date in the past', () => {
+    const past = new Date(now.getTime() - 1000);
+    expect(isBeyondFutureToleranceReal(past, now)).toBe(false);
+  });
+
+  it('is false for a date equal to now', () => {
+    expect(isBeyondFutureToleranceReal(new Date(now.getTime()), now)).toBe(false);
+  });
+
+  it('is false for null', () => {
+    expect(isBeyondFutureToleranceReal(null, now)).toBe(false);
+  });
+
+  it('defaults `now` to the wall clock when not injected', () => {
+    // Deterministic without fake timers: a date far enough in the past can
+    // never be "beyond" whatever `now` actually resolves to.
+    const wayInThePast = new Date('2000-01-01T00:00:00.000Z');
+    expect(isBeyondFutureToleranceReal(wayInThePast)).toBe(false);
   });
 });
 

--- a/tests/unit/database/etl-utils.test.ts
+++ b/tests/unit/database/etl-utils.test.ts
@@ -1,4 +1,11 @@
-import { epochMsToDate, truncate, parseTabRow, toNullable } from '@wxyc/database';
+import {
+  epochMsToDate,
+  truncate,
+  parseTabRow,
+  toNullable,
+  FUTURE_TIMESTAMP_TOLERANCE_MS as FUTURE_TIMESTAMP_TOLERANCE_MS_MOCK,
+  isBeyondFutureTolerance as isBeyondFutureToleranceMock,
+} from '@wxyc/database';
 // jest.unit.config.ts maps the `@wxyc/database` specifier to
 // tests/mocks/database.mock.ts for every unit test, so the `truncate` above
 // exercises that mock's copy, not the real `shared/database/src/legacy/etl-utils.ts`
@@ -103,6 +110,41 @@ describe('isBeyondFutureTolerance (real implementation)', () => {
     // never be "beyond" whatever `now` actually resolves to.
     const wayInThePast = new Date('2000-01-01T00:00:00.000Z');
     expect(isBeyondFutureToleranceReal(wayInThePast)).toBe(false);
+  });
+
+  // tests/mocks/database.mock.ts hand-copies both symbols (it can't import
+  // the real module: etl-utils.ts imports the `db` client at module scope,
+  // which is the very thing the mock exists to stand in for, so a re-export
+  // would be circular). This file is the one place that holds BOTH copies, so
+  // it's the only place that can pin them together.
+  //
+  // Without this, a hand-copy is free to drift, and the drift is invisible:
+  // the consumer tests that actually exercise the bound
+  // (tests/unit/routes/internal.route.test.ts,
+  // tests/unit/jobs/flowsheet-etl/transform.test.ts) resolve `@wxyc/database`
+  // to the mock, so they'd keep asserting against the STALE tolerance and stay
+  // green while production clamped at a different threshold. Tighten the real
+  // constant to 30s without touching the mock and this test — not those —
+  // is what fails.
+  describe('mock parity (tests/mocks/database.mock.ts must not drift)', () => {
+    it('mirrors FUTURE_TIMESTAMP_TOLERANCE_MS exactly', () => {
+      expect(FUTURE_TIMESTAMP_TOLERANCE_MS_MOCK).toBe(FUTURE_TIMESTAMP_TOLERANCE_MS_REAL);
+    });
+
+    it.each([
+      ['1ms inside the boundary', FUTURE_TIMESTAMP_TOLERANCE_MS_REAL - 1],
+      ['exactly at the boundary', FUTURE_TIMESTAMP_TOLERANCE_MS_REAL],
+      ['1ms beyond the boundary', FUTURE_TIMESTAMP_TOLERANCE_MS_REAL + 1],
+      ['far in the future', 60 * 60 * 1000],
+      ['in the past', -1000],
+    ])('agrees with the real predicate for a date %s', (_label, offsetMs) => {
+      const date = new Date(now.getTime() + offsetMs);
+      expect(isBeyondFutureToleranceMock(date, now)).toBe(isBeyondFutureToleranceReal(date, now));
+    });
+
+    it('agrees with the real predicate for null', () => {
+      expect(isBeyondFutureToleranceMock(null, now)).toBe(isBeyondFutureToleranceReal(null, now));
+    });
   });
 });
 

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -129,6 +129,35 @@ describe('flowsheet-etl transform', () => {
     it('returns null when all timestamps are null', () => {
       expect(resolveEntryTimestamp(null, null, null)).toBeNull();
     });
+
+    // BS#2143: a future-dated candidate is treated like a null/0 one — the
+    // function falls through to the next candidate in the preference chain
+    // rather than clamping (an importer back-fills historical rows; clamping
+    // would stamp a months-old row with the import's wall clock — see the
+    // function's doc comment). `now` is injected for determinism.
+    describe('future-tolerance fall-through (BS#2143)', () => {
+      const now = new Date('2026-08-13T18:00:00.000Z');
+      const FAR_FUTURE_MS = now.getTime() + 60 * 60 * 1000; // 1h ahead — well beyond tolerance
+
+      it('falls through to TIME_CREATED when START_TIME is beyond the future tolerance', () => {
+        const result = resolveEntryTimestamp(FAR_FUTURE_MS, CREATED_MS, MODIFIED_MS, now);
+        expect(result?.getTime()).toBe(CREATED_MS);
+      });
+
+      it('falls through to TIME_LAST_MODIFIED when START_TIME and TIME_CREATED are both beyond the future tolerance', () => {
+        const result = resolveEntryTimestamp(FAR_FUTURE_MS, FAR_FUTURE_MS, MODIFIED_MS, now);
+        expect(result?.getTime()).toBe(MODIFIED_MS);
+      });
+
+      it('returns null when all three candidates are beyond the future tolerance', () => {
+        expect(resolveEntryTimestamp(FAR_FUTURE_MS, FAR_FUTURE_MS, FAR_FUTURE_MS, now)).toBeNull();
+      });
+
+      it('leaves an ordinary historical START_TIME untouched (regression: the bound never fires on real data)', () => {
+        const result = resolveEntryTimestamp(VALID_MS, CREATED_MS, MODIFIED_MS, now);
+        expect(result?.getTime()).toBe(VALID_MS);
+      });
+    });
   });
 
   describe('parseMySQLDatetime', () => {

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -348,6 +348,92 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'track', radio_hour: null }));
   });
 
+  // -- add_time / markerTimestamp future-bound (BS#2143). A future or
+  // malformed `entry.startTime` must never reach `add_time` verbatim — see
+  // the doc comment on `markerTimestamp`'s computation in
+  // apps/backend/routes/internal.route.ts for the full clamp-vs-reject
+  // reasoning and why a read-side predicate was rejected instead.
+
+  it('writes add_time verbatim from an ordinary (historical) startTime', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ add_time: new Date(validEntry.startTime) }));
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('clamps a startTime beyond the future tolerance to the delivery clock instead of writing it verbatim, and alerts Sentry', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    const beforeRequest = Date.now();
+    const farFutureStartTime = beforeRequest + 60 * 60 * 1000; // 1h ahead — well beyond the 5-minute tolerance
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, startTime: farFutureStartTime } });
+    const afterRequest = Date.now();
+
+    expect(res.status).toBe(200);
+    const written = lastInsertValues().add_time as Date;
+    expect(written).toBeInstanceOf(Date);
+    // Clamped to "now" at handling time, not to the far-future input value.
+    expect(written.getTime()).toBeGreaterThanOrEqual(beforeRequest);
+    expect(written.getTime()).toBeLessThanOrEqual(afterRequest);
+    expect(written.getTime()).not.toBe(farFutureStartTime);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/startTime beyond future tolerance/),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ subsystem: 'flowsheet-webhook' }),
+        extra: expect.objectContaining({
+          legacy_entry_id: validEntry.id,
+          rejected_start_time_raw: farFutureStartTime,
+        }),
+        fingerprint: ['webhook-future-add-time'],
+      })
+    );
+  });
+
+  it('does not clamp a startTime just inside the future tolerance', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    const justInsideStartTime = Date.now() + 60 * 1000; // 1 minute ahead, well under the 5-minute tolerance
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, startTime: justInsideStartTime } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ add_time: new Date(justInsideStartTime) }));
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not throw and does not write an Invalid Date when startTime is malformed (non-numeric)', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    const beforeRequest = Date.now();
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, startTime: 'not-a-number' } });
+    const afterRequest = Date.now();
+
+    expect(res.status).toBe(200);
+    const written = lastInsertValues().add_time as Date;
+    expect(written).toBeInstanceOf(Date);
+    expect(Number.isNaN(written.getTime())).toBe(false);
+    // Falls back to the delivery clock, same as an absent startTime.
+    expect(written.getTime()).toBeGreaterThanOrEqual(beforeRequest);
+    expect(written.getTime()).toBeLessThanOrEqual(afterRequest);
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
   it('forwards the resolved rotation_id when rotationReleaseId matches a rotation row', async () => {
     // resolveShow → 9999, resolveAlbumId → unlinked, resolveRotationId → 4242.
     mockLimit.mockReset();

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -25,7 +25,13 @@ jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
 }));
 
-import { db, shows } from '@wxyc/database';
+// Resolves to tests/mocks/database.mock.ts under the unit-test moduleNameMapper.
+// `FUTURE_TIMESTAMP_TOLERANCE_MS` is the BS#2143 bound the assertions below
+// straddle — derived from the constant rather than hard-coded so tightening the
+// tolerance can't leave a test asserting the wrong side of the boundary while
+// still passing. tests/unit/database/etl-utils.test.ts pins the mock's copy to
+// the real module's, so this value tracks production.
+import { db, shows, FUTURE_TIMESTAMP_TOLERANCE_MS } from '@wxyc/database';
 import { and, eq, isNull } from 'drizzle-orm';
 import express from 'express';
 import request from 'supertest';
@@ -370,7 +376,9 @@ describe('POST /internal/flowsheet-webhook', () => {
   it('clamps a startTime beyond the future tolerance to the delivery clock instead of writing it verbatim, and alerts Sentry', async () => {
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
     const beforeRequest = Date.now();
-    const farFutureStartTime = beforeRequest + 60 * 60 * 1000; // 1h ahead — well beyond the 5-minute tolerance
+    // 12x the tolerance ahead — unambiguously beyond it, and stays beyond it
+    // however the tolerance is retuned.
+    const farFutureStartTime = beforeRequest + FUTURE_TIMESTAMP_TOLERANCE_MS * 12;
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -402,7 +410,12 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   it('does not clamp a startTime just inside the future tolerance', async () => {
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
-    const justInsideStartTime = Date.now() + 60 * 1000; // 1 minute ahead, well under the 5-minute tolerance
+    // A fifth of the tolerance ahead — inside it by construction, whatever the
+    // tolerance is tuned to. (Not the exact boundary: the handler measures
+    // `now` itself, a few ms after this line, so an exact-boundary offset would
+    // land on the wrong side. `etl-utils.test.ts` covers the exact boundary
+    // with an injected `now`.)
+    const justInsideStartTime = Date.now() + Math.floor(FUTURE_TIMESTAMP_TOLERANCE_MS / 5);
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -414,7 +427,7 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(mockCaptureMessage).not.toHaveBeenCalled();
   });
 
-  it('does not throw and does not write an Invalid Date when startTime is malformed (non-numeric)', async () => {
+  it('does not throw and does not write an Invalid Date when startTime is malformed (non-numeric), and alerts Sentry', async () => {
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
     const beforeRequest = Date.now();
 
@@ -429,6 +442,44 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(written).toBeInstanceOf(Date);
     expect(Number.isNaN(written.getTime())).toBe(false);
     // Falls back to the delivery clock, same as an absent startTime.
+    expect(written.getTime()).toBeGreaterThanOrEqual(beforeRequest);
+    expect(written.getTime()).toBeLessThanOrEqual(afterRequest);
+    // But unlike an absent startTime this is an upstream defect, so it must
+    // NOT be silent — before BS#2143 this class 500'd, which was wrong but
+    // loud; the fix must not trade that for a silent wrong timestamp.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/startTime present but unparseable/),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ subsystem: 'flowsheet-webhook' }),
+        extra: expect.objectContaining({
+          legacy_entry_id: validEntry.id,
+          unparseable_start_time_raw: 'not-a-number',
+          unparseable_start_time_type: 'string',
+        }),
+        fingerprint: ['webhook-unparseable-start-time'],
+      })
+    );
+  });
+
+  // The other half of the split: the common "absent" cases must stay silent,
+  // or a station-normal track row would alert on every single delivery.
+  it.each([
+    ['absent', undefined],
+    ['zero (tubafrenzy "not set" sentinel)', 0],
+    ['null', null],
+  ])('falls back to the delivery clock silently when startTime is %s', async (_label, startTime) => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    const beforeRequest = Date.now();
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, startTime } });
+    const afterRequest = Date.now();
+
+    expect(res.status).toBe(200);
+    const written = lastInsertValues().add_time as Date;
     expect(written.getTime()).toBeGreaterThanOrEqual(beforeRequest);
     expect(written.getTime()).toBeLessThanOrEqual(afterRequest);
     expect(mockCaptureMessage).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #2143

## Mechanism

`apps/backend/routes/internal.route.ts` wrote a flowsheet row's `add_time` straight from the tubafrenzy webhook's caller-supplied `entry.startTime`:

```ts
const markerTimestamp = entry.startTime ? new Date(entry.startTime) : new Date();
```

with no upper bound. A tubafrenzy host with a fast clock, a malformed payload, or a bad manual entry could land a row whose `add_time` is in the future. `jobs/flowsheet-etl`'s `resolveEntryTimestamp` — and, through it, the #2119 April gap import — reads the same upstream fields on the same terms.

That expression carried a second, latent defect: the webhook body is untyped (`req.body ?? {}`, validated only on `action` / `entry.id`), so a non-numeric truthy `startTime` (a string, an object) made `new Date(...)` an Invalid Date and the Drizzle insert threw, 500-ing the whole delivery. `resolveRadioHour`, six lines up, already routed through `epochMsToDate` for exactly that reason; `markerTimestamp` was the one timestamp in the handler that never got the treatment.

## Why it stopped being self-healing

Under the old `ORDER BY id DESC`, a future-dated row sat at the top of the 200-row window and aged out after ~200 more inserts (roughly 15 hours at the station's ~329 entries/day). Since #2132 (6e8a7a79) and #2118's follow-on 54247644 — both merged 2026-08-13 — **three** reads sort on `add_time DESC`, so one such row sorts first and never ages out:

1. **`fetchRecentRows`** (`apps/backend/services/playlist-proxy.service.ts`) — pins the head of `/playlists/recentEntries`, i.e. the entire legacy iOS/Android fleet through the tf#620 bridge.
2. **`X-Last-Modified`** (`apps/backend/controllers/playlist.controller.ts` → `lastModifiedFromTimestamps`, a `Math.max` over `add_time`) — freezes at a future value. Unlike the ordering symptom, nothing recovers this on its own.
3. **`getEntriesByPage`** (`apps/backend/services/flowsheet.service.ts`) — serves public `GET /flowsheet` page 0 and, via `getEntriesByPage(0, 1)` (`flowsheet.controller.ts`), `GET /flowsheet/latest`. **Not named in #2143's issue body** — found while tracing the other two. It is the worst of the three: a single-row read, so one future row makes "latest" permanently wrong for every consumer of that endpoint.

`shows.end_time` is a fourth exposure and comes along for free: `markerTimestamp` also backs the `show_end` → `shows.end_time` fast-path (BS#1861), and both that write and `closeShowFromTerminalShowEndMarker` fire only under `WHERE end_time IS NULL`, so nothing downstream ever corrects a bad value once it lands.

## The fix

A shared bound in `shared/database/src/legacy/etl-utils.ts`:

- `FUTURE_TIMESTAMP_TOLERANCE_MS` = 5 minutes — wide enough for NTP-class drift between the tubafrenzy host and this service, narrow enough not to mask a genuinely misconfigured clock. A plain constant, not an env var: the past-side sibling `LIVE_FS_INSERT_MAX_AGE_HOURS` is env-gated because it's a kill switch an operator may need to disable without a deploy, and this bound has no analogous "turn it off" case.
- `isBeyondFutureTolerance(date, now = new Date())` — pure predicate, `now` injectable so callers and their tests don't depend on wall-clock timing.

### Two writers, two deliberately different decisions

**Webhook (`internal.route.ts`) — CLAMP.** `entry.startTime` now routes through `epochMsToDate` (fixing the Invalid-Date/500 hazard; `0` stays tubafrenzy's "not set" sentinel, as the old bare-falsy check already assumed), and a beyond-tolerance result is clamped to the delivery clock. Clamp, not reject: this is a live flowsheet, and dropping or 500-ing a DJ's entry over a clock-skew problem on tubafrenzy's end is worse than storing a slightly-wrong `add_time`. The decision is documented at the site, per the issue's acceptance criterion.

**ETL (`jobs/flowsheet-etl/transform.ts` `resolveEntryTimestamp`) — FALL THROUGH.** The issue body says "apply the same bound to the ETL twin", and the same *bound* does apply — but not the same *handling*. A beyond-tolerance candidate is treated exactly like a null/0 one: skipped in favour of the next entry in the existing `START_TIME → TIME_CREATED → TIME_LAST_MODIFIED` chain, returning `null` if all three are beyond tolerance. Clamping here would stamp a months-old imported row with the import's wall clock and land it at the head of the very three windows this fix exists to protect — converting a rare upstream defect into a guaranteed self-inflicted one on every import. Falling through costs at most a slightly-stale `TIME_CREATED`, which is an acceptable trade for an importer and an unacceptable one for a live write.

Both sites cross-reference each other in their doc comments so the asymmetry can't be "simplified" away later.

### Why the bound is not inside `epochMsToDate`

`epochMsToDate` is also the converter for `radio_hour`, and a breakpoint's `radio_hour` is *legitimately* in the near future — tubafrenzy logs a breakpoint marker roughly a minute before the top-of-hour it marks (BS#1449). Folding a clamp into the shared converter would silently shift every breakpoint hour backward and reintroduce the exact bug #1449 fixed. Callers that need a future bound apply the predicate themselves, after conversion, only to the fields that need it. `tests/unit/database/etl-utils.test.ts` now pins this with a test asserting `epochMsToDate` returns a far-future date *unchanged*, so the guard fails loudly if someone tries the simplification.

### Why no read-side predicate

Per #2143's acceptance criterion 6, no `add_time <= now()` was added to `fetchRecentRows` or `getEntriesByPage`. It would make a legitimately-live entry invisible for as long as an upstream clock runs fast, and a live flowsheet silently lagging the DJ is a worse failure than the one being fixed — one that fails in the direction nobody notices until a show is on air. It would also only patch one read while `X-Last-Modified` and every other `add_time` consumer stayed exposed.

### Observability

A clamp fires `Sentry.captureMessage` at `warning`, grouped under one stable fingerprint (`['webhook-future-add-time']`), mirroring the CDC dispatcher's `OVERSIZED_FINGERPRINT` / `ERROR_FINGERPRINT` convention. A persistently-fast tubafrenzy clock would otherwise fire on every webhook delivery and, without a shared fingerprint, churn the issue count and make any alert threshold meaningless. Per-occurrence detail (`legacy_entry_id`, the rejected raw value and its ISO form, how far ahead it was) still ships on every event via `tags` / `extra` — only the issue count is capped.

A **second** fingerprint (`['webhook-unparseable-start-time']`) covers the other arm, added in review. Routing `startTime` through `epochMsToDate` fixes the Invalid-Date/500, but `epochMsToDate` returns `null` for two very different things: *absent* (`null` / `undefined` / `0` — every ordinary track row, station-normal) and *present but unparseable* (a string, an object, a non-finite number — always an upstream defect). Collapsing both into a silent fall-back would have traded a loud failure for a silent one: if tubafrenzy ever changed its JSON serializer to ship `startTime` as a string (Jackson's long-as-string is a common config), every `show_start` / `show_end` marker would quietly lose its event timestamp and `shows.end_time` would silently become the delivery time with zero telemetry. So absent stays silent, unparseable alerts — under its own fingerprint, so a serializer regression can't hide inside an ongoing clock-skew issue. The truthiness test is the same one the pre-fix expression used to define "absent", so the set of values that stay silent is unchanged.

### Not touched, verified

The webhook's ON-CONFLICT redelivery path never rewrites `add_time` — it stays anchored to the first INSERT's value alongside `show_id` / `play_order` / `segue` — so a redelivery carrying a bad `startTime` can't poison an already-good row. Confirmed against the refresh set rather than assumed.

## Production sweep (acceptance criterion 5)

Run read-only against production on 2026-08-13:

| Check | Rows |
|---|---|
| `flowsheet` with `add_time > now()` | **0** |
| `flowsheet` with `radio_hour > now()` | **0** |
| `shows` with `end_time > now()` | **0** |

No remediation needed — this change is purely preventive.

## Tests

- `tests/unit/database/etl-utils.test.ts` — boundary cases on both sides of the tolerance (exactly at, 1 ms inside, 1 ms outside), past / equal-to-now / null, the default-`now` path, and the `epochMsToDate`-must-not-clamp regression guard. Imported from the real module (not the `@wxyc/database` mock), mirroring the existing `truncate` / `truncateReal` split in that file. Also (from review) a **mock-parity** block: `tests/mocks/database.mock.ts` hand-copies the constant and the predicate, and it can't import the real module (`etl-utils.ts` imports the `db` client at module scope — the very thing the mock replaces — so a re-export would be circular). Nothing pinned the copy to the original, and the drift would have been invisible, because the consumer tests that actually exercise the bound resolve `@wxyc/database` to the mock: they'd keep asserting against a stale tolerance and stay green while production clamped at a different threshold. This file holds both copies, so it's the one place that can pin them. Verified by tightening the mock to 30 s and confirming three tests fail.
- `tests/unit/jobs/flowsheet-etl/transform.test.ts` — fall-through to `TIME_CREATED`, fall-through to `TIME_LAST_MODIFIED`, all-three-future → `null`, and a regression case that an ordinary historical `START_TIME` is untouched.
- `tests/unit/routes/internal.route.test.ts` — verbatim write for an ordinary `startTime`, clamp + Sentry assertion (message, level, tags, `extra`, fingerprint) for a far-future one, no clamp for one just inside tolerance, and no-throw / no-Invalid-Date for a non-numeric `startTime`.

All four `resolveEntryTimestamp` call sites (`jobs/flowsheet-etl/job.ts` ×2, `jobs/flowsheet-april-gap-import/build-row.ts`, `jobs/flowsheet-april-gap-import/orchestrate.ts`) already `continue` or return `null` on a null result, so the widened null case introduces no new failure mode — a future-dated candidate just joins the existing "couldn't resolve a timestamp" bucket.

## Related

- #2132 — the `fetchRecentRows` ordering change that converts this from transient to permanent
- #2118 — parent analysis of `flowsheet.id`-as-chronological-key; its follow-on 54247644 is what put `getEntriesByPage` / `GET /flowsheet/latest` on `add_time DESC`
- #1888 — the `liveFs:insert` broadcast, another consumer of the same trust-the-upstream-timestamp assumption
- #1449 — the breakpoint `radio_hour` fix that dictates why the bound stays out of `epochMsToDate`
- #2119 — the April gap import, a second consumer of `resolveEntryTimestamp`

## Review findings deliberately left for a human

Two findings from review are real but out of scope for this fix. Recording them here rather than silently expanding the PR.

**1. `startTime = 0` on an `update` for a row BS doesn't hold.** This clamp bounds only the *future* side. A `create`/`update` webhook delivery for an entry Backend has no row for still gets `add_time = now` whenever `startTime` is 0 — and per the BS#351 findings quoted above, *every ordinary track row* in tubafrenzy has `startTime = 0`. Concretely: someone edits a March track entry in the classic UI, tubafrenzy fires an `update`, Backend has no row (BS#351's April cohort is exactly this class), so the upsert INSERTs it with `add_time = now` and pins a months-old track at the head of all three `add_time DESC` reads — permanently, since the conflict path never rewrites `add_time`. That is the same symptom #2143 describes via a more reachable trigger. It is **not a regression from this PR** (the old expression produced the identical `now`), it has a different root cause (an *absent* timestamp, not a future one), and the fix is a different decision — probably falling back to the payload's `timeCreated` the way `resolveEntryTimestamp` does, which is a behavior change on the live write path that deserves its own issue.

**2. Silent drops in `importEntries` when all three ETL candidates are beyond tolerance.** `resolveEntryTimestamp` returning `null` meets a bare `if (!addTime) continue;` at every call site — no counter, no log. In `importEntries` (the bulk-dump path retained for the Phase 6a window) that drop is permanent and the run still reports success. Reachable only if the tubafrenzy MySQL host clock is >5 minutes fast *and* all three of START_TIME / TIME_CREATED / TIME_LAST_MODIFIED land in the skew window — and `runIncremental` self-heals via its `TIME_LAST_MODIFIED > lastRun` watermark, while `flowsheet-etl` is unscheduled today. Adding skip counters is a telemetry expansion across four call sites in a job this PR otherwise doesn't touch.

A third finding — `radio_hour` is left unbounded from the same skewed clock — is now recorded as a known deliberate gap in `isBeyondFutureTolerance`'s doc comment rather than fixed. It is cosmetic (it pins no window and freezes no header; `computeHourMs` passes it through to mobile clients verbatim), and the production sweep found zero such rows.
