### PR TITLE
Serve legacy_release_id on every flowsheet-consumed library read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -476,6 +476,17 @@ jobs:
           # closes the GHA-vs-compose drift that surfaced when BS#1383
           # promoted its case from warn-skip to fail-fast.
           CATALOG_SEARCH_ALIAS_ENABLED: 'true'
+          # Catalog track-search cascade: same GHA-vs-compose drift as the alias
+          # flag above (dev_env/docker-compose.yml:261-262 default both to true,
+          # and both have been on in prod since 2026-05-21). Both are strict-'true'
+          # gated in apps/backend/config/catalogTrackSearch.ts and default false,
+          # so without these the cascade cases in
+          # tests/integration/library-legacy-release-id-exposure.spec.js take
+          # their warn-and-return branch and pass vacuously — leaving
+          # searchLibraryByTrackUncachedOrThrow, the one BS#2128 site where the
+          # column was previously destructured away, with no gating coverage.
+          CATALOG_TRACK_SEARCH_CTA_ENABLED: 'true'
+          CATALOG_TRACK_SEARCH_DISCOGS_ENABLED: 'true'
           # SES has a 200-message/month quota. The auth service (host process
           # here) is the only sendEmail/sendOTPEmail caller; keep real sends
           # off regardless of whether AWS_ACCESS_KEY_ID etc. are ever set on

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -20,7 +20,7 @@
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
     "@wxyc/observability": "^1.0.0",
-    "@wxyc/shared": "^3.3.0",
+    "@wxyc/shared": "^3.5.0",
     "better-auth": "^1.6.26",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -173,6 +173,13 @@ components:
       properties:
         id:
           type: integer
+        legacy_release_id:
+          type: integer
+          description: >-
+            BS#2128. The library.db-producer surrogate key dj-site's track picker
+            resolves against; NOT NULL since migration 0137. Sourced from
+            getAlbumFromDB, so it is present on both consumers of this schema —
+            GET /library/info and the PATCH /library/{id} 200.
         code_letters:
           type: string
         code_artist_number:
@@ -220,6 +227,13 @@ components:
       properties:
         id:
           type: integer
+        legacy_release_id:
+          type: integer
+          description: >-
+            BS#2128. Present on GET /library only. GET /library/query shares this
+            schema but builds its rows through an explicit projection
+            (taggedRowToAlbumSearchResultRow) over library_artist_view, which does
+            not carry the column until the BS#2129 migration adds it.
         code_letters:
           type: string
         code_artist_number:
@@ -419,6 +433,14 @@ components:
       properties:
         id:
           type: integer
+        legacy_release_id:
+          type: integer
+          nullable: true
+          description: >-
+            BS#2128. Null for a library-unlinked rotation row — getRotationFromDB
+            LEFT JOINs library, so there is no library row to source the id from.
+            The only one of the four flowsheet-consumed reads that can be null;
+            the others inner-join library and always carry a value.
         code_letters:
           type: string
         code_artist_number:
@@ -468,6 +490,9 @@ components:
       properties:
         album_id:
           type: integer
+        legacy_release_id:
+          type: integer
+          description: BS#2128. Non-null — getBinFromDB inner-joins library.
         album_title:
           type: string
         artist_name:

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,7 +25,7 @@
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
     "@wxyc/observability": "^1.0.0",
-    "@wxyc/shared": "^3.3.0",
+    "@wxyc/shared": "^3.5.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.19.0",

--- a/apps/backend/services/djs.service.ts
+++ b/apps/backend/services/djs.service.ts
@@ -44,6 +44,9 @@ export const getBinFromDB = async (dj_id: string) => {
       code_number: library.code_number,
       format_name: format.format_name,
       genre_name: genres.genre_name,
+      // BS#2128: `library` is inner-joined below, so every bin row resolves
+      // to a real library row — this is never a synthetic/absent id.
+      legacy_release_id: library.legacy_release_id,
     })
     .from(bins)
     .innerJoin(library, eq(bins.album_id, library.id))

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -300,6 +300,10 @@ export interface Rotation {
   rotation_bin: 'S' | 'L' | 'M' | 'H' | 'N';
   rotation_kill_date: string | null;
   plays: number | null;
+  // Nullable (unlike AlbumSearchResult/BinLibraryDetails/AlbumInfoResponse,
+  // all of which guarantee a real library row): a library-unlinked rotation
+  // row has no library row at all, hence no legacy id (BS#2128).
+  legacy_release_id: number | null;
   reconciled_identity: ReconciledIdentity | null;
 }
 
@@ -397,6 +401,7 @@ export const getRotationFromDB = async (): Promise<Rotation[]> => {
       ${rotation.rotation_bin} AS rotation_bin,
       ${rotation.kill_date} AS rotation_kill_date,
       ${library.plays} AS plays,
+      ${library.legacy_release_id} AS legacy_release_id,
       ${artists.discogs_artist_id} AS discogs_artist_id,
       ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
       ${artists.wikidata_qid} AS wikidata_qid,
@@ -1345,6 +1350,9 @@ const LIBRARY_VIEW_PROJECTION = {
   apple_music_artist_id: artists.apple_music_artist_id,
   bandcamp_id: artists.bandcamp_id,
   artist_id: library.artist_id,
+  // BS#2128: the library row's surrogate key. `library` is INNER JOINed at
+  // the top of this projection's join chain, so it's always populated here.
+  legacy_release_id: library.legacy_release_id,
   // BS#1895 (Not-on-Discogs epic #1280 sub-issue 5): serialize the MD-set
   // flag onto every catalog read surface. `serializeLibraryArtistViewEntry`
   // renames these to camelCase at the wire boundary, matching the
@@ -1399,6 +1407,7 @@ const LIBRARY_VIEW_PROJECTION_RAW = sql`
   ${artists.apple_music_artist_id} AS apple_music_artist_id,
   ${artists.bandcamp_id} AS bandcamp_id,
   ${library.artist_id} AS artist_id,
+  ${library.legacy_release_id} AS legacy_release_id,
   ${library.discogs_unavailable} AS discogs_unavailable,
   ${library.discogs_unavailable_note} AS discogs_unavailable_note,
   ${library.last_discogs_recheck_at} AS last_discogs_recheck_at
@@ -2203,6 +2212,9 @@ export const getAlbumFromDB = async (album_id: number) => {
       spotify_artist_id: artists.spotify_artist_id,
       apple_music_artist_id: artists.apple_music_artist_id,
       bandcamp_id: artists.bandcamp_id,
+      // BS#2128: `library` is inner-joined below and this reads by
+      // `library.id` directly, so the row (and its legacy id) always exists.
+      legacy_release_id: library.legacy_release_id,
       // BS#1895: album-detail read surface (GET /library/info?album_id= —
       // the "GET /library/:id" surface in the issue's terms).
       discogs_unavailable: library.discogs_unavailable,
@@ -2521,11 +2533,10 @@ async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<Tagge
   const legacyIds = items.map((item) => item.library_item?.id).filter((id): id is number => typeof id === 'number');
   if (legacyIds.length === 0) return [];
 
-  // Read the view shape plus legacy_release_id so we can re-order BS rows in
-  // LML's response order below. legacy_release_id is not in
-  // LIBRARY_VIEW_PROJECTION because the public view doesn't expose it.
+  // Read the view shape, which carries legacy_release_id (BS#2128), so we
+  // can re-order BS rows in LML's response order below.
   const rows = (await db
-    .select({ ...LIBRARY_VIEW_PROJECTION, legacy_release_id: library.legacy_release_id })
+    .select(LIBRARY_VIEW_PROJECTION)
     .from(library)
     .innerJoin(artists, eq(artists.id, library.artist_id))
     .innerJoin(format, eq(format.id, library.format_id))
@@ -2545,7 +2556,7 @@ async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<Tagge
     // Bound by the LML response size (already capped server-side). The
     // wrapper trims to caller's `limit` post-cache so the cached entry can
     // serve any smaller caller-`limit` from a single LML + JOIN round-trip.
-    .limit(legacyIds.length)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number | null }>;
+    .limit(legacyIds.length)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number }>;
 
   // CTA-covered library rows are Track 1's responsibility; filter them out so
   // the read layer doesn't double-surface compilations alongside curated CTA
@@ -2568,7 +2579,7 @@ async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<Tagge
   const ctaCovered = new Set(ctaRows.map((r) => r.library_id));
 
   // Index BS rows by legacy_release_id so we can emit them in LML's order.
-  const rowsByLegacyId = new Map<number, LibraryArtistViewEntry & { legacy_release_id: number | null }>();
+  const rowsByLegacyId = new Map<number, LibraryArtistViewEntry & { legacy_release_id: number }>();
   for (const row of rows) {
     if (row.legacy_release_id != null) {
       rowsByLegacyId.set(row.legacy_release_id, row);
@@ -2582,8 +2593,7 @@ async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<Tagge
     const row = rowsByLegacyId.get(legacyId);
     if (!row) continue;
     if (ctaCovered.has(row.id)) continue;
-    const { legacy_release_id: _legacy, ...viewRow } = row;
-    const tagged: TaggedLibraryViewEntry = { ...viewRow };
+    const tagged: TaggedLibraryViewEntry = { ...row };
     if (item.matched_via && item.matched_via.length > 0) {
       tagged.matched_via = item.matched_via;
     }
@@ -2888,6 +2898,7 @@ export async function searchLibraryByCTARaw(
         ${artists.spotify_artist_id} AS spotify_artist_id,
         ${artists.apple_music_artist_id} AS apple_music_artist_id,
         ${artists.bandcamp_id} AS bandcamp_id,
+        ${library.legacy_release_id} AS legacy_release_id,
         ${compilation_track_artist.track_title} AS cta_track_title,
         ${compilation_track_artist.artist_name} AS cta_artist_name,
         DENSE_RANK() OVER (ORDER BY ${library.id}) AS library_rank

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
         "@wxyc/observability": "^1.0.0",
-        "@wxyc/shared": "^3.3.0",
+        "@wxyc/shared": "^3.5.0",
         "better-auth": "^1.6.26",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -111,7 +111,7 @@
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
         "@wxyc/observability": "^1.0.0",
-        "@wxyc/shared": "^3.3.0",
+        "@wxyc/shared": "^3.5.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.19.0",
@@ -6428,10 +6428,10 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "3.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.3.0/59a732ace25762ee1162961d66c00dd7b8faf10e",
-      "integrity": "sha512-sWw3UI/y8utojUBUM6IJy7W26AEIillxftGFmq0vOCrH56lyXO2tTthrTDQz5aLWTZ/weNYhjCa8HN/RizEdEQ==",
-      "license": "MIT",
+      "version": "3.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.5.0/7fcc3eaf9c87383cc82d2c7f90a87bbdee77becc",
+      "integrity": "sha512-R8ziGiqNbJNuhiedSWgq+xaNYRE+Wwvo9Gl2kyQG4tqS9+pA9ig/CT/F4oiIPnehV5Blvt8QbWrfgU4bExjCrQ==",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "date-fns": "^4.4.0"
       },
@@ -14683,7 +14683,7 @@
         "@aws-sdk/client-ses": "^3.1106.0",
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^3.3.0",
+        "@wxyc/shared": "^3.5.0",
         "better-auth": "^1.6.26",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -14730,7 +14730,7 @@
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
-        "@wxyc/shared": "^3.3.0"
+        "@wxyc/shared": "^3.5.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1106.0",
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^3.3.0",
+    "@wxyc/shared": "^3.5.0",
     "better-auth": "^1.6.26",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -2356,6 +2356,10 @@ export type LibraryArtistViewEntry = {
   apple_music_artist_id: string | null;
   bandcamp_id: string | null;
   artist_id: number;
+  // Optional (not on `library_artist_view` until #2129 adds the column to
+  // the view itself); every base-table projection that populates this type
+  // today (BS#2128) always supplies it, since each inner-joins `library`.
+  legacy_release_id?: number | null;
   discogs_unavailable: boolean;
   discogs_unavailable_note: string | null;
   last_discogs_recheck_at: Date | null;

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.69.0",
-    "@wxyc/shared": "^3.3.0"
+    "@wxyc/shared": "^3.5.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/tests/integration/library-legacy-release-id-exposure.spec.js
+++ b/tests/integration/library-legacy-release-id-exposure.spec.js
@@ -1,0 +1,272 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+const { getTestDb } = require('../utils/db');
+const { isMockApiAvailable } = require('../utils/mock_api');
+
+/**
+ * Integration coverage for BS#2128: `library.legacy_release_id` is exposed
+ * on every catalog read surface dj-site's flowsheet picker consumes.
+ *
+ * Four request shapes, per the issue's test plan — none substitutes for
+ * another, since each exercises a distinct site in library.service.ts:
+ *
+ *   1. Distinct artist_name/album_title on GET /library/ — the dominant
+ *      dj-site flowsheet path (libraryViewQuery -> LIBRARY_VIEW_PROJECTION).
+ *   2. Both-mode UNION ALL arms on GET /library/ (identical artist_name and
+ *      album_title, tsvector miss, alias flag on) — LIBRARY_VIEW_PROJECTION_RAW
+ *      on both arms. A column mismatch between the two arms is a Postgres
+ *      "each UNION query must have the same number of columns" error, so a
+ *      plain 200 here is itself part of the assertion.
+ *   3. Cascade-sourced rows (CTA / LML `/lookup`) with the CTA/LML flags on,
+ *      reached when the primary + trigram paths return 0 hits.
+ *   4. Rotation (linked -> value, unlinked -> null), bin, and
+ *      GET /library/info.
+ *
+ * Reuses the Track 2 fixture (tests/fixtures/shape.sql "Track 2" block,
+ * mirrored in tests/fixtures/track-search.fixture.ts) for shapes 1, 3, and
+ * part of 4, since those rows carry known, explicit `legacy_release_id`
+ * values (65880/65881/65882) - no extra DB round-trip needed to learn the
+ * expected value. Shape 2 seeds its own artist/library/alias rows (id 9410)
+ * because it needs a query that tsvector- and trigram-misses the real
+ * artist_name/album_title but alias-hits a variant.
+ */
+
+const CONFIELD = {
+  libraryId: 7100,
+  legacyReleaseId: 65880,
+};
+const CTA_COLLISION = {
+  libraryId: 7102,
+  legacyReleaseId: 65882,
+};
+const QUERIES = {
+  CONFIELD_TRACK: 'vi scose poise',
+  CTA_COLLISION_TRACK: 'wbtr2x cmprs 9azn5',
+};
+
+// Shape 2 fixture — outside the 7000-7199 shape.sql range and the 9001/9101/
+// 9102/9200s/9301s ranges other integration specs already use.
+const ALIAS_ARTIST_ID = 9410;
+const ALIAS_LIBRARY_ID = 9410;
+const ALIAS_LEGACY_RELEASE_ID = 66020;
+const ALIAS_GENRE_ID = 11; // Rock - seeded by dev_env/seed_db.sql
+const ALIAS_FORMAT_ID = 1; // CD - seeded by dev_env/seed_db.sql
+const ALIAS_ARTIST_NAME = 'Zqxvbn Fixture Core';
+const ALIAS_ALBUM_TITLE = 'Nonlexical Fixture Album';
+// Nonce phrase: shares no token with any seeded artist_name/album_title, so
+// it tsvector- and trigram-misses the real row and can only be found via the
+// artist_search_alias variant below.
+const ALIAS_VARIANT = 'Vzbrqk Qmplex Xyzintheta';
+
+const mockApiConfigured = !!process.env.MOCK_API_URL;
+const describeWhenMockConfigured = mockApiConfigured ? describe : describe.skip;
+
+describe('legacy_release_id exposure (BS#2128)', () => {
+  let auth;
+  let sql;
+  const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+  });
+
+  // --------------------------------------------------------------------
+  // Shape 1: distinct artist_name/album_title (dominant dj-site path)
+  // --------------------------------------------------------------------
+  describe('GET /library/ with distinct artist_name/album_title', () => {
+    test('returns legacy_release_id on the library row (LIBRARY_VIEW_PROJECTION)', async () => {
+      const [expected] = await sql.unsafe(`SELECT legacy_release_id FROM ${wxycSchema}.library WHERE id = 7000`);
+      expect(expected.legacy_release_id).toEqual(expect.any(Number));
+
+      const res = await auth
+        .get('/library/')
+        .query({ artist_name: 'Shape Fixture Artist Alpha', album_title: 'Totally Unmatched Nonce Title' })
+        .expect(200);
+
+      const hit = res.body.find((row) => row.id === 7000);
+      expect(hit).toBeDefined();
+      expect(hit.legacy_release_id).toBe(expected.legacy_release_id);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Shape 2: both-mode UNION ALL arms, tsvector miss, alias-only hit
+  // --------------------------------------------------------------------
+  describe('GET /library/ both-mode UNION ALL arms (alias-only hit)', () => {
+    beforeAll(async () => {
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1`, [ALIAS_ARTIST_ID]);
+      await sql.unsafe(
+        `INSERT INTO ${wxycSchema}.artists (id, artist_name, alphabetical_name, code_letters)
+         VALUES ($1, $2, $2, 'ZQ')
+         ON CONFLICT (id) DO NOTHING`,
+        [ALIAS_ARTIST_ID, ALIAS_ARTIST_NAME]
+      );
+      await sql.unsafe(
+        `INSERT INTO ${wxycSchema}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+         VALUES ($1, $2, 941)
+         ON CONFLICT (artist_id, genre_id) DO NOTHING`,
+        [ALIAS_ARTIST_ID, ALIAS_GENRE_ID]
+      );
+      await sql.unsafe(
+        `INSERT INTO ${wxycSchema}.library
+           (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id, legacy_release_id)
+         VALUES ($1, $2, $3, $4, $5, 1, $6, NULL, NULL, $7)
+         ON CONFLICT (id) DO NOTHING`,
+        [
+          ALIAS_LIBRARY_ID,
+          ALIAS_ARTIST_ID,
+          ALIAS_GENRE_ID,
+          ALIAS_FORMAT_ID,
+          ALIAS_ALBUM_TITLE,
+          ALIAS_ARTIST_NAME,
+          ALIAS_LEGACY_RELEASE_ID,
+        ]
+      );
+    });
+
+    afterAll(async () => {
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1`, [ALIAS_ARTIST_ID]);
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.library WHERE id = $1`, [ALIAS_LIBRARY_ID]);
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.genre_artist_crossreference WHERE artist_id = $1`, [ALIAS_ARTIST_ID]);
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.artists WHERE id = $1`, [ALIAS_ARTIST_ID]);
+    });
+
+    test('control: without an alias row, the variant query misses entirely', async () => {
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1`, [ALIAS_ARTIST_ID]);
+
+      const res = await auth
+        .get('/library/')
+        .query({ artist_name: ALIAS_VARIANT, album_title: ALIAS_VARIANT })
+        .expect(200);
+
+      expect(res.body.find((row) => row.id === ALIAS_LIBRARY_ID)).toBeUndefined();
+    });
+
+    test('with the alias row seeded, both UNION arms stay column-aligned and legacy_release_id rides through', async () => {
+      await sql.unsafe(
+        `INSERT INTO ${wxycSchema}.artist_search_alias
+           (artist_id, source, variant, related_artist_id, external_subject_id,
+            external_object_id, active, method, confidence, last_verified_at)
+         VALUES ($1, 'discogs_name_variation', $2, NULL, NULL, NULL, NULL, 'name_variation', 0.95, NOW())
+         ON CONFLICT (artist_id, source, variant) DO UPDATE SET last_verified_at = NOW()`,
+        [ALIAS_ARTIST_ID, ALIAS_VARIANT]
+      );
+
+      // A 200 here already proves the two UNION ALL arms in
+      // searchLibraryByTrigramBoth (LIBRARY_VIEW_PROJECTION_RAW on both) have
+      // the same column count post-fix; a mismatch is a Postgres error, not a
+      // wrong answer.
+      const res = await auth
+        .get('/library/')
+        .query({ artist_name: ALIAS_VARIANT, album_title: ALIAS_VARIANT })
+        .expect(200);
+
+      const hit = res.body.find((row) => row.id === ALIAS_LIBRARY_ID);
+      if (hit === undefined) {
+        console.warn(
+          '[BS#2128] Alias-only hit absent. Likely the backend is running without ' +
+            'CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart `npm run dev`.'
+        );
+        return;
+      }
+      expect(hit.matched_via_alias).toBeDefined();
+      expect(hit.legacy_release_id).toBe(ALIAS_LEGACY_RELEASE_ID);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Shape 3: cascade-sourced rows (CTA / LML) with the flags on
+  // --------------------------------------------------------------------
+  describe('GET /library/ catalog-track-search cascade', () => {
+    test('CTA-sourced hit (Track 1, searchLibraryByCTARaw) carries legacy_release_id', async () => {
+      const res = await auth
+        .get('/library/')
+        .query({ artist_name: QUERIES.CTA_COLLISION_TRACK, album_title: QUERIES.CTA_COLLISION_TRACK })
+        .expect(200);
+
+      const hit = res.body.find((row) => row.id === CTA_COLLISION.libraryId);
+      if (hit === undefined) {
+        console.warn(
+          '[BS#2128] CTA cascade hit absent. Likely the backend is running without ' +
+            'CATALOG_TRACK_SEARCH_CTA_ENABLED=true. Set it in .env and restart `npm run dev`.'
+        );
+        return;
+      }
+      expect(hit.legacy_release_id).toBe(CTA_COLLISION.legacyReleaseId);
+    });
+
+    describeWhenMockConfigured('with mock LML available', () => {
+      beforeAll(async () => {
+        if (!(await isMockApiAvailable())) {
+          throw new Error(
+            'MOCK_API_URL is set but mock-api-server is unreachable; cannot run mock-LML-dependent tests'
+          );
+        }
+      });
+
+      test('LML-bridged hit (Track 2, searchLibraryByTrackUncachedOrThrow) carries legacy_release_id', async () => {
+        const res = await auth
+          .get('/library/')
+          .query({ artist_name: QUERIES.CONFIELD_TRACK, album_title: QUERIES.CONFIELD_TRACK })
+          .expect(200);
+
+        const hit = res.body.find((row) => row.id === CONFIELD.libraryId);
+        if (hit === undefined) {
+          console.warn(
+            '[BS#2128] Track 2 cascade hit absent. Likely the backend is running without ' +
+              'CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=true. Set it in .env and restart `npm run dev`.'
+          );
+          return;
+        }
+        // Pins the site 7 fix: searchLibraryByTrackUncachedOrThrow used to
+        // select legacy_release_id purely for internal re-ordering and then
+        // destructure it away before returning the row.
+        expect(hit.legacy_release_id).toBe(CONFIELD.legacyReleaseId);
+      });
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Shape 4: rotation (linked/unlinked), bin, GET /library/info
+  // --------------------------------------------------------------------
+  describe('rotation, bin, and album-info', () => {
+    test('GET /library/rotation: linked row carries legacy_release_id, unlinked row carries null', async () => {
+      const [linkedLibrary] = await sql.unsafe(`SELECT legacy_release_id FROM ${wxycSchema}.library WHERE id = 7003`);
+      expect(linkedLibrary.legacy_release_id).toEqual(expect.any(Number));
+
+      const res = await auth.get('/library/rotation').expect(200);
+
+      // rotation.id=7012 -> album_id=7003, a non-duplicated (album_id,
+      // rotation_bin) group in the shape fixture, so it survives the
+      // DISTINCT ON collapse under its own rotation_id.
+      const linked = res.body.find((row) => row.rotation_id === 7012);
+      expect(linked).toBeDefined();
+      expect(linked.legacy_release_id).toBe(linkedLibrary.legacy_release_id);
+
+      // rotation.id=7008 -> album_id IS NULL ("Shape Fixture Orphan Two"),
+      // also a non-duplicated hash-partition group, so it survives under its
+      // own rotation_id with no library row to resolve a legacy id from.
+      const unlinked = res.body.find((row) => row.rotation_id === 7008);
+      expect(unlinked).toBeDefined();
+      expect(unlinked.legacy_release_id).toBeNull();
+    });
+
+    test('GET /djs/bin: bin row carries legacy_release_id (library is always inner-joined)', async () => {
+      await auth.post('/djs/bin').send({ album_id: CONFIELD.libraryId }).expect(201);
+      try {
+        const res = await auth.get('/djs/bin').expect(200);
+        const hit = res.body.find((row) => row.album_id === CONFIELD.libraryId);
+        expect(hit).toBeDefined();
+        expect(hit.legacy_release_id).toBe(CONFIELD.legacyReleaseId);
+      } finally {
+        await auth.delete('/djs/bin').query({ album_id: CONFIELD.libraryId });
+      }
+    });
+
+    test('GET /library/info: album-detail row carries legacy_release_id', async () => {
+      const res = await auth.get('/library/info').query({ album_id: CONFIELD.libraryId }).expect(200);
+      expect(res.body.legacy_release_id).toBe(CONFIELD.legacyReleaseId);
+    });
+  });
+});

--- a/tests/unit/scripts/ci-env-surface-parity.test.ts
+++ b/tests/unit/scripts/ci-env-surface-parity.test.ts
@@ -52,13 +52,12 @@ const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
  * step). Each entry must be justified.
  */
 const EXPECTED_ONLY_IN_COMPOSE = [
-  // Why: backend-side feature flags that activate the full track-search
-  // fallback cascade in `tests/integration/library.spec.js` (Track 1 = CTA,
-  // Track 2 = LML cross-ref). The workflow path doesn't set these; whether
-  // that's a coverage gap on the workflow path is tracked separately and
-  // out of scope for this guard.
-  'CATALOG_TRACK_SEARCH_CTA_ENABLED',
-  'CATALOG_TRACK_SEARCH_DISCOGS_ENABLED',
+  // BS#2128 closed the CATALOG_TRACK_SEARCH_{CTA,DISCOGS}_ENABLED divergence
+  // that used to sit here — the workflow now mirrors both, per this guard's
+  // "preferred: mirror the var into the other surface" remedy. The coverage
+  // gap the old `Why:` deferred was real: with the flags unset, the cascade
+  // cases in library-legacy-release-id-exposure.spec.js warn-skipped and
+  // passed vacuously on GHA while passing for real under `ci:testmock`.
 
   // Why: AWS Cognito identifiers from the legacy auth flow. Compose sets
   // them via `.env` substitution; backend defaults work in the workflow's


### PR DESCRIPTION
## Summary

Emits `library.legacy_release_id` on every response surface dj-site's flowsheet picker consumes: flowsheet search (`GET /library/`), rotation, bin, the catalog-track-search cascade stages, and album detail (`GET /library/info`). No DDL — the `/library/query` view path is the separate migration #2129 and deliberately stays untouched here.

Bumps `@wxyc/shared` from `^3.3.0` to `^3.5.0` (WXYC/wxyc-shared#340, published 3.5.0) across `apps/backend`, `apps/auth`, `shared/authentication`, `shared/lml-client` — the contract types (`legacy_release_id` on `AlbumSearchResult`, `AlbumInfoResponse`, `BinLibraryDetails`, `Rotation`) shipped there.

### Nine sites

1. `LibraryArtistViewEntry` (`shared/database/src/schema.ts`) — `legacy_release_id?: number | null`, optional. `library_artist_view` itself doesn't carry the column until #2129; this keeps the type honest for `/library/query` reads while every base-table projection below always supplies it.
2. `Rotation` (`library.service.ts`) — added as `number | null` (not optional — the wire type controls optionality; this internal type is always populated by the SELECT).
3. `LIBRARY_VIEW_PROJECTION` (`library.service.ts`) — the flowsheet-search path.
4. `LIBRARY_VIEW_PROJECTION_RAW` — its raw-SQL mirror, used by both UNION ALL arms in the both-mode alias search. Same relative position in both projections keeps the arms column-for-column aligned.
5. `getRotationFromDB`'s SELECT list.
6. `getBinFromDB` (`djs.service.ts`).
7. `searchLibraryByTrackUncachedOrThrow` (the LML `/lookup` bridge) — this one already selected the column (bolted onto `LIBRARY_VIEW_PROJECTION` for internal re-ordering) and then explicitly destructured it away before returning. Removed the now-redundant bolt-on (site 3 covers it) and the strip.
8. `searchLibraryByCTARaw` — hand-written SELECT list, added the column.
9. `getAlbumFromDB` (`GET /library/info`) — hand-written SELECT, response type `AlbumInfoResponse`.

### Nullability resolution (per the issue's review-comment constraint)

`legacy_release_id` is non-nullable on the wire for `AlbumSearchResult`, `AlbumInfoResponse`, and `BinLibraryDetails`, and nullable only on `Rotation`. For every site feeding the first three types, **resolution 1 applies (guarantee non-null at the query layer)**:

- `LIBRARY_VIEW_PROJECTION` / `LIBRARY_VIEW_PROJECTION_RAW`: `library` is INNER JOINed at the top of the join chain (sites 3, 4, 7 all build on this).
- `getBinFromDB`: INNER JOINs `library` on `bins.album_id = library.id`.
- `getAlbumFromDB`: INNER JOINs `library` and reads by `library.id` directly.
- `searchLibraryByCTARaw`: INNER JOINs `library` on `compilation_track_artist.library_id`.

None of these can emit a row without a real, joined `library` row, so `legacy_release_id` (NOT NULL since migration 0137) is never null on these four wire shapes.

For `Rotation` (site 5, `getRotationFromDB`), the join to `library` is a LEFT JOIN by design — tubafrenzy permits rotation rows with no linked library row, and the wire type is nullable specifically for this case. No resolution needed there; this is the expected/documented nullable case.

### Pre-existing drift noted, not fixed (out of scope)

`searchLibraryByCTARaw`'s hand-written SELECT list was already missing the three `discogs_unavailable*` columns `LIBRARY_VIEW_PROJECTION` has carried since #1895. Left as-is per the issue's guidance to flag rather than fix in this PR. A second reviewer noted the same function also omits `artist_id`, and that its rows are cast as if the projection were complete — so `discogsUnavailable` silently serializes away on cascade rows. Same silent-omission class this issue exists to fix, recurring in the same function; still out of scope here.

### Swagger docs

`apps/backend/app.yaml` documented all four changed surfaces without the field they now return. Added to `Album` (`GET /library/info` and the `PATCH /library/{id}` 200 — both route through the changed `getAlbumFromDB`), `AlbumView`, `Rotation` (the only one marked `nullable`, matching the LEFT JOIN), and `BinLibraryDetails`, mirroring the BS#1965 precedent on `CatalogExportRow`. `AlbumView` carries an explicit caveat: it is shared by `GET /library` (has the field) and `GET /library/query` (does not, until BS#2129). Display-only, not a codegen source.

## Test plan

- [x] `npm run test:unit` — 7271 passed (one unrelated suite hit a jest-worker SIGSEGV on the first run; re-ran in isolation and it passed cleanly — a flaky worker crash, not a regression from this change).
- [x] `npm run lint` — 0 errors (pre-existing warnings only).
- [x] `npm run format:check` — clean.
- [x] `npm run typecheck` — clean across all workspaces.
- [ ] **Integration tests were written but NOT run** — `tests/integration/library-legacy-release-id-exposure.spec.js` needs a live stack (`npm run db:start` + mock LML), which isn't available in this worktree. The spec covers the four request shapes from the issue's test plan:
  1. Distinct `artist_name`/`album_title` on `GET /library/` (site 3).
  2. Both-mode UNION ALL arms with a tsvector miss and an alias-only hit (own fixture rows, id 9410) — a column mismatch between the two arms would surface as a Postgres "each UNION query must have the same number of columns" error, so the 200 assertion itself is part of the coverage.
  3. Cascade-sourced rows via the existing Track 2 fixture (CTA hit on `searchLibraryByCTARaw`, LML hit on `searchLibraryByTrackUncachedOrThrow` — gated on mock LML availability).
  4. Rotation linked (value) vs. unlinked (null), bin, and `GET /library/info`.
- [x] Cascade coverage on gating CI: `CATALOG_TRACK_SEARCH_CTA_ENABLED` + `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED` are now set in the `Integration-Tests` job (`.github/workflows/test.yml`). Both are strict-`'true'` gated and default false, so before this the shape-3 cases took their warn-and-return branch and passed vacuously on GHA — leaving site 7 (`searchLibraryByTrackUncachedOrThrow`), the one place the column was actively being destructured away, with no gating test. `dev_env/docker-compose.yml` already defaulted both to true, so `npm run ci:testmock` was exercising them; this closes the GHA-vs-compose drift, the same remedy BS#1383 applied to `CATALOG_SEARCH_ALIAS_ENABLED`. The BS#958 parity guard's allowlist entry for these two keys — whose `Why:` line deferred exactly this question — is removed accordingly.
- [ ] `wxyc-shared`'s `e2e/contract/openapi-compliance.test.ts` needs no BS-side change — it validates responses generically against whatever `api.yaml` declares, and the schema landed in the already-merged wxyc-shared#340. **But that genericity is also a gap worth naming:** `legacy_release_id` is deliberately *optional* on `AlbumSearchResult` / `AlbumInfoResponse` / `BinLibraryDetails` (the rollout-window choice from wxyc-shared#340), so a response that simply omits the field validates clean. The compliance gate can catch a wrong *type* or an illegal explicit `null`, but not the field going missing. Combined with the integration coverage above, that means a future regression dropping the field is caught by the BS integration suite and by nothing else — the contract check will not save us. Landing an explicit presence assertion in wxyc-shared is the durable fix; until then, treat the #1184 prod-probe checklist as a real gate rather than a formality.
- [ ] Deploy + prod verification is called out in the issue as part of done; this PR is the code change only.

Closes #2128
