### PR TITLE
Add data-driven compilation_track_artist U+FFFD repair script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,16 @@ jobs:
               # tests/integration/bs-2117-crossreference-backfill.spec.js reads
               # (BS#2117 — its resolver + INSERT are executed verbatim):
               - 'scripts/audit/bs_2117_crossref_backfill.sql'
+              # tests/integration/bs-replacement-char-cta.spec.js reads
+              # (BS#2152 — every STMT block is executed verbatim). This one is
+              # load-bearing beyond the usual drift guard: the script ships
+              # with an empty PENDING CAPTURE block, and the spec's
+              # "no quoted string literals" test is the gate that forces
+              # whoever pastes the 14 real rows to add the deferred
+              # byte-exact codepoint assertion in the same change. That gate
+              # only fires if editing the .sql runs the integration suite —
+              # and the paste PR touches nothing but scripts/audit/:
+              - 'scripts/audit/bs_replacement_char_cta.sql'
             db-init:
               - 'dev_env/Dockerfile.init'
               - 'dev_env/init-db.mjs'

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -50,12 +50,12 @@
 -- ============================================================================
 -- OPERATOR-ERROR GUARDS (PR #2154 review)
 -- ============================================================================
--- Nine DO-block guards (five from round 1, two from round 2, two from
--- round 3) run before the corresponding mistake can do damage -- or, for the
--- last one, before a damaged outcome can be COMMITted -- each aborting loudly
--- (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here stops the whole psql
--- run with a nonzero exit and no partial write). Listed in the order they
--- actually run:
+-- Ten DO-block guards (five from round 1, two from round 2, two from
+-- round 3, one from round 4) run before the corresponding mistake can do
+-- damage -- or, for the last two, before a damaged outcome can be COMMITted --
+-- each aborting loudly (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here
+-- stops the whole psql run with a nonzero exit and no partial write). Listed
+-- in the order they actually run:
 --
 --   guard-placeholder-scrub      -- a captured row with a blank
 --                                    legacy_release_id survived the
@@ -213,6 +213,24 @@
 --                                    most one live row can hold that tuple,
 --                                    so this cannot be tripped by an
 --                                    unrelated row.
+--   guard-post-write-nfc-duplicate -- (round 4; runs AFTER guard-repair-complete,
+--                                    still inside the transaction) no two rows
+--                                    within a library_id this run touched are
+--                                    NFC-equal but byte-distinct on
+--                                    (artist_name, track_title). This is the
+--                                    belt-and-braces half of the round 4 fix
+--                                    below: build-targets' twin join now folds
+--                                    to NFC specifically to stop THIS class of
+--                                    duplicate from being created, but this
+--                                    guard checks the outcome directly rather
+--                                    than trusting that the join is the only
+--                                    place such a duplicate could arise --
+--                                    including one that predates this run
+--                                    entirely and simply happened to sit in a
+--                                    library_id this run also touched. See
+--                                    "Unicode normalization" and build-targets'
+--                                    own comment below for the failure mode
+--                                    this closes.
 --
 -- ============================================================================
 -- WHY THIS SCRIPT IS DATA-DRIVEN, NOT LITERAL LIKE ITS PREDECESSORS
@@ -480,11 +498,39 @@
 -- upstream. This script substitutes the tubafrenzy-verified exact original,
 -- not a fuzzy/plausible reconstruction.
 --
--- Unicode normalization: deliberately NOT applied, matching Phase 4's
--- posture (not Phase 2/3.5's). The true values here are copied byte-for-byte
--- out of tubafrenzy, and the catalog-parity harness that surfaced this issue
--- compares byte-exact with no accent/case folding -- normalizing on write is
--- the one thing that could reintroduce a parity mismatch.
+-- Unicode normalization: deliberately NOT applied to writes, matching Phase
+-- 4's posture (not Phase 2/3.5's). The true values here are copied
+-- byte-for-byte out of tubafrenzy, and the catalog-parity harness that
+-- surfaced this issue compares byte-exact with no accent/case folding, so
+-- normalizing what gets WRITTEN is the one thing that could reintroduce a
+-- parity mismatch.
+--
+-- Round 4 adds a narrow exception on the READ side only: twin DETECTION in
+-- build-targets, and the matching re-checks in delete-twins and
+-- repoint-twin-identity, compare `normalize(x, NFC)` rather than raw bytes.
+-- guard-nfc-form pins every captured true_* replacement to NFC, but this
+-- table carries no such invariant on its LIVE rows the way `artists` does
+-- (fold_artist_name, migration 0134) -- a genuinely NFD-stored live twin is
+-- possible, and byte-exact comparison silently missed it: an NFD clean twin
+-- against an NFC capture failed to match, the row classified no-twin,
+-- update-no-twins wrote the NFC value in place, and the table ended up
+-- holding two rows for one credit differing only in composition form --
+-- cta_unique_idx never fired (the bytes genuinely differ) and the postlude's
+-- U+FFFD residual read 0/0, because the corruption really was gone; what was
+-- left behind was a duplicate, not a U+FFFD. See build-targets' own comment
+-- below for the full account, and guard-post-write-nfc-duplicate above for
+-- the belt-and-braces check on the outcome.
+--
+-- Detection widens; writes do not. The three write statements still write
+-- the captured byte-exact true_*/cta.* values verbatim, never a normalized
+-- form -- COALESCE(p.true_artist_name, cta.artist_name) and its track_title
+-- counterpart are untouched by this change. `normalize()` runs only over
+-- this script's small, pending-row-scoped temp tables (`cta_repair_targets`
+-- and guard-post-write-nfc-duplicate's touched-library_id scan) -- never the
+-- two full-table BEFORE/AFTER residual scans, which stay a plain
+-- `LIKE E'%�%'` so they remain servable without a functional index (see
+-- their own comments on why that 1-character leading wildcard is already an
+-- unavoidable sequential scan).
 --
 -- Sequencing vs #1996: both rewrite CTA rows. #1996 is large and blocked on
 -- `library-etl` stopping; this repair is small, frozen residue, and
@@ -864,6 +910,44 @@ SET LOCAL statement_timeout = '30s';
 -- Resolve every pending row against the live table and classify twin/no-twin
 -- by resolving the twin's own row id (not just its existence), carrying over
 -- its identity-link columns for the DELETE branch and the BEFORE print.
+--
+-- Twin detection folds to NFC (round 4 finding). guard-nfc-form pins every
+-- captured true_* value to NFC, but current_*/cta.artist_name/cta.track_title
+-- have no such invariant -- deliberately: this table has no fold trigger the
+-- way `artists` does (fold_artist_name, migration 0134), so a genuinely
+-- NFD-stored LIVE row is possible, and it is exactly the twin this join has
+-- to find. Byte-exact comparison here missed it: an NFD clean twin against an
+-- NFC capture failed to match, the row classified no-twin, update-no-twins
+-- wrote the NFC value in place, and the table ended up holding two rows for
+-- one credit -- differing only in composition form, so cta_unique_idx never
+-- fired (the bytes genuinely differ) and the postlude's U+FFFD residual read
+-- 0/0, because the corruption really was gone; what was left behind was a
+-- duplicate, not a U+FFFD.
+--
+-- `normalize(x, NFC)` (PG13+; prod is PG14 and migration 0134 already depends
+-- on it) folds ONLY this twin comparison -- the cta-side join two lines above
+-- (matching the CORRUPT row against its captured current_*) is deliberately
+-- untouched. The two joins fail differently on a form mismatch, and that
+-- asymmetry is intentional: a miss on the cta-side join drops the row into
+-- the unmatched listing in pending-match-preview above -- visible,
+-- informational, and already covered by that listing's current_is_non_nfc
+-- column -- while a miss on the twin-side join was silent AND wrote. Writes
+-- stay byte-exact: new_artist_name/new_track_title below still COALESCE onto
+-- the captured true_*/cta.* values verbatim, never a normalized form -- see
+-- "Unicode normalization" further down for the full posture.
+--
+-- Classification-semantics widening, called out rather than left for a
+-- reader to discover: a pending row whose NFC-folded post-fix tuple now
+-- matches an existing NFD twin takes the DELETE branch where, pre-fix, it
+-- would have taken UPDATE and produced a duplicate. That is the correct
+-- branch, not an incidental side effect -- deleting the corrupt row leaves
+-- the NFD clean twin as the sole surviving copy of the credit, its identity
+-- link is repointed onto that twin by repoint-twin-identity below, the
+-- U+FFFD is gone, and no byte-distinct duplicate is created. delete-twins and
+-- repoint-twin-identity's own re-checks below fold to NFC the same way, so
+-- they cannot disagree with this classification the way a byte-exact
+-- re-check against an NFC-folded match would (see each statement's own
+-- comment for what disagreeing would have looked like).
 DROP TABLE IF EXISTS pg_temp.cta_repair_targets;
 CREATE TEMP TABLE cta_repair_targets AS
 SELECT
@@ -894,8 +978,8 @@ JOIN wxyc_schema.compilation_track_artist cta
 LEFT JOIN wxyc_schema.compilation_track_artist twin
   ON twin.library_id = cta.library_id
  AND twin.id <> cta.id
- AND twin.artist_name = COALESCE(p.true_artist_name, cta.artist_name)
- AND twin.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title);
+ AND normalize(twin.artist_name, NFC) = normalize(COALESCE(p.true_artist_name, cta.artist_name), NFC)
+ AND normalize(twin.track_title, NFC) IS NOT DISTINCT FROM normalize(COALESCE(p.true_track_title, cta.track_title), NFC);
 -- === END STMT ===
 
 -- === STMT: lock-targets ===
@@ -1030,18 +1114,37 @@ END $$;
 -- documented-precedence merge of the two links) would trade a loud guard
 -- abort for a silent identity-link loss -- worse, not better. Narrow this
 -- guard and fix the repoint together, or leave both as they are.
+--
+-- Groups on `normalize(new_artist_name/new_track_title, NFC)` rather than the
+-- raw columns (round 4). Chosen deliberately, not the alternative of leaving
+-- this byte-exact: `new_artist_name`/`new_track_title` COALESCE onto
+-- `cta.artist_name`/`cta.track_title` for whichever column a pending row
+-- doesn't fix, and THAT column carries no NFC invariant (see "Unicode
+-- normalization" above) -- so two pending rows can converge on the same
+-- credit in a form-mismatched way with no true_* value involved at all. Two
+-- pending rows that converge only after NFC folding are the exact hazard this
+-- guard exists for -- differently-corrupted copies of one credit that would
+-- otherwise collide -- so leaving the grouping byte-exact would silently let
+-- that shape through to update-no-twins, where a real cta_unique_idx
+-- collision is no longer guaranteed (the two rows are NFC-equal, not
+-- byte-equal) and the failure mode reverts to the pre-fix duplicate this
+-- whole round exists to close, just reached from the converging-pending side
+-- instead of the twin-join side.
 DO $$
 DECLARE bad RECORD;
 BEGIN
   FOR bad IN
-    SELECT library_id, new_artist_name, new_track_title, COUNT(*) AS n,
+    SELECT library_id,
+           normalize(new_artist_name, NFC) AS new_artist_name_nfc,
+           normalize(new_track_title, NFC) AS new_track_title_nfc,
+           COUNT(*) AS n,
            array_agg(legacy_release_id ORDER BY legacy_release_id) AS release_ids,
            array_agg(track_position ORDER BY legacy_release_id) AS track_positions
       FROM cta_repair_targets
-     GROUP BY library_id, new_artist_name, new_track_title
+     GROUP BY library_id, normalize(new_artist_name, NFC), normalize(new_track_title, NFC)
     HAVING COUNT(*) > 1
   LOOP
-    RAISE EXCEPTION 'BS#2152 guard: % pending row(s) converge on the same post-fix library_id=% artist_name=% track_title=% (legacy_release_id/track_position pairs: %/%) -- two differently-corrupted copies of one credit would collide under cta_unique_idx on a single UPDATE; resolve which capture is correct (or whether one is a distinct real credit) before re-running', bad.n, bad.library_id, bad.new_artist_name, bad.new_track_title, bad.release_ids, bad.track_positions;
+    RAISE EXCEPTION 'BS#2152 guard: % pending row(s) converge on the same post-fix (NFC-folded) library_id=% artist_name=% track_title=% (legacy_release_id/track_position pairs: %/%) -- two differently-corrupted copies of one credit would collide under cta_unique_idx on a single UPDATE (or leave a form-mismatched duplicate behind, see the NFC folding note above); resolve which capture is correct (or whether one is a distinct real credit) before re-running', bad.n, bad.library_id, bad.new_artist_name_nfc, bad.new_track_title_nfc, bad.release_ids, bad.track_positions;
   END LOOP;
 END $$;
 -- === END STMT ===
@@ -1114,6 +1217,16 @@ SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_tra
 -- their own terms rather than relying on a downstream abort to clean up
 -- after them, which is what would matter to whoever next changes either the
 -- guard or the ordering.
+--
+-- The twin re-check folds to NFC (round 4), propagated from build-targets'
+-- own NFC-folded join above. Left byte-exact, an NFD twin would match
+-- build-targets' join, classify has_twin=true, and then fail THIS re-check
+-- (which requires the twin to still hold `new_artist_name`/`new_track_title`
+-- byte-for-byte) -- silently skipping the repoint. delete-twins' matching
+-- re-check below folds the same way, so both statements keep agreeing on
+-- whether the twin is still the row build-targets found; letting only one of
+-- them fold would reopen the exact "statements disagree" hazard the round 3
+-- lock-targets comment above describes for a different cause.
 UPDATE wxyc_schema.compilation_track_artist twin
    SET track_artist_id = COALESCE(twin.track_artist_id, t.old_track_artist_id),
        track_artist_link_confidence = COALESCE(twin.track_artist_link_confidence, t.old_track_artist_link_confidence),
@@ -1122,8 +1235,8 @@ UPDATE wxyc_schema.compilation_track_artist twin
   FROM cta_repair_targets t
  WHERE t.has_twin
    AND twin.id = t.twin_id
-   AND twin.artist_name = t.new_artist_name
-   AND twin.track_title IS NOT DISTINCT FROM t.new_track_title
+   AND normalize(twin.artist_name, NFC) = normalize(t.new_artist_name, NFC)
+   AND normalize(twin.track_title, NFC) IS NOT DISTINCT FROM normalize(t.new_track_title, NFC)
    AND EXISTS (
      SELECT 1 FROM wxyc_schema.compilation_track_artist cta
       WHERE cta.id = t.id
@@ -1154,6 +1267,17 @@ UPDATE wxyc_schema.compilation_track_artist twin
 -- it; this EXISTS covers the residual build-targets -> lock-targets window,
 -- where the honest answer is to skip the delete and let
 -- `guard-repair-complete` abort the whole transaction rather than guess.
+--
+-- The twin re-check folds to NFC (round 4), matching build-targets' own
+-- NFC-folded join and repoint-twin-identity's identical re-check above. This
+-- is load-bearing, not cosmetic: build-targets now classifies an NFD twin as
+-- has_twin=true, so if this re-check stayed byte-exact it would fail against
+-- that same NFD twin -- the DELETE would silently skip, and
+-- `guard-repair-complete` would then abort the whole run on a row that was
+-- actually classified correctly. Folding this predicate the same way the
+-- join folds is what converts "closed the join, reopened it here" back into
+-- a real fix; see build-targets' own comment for the full account of the
+-- defect this closes.
 DELETE FROM wxyc_schema.compilation_track_artist cta
 USING cta_repair_targets t
 WHERE cta.id = t.id
@@ -1163,8 +1287,8 @@ WHERE cta.id = t.id
   AND EXISTS (
     SELECT 1 FROM wxyc_schema.compilation_track_artist twin
      WHERE twin.id = t.twin_id
-       AND twin.artist_name = t.new_artist_name
-       AND twin.track_title IS NOT DISTINCT FROM t.new_track_title
+       AND normalize(twin.artist_name, NFC) = normalize(t.new_artist_name, NFC)
+       AND normalize(twin.track_title, NFC) IS NOT DISTINCT FROM normalize(t.new_track_title, NFC)
   );
 -- === END STMT ===
 
@@ -1226,6 +1350,56 @@ BEGIN
      )
   LOOP
     RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% (cta_id=% has_twin=% twin_id=%) still holds its corrupt tuple (artist_name=% track_title=%) after the write statements ran -- the repair for this row was SKIPPED, not applied; the usual cause is that its twin was deleted or renamed between build-targets and lock-targets, so delete-twins correctly declined rather than destroy the last copy of the credit. Rolling back; re-run the script to reclassify this row against current live state', bad.legacy_release_id, bad.track_position, bad.cta_id, bad.has_twin, bad.twin_id, bad.old_artist_name, bad.old_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
+-- === STMT: guard-post-write-nfc-duplicate ===
+-- Round 4: the belt-and-braces half of the NFC-folding fix. build-targets'
+-- twin join now folds to NFC specifically so an NFD clean twin is FOUND
+-- instead of missed, which is what stops update-no-twins from writing a
+-- byte-distinct duplicate of it. This guard does not trust that the join is
+-- the only place such a duplicate could arise -- it checks the outcome
+-- directly: after all three write statements have run, no two LIVE rows
+-- sharing a library_id this run touched may be NFC-equal but byte-distinct on
+-- (artist_name, track_title).
+--
+-- Scope is "any library_id in cta_repair_targets", not "only rows this run
+-- wrote" -- deliberately broader, matching guard-repair-complete's own
+-- posture of checking the outcome rather than the mechanism. A pre-existing
+-- NFC/NFD duplicate pair that this run never touched, sitting in a
+-- compilation this run otherwise repaired, is exactly the kind of thing an
+-- operator should see before trusting this run's postlude -- the U+FFFD
+-- residual reads 0/0 either way, and that was the whole failure mode the
+-- round 4 finding started from. Aborting here rolls back this run's own
+-- writes (the same recovery shape as every other guard in this script) but
+-- cannot undo a duplicate that predates this run; the exception message says
+-- so explicitly rather than implying a clean rollback fixes everything it
+-- flags.
+--
+-- `normalize()` here runs only over rows in library_ids from
+-- `cta_repair_targets` -- a handful of compilations per run, not a full-table
+-- scan (see "Unicode normalization" in the header and item 5 of the round 4
+-- review notes: normalize() must never land in the BEFORE/AFTER residual
+-- scans, which stay indexable-scan-shaped LIKE predicates over the whole
+-- table).
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT cta.library_id,
+           normalize(cta.artist_name, NFC) AS artist_name_nfc,
+           normalize(cta.track_title, NFC) AS track_title_nfc,
+           COUNT(*) AS n,
+           array_agg(cta.id ORDER BY cta.id) AS cta_ids,
+           array_agg(cta.artist_name ORDER BY cta.id) AS artist_names,
+           array_agg(cta.track_title ORDER BY cta.id) AS track_titles
+      FROM wxyc_schema.compilation_track_artist cta
+     WHERE cta.library_id IN (SELECT DISTINCT library_id FROM cta_repair_targets)
+     GROUP BY cta.library_id, normalize(cta.artist_name, NFC), normalize(cta.track_title, NFC)
+    HAVING COUNT(*) > 1
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: library_id=% has % rows that are NFC-equal but byte-distinct on (artist_name, track_title) after this run''s writes (cta_ids=%, artist_names=%, track_titles=%) -- this is the exact duplicate class the NFC-folded twin join exists to prevent. Rolling back undoes this run''s own writes but may NOT undo this specific duplicate if it predates this run; investigate the listed rows directly (do they need a manual merge? does an earlier run of this or a sibling script need review?) before re-running', bad.library_id, bad.n, bad.cta_ids, bad.artist_names, bad.track_titles;
   END LOOP;
 END $$;
 -- === END STMT ===

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -1,0 +1,380 @@
+-- V_BS_FFFD_CTA: compilation_track_artist U+FFFD-substitution repair for #2152.
+--
+-- Hand-applied operator script, NOT a Drizzle-tracked migration -- same
+-- posture as scripts/audit/bs_replacement_char_recovery.sql (Phase 1/2),
+-- scripts/audit/bs_replacement_char_phase35.sql (Phase 3.5), and
+-- scripts/audit/bs_replacement_char_phase4.sql (Phase 4, the closest
+-- analogue -- read its header before touching this file). docs/migrations.md
+-- keeps migrations DDL-only; this is DML, so it lives here and is run via
+-- `psql -f` against prod RDS, the same as its three predecessors.
+--
+-- This is the `compilation_track_artist` half of the 2026-08-13 28-value
+-- sweep (#2114 -> PR #2121 covers `library`/`artists`; #2124 covers the two
+-- remaining `artists` rows). 14 values here: 11 `track_title`, 3
+-- `artist_name`. Same corruption class as the rest of the family -- a
+-- literal U+FFFD REPLACEMENT CHARACTER where tubafrenzy's MySQL holds the
+-- real byte, frozen residue from the pre-#454 charset bug fixed 2026-04-24
+-- (`MirrorSQL.makeSqlCommand` now passes `--default-character-set=utf8`).
+-- NOT #1996 -- that ticket is double-encoded CP1252 in this same table,
+-- mechanically reversible; this is substitution, the source byte is gone,
+-- and the only fix is copying the true value back in from tubafrenzy.
+--
+-- ============================================================================
+-- THE TRAP THIS SCRIPT EXISTS TO AVOID: cta_unique_idx
+-- ============================================================================
+-- `cta_unique_idx` is UNIQUE on (library_id, artist_name, track_title)
+-- (shared/database/src/schema.ts:731) and is PERMANENT per #801 D7 -- this
+-- script never touches it. If a corrupt row's correctly-spelled twin
+-- already exists in the same compilation (the insert-only ETL writer kept
+-- both copies whenever the strings differed -- #1996 measured this holds
+-- for 98.5% of its damaged CTA rows), a blanket UPDATE onto the true value
+-- raises a unique violation instead of repairing anything. So every row is
+-- repaired individually:
+--
+--   twin already exists at the post-fix (artist_name, track_title) tuple -> DELETE the corrupt row
+--   no twin                                                               -> UPDATE the corrupt row in place
+--
+-- `compilation_track_artist.artist_name` is free text, not an FK to
+-- `artists` -- neither `fold_artist_name` (migration 0134) nor migration
+-- 0060's `cascade_library_artist_name` trigger reaches these rows. There is
+-- no cascade to lean on the way PR #2121 did for `library.artist_name`;
+-- every row here is written directly.
+--
+-- Migration 0099 (`cta_unique_null_track_idx`) closes the NULL-`track_title`
+-- duplicate loophole `cta_unique_idx` alone leaves open on PG 14 (prod
+-- runtime -- `NULLS NOT DISTINCT` is PG15+). The twin-detection query below
+-- uses `IS NOT DISTINCT FROM` for `track_title`, so a NULL-`track_title` twin
+-- is caught the same way a non-NULL one is -- see the "NULL track_title" spec
+-- cases in the paired integration test.
+--
+-- ============================================================================
+-- WHY THIS SCRIPT IS DATA-DRIVEN, NOT LITERAL LIKE ITS PREDECESSORS
+-- ============================================================================
+-- Phase 1/2/3.5/4 all bake their exact corrupt/correct string literals
+-- straight into the UPDATE statements, because the corrupt rows were
+-- enumerable against a local clone. That path is closed here:
+-- `dev_env/seed-clone.sql` contains NO `compilation_track_artist` data --
+-- the table appears exactly once, in the TRUNCATE list (line 39), with no
+-- `COPY ... FROM stdin` block. (This is also why Phase 4's own informational
+-- postlude claiming "CTA 0 in the 2026-08-12 clone" was a false negative
+-- against an empty table, not evidence the table was clean -- the live count
+-- is 14.) Two local tubafrenzy-sourced `library.db` snapshots were checked
+-- for a usable ground-truth extract (`lml-cutover-snapshots/prod-20260719`
+-- and `.../staging-20260718`, both safely post-2026-04-24): neither is
+-- useful here -- `library.db`'s only table is a flat per-RELEASE `library`
+-- table (id/title/artist/call_letters/artist_call_number/
+-- release_call_number/genre/format/alternate_artist_name/album_artist/label),
+-- with no per-track or per-compilation-credit rows at all. There is nothing
+-- in either snapshot shaped like `compilation_track_artist`, so this class
+-- of ground truth has to come from a live prod Backend read plus either a
+-- *newer* library.db snapshot (if one ever gains track-level data) or
+-- tubafrenzy MySQL directly.
+--
+-- So the 14 `(library_id / legacy_release_id, track_position, column,
+-- corrupt value, true value)` tuples are captured into the
+-- "PENDING CAPTURE" block below as a separate, deadline-bound operator step
+-- (see "Capture procedure"), not invented or fuzzy-matched. AS DELIVERED,
+-- that block holds a single filtered-out placeholder row -- every statement
+-- below is syntactically real and has been run end-to-end against synthetic
+-- fixtures (see the paired integration spec), but with ZERO pending rows
+-- declared, so running this script as-is against prod today is a genuine,
+-- verified no-op. It becomes the actual repair only once an operator fills
+-- in the 14 real rows and re-runs it.
+--
+-- ============================================================================
+-- Capture procedure
+-- ============================================================================
+-- 1. Enumerate the corrupt rows against prod (read-only):
+--
+--      SELECT cta.library_id, l.legacy_release_id, cta.track_position, cta.artist_name, cta.track_title
+--      FROM wxyc_schema.compilation_track_artist cta
+--      JOIN wxyc_schema.library l ON l.id = cta.library_id
+--      WHERE cta.artist_name LIKE E'%�%' OR cta.track_title LIKE E'%�%'
+--      ORDER BY l.legacy_release_id, cta.track_position;
+--
+--    `cta.library_id` is a Backend `library.id`; tubafrenzy keys on
+--    `LIBRARY_RELEASE.ID`, i.e. `legacy_release_id` -- every join to ground
+--    truth routes through that column.
+--
+-- 2. Resolve each row's true string. READ it, never reconstruct it -- these
+--    are exactly the diacritic-bearing names where a plausible guess is
+--    wrong. In preference order:
+--      a. A tubafrenzy-sourced `library.db` snapshot under
+--         `lml-cutover-snapshots/`, IF a future snapshot ever gains
+--         per-track/compilation-credit data (neither snapshot available
+--         while writing this script does -- see above). Confirm the
+--         snapshot postdates 2026-04-24 (the #454 charset fix) before
+--         trusting it.
+--      b. Kattare MySQL directly: `dc1-mysql-01.kattare.com`, database
+--         `wxycmusic`. `--default-character-set=utf8` is MANDATORY (the
+--         whole corruption class exists because a client once connected
+--         without it). Use a MariaDB client, not Homebrew's MySQL 9.x --
+--         it segfaults against the 5.1 server.
+--
+-- 3. Record the exact Unicode codepoint for every non-ASCII character in
+--    the resolved string (e.g. PR #2121's `µ` MICRO SIGN, NOT `μ`
+--    GREEK SMALL LETTER MU -- visually identical, semantically different,
+--    and NFKC/NFKD would silently fold one onto the other). Byte-exact
+--    equality is what the downstream catalog-parity harness checks
+--    (discogs-etl#346), so an approximately-right glyph is a shipped bug.
+--
+-- 4. Fill in the PENDING CAPTURE block below: one row per corrupt value,
+--    using the enumeration query's own columns for `legacy_release_id` /
+--    `track_position` / `current_artist_name` / `current_track_title`, and
+--    the resolved true string in whichever of `true_artist_name` /
+--    `true_track_title` corresponds to the corrupt column. Leave the other
+--    `true_*` column NULL -- it means "this column is not being touched".
+--
+-- 5. Human-review the filled-in block, then run this whole script.
+--
+-- Read-only prelude only, stop before any write (mirrors Phase 4's recipe):
+--
+--   awk '/^BEGIN;/{exit} {print}' scripts/audit/bs_replacement_char_cta.sql \
+--     | psql "$DATABASE_URL"
+--
+-- ============================================================================
+-- Mechanism
+-- ============================================================================
+-- `pending_cta_repair` is a session-local scratch table holding the
+-- captured rows. `cta_repair_targets` resolves each pending row against the
+-- LIVE table (matched on `library_id` + the row's exact captured
+-- `artist_name`/`track_title` -- a combination `cta_unique_idx` /
+-- `cta_unique_null_track_idx` already guarantee is unique, so a pending row
+-- can structurally match at most one live row) and classifies it
+-- twin/no-twin by checking whether another row already holds the post-fix
+-- tuple. The classification is computed ONCE, before `BEGIN`, and both the
+-- audit prelude and the two write statements read that same materialized
+-- table -- so the prelude's SELECT and the writes are the *same* predicate
+-- by construction (org data-safety convention), not two independently
+-- typed-out copies that could drift apart.
+--
+-- Idempotency: `cta_repair_targets`'s join to the live table requires the
+-- row's `artist_name`/`track_title` to still equal the captured (corrupt)
+-- values. Once a row is fixed, that join finds nothing on a re-run --
+-- verified in the paired integration spec.
+--
+-- Not round-trippable: same posture as Phase 1/2/3.5/4. `ef bf bd` is the
+-- UTF-8 encoding of U+FFFD itself; the original byte was already destroyed
+-- upstream. This script substitutes the tubafrenzy-verified exact original,
+-- not a fuzzy/plausible reconstruction.
+--
+-- Unicode normalization: deliberately NOT applied, matching Phase 4's
+-- posture (not Phase 2/3.5's). The true values here are copied byte-for-byte
+-- out of tubafrenzy, and the catalog-parity harness that surfaced this issue
+-- compares byte-exact with no accent/case folding -- normalizing on write is
+-- the one thing that could reintroduce a parity mismatch.
+--
+-- Sequencing vs #1996: both rewrite CTA rows. #1996 is large and blocked on
+-- `library-etl` stopping; this repair is small, frozen residue, and
+-- unblocked. Land this first, per #2152's own note, so #1996's twin
+-- analysis re-derives after this script's writes, not before.
+--
+-- Once run, the ETL stays clear of these rows going forward:
+-- `importCompilationTracks` (jobs/library-etl/job.ts:765) inserts with
+-- `.onConflictDoNothing()` on `cta_unique_idx`, and post-#454 the ETL derives
+-- the correct string, so its next insert for a repaired row conflicts and
+-- no-ops.
+--
+-- ============================================================================
+-- Session guards. Both matter more here than in a typical script because
+-- EVERY predicate below is exact-byte string equality.
+--
+-- client_encoding: if the operator's psql session resolves to a non-UTF8
+-- client encoding, the server reinterprets this file's UTF-8 bytes, every
+-- predicate matches zero rows, and the pre-amble reports 0 -- which reads as
+-- "already repaired" rather than "matched nothing". Declaring it makes that
+-- failure impossible instead of silent.
+--
+-- ON_ERROR_STOP: without it, an error inside the transaction leaves psql
+-- issuing the remaining commands into an aborted transaction, COMMIT
+-- degrades to ROLLBACK, and psql still exits 0.
+-- ============================================================================
+\set ON_ERROR_STOP on
+SET client_encoding TO 'UTF8';
+
+-- === STMT: create-pending-table ===
+DROP TABLE IF EXISTS pending_cta_repair;
+CREATE TEMP TABLE pending_cta_repair (
+  legacy_release_id integer,
+  track_position text,
+  current_artist_name text,
+  current_track_title text,
+  true_artist_name text,
+  true_track_title text
+);
+-- === END STMT ===
+
+-- === STMT: insert-pending-rows ===
+-- ############################################################################
+-- PENDING CAPTURE -- replace the placeholder row below with the 14 rows from
+-- the capture step above. Columns map 1:1 onto the enumeration query's output
+-- (legacy_release_id, track_position, artist_name, track_title) plus the two
+-- true_* replacement columns. Leave true_artist_name OR true_track_title NULL
+-- for whichever column on that row was NOT corrupt -- never fill in a value
+-- you did not read from ground truth.
+--
+-- Example shape (NOT REAL DATA -- do not copy verbatim):
+--   (50340, '3', 'Some Artist', 'La B?te', NULL, 'La Bete'),
+-- ############################################################################
+INSERT INTO pending_cta_repair
+  (legacy_release_id, track_position, current_artist_name, current_track_title, true_artist_name, true_track_title)
+VALUES
+  (NULL, NULL, NULL, NULL, NULL, NULL); -- placeholder; keeps VALUES syntactically valid with 0 rows captured so far
+
+DELETE FROM pending_cta_repair WHERE legacy_release_id IS NULL; -- drop the placeholder
+-- === END STMT ===
+
+-- === STMT: guard-replacement-specified ===
+-- Every declared row must actually fix something.
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT COUNT(*) INTO n FROM pending_cta_repair
+   WHERE true_artist_name IS NULL AND true_track_title IS NULL;
+  IF n > 0 THEN
+    RAISE EXCEPTION 'BS#2152 guard: % declared pending row(s) specify no replacement (both true_artist_name and true_track_title are NULL) -- every row must fix at least one column', n;
+  END IF;
+END $$;
+-- === END STMT ===
+
+-- === STMT: build-targets ===
+-- Resolve every pending row against the live table and classify twin/no-twin.
+-- Computed once; the prelude SELECTs below and the two write statements
+-- further down all read this same table, so they see the identical row set.
+DROP TABLE IF EXISTS cta_repair_targets;
+CREATE TEMP TABLE cta_repair_targets AS
+SELECT
+  p.legacy_release_id,
+  p.track_position,
+  cta.id,
+  cta.library_id,
+  cta.artist_name AS old_artist_name,
+  cta.track_title AS old_track_title,
+  COALESCE(p.true_artist_name, cta.artist_name) AS new_artist_name,
+  COALESCE(p.true_track_title, cta.track_title) AS new_track_title,
+  EXISTS (
+    SELECT 1
+      FROM wxyc_schema.compilation_track_artist other
+     WHERE other.library_id = cta.library_id
+       AND other.id <> cta.id
+       AND other.artist_name = COALESCE(p.true_artist_name, cta.artist_name)
+       AND other.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title)
+  ) AS has_twin
+FROM pending_cta_repair p
+JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
+JOIN wxyc_schema.compilation_track_artist cta
+  ON cta.library_id = l.id
+ AND cta.artist_name = p.current_artist_name
+ AND cta.track_title IS NOT DISTINCT FROM p.current_track_title;
+-- === END STMT ===
+
+-- === STMT: guard-ambiguous-match ===
+-- A pending row resolving to more than one live row should be impossible --
+-- (library_id, artist_name, track_title) is exactly cta_unique_idx's key
+-- (cta_unique_null_track_idx for the NULL-track_title case) -- but this is
+-- asserted defensively rather than assumed. Also catches an accidental
+-- duplicate entry in the pending block itself (both pending copies would
+-- resolve to the same live row, tripping this the same way).
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT legacy_release_id, old_artist_name, old_track_title, COUNT(*) AS n
+      FROM cta_repair_targets
+     GROUP BY legacy_release_id, old_artist_name, old_track_title
+    HAVING COUNT(*) > 1
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% artist_name=% track_title=% matched % live compilation_track_artist rows (or the pending block has a duplicate entry) -- cta_unique_idx / cta_unique_null_track_idx should make this impossible; investigate before proceeding', bad.legacy_release_id, bad.old_artist_name, bad.old_track_title, bad.n;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
+-- ===========================================================
+-- Pre-amble: declared rows, BEFORE classification, BEFORE residual counts.
+-- Same predicate the writes use, per the org data-safety convention --
+-- literally the same materialized table, not a re-typed copy.
+-- ===========================================================
+SELECT '=== V_BS_FFFD_CTA pre-amble: declared pending rows (0 = capture step not yet run) ===' AS section;
+SELECT COUNT(*) AS pending_declared FROM pending_cta_repair;
+
+SELECT 'BEFORE — matched rows + twin classification' AS section;
+SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_track_title,
+       new_artist_name, new_track_title,
+       CASE WHEN has_twin THEN 'DELETE (twin exists)' ELSE 'UPDATE (no twin)' END AS action
+  FROM cta_repair_targets
+ ORDER BY legacy_release_id, track_position;
+
+SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
+SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title
+  FROM pending_cta_repair p
+  LEFT JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
+  LEFT JOIN wxyc_schema.compilation_track_artist cta
+    ON cta.library_id = l.id
+   AND cta.artist_name = p.current_artist_name
+   AND cta.track_title IS NOT DISTINCT FROM p.current_track_title
+ WHERE cta.id IS NULL;
+
+SELECT 'BEFORE — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
+SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
+       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
+
+-- ===========================================================
+-- Transactional write block.
+-- ===========================================================
+BEGIN;
+SET LOCAL statement_timeout = '30s';
+
+-- === STMT: delete-twins ===
+-- The clean twin already carries the truth; the corrupt row is redundant.
+-- Re-checks old_artist_name/old_track_title so a second run (where the row
+-- no longer matches, having already been deleted) is a genuine no-op.
+DELETE FROM wxyc_schema.compilation_track_artist cta
+USING cta_repair_targets t
+WHERE cta.id = t.id
+  AND t.has_twin
+  AND cta.artist_name = t.old_artist_name
+  AND cta.track_title IS NOT DISTINCT FROM t.old_track_title;
+-- === END STMT ===
+
+-- === STMT: update-no-twins ===
+-- No twin exists; safe to rewrite in place. Same re-check for idempotency.
+UPDATE wxyc_schema.compilation_track_artist cta
+   SET artist_name = t.new_artist_name,
+       track_title = t.new_track_title
+  FROM cta_repair_targets t
+ WHERE cta.id = t.id
+   AND NOT t.has_twin
+   AND cta.artist_name = t.old_artist_name
+   AND cta.track_title IS NOT DISTINCT FROM t.old_track_title;
+-- === END STMT ===
+
+COMMIT;
+
+-- ===========================================================
+-- Post-amble verify: every targeted row should show residual=0, and the
+-- overall predicate should return 0/0 -- the desired end state per #2152.
+-- ===========================================================
+SELECT '=== V_BS_FFFD_CTA post-amble: residual count per targeted row (expect 0) ===' AS section;
+SELECT t.legacy_release_id, t.track_position,
+       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist cta
+         WHERE cta.library_id = t.library_id
+           AND cta.artist_name = t.old_artist_name
+           AND cta.track_title IS NOT DISTINCT FROM t.old_track_title) AS residual
+  FROM cta_repair_targets t
+ ORDER BY t.legacy_release_id, t.track_position;
+
+SELECT 'AFTER — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
+SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
+       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
+
+-- Broader-table informational sweep (rotation/flowsheet/artists/library)
+-- already lives in bs_replacement_char_phase4.sql's postlude -- not repeated
+-- here, this script is scoped to compilation_track_artist only.
+
+-- === STMT: analyze ===
+-- Refresh planner stats (BS#934 -- omitting this after #863's migration
+-- regressed /flowsheet/suggest/* to 5s timeouts). ANALYZE cannot run inside
+-- a transaction, so it lives here, outside any BEGIN/COMMIT. See
+-- docs/bulk-update-playbook.md for the full pattern.
+ANALYZE wxyc_schema.compilation_track_artist;
+-- === END STMT ===

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -50,8 +50,9 @@
 -- ============================================================================
 -- OPERATOR-ERROR GUARDS (PR #2154 review)
 -- ============================================================================
--- Seven DO-block guards (five from round 1, two added in round 2's review)
--- run before the corresponding mistake can do damage, each aborting loudly
+-- Nine DO-block guards (five from round 1, two from round 2, two from
+-- round 3) run before the corresponding mistake can do damage -- or, for the
+-- last one, before a damaged outcome can be COMMITted -- each aborting loudly
 -- (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here stops the whole psql
 -- run with a nonzero exit and no partial write). Listed in the order they
 -- actually run:
@@ -76,14 +77,35 @@
 --                                    post-fix tuple, find the genuinely
 --                                    corrupt row as its twin, and DELETE the
 --                                    clean row -- exit 0, no error, and the
---                                    postlude's residual counts go UP (reads
---                                    like a capture mismatch, not data
---                                    loss). Also structurally catches the
---                                    wrong-client_encoding scenario the
---                                    session guards below worry about -- a
---                                    misdecoded session turns every U+FFFD
---                                    predicate into a false negative the
---                                    same way a transposed pair does.
+--                                    post-amble's residual counts UNCHANGED
+--                                    (round 3 correction: the earlier text
+--                                    here said they "go UP", which is wrong
+--                                    for the DELETE path it narrates -- the
+--                                    row destroyed is the CLEAN one, so the
+--                                    U+FFFD population is exactly what it was
+--                                    before the run. Flat counts are the more
+--                                    insidious signal, not the milder one:
+--                                    they read as "this row was already
+--                                    repaired", the same output an idempotent
+--                                    re-run produces). Also structurally
+--                                    catches the wrong-client_encoding
+--                                    scenario the session guards below worry
+--                                    about -- a misdecoded session turns
+--                                    every U+FFFD predicate into a false
+--                                    negative the same way a transposed pair
+--                                    does. Round 3 additionally hard-rejects
+--                                    a NULL current_artist_name on ANY
+--                                    pending row, gated on nothing: prod's
+--                                    `compilation_track_artist.artist_name`
+--                                    is NOT NULL and the enumeration query
+--                                    cannot emit a NULL there, so a NULL is
+--                                    always a paste slip -- and one that
+--                                    silently matches zero live rows rather
+--                                    than aborting, because the pre-round-3
+--                                    NULL test sat inside the
+--                                    `true_artist_name IS NOT NULL` branch
+--                                    and so never applied to a
+--                                    track_title-only repair.
 --   guard-nfc-form                -- a declared true_* replacement is not in
 --                                    NFC Unicode normalization form (round 2
 --                                    MEDIUM finding). Twin detection below
@@ -100,6 +122,22 @@
 --                                    normalization -- preserves the byte-exact
 --                                    write posture documented under
 --                                    "Unicode normalization" below.
+--   guard-unknown-release         -- (round 3) a declared legacy_release_id
+--                                    resolves to no `library` row at all.
+--                                    Every captured id came out of the
+--                                    enumeration query's own
+--                                    `JOIN library l ON l.id = cta.library_id`
+--                                    projection, so an id that matches
+--                                    nothing is a transcription error, not a
+--                                    legitimately-absent release -- and it is
+--                                    the one unmatched shape that CANNOT be
+--                                    an idempotent re-run, since a repaired
+--                                    row's `library` parent does not
+--                                    disappear when the CTA row is fixed.
+--                                    Distinct from the merely-informational
+--                                    "matched no live CTA row" listing right
+--                                    below it, which stays informational for
+--                                    exactly that reason.
 --   guard-post-fix-fffd           -- (runs after build-targets, inside the
 --                                    transaction) a row's post-fix tuple
 --                                    (new_artist_name / new_track_title)
@@ -151,6 +189,30 @@
 --                                    DELETEs would actually be collision-free
 --                                    -- see the guard's own comment below for
 --                                    why that's left alone in this PR.
+--   guard-repair-complete         -- (round 3; runs AFTER the three write
+--                                    statements, still inside the
+--                                    transaction) a targeted row's ORIGINAL
+--                                    corrupt tuple is still live. Every other
+--                                    guard here is a pre-flight check on the
+--                                    capture; this one is a post-condition on
+--                                    the run, and it is what converts each
+--                                    write statement's deliberately-silent
+--                                    concurrency skip into a loud abort. A
+--                                    skip is correct behavior (see the
+--                                    re-checks on all three writes), but a
+--                                    skip that leaves the corruption live is
+--                                    a repair that did not happen, and
+--                                    without this the script COMMITs and
+--                                    exits 0 on it. Not reachable on a
+--                                    legitimate idempotent re-run: an
+--                                    already-repaired row does not appear in
+--                                    `cta_repair_targets` at all, because
+--                                    build-targets' join requires the live
+--                                    row to still hold the captured CORRUPT
+--                                    strings. `cta_unique_idx` guarantees at
+--                                    most one live row can hold that tuple,
+--                                    so this cannot be tripped by an
+--                                    unrelated row.
 --
 -- ============================================================================
 -- WHY THIS SCRIPT IS DATA-DRIVEN, NOT LITERAL LIKE ITS PREDECESSORS
@@ -186,6 +248,18 @@
 -- verified no-op. It becomes the actual repair only once an operator fills
 -- in the 14 real rows and re-runs it.
 --
+-- "Every statement" is meant literally, and round 3 is what made it true.
+-- Through round 2 the read-only pre-amble (`pending_match_preview` and its
+-- three SELECTs) and the post-amble residual reads carried no
+-- `-- === STMT: ... ===` tags, so the spec's extractor never saw them and
+-- nothing executed them -- the spec only pinned their POSITION in the file
+-- via `indexOf`. A typo or a column drift in the post-amble would therefore
+-- pass the entire suite and then abort the real prod run under
+-- ON_ERROR_STOP mid-transaction, AFTER the DELETE/UPDATE and BEFORE COMMIT,
+-- rolling back a repair that had actually succeeded; the same typo in the
+-- pre-amble would kill the documented read-only `awk` preview outright.
+-- Both sections are tagged blocks now and the spec runs them.
+--
 -- ============================================================================
 -- Capture procedure
 -- ============================================================================
@@ -204,17 +278,45 @@
 -- 2. Resolve each row's true string. READ it, never reconstruct it -- these
 --    are exactly the diacritic-bearing names where a plausible guess is
 --    wrong. In preference order:
---      a. A tubafrenzy-sourced `library.db` snapshot under
+--      a. This repo's OWN reader: `fetchLegacyCompilationTracks`
+--         (jobs/library-etl/job.ts), which selects LIBRARY_RELEASE_ID /
+--         ARTIST_NAME / TRACK_TITLE / TRACK_POSITION out of tubafrenzy's
+--         `COMPILATION_TRACK_ARTIST` through `legacyDB.send`
+--         (shared/database/src/legacy/sql.mirror.ts), which passes
+--         `--default-character-set=utf8` unconditionally. Preferred over
+--         (c) for three reasons: the mandatory charset flag is structural
+--         rather than something the operator has to remember, its key is
+--         already `LIBRARY_RELEASE_ID` -- i.e. exactly the
+--         `legacy_release_id` keyspace the pending block wants, no
+--         translation step -- and it is the SAME reader whose output the
+--         post-#454 ETL writes into the live Backend column, so its values
+--         land in the same trim/whitespace regime the byte-exact predicates
+--         below compare against. Two transforms to know about, both benign
+--         for the same reason: the query REPLACEs embedded tabs/newlines
+--         with spaces (its output is tab-delimited), and the parser trims
+--         each field and maps empty to NULL -- so a NULL TRACK_TITLE round-
+--         trips to NULL correctly, which is the shape 3 of the 14 rows need.
+--      b. A tubafrenzy-sourced `library.db` snapshot under
 --         `lml-cutover-snapshots/`, IF a future snapshot ever gains
 --         per-track/compilation-credit data (neither snapshot available
 --         while writing this script does -- see above). Confirm the
 --         snapshot postdates 2026-04-24 (the #454 charset fix) before
 --         trusting it.
---      b. Kattare MySQL directly: `dc1-mysql-01.kattare.com`, database
+--      c. Kattare MySQL directly: `dc1-mysql-01.kattare.com`, database
 --         `wxycmusic`. `--default-character-set=utf8` is MANDATORY (the
 --         whole corruption class exists because a client once connected
 --         without it). Use a MariaDB client, not Homebrew's MySQL 9.x --
 --         it segfaults against the 5.1 server.
+--
+--    Whichever channel is used, NOTHING in this script verifies that a
+--    pending row's true_* value actually corresponds to the tubafrenzy row
+--    for that credit -- the guards check internal consistency (is current_*
+--    corrupt, is true_* clean, is it NFC, does the release resolve), never
+--    correspondence to ground truth. A true_* value that is clean, NFC, and
+--    simply WRONG passes every one of them and commits. That is why step 2
+--    is a read and step 5 is a human review, and it is the strongest
+--    argument for channel (a): a programmatic read cannot transpose two rows
+--    the way 14 hand-pastes can.
 --
 -- 3. Record the exact Unicode codepoint for every non-ASCII character in
 --    the resolved string (e.g. PR #2121's `µ` MICRO SIGN, NOT `μ`
@@ -267,8 +369,11 @@
 --
 -- This shows the declared-row count (plus the matched/unmatched split, PR
 -- #2154 review round 2) and the two full-table informational checks
--- (unmatched pending rows, overall residual count) -- it does NOT show the
--- twin/no-twin classification, because that classification (`build-targets`)
+-- (unmatched pending rows, overall residual count). It also runs the first
+-- five guards, so a transposed, NULL-keyed, non-NFC, nothing-to-fix, or
+-- unknown-release capture aborts here -- in a read-only preview, before the
+-- operator has committed to anything. It does NOT show the twin/no-twin
+-- classification, because that classification (`build-targets`)
 -- now runs INSIDE the transaction (see "Mechanism" below, PR #2154 review
 -- round 1). To preview the FULL classification and writes without persisting
 -- anything, run the script with its `COMMIT;` swapped for `ROLLBACK;` --
@@ -315,20 +420,55 @@
 -- predicate by construction (org data-safety convention), not independently
 -- typed-out copies that could drift apart.
 --
--- What this buys is atomicity, NOT elimination of the race window (round 2
--- correction -- the round 1 text overclaimed "no window between classifying
--- a row and acting on that classification"). `CREATE TEMP TABLE ... AS
--- SELECT` under READ COMMITTED takes no row lock, and every later statement
--- in this script takes its own fresh snapshot, so `library-etl` can still
--- commit a clean twin (or a librarian can still hand-edit the row) between
--- `build-targets` and `update-no-twins`/`delete-twins`/`repoint-twin-identity`
--- -- and the re-check re-checks each of those three statements carry (see
--- their own comments; `repoint-twin-identity`'s was added in round 2) exist
--- precisely because that window is real. The narrowing is real too: what
--- used to be a live, unguarded write racing a live table is now a
--- transaction that either commits a fully self-consistent set of writes or
--- rolls back the whole thing cleanly on any surprise -- narrowed and made
--- fail-safe, not race-free.
+-- What the transaction alone buys is atomicity, NOT elimination of the race
+-- window (round 2 correction -- the round 1 text overclaimed "no window
+-- between classifying a row and acting on that classification").
+-- `CREATE TEMP TABLE ... AS SELECT` under READ COMMITTED takes no row lock,
+-- and every later statement in this script takes its own fresh snapshot, so
+-- through round 2 `library-etl` could still commit a clean twin (or a
+-- librarian could still hand-edit the row) between `build-targets` and any
+-- of the three write statements.
+--
+-- Round 3 closes that window on existing rows with an explicit lock rather
+-- than continuing to narrow it. `lock-targets` runs immediately after
+-- `build-targets` and takes `SELECT ... FOR UPDATE` row locks on every
+-- classified corrupt row AND every twin it resolved, in ascending `id` order
+-- (ordered so two operators running overlapping repairs, or this script
+-- against any other id-ordered writer, queue instead of deadlocking). Once
+-- that statement returns, no other session can UPDATE or DELETE any row this
+-- run intends to touch until this transaction ends. That leaves exactly ONE
+-- window on existing rows -- `build-targets` to `lock-targets` -- and the
+-- re-checks the three write statements carry are precisely what closes it:
+-- each re-reads post-lock, so it sees any change that landed pre-lock, and
+-- nothing can change after. Two consequences the earlier shape did not have:
+--
+--   * The write statements can no longer DISAGREE with each other. Through
+--     round 2, `repoint-twin-identity` could fire, a concurrent edit could
+--     land, and `delete-twins` could then correctly skip -- leaving the
+--     corrupt row's identity link live on BOTH rows, committed, exit 0. The
+--     re-check each statement carried made each one individually correct and
+--     the pair jointly wrong. Under the lock they read identical state.
+--   * Both statements now re-check the TWIN as well as the corrupt row (see
+--     their own comments). Through round 2 neither did, so a twin deleted or
+--     renamed in that window let `delete-twins` remove what had become the
+--     ONLY remaining copy of the credit -- and unlike the UPDATE branch,
+--     which fails safe into a 23505, the DELETE branch had no tripwire at
+--     all.
+--
+-- What the lock canNOT do is prevent an INSERT: you cannot lock a row that
+-- does not exist, so `library-etl` committing a BRAND-NEW clean twin for a
+-- row this run classified as no-twin is still possible. That case stays
+-- fail-safe rather than guarded -- `update-no-twins` raises 23505,
+-- ON_ERROR_STOP aborts, and the whole transaction rolls back cleanly, which
+-- is the correct outcome (re-run; `build-targets` then classifies it
+-- has_twin and takes the DELETE branch). Lock waits are bounded by the
+-- `SET LOCAL statement_timeout = '30s'` above: if a concurrent writer holds
+-- a conflicting lock longer than that, this run aborts rather than hangs.
+--
+-- So: race-free with respect to concurrent modification and deletion of the
+-- rows it classified, fail-safe with respect to concurrent insertion of new
+-- ones. `guard-repair-complete` below is the backstop for both -- it refuses
+-- to COMMIT a run in which any targeted row's corrupt tuple is still live.
 --
 -- Idempotency: `cta_repair_targets`'s join to the live table requires the
 -- row's `artist_name`/`track_title` to still equal the captured (corrupt)
@@ -352,10 +492,52 @@
 -- analysis re-derives after this script's writes, not before.
 --
 -- Once run, the ETL stays clear of these rows going forward:
--- `importCompilationTracks` (jobs/library-etl/job.ts:765) inserts with
--- `.onConflictDoNothing()` on `cta_unique_idx`, and post-#454 the ETL derives
--- the correct string, so its next insert for a repaired row conflicts and
--- no-ops.
+-- `importCompilationTracks` (jobs/library-etl/job.ts) inserts with a bare,
+-- UNTARGETED `.onConflictDoNothing()`, and post-#454 the ETL derives the
+-- correct string, so its next insert for a repaired row conflicts and no-ops.
+-- Untargeted is load-bearing and not an oversight (round 3 correction -- the
+-- earlier text here said "on `cta_unique_idx`", which would be a narrower and
+-- broken thing to write): a bare DO NOTHING suppresses a conflict on ANY
+-- unique index on the table, so it covers `cta_unique_null_track_idx`
+-- (migration 0099) too. An arbiter spelled `ON CONFLICT (library_id,
+-- artist_name, track_title)` would not -- under a plain unique index NULLs
+-- are distinct on PG 14, so a NULL-`track_title` re-insert would never
+-- conflict against `cta_unique_idx`, would fall through to a real INSERT, and
+-- would then fail against the partial index instead of no-opping. The
+-- distinction matters here because 3 of this script's 14 rows are
+-- `artist_name` repairs, which is where NULL `track_title` lives.
+--
+-- ============================================================================
+-- Triggers that DO fire on these writes
+-- ============================================================================
+-- Two, both wanted, neither requiring anything of the operator -- listed
+-- because "what else moves when I run this" is the question this section
+-- exists to answer, and a reader should not have to go find out:
+--
+--   `touch_library_watermark_from_compilation_track_artist` (migration 0138,
+--   narrowed by 0143) -- FOR EACH STATEMENT, and after 0143 its UPDATE leg is
+--   `UPDATE OF id, library_id, artist_name, track_title`. `delete-twins`
+--   fires it via the DELETE leg and `update-no-twins` via the UPDATE leg
+--   (both of its SET columns are in that list), so the catalog-export
+--   watermark advances and `GET /library/catalog/compilation-tracks` reflects
+--   the repair on its next conditional GET. That is the desired outcome: the
+--   export's projected `artist_name`/`track_title` are exactly what this
+--   script rewrites. `repoint-twin-identity` deliberately does NOT advance it
+--   -- all four columns it SETs (the three `track_artist_*` and
+--   `track_position`) are on 0143's excluded list, which is the whole point
+--   of that migration.
+--
+--   `cdc_compilation_track_artist` (migration 0046) -- FOR EACH ROW, on
+--   INSERT/UPDATE/DELETE, structurally unqualified (Postgres does not narrow
+--   ROW-level triggers with `OF <columns>`), so every row this script touches
+--   emits a `pg_notify('cdc', ...)`, including the repoint's. `pg_notify`
+--   payloads are queued and delivered at COMMIT, not at statement time, so
+--   `/cdc` consumers see one burst after the repair lands and never a
+--   half-applied intermediate state -- and the documented
+--   "swap COMMIT; for ROLLBACK;" dry run emits nothing at all. Worth knowing
+--   before running this during a live show: the DELETE events name rows that
+--   no longer exist by design, which is the normal shape for this table's
+--   twin-dedup writes, not an anomaly for a consumer to reconcile.
 --
 -- ============================================================================
 -- Session guards. Both matter more here than in a typical script because
@@ -390,9 +572,23 @@ CREATE TEMP TABLE pending_cta_repair (
 -- === STMT: insert-pending-rows ===
 -- ############################################################################
 -- PENDING CAPTURE -- replace the placeholder row below with the 14 rows from
--- the capture step above. Columns map 1:1 onto the enumeration query's output
--- (legacy_release_id, track_position, artist_name, track_title) plus the two
--- true_* replacement columns. Leave true_artist_name OR true_track_title NULL
+-- the capture step above. The four capture columns come from the enumeration
+-- query in the same left-to-right order it prints them -- but NOT 1:1 (round 3
+-- correction to the earlier wording here): that query projects FIVE columns and
+-- leads with `cta.library_id`, which this block does not carry and must be
+-- dropped from the paste. Take columns 2-5 (legacy_release_id, track_position,
+-- artist_name, track_title), then append the two true_* replacement columns.
+-- Pasting all five shifts every value one slot left, landing the numeric
+-- library_id in legacy_release_id and the real legacy_release_id in
+-- track_position. With both true_* values also supplied that is seven values
+-- for six columns, so Postgres rejects the INSERT outright ("INSERT has more
+-- expressions than target columns") and the slip is loud. It is only quiet on
+-- a row that supplies ONE true_* value, where the counts happen to line up:
+-- there, guard-unknown-release catches it if the shifted library_id resolves
+-- to no `library` row, and the informational unmatched listing catches it if
+-- it resolves to the wrong one. Neither is a substitute for checking the
+-- paste -- drop `library_id` before you paste.
+-- Leave true_artist_name OR true_track_title NULL
 -- for whichever column on that row was NOT corrupt -- never fill in a value
 -- you did not read from ground truth.
 --
@@ -468,21 +664,48 @@ END $$;
 -- row would match the CLEAN live row (its current_* equals the clean live
 -- value), compute the CORRUPT string as its post-fix tuple, find the
 -- genuinely corrupt row as its twin, and DELETE the clean row -- exit 0, no
--- error, and the postlude's residual counts go UP (reads like a capture
--- mismatch, not data loss). This also structurally catches the
--- wrong-client_encoding scenario the session guards above worry about: a
--- misdecoded session turns every U+FFFD predicate into a false negative the
--- same way a transposed pair does.
+-- error, and the post-amble's residual counts UNCHANGED (round 3 correction:
+-- this said "go UP", which is wrong for the DELETE path it describes -- the
+-- row destroyed is the CLEAN one, so the U+FFFD population is exactly what it
+-- was before the run. Flat counts are worse than rising ones here, not
+-- milder: they are also what a successful idempotent re-run prints, so the
+-- output actively reads as "already repaired"). This also structurally
+-- catches the wrong-client_encoding scenario the session guards above worry
+-- about: a misdecoded session turns every U+FFFD predicate into a false
+-- negative the same way a transposed pair does.
 DO $$
 DECLARE bad RECORD;
 BEGIN
   FOR bad IN
     SELECT legacy_release_id, track_position, current_artist_name, current_track_title,
-           true_artist_name, true_track_title
+           true_artist_name, true_track_title,
+           -- Name the actual fault rather than making the operator infer it
+           -- from a message that ORs two unrelated diagnoses together. The
+           -- two causes have different fixes: a NULL current_artist_name is a
+           -- structurally short paste, a transposition is a
+           -- right-values-wrong-slots paste.
+           CASE
+             WHEN current_artist_name IS NULL
+               THEN 'current_artist_name is NULL -- the live column is NOT NULL and the enumeration query cannot emit a NULL there, so this row is short a column (did the paste drop one, or include the query''s leading library_id?)'
+             ELSE 'looks transposed or uncorrupted -- every current_* column being fixed must contain U+FFFD and every true_* replacement must not; verify the capture was not pasted backwards (or check client_encoding)'
+           END AS reason
       FROM pending_cta_repair
-     WHERE (true_artist_name IS NOT NULL AND (
-             current_artist_name IS NULL
-             OR current_artist_name NOT LIKE '%' || chr(65533) || '%'
+     -- UNCONDITIONAL, not gated on which column is being fixed (round 3
+     -- finding): prod's compilation_track_artist.artist_name is NOT NULL and
+     -- the enumeration query cannot emit a NULL there, so a NULL
+     -- current_artist_name is ALWAYS a paste slip -- on a track_title-only
+     -- repair just as much as on an artist_name one. Before round 3 the NULL
+     -- test lived only inside the `true_artist_name IS NOT NULL` branch below,
+     -- so on the 11 track_title-only rows a NULLed current_artist_name sailed
+     -- through every guard, matched no live row in build-targets (the join
+     -- requires `cta.artist_name = p.current_artist_name`), and committed as a
+     -- silent no-op with the corruption intact. No equivalent test exists for
+     -- current_track_title: NULL is a legitimate value there (migration 0099 /
+     -- cta_unique_null_track_idx), which is exactly the shape 3 of the 14 rows
+     -- have.
+     WHERE current_artist_name IS NULL
+        OR (true_artist_name IS NOT NULL AND (
+             current_artist_name NOT LIKE '%' || chr(65533) || '%'
              OR true_artist_name LIKE '%' || chr(65533) || '%'
            ))
         OR (true_track_title IS NOT NULL AND (
@@ -491,7 +714,7 @@ BEGIN
              OR true_track_title LIKE '%' || chr(65533) || '%'
            ))
   LOOP
-    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% looks transposed or uncorrupted (current_artist_name=% current_track_title=% true_artist_name=% true_track_title=%) -- every current_* column being fixed must contain U+FFFD and every true_* replacement must not; verify the capture was not pasted backwards (or check client_encoding)', bad.legacy_release_id, bad.track_position, bad.current_artist_name, bad.current_track_title, bad.true_artist_name, bad.true_track_title;
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% %  (current_artist_name=% current_track_title=% true_artist_name=% true_track_title=%)', bad.legacy_release_id, bad.track_position, bad.reason, bad.current_artist_name, bad.current_track_title, bad.true_artist_name, bad.true_track_title;
   END LOOP;
 END $$;
 -- === END STMT ===
@@ -530,18 +753,40 @@ BEGIN
 END $$;
 -- === END STMT ===
 
--- INFO: one shared join, read by both the count below and the unmatched-row
--- listing below it, so the two cannot drift the way two hand-duplicated
--- copies of the same predicate could (LOW finding, PR #2154 review round 2
--- -- this predicate is still a separate hand-typed copy of build-targets'
--- own join further down, which is unavoidable: this runs before BEGIN and
--- build-targets deliberately runs inside the transaction, so they cannot
--- physically share one temp table -- but the two reads THIS side of that
--- boundary no longer duplicate each other).
+-- === STMT: pending-match-preview ===
+-- INFO: one shared join, read by the count below, the unmatched-row listing
+-- below it, and `guard-unknown-release` after that, so the three cannot drift
+-- the way hand-duplicated copies of the same predicate could (LOW finding, PR
+-- #2154 review round 2 -- this predicate is still a separate hand-typed copy
+-- of build-targets' own join further down, which is unavoidable: this runs
+-- before BEGIN and build-targets deliberately runs inside the transaction, so
+-- they cannot physically share one temp table -- but the reads THIS side of
+-- that boundary no longer duplicate each other).
+--
+-- Tagged as a STMT block in round 3 so the paired integration spec actually
+-- EXECUTES it; through round 2 the spec only pinned this section's position
+-- in the file with `indexOf` and a typo here would have survived the whole
+-- suite to kill the documented read-only `awk` preview in front of the
+-- operator. Same for the residual reads below and in the post-amble.
 DROP TABLE IF EXISTS pg_temp.pending_match_preview;
 CREATE TEMP TABLE pending_match_preview AS
 SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title,
-       cta.id AS matched_cta_id
+       l.id AS matched_library_id,
+       cta.id AS matched_cta_id,
+       -- Non-NFC diagnosis on the CURRENT (corrupt) side, informational only
+       -- (round 3). guard-nfc-form hard-rejects a non-NFC true_* replacement;
+       -- the same slip on a current_* value cannot be a hard rejection here,
+       -- because this table has no normalization invariant and a genuinely
+       -- NFD-stored live row is possible (it is the exact condition
+       -- `jobs/artist-unicode-dedup` + migration 0134's fold exist to clean up
+       -- on `artists`, which is a table that DOES have the invariant). So it
+       -- is surfaced where it is actionable instead: on the unmatched listing,
+       -- naming the reason a row that looks right matched nothing. Byte-exact
+       -- equality is what build-targets joins on, so an NFD current_* misses
+       -- an NFC live row silently.
+       (current_artist_name IS NOT NULL AND current_artist_name IS NOT NFC NORMALIZED)
+         OR (current_track_title IS NOT NULL AND current_track_title IS NOT NFC NORMALIZED)
+         AS current_is_non_nfc
   FROM pending_cta_repair p
   LEFT JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
   LEFT JOIN wxyc_schema.compilation_track_artist cta
@@ -562,13 +807,51 @@ SELECT COUNT(*) AS pending_declared,
   FROM pending_match_preview;
 
 SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
-SELECT legacy_release_id, track_position, current_artist_name, current_track_title
+SELECT legacy_release_id, track_position, current_artist_name, current_track_title,
+       matched_library_id IS NULL AS release_not_found,
+       current_is_non_nfc
   FROM pending_match_preview
  WHERE matched_cta_id IS NULL;
+-- === END STMT ===
 
+-- === STMT: guard-unknown-release ===
+-- Round 3 finding: an unmatched pending row is normally informational (an
+-- idempotent re-run matches nothing, legitimately) -- but ONE unmatched shape
+-- can never be that, and it was being swept into the same INFO listing as the
+-- benign one. Every captured legacy_release_id came out of the enumeration
+-- query's own `JOIN wxyc_schema.library l ON l.id = cta.library_id`
+-- projection, so an id that resolves to no `library` row at all is a
+-- transcription error in the paste. Repairing a CTA row does not delete or
+-- re-key its `library` parent, so a re-run of a completed repair still
+-- resolves every one of its releases -- which is what makes this safe to
+-- abort on where "matched no CTA row" is not.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT legacy_release_id, track_position, current_artist_name, current_track_title
+      FROM pending_match_preview
+     WHERE matched_library_id IS NULL
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% (track_position=% current_artist_name=% current_track_title=%) matches no row in wxyc_schema.library -- every captured id came from the enumeration query''s own JOIN to library, so an id that resolves to nothing is a paste/transcription error, not an already-repaired row; re-check this row against the enumeration output (a common cause is pasting the query''s leading cta.library_id column, which is a DIFFERENT keyspace from legacy_release_id)', bad.legacy_release_id, bad.track_position, bad.current_artist_name, bad.current_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
+-- === STMT: before-residual ===
+-- One sequential scan, not two (round 3): both counts are 1-character
+-- leading-wildcard LIKEs, which no index on this table can serve -- the
+-- pg_trgm GIN indexes extract zero trigrams from a single character -- so
+-- each is a guaranteed full-table scan. Two scalar subqueries scanned the
+-- table twice for one line of output; COUNT(*) FILTER does it in one pass.
+-- The same rewrite is applied to the post-amble's AFTER counterpart, where
+-- it also runs inside the write transaction and so has a real cost (see the
+-- statement_timeout note there).
 SELECT 'BEFORE — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
-SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
-       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
+SELECT COUNT(*) FILTER (WHERE artist_name LIKE E'%�%') AS artist_name_residual,
+       COUNT(*) FILTER (WHERE track_title LIKE E'%�%') AS track_title_residual
+  FROM wxyc_schema.compilation_track_artist;
+-- === END STMT ===
 
 -- ===========================================================
 -- Transactional block. Classification (`build-targets`) runs INSIDE this
@@ -613,6 +896,46 @@ LEFT JOIN wxyc_schema.compilation_track_artist twin
  AND twin.id <> cta.id
  AND twin.artist_name = COALESCE(p.true_artist_name, cta.artist_name)
  AND twin.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title);
+-- === END STMT ===
+
+-- === STMT: lock-targets ===
+-- Round 3: take real row locks on everything this run intends to write,
+-- immediately after classification, instead of continuing to narrow the
+-- classify-then-write window with re-checks alone. Covers BOTH sides of each
+-- repair -- the corrupt row (`t.id`) and the twin it resolved (`t.twin_id`) --
+-- because the write statements read and mutate both, and through round 2 only
+-- the corrupt row was ever re-checked. See "Mechanism" above for the full
+-- account of what this closes and what it structurally cannot (a concurrent
+-- INSERT of a brand-new twin, which stays fail-safe via 23505 + rollback).
+--
+-- ORDER BY cta.id is deadlock avoidance, not cosmetics: `LockRows` sits above
+-- `Sort` in the plan, so rows are locked in ascending id order, and any other
+-- id-ordered writer -- including a second operator running this same script
+-- against an overlapping capture -- queues behind this one rather than
+-- deadlocking against it.
+--
+-- `FOR UPDATE` rather than `FOR NO KEY UPDATE` costs nothing here: the
+-- stronger mode's extra effect is blocking the `FOR KEY SHARE` an FK check
+-- takes on a REFERENCED row, and nothing in the schema references
+-- `compilation_track_artist` (checked against pg_constraint, not assumed --
+-- `confrelid = 'wxyc_schema.compilation_track_artist'::regclass` returns no
+-- rows). The DELETE branch needs the stronger mode anyway.
+--
+-- UNION (not UNION ALL) so a row that is both some target's corrupt row and
+-- another target's twin is locked once. `SET LOCAL statement_timeout = '30s'`
+-- above bounds the wait: a conflicting writer holding its lock longer aborts
+-- this run cleanly instead of parking it behind `library-etl`'s 30-minute
+-- cycle. Prints the locked ids, which is genuine operator signal -- the count
+-- should be the matched-row count plus the number of twins.
+SELECT cta.id AS locked_cta_id
+  FROM wxyc_schema.compilation_track_artist cta
+ WHERE cta.id IN (
+         SELECT t.id FROM cta_repair_targets t
+          UNION
+         SELECT t.twin_id FROM cta_repair_targets t WHERE t.twin_id IS NOT NULL
+       )
+ ORDER BY cta.id
+   FOR UPDATE;
 -- === END STMT ===
 
 -- === STMT: guard-post-fix-fffd ===
@@ -760,12 +1083,37 @@ SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_tra
 -- before repointing (LOW finding, PR #2154 review round 2) -- mirrors
 -- delete-twins' own re-check below, which this statement previously lacked.
 -- Without it, a concurrent edit to the corrupt row landing between
--- build-targets and here (real: see "Mechanism" above on why classifying
--- inside the transaction narrows, but does not close, that window) would
--- still repoint the twin's identity link even though delete-twins' own
--- re-check would then correctly skip deleting the now-changed corrupt row --
--- repointing without deleting, silently duplicating the identity link across
--- two live rows.
+-- build-targets and here would still repoint the twin's identity link even
+-- though delete-twins' own re-check would then correctly skip deleting the
+-- now-changed corrupt row -- repointing without deleting, silently
+-- duplicating the identity link across two live rows.
+--
+-- That round 2 fix closed the build-targets -> here half of the window but
+-- not the here -> delete-twins half (round 3 finding): an edit landing
+-- BETWEEN these two statements produced the identical duplicated-link
+-- outcome, because each statement's re-check made it individually correct
+-- while the pair disagreed. `lock-targets` above is what actually closes it
+-- -- both statements now read state that cannot change between them -- and
+-- the re-checks remain as what catches an edit from the one surviving
+-- window, build-targets -> lock-targets.
+--
+-- Round 3 also re-checks the TWIN, not just the corrupt row. `twin.id =
+-- t.twin_id` alone matches on identity, which survives a rename: if the twin
+-- was edited in that window it is no longer the row that holds the post-fix
+-- tuple, and repointing the corrupt row's identity link onto it writes the
+-- link to the wrong credit. Requiring the twin to still hold
+-- `new_artist_name`/`new_track_title` makes this statement and delete-twins
+-- fire on exactly the same condition, so they cannot disagree.
+--
+-- This particular clause is the INNER of two independent defenses, and is
+-- deliberately not pinned by its own test because it currently has no
+-- observable effect to pin: any run in which delete-twins skips leaves the
+-- corrupt tuple live, and guard-repair-complete then rolls the whole
+-- transaction back -- discarding a wrongly-repointed link along with
+-- everything else. It is here so that the two statements stay coherent on
+-- their own terms rather than relying on a downstream abort to clean up
+-- after them, which is what would matter to whoever next changes either the
+-- guard or the ordering.
 UPDATE wxyc_schema.compilation_track_artist twin
    SET track_artist_id = COALESCE(twin.track_artist_id, t.old_track_artist_id),
        track_artist_link_confidence = COALESCE(twin.track_artist_link_confidence, t.old_track_artist_link_confidence),
@@ -774,6 +1122,8 @@ UPDATE wxyc_schema.compilation_track_artist twin
   FROM cta_repair_targets t
  WHERE t.has_twin
    AND twin.id = t.twin_id
+   AND twin.artist_name = t.new_artist_name
+   AND twin.track_title IS NOT DISTINCT FROM t.new_track_title
    AND EXISTS (
      SELECT 1 FROM wxyc_schema.compilation_track_artist cta
       WHERE cta.id = t.id
@@ -787,12 +1137,35 @@ UPDATE wxyc_schema.compilation_track_artist twin
 -- corrupt row had, repointed above); the corrupt row is redundant.
 -- Re-checks old_artist_name/old_track_title so a second run (where the row
 -- no longer matches, having already been deleted) is a genuine no-op.
+--
+-- ALSO re-checks that the twin still EXISTS and still holds the post-fix
+-- tuple (round 3 finding). This is the one statement in the script that can
+-- destroy data outright, and through round 2 it verified only the row it was
+-- about to delete -- never the row that was supposed to be carrying the
+-- credit forward. `twin.id = t.twin_id` from build-targets is a snapshot: if
+-- the twin was deleted or renamed between classification and here, the DELETE
+-- still fired and removed what had by then become the ONLY remaining copy of
+-- that compilation credit, committing at exit 0 with a per-row residual of 0
+-- (the residual counts the OLD tuple, which the delete genuinely removed).
+-- The UPDATE branch has never had this exposure -- writing onto a
+-- concurrently-created twin raises 23505 and rolls the run back -- so the
+-- DELETE branch was the only one without a tripwire. `lock-targets` above now
+-- prevents the twin from being touched at all once this run has classified
+-- it; this EXISTS covers the residual build-targets -> lock-targets window,
+-- where the honest answer is to skip the delete and let
+-- `guard-repair-complete` abort the whole transaction rather than guess.
 DELETE FROM wxyc_schema.compilation_track_artist cta
 USING cta_repair_targets t
 WHERE cta.id = t.id
   AND t.has_twin
   AND cta.artist_name = t.old_artist_name
-  AND cta.track_title IS NOT DISTINCT FROM t.old_track_title;
+  AND cta.track_title IS NOT DISTINCT FROM t.old_track_title
+  AND EXISTS (
+    SELECT 1 FROM wxyc_schema.compilation_track_artist twin
+     WHERE twin.id = t.twin_id
+       AND twin.artist_name = t.new_artist_name
+       AND twin.track_title IS NOT DISTINCT FROM t.new_track_title
+  );
 -- === END STMT ===
 
 -- === STMT: update-no-twins ===
@@ -806,6 +1179,73 @@ UPDATE wxyc_schema.compilation_track_artist cta
    AND cta.artist_name = t.old_artist_name
    AND cta.track_title IS NOT DISTINCT FROM t.old_track_title;
 -- === END STMT ===
+
+-- === STMT: guard-repair-complete ===
+-- Round 3: the post-condition. Every other guard in this script checks the
+-- CAPTURE before it can do damage; this one checks the RUN before it can be
+-- committed, and it exists because all three write statements above skip
+-- silently by design.
+--
+-- Skipping is the correct behavior for each of them individually -- it is
+-- what makes a re-run idempotent, and what makes a concurrent edit
+-- non-destructive. But "skipped" and "repaired" produce the same exit code,
+-- and the case that matters is the one where the skip leaves the corruption
+-- live: `delete-twins` declining because the twin vanished in the
+-- build-targets -> lock-targets window. Without this guard the script COMMITs
+-- that outcome at exit 0, and the operator's evidence is a residual count
+-- that reads 1 -- indistinguishable at a glance from the pre-run state, in a
+-- postlude whose whole framing is "desired end state: 0 / 0".
+--
+-- The predicate is deliberately the same one the post-amble prints per row.
+-- Zero false positives on a legitimate re-run: build-targets' join requires
+-- the live row to still hold the captured CORRUPT strings, so an
+-- already-repaired row never enters `cta_repair_targets` in the first place.
+-- Nor on a benign concurrent edit: a row someone else changed no longer holds
+-- the old tuple either, so it passes here and this run simply wrote nothing
+-- for it. And it cannot be tripped by an unrelated row, because
+-- cta_unique_idx / cta_unique_null_track_idx make at most one live row able
+-- to hold that tuple. What remains is exactly the failure it is for: the
+-- repair did not happen.
+--
+-- Aborting rolls the transaction back whole, which is also the right recovery
+-- shape -- a re-run reclassifies from live state (a vanished twin becomes a
+-- no-twin row and takes the UPDATE branch) instead of retrying a
+-- classification that is now stale.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT t.legacy_release_id, t.track_position, t.id AS cta_id,
+           t.old_artist_name, t.old_track_title, t.has_twin, t.twin_id
+      FROM cta_repair_targets t
+     WHERE EXISTS (
+       SELECT 1 FROM wxyc_schema.compilation_track_artist cta
+        WHERE cta.library_id = t.library_id
+          AND cta.artist_name = t.old_artist_name
+          AND cta.track_title IS NOT DISTINCT FROM t.old_track_title
+     )
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% (cta_id=% has_twin=% twin_id=%) still holds its corrupt tuple (artist_name=% track_title=%) after the write statements ran -- the repair for this row was SKIPPED, not applied; the usual cause is that its twin was deleted or renamed between build-targets and lock-targets, so delete-twins correctly declined rather than destroy the last copy of the credit. Rolling back; re-run the script to reclassify this row against current live state', bad.legacy_release_id, bad.track_position, bad.cta_id, bad.has_twin, bad.twin_id, bad.old_artist_name, bad.old_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
+-- Raise the statement timeout for the read-only post-amble below (round 3
+-- finding). `SET LOCAL` is last-write-wins within the transaction, so the 30s
+-- cap stays in force over every statement that WRITES -- this only relaxes
+-- the two full-table residual scans that follow, and only after the repair
+-- has already succeeded.
+--
+-- Necessary because those scans are unindexable by construction (1-character
+-- leading-wildcard LIKE; the pg_trgm GIN indexes extract zero trigrams from a
+-- single character) and they run INSIDE the write transaction, where the
+-- reason they are inside is the dry-run recipe, not correctness. Under the
+-- flat 30s cap a cold cache or I/O contention from the concurrent 30-minute
+-- library-etl cycle could time the scan out, and ON_ERROR_STOP would then
+-- roll back a repair that had fully succeeded -- destroying a correct result
+-- to fail a verification read. Kept finite rather than 0 so a genuinely
+-- pathological scan still ends while holding this run's row locks.
+SET LOCAL statement_timeout = '5min';
 
 -- ===========================================================
 -- Post-amble verify: every targeted row should show residual=0, and the
@@ -826,6 +1266,7 @@ UPDATE wxyc_schema.compilation_track_artist cta
 -- `COMMIT;`/`ROLLBACK;` line makes them visible on both the real run and the
 -- dry-run preview alike.
 -- ===========================================================
+-- === STMT: post-amble-residual ===
 SELECT '=== V_BS_FFFD_CTA post-amble: residual count per targeted row (expect 0) ===' AS section;
 -- Prints the LIVE `track_position` (NIT, PR #2154 review round 2 -- this
 -- used to print the CAPTURED value from cta_repair_targets, which is not
@@ -846,9 +1287,14 @@ SELECT t.legacy_release_id,
     ON live.id = COALESCE(t.twin_id, t.id)
  ORDER BY t.legacy_release_id, live.track_position;
 
+-- One sequential scan, not two -- see the BEFORE counterpart's comment. It
+-- matters more here: this pair runs inside the write transaction, holding
+-- this run's row locks, after the repair has already succeeded.
 SELECT 'AFTER — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
-SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
-       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
+SELECT COUNT(*) FILTER (WHERE artist_name LIKE E'%�%') AS artist_name_residual,
+       COUNT(*) FILTER (WHERE track_title LIKE E'%�%') AS track_title_residual
+  FROM wxyc_schema.compilation_track_artist;
+-- === END STMT ===
 
 -- Broader-table informational sweep (rotation/flowsheet/artists/library)
 -- already lives in bs_replacement_char_phase4.sql's postlude -- not repeated

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -48,6 +48,72 @@
 -- cases in the paired integration test.
 --
 -- ============================================================================
+-- OPERATOR-ERROR GUARDS (PR #2154 review)
+-- ============================================================================
+-- Five DO-block guards run before the corresponding mistake can do damage,
+-- each aborting loudly (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here
+-- stops the whole psql run with a nonzero exit and no partial write):
+--
+--   guard-placeholder-scrub      -- a captured row with a blank
+--                                    legacy_release_id survived the
+--                                    exact-placeholder scrub -- a paste
+--                                    error, not the shipped row.
+--   guard-replacement-specified  -- a declared row fixes nothing (both
+--                                    true_* columns NULL).
+--   guard-capture-sanity         -- a declared row's current_*/true_* pair
+--                                    looks transposed: current_* lacks
+--                                    U+FFFD, or true_* contains it. The
+--                                    capture procedure's clipboard step puts
+--                                    BOTH strings on the clipboard at once
+--                                    for each of the 14 hand-pasted rows, so
+--                                    a swap on any one of them is one slip
+--                                    away. Unguarded, a transposed row would
+--                                    match the CLEAN live row (its
+--                                    current_* equals the clean value),
+--                                    compute the CORRUPT string as its
+--                                    post-fix tuple, find the genuinely
+--                                    corrupt row as its twin, and DELETE the
+--                                    clean row -- exit 0, no error, and the
+--                                    postlude's residual counts go UP (reads
+--                                    like a capture mismatch, not data
+--                                    loss). Also structurally catches the
+--                                    wrong-client_encoding scenario the
+--                                    session guards below worry about -- a
+--                                    misdecoded session turns every U+FFFD
+--                                    predicate into a false negative the
+--                                    same way a transposed pair does.
+--   guard-ambiguous-match         -- a pending row resolves to more than one
+--                                    LIVE row (structurally impossible under
+--                                    cta_unique_idx / cta_unique_null_track_idx,
+--                                    asserted defensively; also catches an
+--                                    accidental duplicate pending entry that
+--                                    both resolve to the SAME live row).
+--   guard-converging-pending      -- two (or more) pending rows resolve to
+--                                    the SAME post-fix (library_id,
+--                                    artist_name, track_title) tuple as EACH
+--                                    OTHER, live twin or not. #2114
+--                                    established the damage is per-row
+--                                    (`La Forêt` survived the same 0xEA
+--                                    byte that killed `La Bête`), and #1996
+--                                    measured the double-ingest shape (two
+--                                    differently-corrupted copies of one
+--                                    credit) at 98.5% of this table's
+--                                    damaged rows -- so two convergent
+--                                    pending rows is the EXPECTED shape, not
+--                                    an exotic one. `guard-ambiguous-match`
+--                                    cannot catch this -- it groups on the
+--                                    OLD (corrupt) tuple, which differs
+--                                    between the two rows; this groups on
+--                                    the resolved NEW (post-fix) tuple
+--                                    instead. Without it, both rows classify
+--                                    independently as no-twin and both land
+--                                    in the single set-based
+--                                    update-no-twins UPDATE, which raises a
+--                                    raw 23505 instead of a named guard
+--                                    message identifying which rows
+--                                    collided.
+--
+-- ============================================================================
 -- WHY THIS SCRIPT IS DATA-DRIVEN, NOT LITERAL LIKE ITS PREDECESSORS
 -- ============================================================================
 -- Phase 1/2/3.5/4 all bake their exact corrupt/correct string literals
@@ -118,6 +184,17 @@
 --    equality is what the downstream catalog-parity harness checks
 --    (discogs-etl#346), so an approximately-right glyph is a shipped bug.
 --
+--    Known gap, deliberately deferred (PR #2154 review): Phase 4's
+--    strongest guard against exactly this mistake was an automated
+--    byte-assertion that the SCRIPT TEXT itself uses the correct codepoints
+--    (the `µ` U+00B5 vs `μ` U+03BC trap, exercised in
+--    bs-replacement-char-phase4.spec.js). That guard can't be written here
+--    yet -- there is no script text to assert against until an operator has
+--    actually captured and pasted the 14 real values (see "WHY THIS SCRIPT
+--    IS DATA-DRIVEN" above). Whoever fills in the PENDING CAPTURE block
+--    should add that same byte-assertion test as part of that follow-up --
+--    this is a known, named gap, not a silent omission.
+--
 -- 4. Fill in the PENDING CAPTURE block below: one row per corrupt value,
 --    using the enumeration query's own columns for `legacy_release_id` /
 --    `track_position` / `current_artist_name` / `current_track_title`, and
@@ -127,26 +204,55 @@
 --
 -- 5. Human-review the filled-in block, then run this whole script.
 --
--- Read-only prelude only, stop before any write (mirrors Phase 4's recipe):
+-- Read-only prelude, stop before any write:
 --
 --   awk '/^BEGIN;/{exit} {print}' scripts/audit/bs_replacement_char_cta.sql \
 --     | psql "$DATABASE_URL"
+--
+-- This shows the declared-row count and the two full-table informational
+-- checks (unmatched pending rows, overall residual count) -- it does NOT
+-- show the twin/no-twin classification, because that classification
+-- (`build-targets`) now runs INSIDE the transaction (see "Mechanism" below,
+-- PR #2154 review). To preview the FULL classification and writes without
+-- persisting anything, run the script with its `COMMIT;` swapped for
+-- `ROLLBACK;` -- this executes the real guards and the real DELETE/UPDATE
+-- inside a real transaction (so a would-be `cta_unique_idx` violation
+-- surfaces exactly as it would for real), then discards everything:
+--
+--   sed 's/^COMMIT;$/ROLLBACK;/' scripts/audit/bs_replacement_char_cta.sql \
+--     | psql "$DATABASE_URL"
+--
+-- (`ANALYZE` still runs after -- harmless, it only refreshes planner stats,
+-- never data.)
 --
 -- ============================================================================
 -- Mechanism
 -- ============================================================================
 -- `pending_cta_repair` is a session-local scratch table holding the
--- captured rows. `cta_repair_targets` resolves each pending row against the
--- LIVE table (matched on `library_id` + the row's exact captured
--- `artist_name`/`track_title` -- a combination `cta_unique_idx` /
+-- captured rows, sanity-checked (`guard-capture-sanity`) before it is ever
+-- joined against the live table. `cta_repair_targets` resolves each pending
+-- row against the LIVE table (matched on `library_id` + the row's exact
+-- captured `artist_name`/`track_title` -- a combination `cta_unique_idx` /
 -- `cta_unique_null_track_idx` already guarantee is unique, so a pending row
--- can structurally match at most one live row) and classifies it
--- twin/no-twin by checking whether another row already holds the post-fix
--- tuple. The classification is computed ONCE, before `BEGIN`, and both the
--- audit prelude and the two write statements read that same materialized
--- table -- so the prelude's SELECT and the writes are the *same* predicate
--- by construction (org data-safety convention), not two independently
--- typed-out copies that could drift apart.
+-- can structurally match at most one live row) and classifies twin/no-twin
+-- by resolving the twin's OWN row id (`twin_id`), not just its existence --
+-- this also carries over the twin's `track_artist_id` /
+-- `track_artist_link_confidence` / `track_artist_link_method` /
+-- `track_position` so the DELETE branch can preserve the corrupt row's
+-- identity link onto the twin (see `delete-twins` below) and the BEFORE
+-- print can show both sides.
+--
+-- Classification now runs INSIDE the transaction -- `BEGIN` precedes
+-- `build-targets`, not the reverse (PR #2154 review). `library-etl`'s
+-- `importCompilationTracks` writes this table every 30 minutes; classifying
+-- before `BEGIN` left a window where a concurrent insert of a clean twin
+-- between classification and the write could flip a no-twin row's UPDATE
+-- into a live 23505 mid-run. The audit prelude's "matched rows" SELECT and
+-- the two write statements now all read the SAME `cta_repair_targets`,
+-- materialized inside the SAME transaction -- so they are the *same*
+-- predicate by construction (org data-safety convention), not independently
+-- typed-out copies that could drift apart, and there is no window between
+-- classifying a row and acting on that classification.
 --
 -- Idempotency: `cta_repair_targets`'s join to the live table requires the
 -- row's `artist_name`/`track_title` to still equal the captured (corrupt)
@@ -183,7 +289,8 @@
 -- client encoding, the server reinterprets this file's UTF-8 bytes, every
 -- predicate matches zero rows, and the pre-amble reports 0 -- which reads as
 -- "already repaired" rather than "matched nothing". Declaring it makes that
--- failure impossible instead of silent.
+-- failure impossible instead of silent. `guard-capture-sanity` below is a
+-- second, independent line of defense against the same failure mode.
 --
 -- ON_ERROR_STOP: without it, an error inside the transaction leaves psql
 -- issuing the remaining commands into an aborted transaction, COMMIT
@@ -193,14 +300,14 @@
 SET client_encoding TO 'UTF8';
 
 -- === STMT: create-pending-table ===
-DROP TABLE IF EXISTS pending_cta_repair;
+DROP TABLE IF EXISTS pg_temp.pending_cta_repair;
 CREATE TEMP TABLE pending_cta_repair (
   legacy_release_id integer,
-  track_position text,
-  current_artist_name text,
-  current_track_title text,
-  true_artist_name text,
-  true_track_title text
+  track_position varchar(20),
+  current_artist_name varchar(255),
+  current_track_title varchar(255),
+  true_artist_name varchar(255),
+  true_track_title varchar(255)
 );
 -- === END STMT ===
 
@@ -221,7 +328,38 @@ INSERT INTO pending_cta_repair
 VALUES
   (NULL, NULL, NULL, NULL, NULL, NULL); -- placeholder; keeps VALUES syntactically valid with 0 rows captured so far
 
-DELETE FROM pending_cta_repair WHERE legacy_release_id IS NULL; -- drop the placeholder
+-- Scrub ONLY the exact placeholder shape (every column NULL) -- MEDIUM
+-- finding (PR #2154 review). A genuinely captured row that happens to carry
+-- a blank legacy_release_id (a paste slip, NOT the placeholder) still has
+-- non-NULL data in at least one other column, so it survives this DELETE
+-- and is caught by the dedicated guard-placeholder-scrub block below
+-- instead of being silently swept away alongside the real placeholder.
+DELETE FROM pending_cta_repair
+ WHERE legacy_release_id IS NULL
+   AND track_position IS NULL
+   AND current_artist_name IS NULL
+   AND current_track_title IS NULL
+   AND true_artist_name IS NULL
+   AND true_track_title IS NULL;
+-- === END STMT ===
+
+-- === STMT: guard-placeholder-scrub ===
+-- Anything still holding a NULL legacy_release_id after the exact-placeholder
+-- scrub above is not the shipped placeholder (already removed) -- it is a
+-- capture paste error: a real row missing the one column the whole repair
+-- joins on. Previously `pending_declared` was counted AFTER an unconditional
+-- `WHERE legacy_release_id IS NULL` delete, so nothing distinguished "14
+-- captured" from "13 captured + 1 silently dropped" (PR #2154 review
+-- reproduction: 2 captured rows, one with a blank legacy_release_id ->
+-- INSERT 0 2, DELETE 1, pending_declared = 1, no warning).
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT COUNT(*) INTO n FROM pending_cta_repair WHERE legacy_release_id IS NULL;
+  IF n > 0 THEN
+    RAISE EXCEPTION 'BS#2152 guard: % declared pending row(s) have a NULL legacy_release_id -- the exact all-NULL placeholder has already been scrubbed, so this is a capture paste error, not the shipped row; every real captured row must carry its legacy_release_id from the enumeration query', n;
+  END IF;
+END $$;
 -- === END STMT ===
 
 -- === STMT: guard-replacement-specified ===
@@ -237,11 +375,72 @@ BEGIN
 END $$;
 -- === END STMT ===
 
+-- === STMT: guard-capture-sanity ===
+-- HIGH finding (PR #2154 review): nothing upstream of this guard verifies
+-- that current_* actually holds the U+FFFD-corrupted value and true_* holds
+-- the clean replacement. The capture procedure's clipboard step puts BOTH
+-- strings on the clipboard for each of the 14 hand-pasted rows, so a
+-- transposed paste on any one row is one slip away. Unguarded, a transposed
+-- row would match the CLEAN live row (its current_* equals the clean live
+-- value), compute the CORRUPT string as its post-fix tuple, find the
+-- genuinely corrupt row as its twin, and DELETE the clean row -- exit 0, no
+-- error, and the postlude's residual counts go UP (reads like a capture
+-- mismatch, not data loss). This also structurally catches the
+-- wrong-client_encoding scenario the session guards above worry about: a
+-- misdecoded session turns every U+FFFD predicate into a false negative the
+-- same way a transposed pair does.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT legacy_release_id, track_position, current_artist_name, current_track_title,
+           true_artist_name, true_track_title
+      FROM pending_cta_repair
+     WHERE (true_artist_name IS NOT NULL AND (
+             current_artist_name IS NULL
+             OR current_artist_name NOT LIKE '%' || chr(65533) || '%'
+             OR true_artist_name LIKE '%' || chr(65533) || '%'
+           ))
+        OR (true_track_title IS NOT NULL AND (
+             current_track_title IS NULL
+             OR current_track_title NOT LIKE '%' || chr(65533) || '%'
+             OR true_track_title LIKE '%' || chr(65533) || '%'
+           ))
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% looks transposed or uncorrupted (current_artist_name=% current_track_title=% true_artist_name=% true_track_title=%) -- every current_* column being fixed must contain U+FFFD and every true_* replacement must not; verify the capture was not pasted backwards (or check client_encoding)', bad.legacy_release_id, bad.track_position, bad.current_artist_name, bad.current_track_title, bad.true_artist_name, bad.true_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
+SELECT '=== V_BS_FFFD_CTA pre-amble: declared pending rows (0 = capture step not yet run) ===' AS section;
+SELECT COUNT(*) AS pending_declared FROM pending_cta_repair;
+
+SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
+SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title
+  FROM pending_cta_repair p
+  LEFT JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
+  LEFT JOIN wxyc_schema.compilation_track_artist cta
+    ON cta.library_id = l.id
+   AND cta.artist_name = p.current_artist_name
+   AND cta.track_title IS NOT DISTINCT FROM p.current_track_title
+ WHERE cta.id IS NULL;
+
+SELECT 'BEFORE — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
+SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
+       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
+
+-- ===========================================================
+-- Transactional block. Classification (`build-targets`) runs INSIDE this
+-- transaction (PR #2154 review) -- see "Mechanism" above for why.
+-- ===========================================================
+BEGIN;
+SET LOCAL statement_timeout = '30s';
+
 -- === STMT: build-targets ===
--- Resolve every pending row against the live table and classify twin/no-twin.
--- Computed once; the prelude SELECTs below and the two write statements
--- further down all read this same table, so they see the identical row set.
-DROP TABLE IF EXISTS cta_repair_targets;
+-- Resolve every pending row against the live table and classify twin/no-twin
+-- by resolving the twin's own row id (not just its existence), carrying over
+-- its identity-link columns for the DELETE branch and the BEFORE print.
+DROP TABLE IF EXISTS pg_temp.cta_repair_targets;
 CREATE TEMP TABLE cta_repair_targets AS
 SELECT
   p.legacy_release_id,
@@ -250,22 +449,29 @@ SELECT
   cta.library_id,
   cta.artist_name AS old_artist_name,
   cta.track_title AS old_track_title,
+  cta.track_position AS old_track_position,
+  cta.track_artist_id AS old_track_artist_id,
+  cta.track_artist_link_confidence AS old_track_artist_link_confidence,
+  cta.track_artist_link_method AS old_track_artist_link_method,
   COALESCE(p.true_artist_name, cta.artist_name) AS new_artist_name,
   COALESCE(p.true_track_title, cta.track_title) AS new_track_title,
-  EXISTS (
-    SELECT 1
-      FROM wxyc_schema.compilation_track_artist other
-     WHERE other.library_id = cta.library_id
-       AND other.id <> cta.id
-       AND other.artist_name = COALESCE(p.true_artist_name, cta.artist_name)
-       AND other.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title)
-  ) AS has_twin
+  twin.id AS twin_id,
+  twin.track_position AS twin_track_position,
+  twin.track_artist_id AS twin_track_artist_id,
+  twin.track_artist_link_confidence AS twin_track_artist_link_confidence,
+  twin.track_artist_link_method AS twin_track_artist_link_method,
+  (twin.id IS NOT NULL) AS has_twin
 FROM pending_cta_repair p
 JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
 JOIN wxyc_schema.compilation_track_artist cta
   ON cta.library_id = l.id
  AND cta.artist_name = p.current_artist_name
- AND cta.track_title IS NOT DISTINCT FROM p.current_track_title;
+ AND cta.track_title IS NOT DISTINCT FROM p.current_track_title
+LEFT JOIN wxyc_schema.compilation_track_artist twin
+  ON twin.library_id = cta.library_id
+ AND twin.id <> cta.id
+ AND twin.artist_name = COALESCE(p.true_artist_name, cta.artist_name)
+ AND twin.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title);
 -- === END STMT ===
 
 -- === STMT: guard-ambiguous-match ===
@@ -289,43 +495,72 @@ BEGIN
 END $$;
 -- === END STMT ===
 
--- ===========================================================
--- Pre-amble: declared rows, BEFORE classification, BEFORE residual counts.
--- Same predicate the writes use, per the org data-safety convention --
--- literally the same materialized table, not a re-typed copy.
--- ===========================================================
-SELECT '=== V_BS_FFFD_CTA pre-amble: declared pending rows (0 = capture step not yet run) ===' AS section;
-SELECT COUNT(*) AS pending_declared FROM pending_cta_repair;
+-- === STMT: guard-converging-pending ===
+-- HIGH/MEDIUM finding (PR #2154 review): `has_twin` above only asks whether
+-- the LIVE table already holds the post-fix tuple -- it never asks whether
+-- another PENDING row resolves to the SAME post-fix tuple. Two differently-
+-- corrupted copies of one compilation credit (#2114's damage is per-row --
+-- `La Forêt` survived the same 0xEA byte that killed `La Bête`; #1996
+-- measured this double-ingest shape at 98.5% of this table's damaged rows)
+-- can both independently classify no-twin and then both land in the single
+-- set-based update-no-twins UPDATE, which raises cta_unique_idx /
+-- cta_unique_null_track_idx instead of failing with a named message.
+-- guard-ambiguous-match cannot catch this -- it groups on the OLD (corrupt)
+-- tuple, which differs between the two rows; this groups on the resolved
+-- NEW (post-fix) tuple instead.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT library_id, new_artist_name, new_track_title, COUNT(*) AS n,
+           array_agg(legacy_release_id ORDER BY legacy_release_id) AS release_ids,
+           array_agg(track_position ORDER BY legacy_release_id) AS track_positions
+      FROM cta_repair_targets
+     GROUP BY library_id, new_artist_name, new_track_title
+    HAVING COUNT(*) > 1
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: % pending row(s) converge on the same post-fix library_id=% artist_name=% track_title=% (legacy_release_id/track_position pairs: %/%) -- two differently-corrupted copies of one credit would collide under cta_unique_idx on a single UPDATE; resolve which capture is correct (or whether one is a distinct real credit) before re-running', bad.n, bad.library_id, bad.new_artist_name, bad.new_track_title, bad.release_ids, bad.track_positions;
+  END LOOP;
+END $$;
+-- === END STMT ===
 
 SELECT 'BEFORE — matched rows + twin classification' AS section;
 SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_track_title,
        new_artist_name, new_track_title,
-       CASE WHEN has_twin THEN 'DELETE (twin exists)' ELSE 'UPDATE (no twin)' END AS action
+       CASE WHEN has_twin THEN 'DELETE (twin exists)' ELSE 'UPDATE (no twin)' END AS action,
+       old_track_position, old_track_artist_id, old_track_artist_link_confidence, old_track_artist_link_method,
+       twin_id, twin_track_position, twin_track_artist_id, twin_track_artist_link_confidence, twin_track_artist_link_method
   FROM cta_repair_targets
  ORDER BY legacy_release_id, track_position;
 
-SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
-SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title
-  FROM pending_cta_repair p
-  LEFT JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
-  LEFT JOIN wxyc_schema.compilation_track_artist cta
-    ON cta.library_id = l.id
-   AND cta.artist_name = p.current_artist_name
-   AND cta.track_title IS NOT DISTINCT FROM p.current_track_title
- WHERE cta.id IS NULL;
-
-SELECT 'BEFORE — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
-SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
-       (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE track_title LIKE E'%�%') AS track_title_residual;
-
--- ===========================================================
--- Transactional write block.
--- ===========================================================
-BEGIN;
-SET LOCAL statement_timeout = '30s';
+-- === STMT: repoint-twin-identity ===
+-- MEDIUM finding (PR #2154 review): before dropping the corrupt row,
+-- repoint its per-track identity link (BS#1990 / #801 S1 -- track_artist_id
+-- + track_artist_link_confidence + track_artist_link_method) and
+-- track_position onto the surviving twin, COALESCE-preserving the twin's own
+-- non-NULL values -- the corrupt row is the OLDER of the pair (the ETL's
+-- insert-only writer kept both when the strings diverged), so it is the more
+-- likely of the two to already carry an `lml_backfill` link the clean twin
+-- lacks. Same COALESCE-preserve-then-delete shape as
+-- `jobs/artist-unicode-dedup/merge.ts`'s survivor repoint. The BEFORE print
+-- above projects all four columns for both rows so an operator reviewing the
+-- output can see exactly what this carries over before it runs. A separate
+-- statement (not fused into delete-twins below) so each STMT block keeps the
+-- one-statement-per-block shape the paired integration spec's extractor
+-- relies on.
+UPDATE wxyc_schema.compilation_track_artist twin
+   SET track_artist_id = COALESCE(twin.track_artist_id, t.old_track_artist_id),
+       track_artist_link_confidence = COALESCE(twin.track_artist_link_confidence, t.old_track_artist_link_confidence),
+       track_artist_link_method = COALESCE(twin.track_artist_link_method, t.old_track_artist_link_method),
+       track_position = COALESCE(twin.track_position, t.old_track_position)
+  FROM cta_repair_targets t
+ WHERE t.has_twin
+   AND twin.id = t.twin_id;
+-- === END STMT ===
 
 -- === STMT: delete-twins ===
--- The clean twin already carries the truth; the corrupt row is redundant.
+-- The clean twin now carries the truth (plus whatever identity link the
+-- corrupt row had, repointed above); the corrupt row is redundant.
 -- Re-checks old_artist_name/old_track_title so a second run (where the row
 -- no longer matches, having already been deleted) is a genuine no-op.
 DELETE FROM wxyc_schema.compilation_track_artist cta
@@ -353,6 +588,8 @@ COMMIT;
 -- ===========================================================
 -- Post-amble verify: every targeted row should show residual=0, and the
 -- overall predicate should return 0/0 -- the desired end state per #2152.
+-- `cta_repair_targets` is a TEMP TABLE without ON COMMIT DROP, so it is
+-- still readable here, after COMMIT, in this same session.
 -- ===========================================================
 SELECT '=== V_BS_FFFD_CTA post-amble: residual count per targeted row (expect 0) ===' AS section;
 SELECT t.legacy_release_id, t.track_position,

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -50,9 +50,11 @@
 -- ============================================================================
 -- OPERATOR-ERROR GUARDS (PR #2154 review)
 -- ============================================================================
--- Five DO-block guards run before the corresponding mistake can do damage,
--- each aborting loudly (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here
--- stops the whole psql run with a nonzero exit and no partial write):
+-- Seven DO-block guards (five from round 1, two added in round 2's review)
+-- run before the corresponding mistake can do damage, each aborting loudly
+-- (`\set ON_ERROR_STOP on`, so a RAISE EXCEPTION here stops the whole psql
+-- run with a nonzero exit and no partial write). Listed in the order they
+-- actually run:
 --
 --   guard-placeholder-scrub      -- a captured row with a blank
 --                                    legacy_release_id survived the
@@ -82,6 +84,38 @@
 --                                    misdecoded session turns every U+FFFD
 --                                    predicate into a false negative the
 --                                    same way a transposed pair does.
+--   guard-nfc-form                -- a declared true_* replacement is not in
+--                                    NFC Unicode normalization form (round 2
+--                                    MEDIUM finding). Twin detection below
+--                                    joins on exact byte equality, so a
+--                                    true_* value pasted out of a source that
+--                                    yields a different normalization form
+--                                    (e.g. NFD) can silently miss a live twin
+--                                    already stored in NFC -- the row
+--                                    classifies no-twin, the UPDATE writes a
+--                                    byte-distinct duplicate, and
+--                                    cta_unique_idx does not fire because the
+--                                    two rows are not byte-identical. A
+--                                    capture-time rejection, not a write-time
+--                                    normalization -- preserves the byte-exact
+--                                    write posture documented under
+--                                    "Unicode normalization" below.
+--   guard-post-fix-fffd           -- (runs after build-targets, inside the
+--                                    transaction) a row's post-fix tuple
+--                                    (new_artist_name / new_track_title)
+--                                    still contains U+FFFD (round 2 HIGH
+--                                    finding). new_* is
+--                                    COALESCE(true_*, cta.*), so a row
+--                                    corrupt in BOTH columns but captured
+--                                    with only one true_* replacement leaves
+--                                    the untouched column's U+FFFD in the
+--                                    write -- silently destroying data if a
+--                                    twin happens to match on the fixed
+--                                    column alone, or silently leaving a
+--                                    corrupt column behind if not. See step 4
+--                                    of the capture procedure below for the
+--                                    correct one-row-carries-both-values
+--                                    shape this guard enforces.
 --   guard-ambiguous-match         -- a pending row resolves to more than one
 --                                    LIVE row (structurally impossible under
 --                                    cta_unique_idx / cta_unique_null_track_idx,
@@ -111,7 +145,12 @@
 --                                    update-no-twins UPDATE, which raises a
 --                                    raw 23505 instead of a named guard
 --                                    message identifying which rows
---                                    collided.
+--                                    collided. Deliberately over-broad: it
+--                                    aborts even when both converging rows
+--                                    classify has_twin=true, where the two
+--                                    DELETEs would actually be collision-free
+--                                    -- see the guard's own comment below for
+--                                    why that's left alone in this PR.
 --
 -- ============================================================================
 -- WHY THIS SCRIPT IS DATA-DRIVEN, NOT LITERAL LIKE ITS PREDECESSORS
@@ -193,14 +232,31 @@
 --    actually captured and pasted the 14 real values (see "WHY THIS SCRIPT
 --    IS DATA-DRIVEN" above). Whoever fills in the PENDING CAPTURE block
 --    should add that same byte-assertion test as part of that follow-up --
---    this is a known, named gap, not a silent omission.
+--    this is a known, named gap, not a silent omission. The INVERSE is
+--    enforced today (PR #2154 review round 2): the paired integration
+--    spec's "still just the all-NULL placeholder" test asserts the shipped
+--    `insert-pending-rows` block carries no quoted string literals, so it
+--    goes red the moment real rows land -- whoever fills in this block
+--    cannot do so without also updating that test, which is exactly where
+--    the deferred byte-assertion belongs.
 --
--- 4. Fill in the PENDING CAPTURE block below: one row per corrupt value,
---    using the enumeration query's own columns for `legacy_release_id` /
---    `track_position` / `current_artist_name` / `current_track_title`, and
---    the resolved true string in whichever of `true_artist_name` /
---    `true_track_title` corresponds to the corrupt column. Leave the other
---    `true_*` column NULL -- it means "this column is not being touched".
+-- 4. Fill in the PENDING CAPTURE block below: ONE ROW PER CORRUPT LIVE ROW
+--    (not one row per corrupt VALUE), using the enumeration query's own
+--    columns for `legacy_release_id` / `track_position` /
+--    `current_artist_name` / `current_track_title`. If the row is corrupt in
+--    only ONE column, put the resolved true string in that column's
+--    `true_*` slot and leave the OTHER `true_*` column NULL -- it means
+--    "this column is not being touched". If the row is corrupt in BOTH
+--    columns (the enumeration query's own `artist_name` AND `track_title`
+--    both match the U+FFFD pattern), that SAME single row must carry BOTH
+--    `true_artist_name` AND `true_track_title` -- do NOT split one corrupt
+--    row into two separate pending rows, one per column. A split capture
+--    leaves each row's untouched column still corrupt in its computed
+--    post-fix tuple; `guard-post-fix-fffd` now catches that directly (round
+--    2 HIGH finding -- see the guard list above), and in the twin-existing
+--    case a split capture can also converge onto `guard-ambiguous-match`
+--    with a message that, for this specific cause, misleadingly blames
+--    `cta_unique_idx` rather than the split itself.
 --
 -- 5. Human-review the filled-in block, then run this whole script.
 --
@@ -209,21 +265,27 @@
 --   awk '/^BEGIN;/{exit} {print}' scripts/audit/bs_replacement_char_cta.sql \
 --     | psql "$DATABASE_URL"
 --
--- This shows the declared-row count and the two full-table informational
--- checks (unmatched pending rows, overall residual count) -- it does NOT
--- show the twin/no-twin classification, because that classification
--- (`build-targets`) now runs INSIDE the transaction (see "Mechanism" below,
--- PR #2154 review). To preview the FULL classification and writes without
--- persisting anything, run the script with its `COMMIT;` swapped for
--- `ROLLBACK;` -- this executes the real guards and the real DELETE/UPDATE
--- inside a real transaction (so a would-be `cta_unique_idx` violation
--- surfaces exactly as it would for real), then discards everything:
+-- This shows the declared-row count (plus the matched/unmatched split, PR
+-- #2154 review round 2) and the two full-table informational checks
+-- (unmatched pending rows, overall residual count) -- it does NOT show the
+-- twin/no-twin classification, because that classification (`build-targets`)
+-- now runs INSIDE the transaction (see "Mechanism" below, PR #2154 review
+-- round 1). To preview the FULL classification and writes without persisting
+-- anything, run the script with its `COMMIT;` swapped for `ROLLBACK;` --
+-- this executes the real guards and the real DELETE/UPDATE inside a real
+-- transaction (so a would-be `cta_unique_idx` violation surfaces exactly as
+-- it would for real), including the post-amble's residual counts (moved to
+-- run BEFORE `COMMIT;`/`ROLLBACK;` in round 2 -- see the comment above the
+-- post-amble further down for why that move was necessary, not optional),
+-- then discards everything:
 --
 --   sed 's/^COMMIT;$/ROLLBACK;/' scripts/audit/bs_replacement_char_cta.sql \
 --     | psql "$DATABASE_URL"
 --
--- (`ANALYZE` still runs after -- harmless, it only refreshes planner stats,
--- never data.)
+-- `ANALYZE` still runs after the ROLLBACK -- harmless, it only refreshes
+-- planner stats, never data. It also runs perfectly well INSIDE a
+-- transaction (see the `analyze` STMT block's own comment near the bottom
+-- for why it stays outside this one anyway).
 --
 -- ============================================================================
 -- Mechanism
@@ -243,7 +305,7 @@
 -- print can show both sides.
 --
 -- Classification now runs INSIDE the transaction -- `BEGIN` precedes
--- `build-targets`, not the reverse (PR #2154 review). `library-etl`'s
+-- `build-targets`, not the reverse (PR #2154 review round 1). `library-etl`'s
 -- `importCompilationTracks` writes this table every 30 minutes; classifying
 -- before `BEGIN` left a window where a concurrent insert of a clean twin
 -- between classification and the write could flip a no-twin row's UPDATE
@@ -251,8 +313,22 @@
 -- the two write statements now all read the SAME `cta_repair_targets`,
 -- materialized inside the SAME transaction -- so they are the *same*
 -- predicate by construction (org data-safety convention), not independently
--- typed-out copies that could drift apart, and there is no window between
--- classifying a row and acting on that classification.
+-- typed-out copies that could drift apart.
+--
+-- What this buys is atomicity, NOT elimination of the race window (round 2
+-- correction -- the round 1 text overclaimed "no window between classifying
+-- a row and acting on that classification"). `CREATE TEMP TABLE ... AS
+-- SELECT` under READ COMMITTED takes no row lock, and every later statement
+-- in this script takes its own fresh snapshot, so `library-etl` can still
+-- commit a clean twin (or a librarian can still hand-edit the row) between
+-- `build-targets` and `update-no-twins`/`delete-twins`/`repoint-twin-identity`
+-- -- and the re-check re-checks each of those three statements carry (see
+-- their own comments; `repoint-twin-identity`'s was added in round 2) exist
+-- precisely because that window is real. The narrowing is real too: what
+-- used to be a live, unguarded write racing a live table is now a
+-- transaction that either commits a fully self-consistent set of writes or
+-- rolls back the whole thing cleanly on any surprise -- narrowed and made
+-- fail-safe, not race-free.
 --
 -- Idempotency: `cta_repair_targets`'s join to the live table requires the
 -- row's `artist_name`/`track_title` to still equal the captured (corrupt)
@@ -320,8 +396,16 @@ CREATE TEMP TABLE pending_cta_repair (
 -- for whichever column on that row was NOT corrupt -- never fill in a value
 -- you did not read from ground truth.
 --
--- Example shape (NOT REAL DATA -- do not copy verbatim):
---   (50340, '3', 'Some Artist', 'La B?te', NULL, 'La Bete'),
+-- Example shape (NOT REAL DATA -- do not copy verbatim; corrected in PR
+-- #2154 review round 2 -- the prior example modeled the exact accent-
+-- stripping approximation step 3 above forbids, `?` -> `e`, not a genuine
+-- U+FFFD substitution, and would have been rejected by guard-capture-sanity
+-- outright). This shows the track_title-only-corrupt case: current_*
+-- carries the real U+FFFD REPLACEMENT CHARACTER (not a `?`), true_track_title
+-- carries the resolved accented string read from ground truth, and
+-- true_artist_name is left NULL because artist_name on this row was never
+-- corrupted:
+--   (50340, '3', 'Csillagrablók', 'Rem�nytelen T�nc', NULL, 'Reménytelen Tánc'),
 -- ############################################################################
 INSERT INTO pending_cta_repair
   (legacy_release_id, track_position, current_artist_name, current_track_title, true_artist_name, true_track_title)
@@ -412,18 +496,75 @@ BEGIN
 END $$;
 -- === END STMT ===
 
-SELECT '=== V_BS_FFFD_CTA pre-amble: declared pending rows (0 = capture step not yet run) ===' AS section;
-SELECT COUNT(*) AS pending_declared FROM pending_cta_repair;
+-- === STMT: guard-nfc-form ===
+-- MEDIUM finding (PR #2154 review round 2): twin detection below joins on
+-- exact byte equality (`IS NOT DISTINCT FROM` over `varchar`), so a true_*
+-- value captured in a non-NFC Unicode normalization form (e.g. pasted out of
+-- a MySQL client that yields NFD) can silently miss a genuinely clean live
+-- twin already stored in NFC -- the row classifies no-twin, the UPDATE
+-- writes a byte-distinct duplicate, and cta_unique_idx does not fire because
+-- the two rows are not byte-identical, leaving TWO rows for one credit while
+-- the postlude still reports the desired 0 / 0. This is exactly the
+-- normalization-mismatch failure mode `fold_artist_name` (migration 0134)
+-- and `jobs/artist-unicode-dedup` exist to correct on `artists`; this table
+-- has neither.
+--
+-- Capture-time rejection, not write-time normalization: this guard REJECTS
+-- a non-NFC true_* value rather than silently normalizing it, preserving the
+-- deliberate byte-exact write posture documented under "Unicode
+-- normalization" further down. If this guard fires, re-copy the true value
+-- from a source that yields NFC -- do not hand-normalize it, per the same
+-- "READ it, never reconstruct it" rule the capture procedure already states
+-- for accents above.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT legacy_release_id, track_position, true_artist_name, true_track_title
+      FROM pending_cta_repair
+     WHERE (true_artist_name IS NOT NULL AND true_artist_name IS NOT NFC NORMALIZED)
+        OR (true_track_title IS NOT NULL AND true_track_title IS NOT NFC NORMALIZED)
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% has a true_* replacement that is not NFC-normalized (true_artist_name=% true_track_title=%) -- twin detection is byte-exact, so a non-NFC paste can miss a live NFC twin and leave a duplicate row behind instead of repairing in place; re-copy the true value from a source that yields NFC rather than hand-normalizing it', bad.legacy_release_id, bad.track_position, bad.true_artist_name, bad.true_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
 
-SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
-SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title
+-- INFO: one shared join, read by both the count below and the unmatched-row
+-- listing below it, so the two cannot drift the way two hand-duplicated
+-- copies of the same predicate could (LOW finding, PR #2154 review round 2
+-- -- this predicate is still a separate hand-typed copy of build-targets'
+-- own join further down, which is unavoidable: this runs before BEGIN and
+-- build-targets deliberately runs inside the transaction, so they cannot
+-- physically share one temp table -- but the two reads THIS side of that
+-- boundary no longer duplicate each other).
+DROP TABLE IF EXISTS pg_temp.pending_match_preview;
+CREATE TEMP TABLE pending_match_preview AS
+SELECT p.legacy_release_id, p.track_position, p.current_artist_name, p.current_track_title,
+       cta.id AS matched_cta_id
   FROM pending_cta_repair p
   LEFT JOIN wxyc_schema.library l ON l.legacy_release_id = p.legacy_release_id
   LEFT JOIN wxyc_schema.compilation_track_artist cta
     ON cta.library_id = l.id
    AND cta.artist_name = p.current_artist_name
-   AND cta.track_title IS NOT DISTINCT FROM p.current_track_title
- WHERE cta.id IS NULL;
+   AND cta.track_title IS NOT DISTINCT FROM p.current_track_title;
+
+SELECT '=== V_BS_FFFD_CTA pre-amble: declared pending rows (0 = capture step not yet run) ===' AS section;
+-- `pending_matched` alongside `pending_declared` (LOW finding, PR #2154
+-- review round 2): a pending row matching no live row cannot be a hard
+-- error (an idempotent re-run legitimately matches nothing once a prior run
+-- already fixed it), so this stays informational -- but previously it was
+-- visible only via the unmatched-row SELECT below, and every OTHER operator
+-- slip in this script aborts loudly. This surfaces the count at a glance.
+SELECT COUNT(*) AS pending_declared,
+       COUNT(*) FILTER (WHERE matched_cta_id IS NOT NULL) AS pending_matched,
+       COUNT(*) FILTER (WHERE matched_cta_id IS NULL) AS pending_unmatched
+  FROM pending_match_preview;
+
+SELECT 'INFO — declared pending rows that did NOT match a live row (already-fixed re-run, or a capture mismatch)' AS section;
+SELECT legacy_release_id, track_position, current_artist_name, current_track_title
+  FROM pending_match_preview
+ WHERE matched_cta_id IS NULL;
 
 SELECT 'BEFORE — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
 SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
@@ -474,6 +615,45 @@ LEFT JOIN wxyc_schema.compilation_track_artist twin
  AND twin.track_title IS NOT DISTINCT FROM COALESCE(p.true_track_title, cta.track_title);
 -- === END STMT ===
 
+-- === STMT: guard-post-fix-fffd ===
+-- HIGH finding (PR #2154 review round 2): nothing upstream of this guard
+-- asserts that the POST-FIX tuple is actually U+FFFD-free. new_artist_name /
+-- new_track_title above are COALESCE(true_*, cta.*), so a row corrupt in
+-- BOTH columns but captured with only one true_* replacement leaves the
+-- untouched column's U+FFFD sitting in the write. Two reproduced
+-- consequences this guard closes:
+--   * Silent row destruction: a genuinely clean twin exists for the FIXED
+--     column alone (e.g. two rows share the same still-corrupt
+--     artist_name, and only one of them also has a corrupt track_title,
+--     fixed without also fixing the artist_name) -- the post-fix tuple
+--     still carries the corrupt artist_name, matches the OTHER
+--     still-corrupt row as its twin, and DELETEs the row that was actually
+--     being repaired while the corruption survives on the "twin" left
+--     behind.
+--   * Silent partial repair: no twin exists, so the UPDATE runs and writes
+--     the one column that was fixed, leaving the other silently corrupt --
+--     exit 0, per-row residual 0 for this row's OLD tuple, but the U+FFFD
+--     is still live under its NEW tuple, and the overall residual counter
+--     stays non-zero with no row-level indication of which row is still
+--     wrong.
+-- See step 4 of the capture procedure above: a row corrupt in both columns
+-- needs ONE pending row carrying BOTH true_artist_name and true_track_title,
+-- never two separate pending rows.
+DO $$
+DECLARE bad RECORD;
+BEGIN
+  FOR bad IN
+    SELECT legacy_release_id, track_position, old_artist_name, old_track_title,
+           new_artist_name, new_track_title
+      FROM cta_repair_targets
+     WHERE new_artist_name LIKE '%' || chr(65533) || '%'
+        OR new_track_title LIKE '%' || chr(65533) || '%'
+  LOOP
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% still carries U+FFFD in its post-fix tuple (new_artist_name=% new_track_title=%) -- this row is corrupt in a column the pending capture did not supply a true_* replacement for; a row corrupt in BOTH artist_name and track_title needs ONE pending row with BOTH true_artist_name and true_track_title filled in (see the header capture procedure, step 4), not a row that only fixes one column', bad.legacy_release_id, bad.track_position, bad.new_artist_name, bad.new_track_title;
+  END LOOP;
+END $$;
+-- === END STMT ===
+
 -- === STMT: guard-ambiguous-match ===
 -- A pending row resolving to more than one live row should be impossible --
 -- (library_id, artist_name, track_title) is exactly cta_unique_idx's key
@@ -508,6 +688,25 @@ END $$;
 -- guard-ambiguous-match cannot catch this -- it groups on the OLD (corrupt)
 -- tuple, which differs between the two rows; this groups on the resolved
 -- NEW (post-fix) tuple instead.
+--
+-- Deliberately over-broad (LOW finding, PR #2154 review round 2): this
+-- aborts regardless of `has_twin`, including the case where BOTH converging
+-- rows classify has_twin=true -- two corrupt copies converging on a THIRD,
+-- already-clean live row (the 98.5% double-ingest shape this comment's own
+-- measurement cites, just with a clean twin also present). There, DELETE +
+-- DELETE would actually be collision-free and correct, and this guard's
+-- "resolve which capture is correct" message is wrong for that specific
+-- shape -- both captures are correct, they just both point at the same
+-- surviving twin. It is left broad on purpose: neutering it for that one
+-- case exposes a second, coupled bug in `repoint-twin-identity` below --
+-- `UPDATE ... FROM` with two matching source rows is non-deterministic in
+-- PostgreSQL, so `repoint-twin-identity` would report `UPDATE 1` and
+-- arbitrarily keep only one of the two source rows' identity links,
+-- silently discarding the other. Narrowing this guard without also making
+-- that repoint deterministic (`DISTINCT ON`, or an aggregated,
+-- documented-precedence merge of the two links) would trade a loud guard
+-- abort for a silent identity-link loss -- worse, not better. Narrow this
+-- guard and fix the repoint together, or leave both as they are.
 DO $$
 DECLARE bad RECORD;
 BEGIN
@@ -534,7 +733,7 @@ SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_tra
  ORDER BY legacy_release_id, track_position;
 
 -- === STMT: repoint-twin-identity ===
--- MEDIUM finding (PR #2154 review): before dropping the corrupt row,
+-- MEDIUM finding (PR #2154 review round 1): before dropping the corrupt row,
 -- repoint its per-track identity link (BS#1990 / #801 S1 -- track_artist_id
 -- + track_artist_link_confidence + track_artist_link_method) and
 -- track_position onto the surviving twin, COALESCE-preserving the twin's own
@@ -544,10 +743,29 @@ SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_tra
 -- lacks. Same COALESCE-preserve-then-delete shape as
 -- `jobs/artist-unicode-dedup/merge.ts`'s survivor repoint. The BEFORE print
 -- above projects all four columns for both rows so an operator reviewing the
--- output can see exactly what this carries over before it runs. A separate
--- statement (not fused into delete-twins below) so each STMT block keeps the
--- one-statement-per-block shape the paired integration spec's extractor
--- relies on.
+-- output can see exactly what this carries over before it runs.
+--
+-- Kept as a separate statement from delete-twins below -- NOT because the
+-- integration spec's extractor requires one-statement-per-block (LOW finding
+-- correction, PR #2154 review round 2: it doesn't -- create-pending-table,
+-- insert-pending-rows, and build-targets each already carry 2-3 statements
+-- and `sql.unsafe()` runs a multi-statement block fine). The real reason is
+-- operator legibility: `psql -f` echoes each statement's own row count
+-- (`UPDATE N` / `DELETE N`) as it runs, so keeping the identity-link repoint
+-- and the corrupt-row removal as two statements lets an operator watching
+-- the run confirm both counts independently instead of reading one opaque
+-- combined number.
+--
+-- Re-checks that the SOURCE (corrupt) row is still in its captured state
+-- before repointing (LOW finding, PR #2154 review round 2) -- mirrors
+-- delete-twins' own re-check below, which this statement previously lacked.
+-- Without it, a concurrent edit to the corrupt row landing between
+-- build-targets and here (real: see "Mechanism" above on why classifying
+-- inside the transaction narrows, but does not close, that window) would
+-- still repoint the twin's identity link even though delete-twins' own
+-- re-check would then correctly skip deleting the now-changed corrupt row --
+-- repointing without deleting, silently duplicating the identity link across
+-- two live rows.
 UPDATE wxyc_schema.compilation_track_artist twin
    SET track_artist_id = COALESCE(twin.track_artist_id, t.old_track_artist_id),
        track_artist_link_confidence = COALESCE(twin.track_artist_link_confidence, t.old_track_artist_link_confidence),
@@ -555,7 +773,13 @@ UPDATE wxyc_schema.compilation_track_artist twin
        track_position = COALESCE(twin.track_position, t.old_track_position)
   FROM cta_repair_targets t
  WHERE t.has_twin
-   AND twin.id = t.twin_id;
+   AND twin.id = t.twin_id
+   AND EXISTS (
+     SELECT 1 FROM wxyc_schema.compilation_track_artist cta
+      WHERE cta.id = t.id
+        AND cta.artist_name = t.old_artist_name
+        AND cta.track_title IS NOT DISTINCT FROM t.old_track_title
+   );
 -- === END STMT ===
 
 -- === STMT: delete-twins ===
@@ -583,22 +807,44 @@ UPDATE wxyc_schema.compilation_track_artist cta
    AND cta.track_title IS NOT DISTINCT FROM t.old_track_title;
 -- === END STMT ===
 
-COMMIT;
-
 -- ===========================================================
 -- Post-amble verify: every targeted row should show residual=0, and the
 -- overall predicate should return 0/0 -- the desired end state per #2152.
--- `cta_repair_targets` is a TEMP TABLE without ON COMMIT DROP, so it is
--- still readable here, after COMMIT, in this same session.
+--
+-- Runs INSIDE the transaction, BEFORE `COMMIT;` (MEDIUM finding, PR #2154
+-- review round 2 -- this used to run after COMMIT). `cta_repair_targets` and
+-- the write statements' effects are visible here via ordinary
+-- read-your-own-writes regardless of whether this run goes on to COMMIT or
+-- (dry-run) ROLLBACK. Running it after COMMIT broke the documented dry-run
+-- "swap COMMIT; for ROLLBACK;" preview outright: once build-targets moved
+-- inside the transaction (round 1), a ROLLBACK undoes the
+-- `CREATE TEMP TABLE cta_repair_targets AS SELECT` along with everything
+-- else in the transaction, so a post-COMMIT-position read against a table
+-- that no longer exists aborted the whole script
+-- (`ERROR: relation "cta_repair_targets" does not exist`, psql exit 3)
+-- before ever reaching ANALYZE. Moving these reads to before the
+-- `COMMIT;`/`ROLLBACK;` line makes them visible on both the real run and the
+-- dry-run preview alike.
 -- ===========================================================
 SELECT '=== V_BS_FFFD_CTA post-amble: residual count per targeted row (expect 0) ===' AS section;
-SELECT t.legacy_release_id, t.track_position,
+-- Prints the LIVE `track_position` (NIT, PR #2154 review round 2 -- this
+-- used to print the CAPTURED value from cta_repair_targets, which is not
+-- what #2152's acceptance criteria mean by "the permanent record" once this
+-- output gets pasted onto the issue). `track_position` participates in no
+-- matching predicate anywhere in this script, so the captured value can
+-- differ from the live one; joins to the row that actually survived the run
+-- -- the twin for a DELETE branch (post-repoint), or the same row for an
+-- UPDATE branch.
+SELECT t.legacy_release_id,
+       live.track_position AS live_track_position,
        (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist cta
          WHERE cta.library_id = t.library_id
            AND cta.artist_name = t.old_artist_name
            AND cta.track_title IS NOT DISTINCT FROM t.old_track_title) AS residual
   FROM cta_repair_targets t
- ORDER BY t.legacy_release_id, t.track_position;
+  LEFT JOIN wxyc_schema.compilation_track_artist live
+    ON live.id = COALESCE(t.twin_id, t.id)
+ ORDER BY t.legacy_release_id, live.track_position;
 
 SELECT 'AFTER — overall residual U+FFFD, wxyc_schema.compilation_track_artist (desired end state: 0 / 0)' AS section;
 SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_name LIKE E'%�%') AS artist_name_residual,
@@ -608,10 +854,22 @@ SELECT (SELECT COUNT(*) FROM wxyc_schema.compilation_track_artist WHERE artist_n
 -- already lives in bs_replacement_char_phase4.sql's postlude -- not repeated
 -- here, this script is scoped to compilation_track_artist only.
 
+COMMIT;
+
 -- === STMT: analyze ===
 -- Refresh planner stats (BS#934 -- omitting this after #863's migration
--- regressed /flowsheet/suggest/* to 5s timeouts). ANALYZE cannot run inside
--- a transaction, so it lives here, outside any BEGIN/COMMIT. See
--- docs/bulk-update-playbook.md for the full pattern.
+-- regressed /flowsheet/suggest/* to 5s timeouts). ANALYZE CAN run inside a
+-- transaction (LOW finding, PR #2154 review round 2 -- verified:
+-- `BEGIN; ANALYZE ...; COMMIT;` succeeds; it is VACUUM, not ANALYZE, that
+-- Postgres refuses inside a transaction block. This corrected claim was
+-- inherited from bs_replacement_char_phase4.sql's own analyze comment;
+-- fixed here only -- that file is out of scope for this PR). It stays
+-- outside this script's BEGIN/COMMIT anyway, matching the bulk-update
+-- playbook's "paired post-script step" convention
+-- (docs/bulk-update-playbook.md checklist item 4): a stats refresh isn't
+-- part of the data change being committed or rolled back, and running it
+-- unconditionally here means it still executes after the dry-run preview's
+-- ROLLBACK too -- itself harmless, since ANALYZE only touches planner
+-- statistics, never table data.
 ANALYZE wxyc_schema.compilation_track_artist;
 -- === END STMT ===

--- a/scripts/audit/bs_replacement_char_cta.sql
+++ b/scripts/audit/bs_replacement_char_cta.sql
@@ -266,7 +266,9 @@
 -- verified no-op. It becomes the actual repair only once an operator fills
 -- in the 14 real rows and re-runs it.
 --
--- "Every statement" is meant literally, and round 3 is what made it true.
+-- "Every statement" is meant literally -- round 3 made it nearly true and
+-- round 5 finished it (the `before-matched-rows` print was still untagged
+-- after round 3, so the claim below was overstated until round 5 tagged it).
 -- Through round 2 the read-only pre-amble (`pending_match_preview` and its
 -- three SELECTs) and the post-amble residual reads carried no
 -- `-- === STMT: ... ===` tags, so the spec's extractor never saw them and
@@ -733,7 +735,17 @@ BEGIN
            CASE
              WHEN current_artist_name IS NULL
                THEN 'current_artist_name is NULL -- the live column is NOT NULL and the enumeration query cannot emit a NULL there, so this row is short a column (did the paste drop one, or include the query''s leading library_id?)'
-             ELSE 'looks transposed or uncorrupted -- every current_* column being fixed must contain U+FFFD and every true_* replacement must not; verify the capture was not pasted backwards (or check client_encoding)'
+             WHEN (true_artist_name IS NOT NULL AND (
+                     current_artist_name NOT LIKE '%' || chr(65533) || '%'
+                     OR true_artist_name LIKE '%' || chr(65533) || '%'
+                   ))
+               OR (true_track_title IS NOT NULL AND (
+                     current_track_title IS NULL
+                     OR current_track_title NOT LIKE '%' || chr(65533) || '%'
+                     OR true_track_title LIKE '%' || chr(65533) || '%'
+                   ))
+               THEN 'looks transposed or uncorrupted -- every current_* column being fixed must contain U+FFFD and every true_* replacement must not; verify the capture was not pasted backwards (or check client_encoding)'
+             ELSE 'a true_* replacement has leading/trailing whitespace or is empty -- it would be written verbatim, and a repaired row that differs from the ETL''s trimmed insert by whitespace is no longer suppressed by importCompilationTracks'' ON CONFLICT DO NOTHING, so the next 30-minute cycle re-creates the duplicate this script exists to avoid. Trim it (or use NULL for a genuinely absent track_title)'
            END AS reason
       FROM pending_cta_repair
      -- UNCONDITIONAL, not gated on which column is being fixed (round 3
@@ -758,6 +770,24 @@ BEGIN
              current_track_title IS NULL
              OR current_track_title NOT LIKE '%' || chr(65533) || '%'
              OR true_track_title LIKE '%' || chr(65533) || '%'
+           ))
+     -- Round 5 finding: a true_* value with leading/trailing whitespace (or an
+     -- empty string) passed every guard and was written verbatim. Capture
+     -- channel (a) in the procedure above trims and maps empty to NULL, but
+     -- channel (c) -- raw Kattare MySQL, which this script's header explicitly
+     -- offers -- does not. The consequence is not cosmetic: `library-etl`'s
+     -- importCompilationTracks inserts the TRIMMED string, its
+     -- `ON CONFLICT DO NOTHING` is keyed on cta_unique_idx, and a repaired row
+     -- that differs by whitespace no longer conflicts with it -- so the next
+     -- 30-minute cycle inserts the ETL's copy alongside the repaired one and
+     -- re-creates exactly the duplicate this whole script is built to avoid.
+        OR (true_artist_name IS NOT NULL AND (
+             btrim(true_artist_name) <> true_artist_name
+             OR true_artist_name = ''
+           ))
+        OR (true_track_title IS NOT NULL AND (
+             btrim(true_track_title) <> true_track_title
+             OR true_track_title = ''
            ))
   LOOP
     RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% track_position=% %  (current_artist_name=% current_track_title=% true_artist_name=% true_track_title=%)', bad.legacy_release_id, bad.track_position, bad.reason, bad.current_artist_name, bad.current_track_title, bad.true_artist_name, bad.true_track_title;
@@ -948,6 +978,19 @@ SET LOCAL statement_timeout = '30s';
 -- they cannot disagree with this classification the way a byte-exact
 -- re-check against an NFC-folded match would (see each statement's own
 -- comment for what disagreeing would have looked like).
+--
+-- Residual limitation of that widening, stated rather than left implicit
+-- (round 5 finding): on this path the surviving row is the NFD twin,
+-- byte-for-byte, so the NFC bytes the operator captured from tubafrenzy are
+-- DISCARDED -- `artist_name = <captured true value>` is false afterwards even
+-- though the credit is correct and the U+FFFD is gone. This is accepted, not
+-- fixed: normalizing the twin would mean writing a row that was never
+-- corrupt, widening this script's blast radius past the 14 rows it declares.
+-- It is bounded (canonically-equivalent text, same glyphs) but it is NOT
+-- byte-exactness, and the catalog-parity harness this script's header cites
+-- (discogs-etl#346) compares bytes. The BEFORE print projects
+-- twin_artist_name/twin_track_title alongside new_artist_name/new_track_title
+-- precisely so an operator can SEE the two differ before committing.
 DROP TABLE IF EXISTS pg_temp.cta_repair_targets;
 CREATE TEMP TABLE cta_repair_targets AS
 SELECT
@@ -965,6 +1008,16 @@ SELECT
   COALESCE(p.true_track_title, cta.track_title) AS new_track_title,
   twin.id AS twin_id,
   twin.track_position AS twin_track_position,
+  -- Carried for the BEFORE print only (round 5 finding). On the widened
+  -- DELETE branch below, the row that SURVIVES is the twin, byte-for-byte --
+  -- so when the twin is NFD and the capture is NFC, what remains is NOT the
+  -- value the operator read out of Kattare. Projecting the twin's own
+  -- name/title next to new_artist_name/new_track_title is the only way that
+  -- divergence is visible in the run output; without it the postlude reads
+  -- 0/0 residual, no duplicate, exit 0, and the discarded ground-truth bytes
+  -- leave no trace at all.
+  twin.artist_name AS twin_artist_name,
+  twin.track_title AS twin_track_title,
   twin.track_artist_id AS twin_track_artist_id,
   twin.track_artist_link_confidence AS twin_track_artist_link_confidence,
   twin.track_artist_link_method AS twin_track_artist_link_method,
@@ -1062,12 +1115,32 @@ END $$;
 -- === END STMT ===
 
 -- === STMT: guard-ambiguous-match ===
--- A pending row resolving to more than one live row should be impossible --
--- (library_id, artist_name, track_title) is exactly cta_unique_idx's key
--- (cta_unique_null_track_idx for the NULL-track_title case) -- but this is
--- asserted defensively rather than assumed. Also catches an accidental
--- duplicate entry in the pending block itself (both pending copies would
--- resolve to the same live row, tripping this the same way).
+-- Three distinct causes reach this guard, and round 5 corrected the message,
+-- which named only the first and called the others impossible:
+--
+-- (1) Two live rows matching one pending row's CORRUPT tuple. That really is
+--     structurally impossible -- (library_id, artist_name, track_title) is
+--     exactly cta_unique_idx's key (cta_unique_null_track_idx for the
+--     NULL-track_title case) and the cta-side join is byte-exact. Asserted
+--     defensively rather than assumed.
+--
+-- (2) The NFC-FOLDED twin join matching more than one live twin. This is NOT
+--     impossible and is new as of round 4: the twin join compares
+--     `normalize(..., NFC)`, and NO unique index backs the folded key.
+--     cta_unique_null_track_idx in particular is precisely the index that
+--     cannot constrain two NFC-equal, byte-distinct names. A pre-existing
+--     NFD/NFC clean pair in the same compilation therefore fans one pending
+--     row out to two target rows, which group here on their shared (identical)
+--     old_* tuple and trip this guard. Reproduced on both the non-NULL and the
+--     NULL-track_title paths.
+--
+--     Aborting is the RIGHT outcome for (2) -- the run genuinely cannot tell
+--     which of the two live rows should survive as the twin -- but an operator
+--     told "cta_unique_idx should make this impossible" will go looking for a
+--     violated index and find none.
+--
+-- (3) An accidental duplicate entry in the pending block itself (both pending
+--     copies resolve to the same live row, tripping this the same way).
 DO $$
 DECLARE bad RECORD;
 BEGIN
@@ -1077,7 +1150,7 @@ BEGIN
      GROUP BY legacy_release_id, old_artist_name, old_track_title
     HAVING COUNT(*) > 1
   LOOP
-    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% artist_name=% track_title=% matched % live compilation_track_artist rows (or the pending block has a duplicate entry) -- cta_unique_idx / cta_unique_null_track_idx should make this impossible; investigate before proceeding', bad.legacy_release_id, bad.old_artist_name, bad.old_track_title, bad.n;
+    RAISE EXCEPTION 'BS#2152 guard: legacy_release_id=% artist_name=% track_title=% resolved to % target rows, expected 1 -- most likely the NFC-folded twin join matched MORE THAN ONE live twin (two live rows that are canonically equal but byte-distinct; no unique index constrains that -- cta_unique_idx and cta_unique_null_track_idx are byte-exact, so neither is violated and neither would have prevented it). Other causes: a duplicate entry in the pending block, or -- structurally impossible under cta_unique_idx, so check it last -- two live rows matching the corrupt tuple. Inspect the live rows for this compilation and decide which should survive before re-running', bad.legacy_release_id, bad.old_artist_name, bad.old_track_title, bad.n;
   END LOOP;
 END $$;
 -- === END STMT ===
@@ -1144,19 +1217,44 @@ BEGIN
      GROUP BY library_id, normalize(new_artist_name, NFC), normalize(new_track_title, NFC)
     HAVING COUNT(*) > 1
   LOOP
-    RAISE EXCEPTION 'BS#2152 guard: % pending row(s) converge on the same post-fix (NFC-folded) library_id=% artist_name=% track_title=% (legacy_release_id/track_position pairs: %/%) -- two differently-corrupted copies of one credit would collide under cta_unique_idx on a single UPDATE (or leave a form-mismatched duplicate behind, see the NFC folding note above); resolve which capture is correct (or whether one is a distinct real credit) before re-running', bad.n, bad.library_id, bad.new_artist_name_nfc, bad.new_track_title_nfc, bad.release_ids, bad.track_positions;
+    RAISE EXCEPTION 'BS#2152 guard: % pending row(s) converge on the same post-fix (NFC-folded) library_id=% artist_name=% track_title=% (legacy_release_id/track_position pairs: %/%) -- two differently-corrupted copies of one credit would collide under cta_unique_idx on a single UPDATE (or leave a form-mismatched duplicate behind, see the NFC folding note above). Two shapes reach this, with different fixes: (a) the captures disagree or one is a distinct real credit -- resolve which is correct before re-running; (b) BOTH captures are correct and both copies are genuinely the same credit (the 98.5%% double-ingest shape) -- this guard is deliberately over-broad and fires on that too, and the fix is NOT to edit the captures: split the converging rows across two sequential invocations of this script, so each run repairs one copy and the second run sees the first''s result as an ordinary twin', bad.n, bad.library_id, bad.new_artist_name_nfc, bad.new_track_title_nfc, bad.release_ids, bad.track_positions;
   END LOOP;
 END $$;
 -- === END STMT ===
 
+-- === STMT: before-matched-rows ===
+-- Round 5 finding: this block carried no `-- === STMT: ... ===` tags, so the
+-- spec's extractor never saw it and nothing executed it -- the single
+-- statement in this file that reverting broke no test. That is precisely the
+-- gap the "Every statement is meant literally" note above claims round 3
+-- closed; the claim was false for this one statement. Mutation-checked:
+-- renaming a column here left Jest 36/36 green while a real `psql -f` run
+-- with a live pending row exited 3 (`column ... does not exist`), aborting
+-- the transaction in front of the operator. It fails SAFE -- it precedes
+-- every write -- but it kills the run, and it is the only operator-facing
+-- output of the twin/no-twin decision.
+--
+-- twin_artist_name/twin_track_title (round 5) make the DELETE branch's
+-- byte-divergence visible: compare them against new_artist_name/
+-- new_track_title. `twin_is_byte_exact` does the comparison for the operator
+-- -- FALSE on a DELETE row means the surviving twin does NOT hold the
+-- captured bytes (canonically equal, different composition form; see
+-- build-targets' residual-limitation note).
 SELECT 'BEFORE — matched rows + twin classification' AS section;
 SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_track_title,
        new_artist_name, new_track_title,
        CASE WHEN has_twin THEN 'DELETE (twin exists)' ELSE 'UPDATE (no twin)' END AS action,
        old_track_position, old_track_artist_id, old_track_artist_link_confidence, old_track_artist_link_method,
-       twin_id, twin_track_position, twin_track_artist_id, twin_track_artist_link_confidence, twin_track_artist_link_method
+       twin_id, twin_track_position, twin_artist_name, twin_track_title,
+       CASE
+         WHEN NOT has_twin THEN NULL
+         ELSE (twin_artist_name = new_artist_name
+               AND twin_track_title IS NOT DISTINCT FROM new_track_title)
+       END AS twin_is_byte_exact,
+       twin_track_artist_id, twin_track_artist_link_confidence, twin_track_artist_link_method
   FROM cta_repair_targets
  ORDER BY legacy_release_id, track_position;
+-- === END STMT ===
 
 -- === STMT: repoint-twin-identity ===
 -- MEDIUM finding (PR #2154 review round 1): before dropping the corrupt row,
@@ -1227,10 +1325,38 @@ SELECT legacy_release_id, track_position, id AS cta_id, old_artist_name, old_tra
 -- whether the twin is still the row build-targets found; letting only one of
 -- them fold would reopen the exact "statements disagree" hazard the round 3
 -- lock-targets comment above describes for a different cause.
+-- Round 5 finding: the three identity columns move as ONE TUPLE, not
+-- column-by-column. `track_artist_id` + `track_artist_link_confidence` +
+-- `track_artist_link_method` are a single logical fact plus its provenance --
+-- migration 0140 says so in as many words ("per #801 D6, provenance lives on
+-- these three columns only", no sidecar table). COALESCEing them
+-- independently merges two DIFFERENT links into one incoherent row: a twin
+-- holding (id=1111, confidence=NULL, method='librarian') against a corrupt
+-- row holding (id=4242, confidence=0.50, method='lml_backfill') produced
+-- (id=1111, confidence=0.5, method='librarian') -- a machine confidence
+-- computed for artist 4242, attached to artist 1111, labelled human-entered.
+-- Exit 0, every guard green, nothing in the postlude showing it. And
+-- `jobs/library-identity-consumer/writer.ts` treats method='librarian' as
+-- permanent precedence, so a row mislabelled that way is skipped by that job
+-- forever.
+--
+-- The partial shape is reachable today without the (unshipped) librarian
+-- writer: `track_artist_id` is ON DELETE SET NULL on artists.id (migration
+-- 0140), so any artist deletion leaves (id=NULL, confidence=0.93,
+-- method='lml_backfill') behind.
+--
+-- The per-column shape was inherited from `jobs/artist-unicode-dedup/
+-- merge.ts`, cited as the donor in this block's header -- but that donor's
+-- IDENTITY_COLUMNS are six MUTUALLY INDEPENDENT external ids
+-- (discogs/musicbrainz/wikidata/spotify/apple/bandcamp), where per-column
+-- COALESCE is exactly right. The shape was correct there and wrong here.
+--
+-- `track_position` stays independent: it is an ordinary scalar with no
+-- provenance columns bound to it, so COALESCE-preserve remains correct.
 UPDATE wxyc_schema.compilation_track_artist twin
-   SET track_artist_id = COALESCE(twin.track_artist_id, t.old_track_artist_id),
-       track_artist_link_confidence = COALESCE(twin.track_artist_link_confidence, t.old_track_artist_link_confidence),
-       track_artist_link_method = COALESCE(twin.track_artist_link_method, t.old_track_artist_link_method),
+   SET track_artist_id = CASE WHEN twin.track_artist_id IS NULL THEN t.old_track_artist_id ELSE twin.track_artist_id END,
+       track_artist_link_confidence = CASE WHEN twin.track_artist_id IS NULL THEN t.old_track_artist_link_confidence ELSE twin.track_artist_link_confidence END,
+       track_artist_link_method = CASE WHEN twin.track_artist_id IS NULL THEN t.old_track_artist_link_method ELSE twin.track_artist_link_method END,
        track_position = COALESCE(twin.track_position, t.old_track_position)
   FROM cta_repair_targets t
  WHERE t.has_twin
@@ -1364,18 +1490,30 @@ END $$;
 -- sharing a library_id this run touched may be NFC-equal but byte-distinct on
 -- (artist_name, track_title).
 --
--- Scope is "any library_id in cta_repair_targets", not "only rows this run
--- wrote" -- deliberately broader, matching guard-repair-complete's own
--- posture of checking the outcome rather than the mechanism. A pre-existing
--- NFC/NFD duplicate pair that this run never touched, sitting in a
--- compilation this run otherwise repaired, is exactly the kind of thing an
--- operator should see before trusting this run's postlude -- the U+FFFD
--- residual reads 0/0 either way, and that was the whole failure mode the
--- round 4 finding started from. Aborting here rolls back this run's own
--- writes (the same recovery shape as every other guard in this script) but
--- cannot undo a duplicate that predates this run; the exception message says
--- so explicitly rather than implying a clean rollback fixes everything it
--- flags.
+-- Scope: candidate GROUPS are drawn from every library_id this run touched,
+-- but a group only ABORTS if at least one of its rows was actually WRITTEN by
+-- this run (round 5 finding). Through round 4 the guard aborted on any
+-- NFC-duplicate pair in a touched library_id, including one it never wrote --
+-- so a single legitimate no-twin UPDATE in a compilation that happened to
+-- already contain an unrelated `Björk` NFC / `Björk` NFD pair rolled back the
+-- entire 14-row repair, and the repair could not complete until a human
+-- merged a duplicate that had nothing to do with it. Reproduced end to end:
+-- `update-no-twins` reported `UPDATE 1`, this guard fired, everything rolled
+-- back, the corrupt row survived. That is a false abort, not a safety net --
+-- and it is invisible to the read-only `awk` prelude, which stops at `BEGIN;`
+-- while every one of these statements runs after it.
+--
+-- Narrowing to written rows preserves exactly what the guard is for -- a
+-- duplicate this run CREATED or contributed to -- and makes its rollback
+-- advice honest: undoing this run's writes genuinely removes this run's half
+-- of the pair. Pre-existing duplicates the run never touched are a real thing
+-- an operator may want to know about, but they are #1996's territory, not a
+-- reason to refuse a U+FFFD repair; the post-amble residual reads are where
+-- that belongs.
+--
+-- "Written by this run" = the no-twin rows update-no-twins UPDATEd, plus the
+-- surviving twins repoint-twin-identity wrote to (the DELETE branch's
+-- survivor). The deleted rows themselves are gone and cannot be in a group.
 --
 -- `normalize()` here runs only over rows in library_ids from
 -- `cta_repair_targets` -- a handful of compilations per run, not a full-table
@@ -1398,8 +1536,13 @@ BEGIN
      WHERE cta.library_id IN (SELECT DISTINCT library_id FROM cta_repair_targets)
      GROUP BY cta.library_id, normalize(cta.artist_name, NFC), normalize(cta.track_title, NFC)
     HAVING COUNT(*) > 1
+       AND bool_or(cta.id IN (
+             SELECT t.id FROM cta_repair_targets t WHERE NOT t.has_twin
+             UNION
+             SELECT t.twin_id FROM cta_repair_targets t WHERE t.has_twin
+           ))
   LOOP
-    RAISE EXCEPTION 'BS#2152 guard: library_id=% has % rows that are NFC-equal but byte-distinct on (artist_name, track_title) after this run''s writes (cta_ids=%, artist_names=%, track_titles=%) -- this is the exact duplicate class the NFC-folded twin join exists to prevent. Rolling back undoes this run''s own writes but may NOT undo this specific duplicate if it predates this run; investigate the listed rows directly (do they need a manual merge? does an earlier run of this or a sibling script need review?) before re-running', bad.library_id, bad.n, bad.cta_ids, bad.artist_names, bad.track_titles;
+    RAISE EXCEPTION 'BS#2152 guard: library_id=% has % rows that are NFC-equal but byte-distinct on (artist_name, track_title) after this run''s writes, and at least one of them was written by THIS run (cta_ids=%, artist_names=%, track_titles=%) -- this is the exact duplicate class the NFC-folded twin join exists to prevent. Rolling back removes this run''s half of the pair; investigate the listed rows before re-running (is the captured true_* value in a different composition form than the live row it should have matched?)', bad.library_id, bad.n, bad.cta_ids, bad.artist_names, bad.track_titles;
   END LOOP;
 END $$;
 -- === END STMT ===

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -17,6 +17,16 @@
  * DDL/DML the operator will run -- only the pending DATA differs between
  * this spec and prod.
  *
+ * "The actual DDL/DML" is meant literally as of round 3. Through round 2 the
+ * script's read-only pre-amble and its post-amble residual reads carried no
+ * STMT tags, so this spec only pinned their POSITION in the file with
+ * `indexOf` and never executed a line of them -- a typo in the post-amble
+ * would have passed the whole suite and then aborted the real prod run under
+ * ON_ERROR_STOP after the writes and before COMMIT, rolling back a repair
+ * that had succeeded. They are tagged blocks now and `runRepairScript` runs
+ * them, along with the `SET LOCAL statement_timeout` lines and the
+ * `lock-targets` row locks, in the exact order `psql -f` would.
+ *
  * The throwaway `compilation_track_artist` table replicates BOTH production
  * unique indexes (`cta_unique_idx` and its NULL-track_title complement) --
  * unlike bs-replacement-char-phase4.spec.js's plain `text` columns, that
@@ -47,13 +57,19 @@ const EXPECTED_BLOCKS = [
   'guard-replacement-specified',
   'guard-capture-sanity',
   'guard-nfc-form',
+  'pending-match-preview',
+  'guard-unknown-release',
+  'before-residual',
   'build-targets',
+  'lock-targets',
   'guard-post-fix-fffd',
   'guard-ambiguous-match',
   'guard-converging-pending',
   'repoint-twin-identity',
   'delete-twins',
   'update-no-twins',
+  'guard-repair-complete',
+  'post-amble-residual',
   'analyze',
 ];
 
@@ -105,7 +121,27 @@ function extractStmtBlocks(scriptText, targetSchema) {
     if (!endMatch) {
       throw new Error(`STMT block "${name}" has no matching "-- === END STMT ===" marker`);
     }
-    blocks[name] = scriptText.slice(contentStart, endMatch.index).replace(/wxyc_schema\./g, `${targetSchema}.`);
+    const body = scriptText.slice(contentStart, endMatch.index);
+    // A MISSING end marker throws loudly above; a TYPO'd one used to be
+    // silent, and silently much worse (PR #2154 review round 3). `endRe.exec`
+    // simply scans on to the NEXT end marker in the file, so block N absorbs
+    // block N+1's SQL -- the intervening `-- === STMT: ... ===` line is an
+    // inert SQL comment, so it executes without complaint. Block N+1 still
+    // extracts separately from its own start marker, so its statements then
+    // run TWICE per pass, and `.count` on a now multi-statement `unsafe()` no
+    // longer means "rows this statement affected". Neither the non-empty
+    // check nor the indexOf-based ordering tests notice: the block names and
+    // their order are still exactly right. The spec would be validating a
+    // different execution shape than the operator's `psql -f` run, which is
+    // the one thing this whole extractor exists to prevent.
+    if (startRe.test(body)) {
+      startRe.lastIndex = 0;
+      throw new Error(
+        `STMT block "${name}" swallowed a nested "-- === STMT: ... ===" start marker -- its own "-- === END STMT ===" is missing or misspelled, so it absorbed the following block`
+      );
+    }
+    startRe.lastIndex = 0;
+    blocks[name] = body.replace(/wxyc_schema\./g, `${targetSchema}.`);
   }
   return blocks;
 }
@@ -232,7 +268,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
    * real `BEGIN`/`COMMIT` here is safe: this is a dedicated reserved
    * connection, not the shared pool the extractor's own comment warns about.
    */
-  async function runRepairScript(insertPhase) {
+  async function runRepairScript(insertPhase, hooks = {}) {
     const reservedSql = await sql.reserve();
     let inTransaction = false;
     try {
@@ -242,17 +278,40 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       await reservedSql.unsafe(blocks['guard-replacement-specified']);
       await reservedSql.unsafe(blocks['guard-capture-sanity']);
       await reservedSql.unsafe(blocks['guard-nfc-form']);
+      await reservedSql.unsafe(blocks['pending-match-preview']);
+      await reservedSql.unsafe(blocks['guard-unknown-release']);
+      await reservedSql.unsafe(blocks['before-residual']);
 
       await reservedSql.unsafe('BEGIN');
       inTransaction = true;
       await reservedSql.unsafe("SET LOCAL statement_timeout = '30s'");
       await reservedSql.unsafe(blocks['build-targets']);
+      // The one window `lock-targets` cannot close is the one in front of
+      // it. Tests that need to land a concurrent write inside that window
+      // inject it here rather than hand-copying this sequence (PR #2154
+      // review round 3) -- a copy drifts from the real 20-block order, and
+      // more importantly a copy that lacks this function's catch/ROLLBACK
+      // hands an aborted-transaction connection back to the shared max:5
+      // pool, where postgres-js's `release()` issues no ROLLBACK or DISCARD
+      // of its own. The next query to draw that connection -- including
+      // afterAll's DROP SCHEMA, under --runInBand -- then fails with
+      // "current transaction is aborted", masking whatever actually broke.
+      if (hooks.afterBuildTargets) {
+        await hooks.afterBuildTargets(reservedSql);
+      }
+      await reservedSql.unsafe(blocks['lock-targets']);
       await reservedSql.unsafe(blocks['guard-post-fix-fffd']);
       await reservedSql.unsafe(blocks['guard-ambiguous-match']);
       await reservedSql.unsafe(blocks['guard-converging-pending']);
+      if (hooks.afterGuards) {
+        await hooks.afterGuards(reservedSql);
+      }
       await reservedSql.unsafe(blocks['repoint-twin-identity']);
       const deleteResult = await reservedSql.unsafe(blocks['delete-twins']);
       const updateResult = await reservedSql.unsafe(blocks['update-no-twins']);
+      await reservedSql.unsafe(blocks['guard-repair-complete']);
+      await reservedSql.unsafe("SET LOCAL statement_timeout = '5min'");
+      await reservedSql.unsafe(blocks['post-amble-residual']);
       await reservedSql.unsafe('COMMIT');
       inTransaction = false;
 
@@ -311,11 +370,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].n;
   }
 
-  test('extracts exactly the 14 expected STMT blocks, in order', () => {
+  test('extracts exactly the 20 expected STMT blocks, in order', () => {
     expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
     for (const name of EXPECTED_BLOCKS) {
       expect(blocks[name].trim().length).toBeGreaterThan(0);
     }
+  });
+
+  test("extractStmtBlocks refuses a block that swallowed the next one (round 3: a TYPO'd END marker, unlike a missing one, used to be silent -- the block absorbs its successor's SQL and that successor then executes twice per run, with every name/order assertion still green)", () => {
+    const sabotaged = scriptText.replace('-- === END STMT ===', '-- === END STMTT ===');
+    expect(sabotaged).not.toBe(scriptText);
+    expect(() => extractStmtBlocks(sabotaged, TEST_SCHEMA)).toThrow('swallowed a nested');
   });
 
   test('the transaction boundary is positioned correctly: BEGIN; precedes build-targets, COMMIT; precedes the final ANALYZE (MEDIUM finding, PR #2154 review round 2 -- a prior version of this test only asserted BEGIN;/COMMIT; existed SOMEWHERE in the file, which cannot detect either boundary moving to the wrong side of a STMT block; verified against the review-cited regression: a verbatim revert of round 1\'s "classify inside the transaction" fix, or moving ANALYZE inside the transaction, both left the old assertion-only-existence version of this test green)', () => {
@@ -353,6 +418,42 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     expect(postAmbleIdx).toBeLessThan(commitIdx);
   });
 
+  test('the statement_timeout is raised ONLY after the last write, so a slow residual scan cannot roll back a repair that already succeeded -- and the 30s cap still covers every writing statement (round 3 finding)', () => {
+    // The AFTER residual counts are two unindexable full-table scans by
+    // construction (1-character leading-wildcard LIKE; the pg_trgm GIN indexes
+    // extract zero trigrams from one character), and they run INSIDE the write
+    // transaction because the dry-run recipe requires it. Under the flat 30s
+    // cap, a cold cache or I/O contention from the concurrent 30-minute
+    // library-etl cycle times the scan out, ON_ERROR_STOP aborts, COMMIT is
+    // never reached -- and a fully correct 14-row repair is destroyed to fail
+    // a verification read.
+    //
+    // `SET LOCAL` is last-write-wins within the transaction, so the ORDER is
+    // the entire fix: raised after the writes, the 30s bound still governs
+    // every statement that writes (including the lock wait in lock-targets,
+    // where timing out is the DESIRED behavior -- abort rather than park
+    // behind a concurrent writer). Raised any earlier and that bound is gone.
+    const beginIdx = scriptText.indexOf('\nBEGIN;\n');
+    const writeCapIdx = scriptText.indexOf("SET LOCAL statement_timeout = '30s';");
+    const lastWriteEndIdx = scriptText.indexOf(
+      '-- === END STMT ===',
+      scriptText.indexOf('-- === STMT: update-no-twins ===')
+    );
+    const raisedCapIdx = scriptText.indexOf("SET LOCAL statement_timeout = '5min';");
+    const postAmbleIdx = scriptText.indexOf('-- === STMT: post-amble-residual ===');
+    const commitIdx = scriptText.indexOf('\nCOMMIT;\n');
+
+    expect(writeCapIdx).toBeGreaterThan(-1);
+    expect(raisedCapIdx).toBeGreaterThan(-1);
+    expect(postAmbleIdx).toBeGreaterThan(-1);
+
+    expect(writeCapIdx).toBeGreaterThan(beginIdx);
+    expect(writeCapIdx).toBeLessThan(lastWriteEndIdx);
+    expect(raisedCapIdx).toBeGreaterThan(lastWriteEndIdx);
+    expect(raisedCapIdx).toBeLessThan(postAmbleIdx);
+    expect(postAmbleIdx).toBeLessThan(commitIdx);
+  });
+
   test('the shipped insert-pending-rows block carries no quoted string literals in its SQL -- i.e. it is still just the all-NULL placeholder (the missing enforcement gate, PR #2154 review round 2)', () => {
     // The deferred byte-exact codepoint assertion (Phase 4's
     // scriptUsesTheRightCodepoints analogue, see the header's "Known gap,
@@ -370,6 +471,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       .map((line) => line.replace(/--.*$/, ''))
       .join('\n');
     expect(sqlOnly).not.toMatch(/'/);
+    // Dollar quoting is the hole the single-quote check alone leaves open
+    // (round 3 finding). `$$Csillagrablók$$` and `$t$Reménytelen Tánc$t$` are
+    // both valid PostgreSQL string literals containing zero apostrophes, and
+    // they are exactly what an operator (or an agent) reaches for to avoid
+    // escaping the apostrophes real track titles contain. Traced end to end:
+    // with real dollar-quoted rows pasted in, every guard passes, the
+    // synthetic-fixture tests match nothing against their own libraries, and
+    // the whole suite stays green -- so the header's "goes red the moment
+    // real rows land" contract, and the byte-assertion gate it defers to,
+    // would both be bypassable without this second assertion.
+    expect(sqlOnly).not.toMatch(/\$[A-Za-z_]*\$/);
   });
 
   test('the shipped insert-pending-rows block (as committed) is a genuine no-op', async () => {
@@ -1040,10 +1152,15 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       track_artist_link_method: 'lml_backfill',
     });
 
-    const reservedSql = await sql.reserve();
-    try {
-      await reservedSql.unsafe(blocks['create-pending-table']);
-      await insertSyntheticPendingRows(reservedSql, [
+    // Injected through runRepairScript's own hook rather than hand-copying
+    // the block sequence (PR #2154 review round 3). The inlined copy this
+    // replaces both drifted from the real order and, lacking the helper's
+    // catch/ROLLBACK, could hand an aborted-transaction connection back to
+    // the shared pool. The hook fires between build-targets and lock-targets,
+    // which after round 3 is the ONLY window in which a concurrent edit to a
+    // classified row is still possible at all.
+    await runRepairScript(
+      withSyntheticPendingRows([
         {
           legacy_release_id: 90026,
           track_position: '4',
@@ -1051,36 +1168,20 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
           current_track_title: 'Sonido C�smico',
           true_track_title: 'Sonido Cósmico',
         },
-      ]);
-      await reservedSql.unsafe(blocks['guard-placeholder-scrub']);
-      await reservedSql.unsafe(blocks['guard-replacement-specified']);
-      await reservedSql.unsafe(blocks['guard-capture-sanity']);
-      await reservedSql.unsafe(blocks['guard-nfc-form']);
-
-      await reservedSql.unsafe('BEGIN');
-      await reservedSql.unsafe("SET LOCAL statement_timeout = '30s'");
-      await reservedSql.unsafe(blocks['build-targets']);
-      await reservedSql.unsafe(blocks['guard-post-fix-fffd']);
-      await reservedSql.unsafe(blocks['guard-ambiguous-match']);
-      await reservedSql.unsafe(blocks['guard-converging-pending']);
-
-      // Simulate the concurrent edit from a SECOND session. READ COMMITTED
-      // means this ordinary UPDATE is not blocked by the open transaction
-      // above -- build-targets' CREATE TEMP TABLE ... AS SELECT took no row
-      // lock.
-      await sql`
-        UPDATE ${sql(TEST_SCHEMA)}.compilation_track_artist
-           SET artist_name = 'Somebody Else Entirely'
-         WHERE id = ${corruptId}
-      `;
-
-      await reservedSql.unsafe(blocks['repoint-twin-identity']);
-      await reservedSql.unsafe(blocks['delete-twins']);
-      await reservedSql.unsafe(blocks['update-no-twins']);
-      await reservedSql.unsafe('COMMIT');
-    } finally {
-      reservedSql.release();
-    }
+      ]),
+      {
+        afterBuildTargets: async () => {
+          // A SECOND session. READ COMMITTED means this ordinary UPDATE is
+          // not blocked here -- build-targets' CREATE TEMP TABLE ... AS
+          // SELECT took no row lock, and lock-targets has not run yet.
+          await sql`
+            UPDATE ${sql(TEST_SCHEMA)}.compilation_track_artist
+               SET artist_name = 'Somebody Else Entirely'
+             WHERE id = ${corruptId}
+          `;
+        },
+      }
+    );
 
     // The twin's identity link was NOT repointed -- the re-check in
     // repoint-twin-identity found the corrupt row no longer matched its
@@ -1094,5 +1195,224 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     // twins' own pre-existing re-check already covered this half).
     const corrupt = await ctaRow(corruptId);
     expect(corrupt.artist_name).toBe('Somebody Else Entirely');
+
+    // guard-repair-complete does NOT fire here, and that is the intended
+    // asymmetry: nothing live still holds the captured corrupt tuple (the
+    // concurrent editor rewrote it), so this run legitimately wrote nothing
+    // and committed. Contrast the vanished-twin test below, where the corrupt
+    // tuple IS still live after the writes and the guard aborts.
+  });
+
+  // ==========================================================================
+  // Round 3 review findings (PR #2154 review, third pass).
+  // ==========================================================================
+
+  test('HIGH: a twin deleted between build-targets and lock-targets makes delete-twins decline, and guard-repair-complete refuses to COMMIT the un-repaired run -- the corrupt row is the last copy of the credit and survives', async () => {
+    // Through round 2 both write statements re-checked only the row they were
+    // about to touch, never the twin that was supposed to carry the credit
+    // forward. `twin.id = t.twin_id` is a snapshot from build-targets, so a
+    // twin deleted (or renamed) in the window let delete-twins remove what had
+    // by then become the ONLY remaining copy -- committing at exit 0, with a
+    // per-row residual of 0 because the residual counts the OLD tuple, which
+    // the delete genuinely did remove. The UPDATE branch never had this
+    // exposure (it fails safe into a 23505); the DELETE branch had no tripwire.
+    const libraryId = await seedLibrary(90030);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2');
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '7');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90030,
+            track_position: '7',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico',
+          },
+        ]),
+        {
+          afterBuildTargets: async () => {
+            await sql`
+              DELETE FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${twinId}
+            `;
+          },
+        }
+      )
+    ).rejects.toThrow('still holds its corrupt tuple');
+
+    // The credit survives. This is the assertion the whole finding is about:
+    // without delete-twins' twin re-check the corrupt row is gone here and the
+    // compilation has lost the credit entirely, with the script reporting
+    // success. Corrupt-but-present is recoverable; absent is not.
+    const corrupt = await ctaRow(corruptId);
+    expect(corrupt.artist_name).toBe('Hermanos Gutiérrez');
+    expect(corrupt.track_title).toBe('Sonido C�smico');
+    // Only the concurrently-deleted twin is gone -- that delete belongs to
+    // another committed transaction and is not ours to roll back.
+    expect(await ctaCount(libraryId)).toBe(1);
+  });
+
+  test('HIGH: lock-targets takes real row locks on BOTH the corrupt row and its twin, so no concurrent writer can reach them between classification and the writes', async () => {
+    // The mechanism the round 3 concurrency fixes rest on. Through round 2 the
+    // script narrowed the classify-then-write window with re-checks but never
+    // closed it, which is what let repoint-twin-identity and delete-twins
+    // disagree with each other (repoint fires, edit lands, delete correctly
+    // declines -- identity link duplicated across two live rows, committed).
+    // Both are locked: the twin matters as much as the corrupt row, since the
+    // write statements read and mutate both.
+    const libraryId = await seedLibrary(90031);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2');
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '7');
+
+    // Bounded with lock_timeout so a genuinely-held lock surfaces as an error
+    // rather than hanging the suite forever if this assertion ever regresses.
+    async function tryConcurrentUpdate(id) {
+      const other = await sql.reserve();
+      try {
+        await other.unsafe('BEGIN');
+        await other.unsafe("SET LOCAL lock_timeout = '250ms'");
+        try {
+          await other.unsafe(
+            `UPDATE ${TEST_SCHEMA}.compilation_track_artist SET track_position = '99' WHERE id = ${id}`
+          );
+          await other.unsafe('ROLLBACK');
+          return null;
+        } catch (err) {
+          await other.unsafe('ROLLBACK');
+          return err;
+        }
+      } finally {
+        other.release();
+      }
+    }
+
+    const blocked = {};
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90031,
+          track_position: '7',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico',
+        },
+      ]),
+      {
+        // AFTER lock-targets (afterGuards runs later in the sequence), so the
+        // locks are held. The same writes succeed from the afterBuildTargets
+        // hook the two tests above use, which is precisely the difference the
+        // lock makes.
+        afterGuards: async () => {
+          blocked.corrupt = await tryConcurrentUpdate(corruptId);
+          blocked.twin = await tryConcurrentUpdate(twinId);
+        },
+      }
+    );
+
+    expect(blocked.corrupt).not.toBeNull();
+    expect(blocked.corrupt.code).toBe('55P03'); // lock_not_available
+    expect(blocked.twin).not.toBeNull();
+    expect(blocked.twin.code).toBe('55P03');
+
+    // The repair itself still completed normally with the locks held.
+    expect(result.deleted).toBe(1);
+    expect(result.updated).toBe(0);
+    const twin = await ctaRow(twinId);
+    expect(twin.track_title).toBe('Sonido Cósmico');
+    expect(await ctaCount(libraryId)).toBe(1);
+  });
+
+  test('MEDIUM: the shipped scrub DELETE is conditional on the FULL all-NULL placeholder shape -- reverting it to the unconditional `WHERE legacy_release_id IS NULL` form is caught', async () => {
+    // Round 3 finding: no test previously ran the SHIPPED scrub against any
+    // row but its own placeholder. The synthetic path skips
+    // `insert-pending-rows` entirely, and the one test that does execute it
+    // carries zero other pending rows -- where the conditional and
+    // unconditional DELETEs are indistinguishable. So the round 2 fix for this
+    // exact bug was pinned only by the guard's existence, not by the scrub's
+    // conditionality, and reverting the scrub left the whole suite green.
+    //
+    // The paste-slip row has to exist BEFORE the shipped block runs, or its
+    // scrub never sees it -- which is why this cannot be expressed through
+    // withSyntheticPendingRows.
+    await seedLibrary(90027);
+    await expect(
+      runRepairScript(async (reservedSql) => {
+        await insertSyntheticPendingRows(reservedSql, [
+          {
+            legacy_release_id: null,
+            track_position: '2',
+            current_artist_name: 'Some Other Artist',
+            current_track_title: 'Some Other Title',
+            true_artist_name: 'Fixed Other Artist',
+          },
+        ]);
+        await reservedSql.unsafe(blocks['insert-pending-rows']);
+      })
+    ).rejects.toThrow('already been scrubbed');
+  });
+
+  test('MEDIUM: a NULL current_artist_name on a track_title-only repair aborts via guard-capture-sanity instead of silently matching nothing', async () => {
+    // Round 3 finding: guard-capture-sanity's NULL test sat inside the
+    // `true_artist_name IS NOT NULL` branch, so it never applied to the 11
+    // track_title-only rows -- where a NULLed current_artist_name passed every
+    // guard, matched no live row (build-targets joins on
+    // `cta.artist_name = p.current_artist_name`), and committed as a silent
+    // no-op with the corruption intact. prod's artist_name column is NOT NULL
+    // and the enumeration query cannot emit a NULL there, so this is always a
+    // paste slip and is now always fatal.
+    const libraryId = await seedLibrary(90028);
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90028,
+            track_position: '4',
+            current_artist_name: null, // paste slip -- one column short
+            current_track_title: 'Rem�nytelen T�nc',
+            true_track_title: 'Reménytelen Tánc',
+          },
+        ])
+      )
+      // The guard names the ACTUAL fault rather than ORing both of its
+      // diagnoses into one message -- a short paste and a transposed paste
+      // have different fixes, and this fragment would match the transposed
+      // wording too if it didn't.
+    ).rejects.toThrow('current_artist_name is NULL');
+
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrablók');
+    expect(row.track_title).toBe('Rem�nytelen T�nc');
+  });
+
+  test('MEDIUM: a legacy_release_id resolving to no library row aborts via guard-unknown-release, not the merely-informational unmatched listing', async () => {
+    // The one unmatched shape that can never be an idempotent re-run:
+    // repairing a CTA row does not delete or re-key its `library` parent, so a
+    // release id that resolves to nothing is a transcription error in the
+    // paste. Before round 3 it was swept into the same INFO listing as the
+    // benign already-fixed case and the run exited 0.
+    const libraryId = await seedLibrary(90029);
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90999, // no library row carries this id
+            track_position: '4',
+            current_artist_name: 'Csillagrablók',
+            current_track_title: 'Rem�nytelen T�nc',
+            true_track_title: 'Reménytelen Tánc',
+          },
+        ])
+      )
+      // Schema-free fragment: the message names wxyc_schema.library, which the
+      // extractor rewrites to the throwaway schema.
+    ).rejects.toThrow('matches no row in');
+
+    const row = await ctaRow(corruptId);
+    expect(row.track_title).toBe('Rem�nytelen T�nc');
   });
 });

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -38,6 +38,15 @@
  * varchar(255)/varchar(20) lengths as prod (PR #2154 review NIT) -- plain
  * `text` would silently accept a captured value too long for the real
  * column.
+ *
+ * Round 4 adds coverage for the Unicode-composition-form defect: the twin
+ * join, and the delete-twins/repoint-twin-identity re-checks that mirror it,
+ * now compare `normalize(x, NFC)` rather than raw bytes, so a genuinely
+ * NFD-stored live twin is FOUND instead of silently missed (see the script's
+ * own header and build-targets' own comment for the full failure mode). The
+ * "round 4" tests below pin the specific scenario that motivated the fix
+ * (an NFD twin now takes the DELETE branch and leaves exactly one row) plus
+ * the new `guard-post-write-nfc-duplicate` belt-and-braces check.
  */
 
 const fs = require('fs');
@@ -69,6 +78,7 @@ const EXPECTED_BLOCKS = [
   'delete-twins',
   'update-no-twins',
   'guard-repair-complete',
+  'guard-post-write-nfc-duplicate',
   'post-amble-residual',
   'analyze',
 ];
@@ -310,6 +320,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       const deleteResult = await reservedSql.unsafe(blocks['delete-twins']);
       const updateResult = await reservedSql.unsafe(blocks['update-no-twins']);
       await reservedSql.unsafe(blocks['guard-repair-complete']);
+      await reservedSql.unsafe(blocks['guard-post-write-nfc-duplicate']);
       await reservedSql.unsafe("SET LOCAL statement_timeout = '5min'");
       await reservedSql.unsafe(blocks['post-amble-residual']);
       await reservedSql.unsafe('COMMIT');
@@ -370,7 +381,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].n;
   }
 
-  test('extracts exactly the 20 expected STMT blocks, in order', () => {
+  test('extracts exactly the 21 expected STMT blocks, in order', () => {
     expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
     for (const name of EXPECTED_BLOCKS) {
       expect(blocks[name].trim().length).toBeGreaterThan(0);
@@ -1414,5 +1425,203 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
 
     const row = await ctaRow(corruptId);
     expect(row.track_title).toBe('Rem�nytelen T�nc');
+  });
+
+  // ==========================================================================
+  // Round 4 review findings (Unicode composition-form mismatch, BS#2152).
+  // ==========================================================================
+
+  test('BS#2152 round 4: an NFD-stored clean twin against an NFC true_* capture now classifies as a twin, takes the DELETE branch, and leaves exactly one (NFD) row with the U+FFFD gone', async () => {
+    // The defect this round closes: build-targets' twin join used to compare
+    // twin.artist_name/twin.track_title to the post-fix tuple byte-exactly.
+    // guard-nfc-form pins every captured true_* value to NFC, but a LIVE row
+    // carries no such invariant -- this table has no fold trigger the way
+    // `artists` does -- so a genuinely NFD-stored clean twin is possible, and
+    // it is exactly what the byte-exact join missed. Before this fix, the
+    // run below would classify no-twin, UPDATE the corrupt row onto the NFC
+    // value, and leave TWO rows (one NFD, one NFC) for the same credit --
+    // with the postlude still reading 0/0, because the U+FFFD really was
+    // gone; what was left behind was a duplicate, not a U+FFFD.
+    const libraryId = await seedLibrary(90040);
+    const nfdTrackTitle = 'Sonido Cósmico'.normalize('NFD');
+    expect(nfdTrackTitle).not.toBe('Sonido Cósmico');
+    expect(nfdTrackTitle.normalize('NFC')).toBe('Sonido Cósmico');
+
+    // The corrupt row carries an identity link the clean twin lacks (the
+    // usual shape -- the corrupt row is the OLDER ingestion, see
+    // repoint-twin-identity's own comment). This is deliberate, not just
+    // fixture texture: repoint-twin-identity has its OWN NFC-folded
+    // twin-match re-check (coupling 2 in the round 4 review), separate from
+    // delete-twins'. A mutation that reverted ONLY repoint's fold would
+    // still let delete-twins remove the corrupt row correctly -- same row
+    // counts, same surviving id, same bytes -- but the identity link would
+    // silently fail to carry over, since repoint's own WHERE would then
+    // match zero rows against this NFD twin. Asserting on the identity
+    // columns below is what makes that failure mode visible instead of
+    // masked by delete-twins' independent fix.
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', nfdTrackTitle, '2');
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '7', {
+      track_artist_id: 4242,
+      track_artist_link_confidence: 0.93,
+      track_artist_link_method: 'lml_backfill',
+    });
+
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90040,
+          track_position: '7',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico', // NFC, as guard-nfc-form requires
+        },
+      ])
+    );
+
+    expect(result.deleted).toBe(1);
+    expect(result.updated).toBe(0);
+
+    // Exactly one row survives -- the corrupt row is gone, not duplicated.
+    expect(await ctaCount(libraryId)).toBe(1);
+    const remaining = await sql`
+      SELECT id, artist_name, track_title FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE library_id = ${libraryId}
+    `;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(twinId);
+
+    // The surviving row is the ORIGINAL NFD twin, byte for byte -- detection
+    // folds to NFC, writes never do. The corrupt row was DELETEd, not
+    // rewritten, so nothing here was ever written in a normalized form.
+    expect(remaining[0].track_title).toBe(nfdTrackTitle);
+    expect(remaining[0].track_title.normalize('NFC')).toBe('Sonido Cósmico');
+
+    // The corrupt row's identity link carried over onto the NFD twin --
+    // this only happens if repoint-twin-identity's OWN NFC-folded
+    // twin-match re-check actually fired against the NFD twin (see the
+    // seeding comment above for why this is load-bearing, not incidental).
+    const twin = await ctaRow(twinId);
+    expect(twin.track_artist_id).toBe(4242);
+    expect(twin.track_artist_link_confidence).toBeCloseTo(0.93);
+    expect(twin.track_artist_link_method).toBe('lml_backfill');
+
+    const corruptGone = await sql`
+      SELECT id FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${corruptId}
+    `;
+    expect(corruptGone).toHaveLength(0);
+
+    // The U+FFFD predicate is 0 across both columns -- the same postlude
+    // read the pre-fix defect also passed, which is why this scenario needs
+    // its own row-count/identity assertions rather than trusting the
+    // residual count alone.
+    const [{ remainingFffd }] = await sql`
+      SELECT COUNT(*)::int AS "remainingFffd"
+      FROM ${sql(TEST_SCHEMA)}.compilation_track_artist
+      WHERE library_id = ${libraryId}
+        AND (artist_name LIKE '%' || chr(65533) || '%' OR track_title LIKE '%' || chr(65533) || '%')
+    `;
+    expect(remainingFffd).toBe(0);
+  });
+
+  test('BS#2152 round 4: two pending rows converging only AFTER NFC folding (via the untouched COALESCE column) abort via guard-converging-pending', async () => {
+    // Coupling 3 from the round 4 review: guard-converging-pending groups on
+    // the post-fix tuple, but `new_artist_name`/`new_track_title` COALESCE
+    // onto whichever column a pending row does NOT fix -- and that untouched
+    // column carries no NFC invariant (see "Unicode normalization" above).
+    // So two pending rows can converge on the same real credit via a form
+    // mismatch alone, with no true_* value even involved in the mismatch
+    // that causes the convergence. Byte-exact grouping would miss this and
+    // let BOTH rows reach update-no-twins, which -- being NFC-equal but
+    // byte-DISTINCT -- does NOT trip cta_unique_idx, so the run would exit 0
+    // having created exactly the round-4 duplicate class this whole fix
+    // exists to prevent.
+    const libraryId = await seedLibrary(90042);
+    const nfdTrackTitle = 'Sonido Cósmico'.normalize('NFD');
+
+    // Row A: corrupt artist_name; track_title untouched and stored NFD.
+    await seedCta(libraryId, 'Hermanos Guti�rrez', nfdTrackTitle, '1');
+    // Row B: artist_name already clean NFC; corrupt track_title.
+    await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '2');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90042,
+            track_position: '1',
+            current_artist_name: 'Hermanos Guti�rrez',
+            current_track_title: nfdTrackTitle,
+            true_artist_name: 'Hermanos Gutiérrez', // NFC
+            // true_track_title omitted -- new_track_title COALESCEs onto
+            // this row's own (NFD) live track_title.
+          },
+          {
+            legacy_release_id: 90042,
+            track_position: '2',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico', // NFC
+            // true_artist_name omitted -- new_artist_name COALESCEs onto
+            // this row's own (already-NFC) live artist_name.
+          },
+        ])
+      )
+      // Guard-specific fragment -- distinguishes a genuine
+      // guard-converging-pending catch from guard-post-write-nfc-duplicate,
+      // which would ALSO fire on this exact scenario if THIS guard's own
+      // fold were reverted (see the round 4 mutation table): the two guards
+      // overlap on this input, so only the message text tells them apart.
+    ).rejects.toThrow('converge on the same post-fix');
+
+    // Both rows survive untouched -- the transaction rolled back before
+    // either write statement ran.
+    const rows = await sql`
+      SELECT artist_name, track_title FROM ${sql(TEST_SCHEMA)}.compilation_track_artist
+      WHERE library_id = ${libraryId} ORDER BY track_position
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].artist_name).toBe('Hermanos Guti�rrez');
+    expect(rows[0].track_title).toBe(nfdTrackTitle);
+    expect(rows[1].artist_name).toBe('Hermanos Gutiérrez');
+    expect(rows[1].track_title).toBe('Sonido C�smico');
+  });
+
+  test('BS#2152 round 4: guard-post-write-nfc-duplicate fires when a touched library_id holds two NFC-equal, byte-distinct rows', async () => {
+    // The belt-and-braces half of the round 4 fix: this guard checks the
+    // OUTCOME (no two live rows in a touched library_id are NFC-equal but
+    // byte-distinct), not just the twin-join mechanism that is supposed to
+    // prevent it. Reproduced here via a pre-existing NFC/NFD pair the run
+    // never touches directly, sitting in a compilation this run otherwise
+    // repairs -- scope is "library_id in cta_repair_targets", deliberately
+    // broader than "rows this run wrote", per the guard's own comment.
+    const libraryId = await seedLibrary(90041);
+    const nfdTitle = 'Sonido Cósmico'.normalize('NFD');
+    await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '1'); // NFC
+    await seedCta(libraryId, 'Hermanos Gutiérrez', nfdTitle, '2'); // NFD -- same credit, pre-existing duplicate
+
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90041,
+            track_position: '4',
+            current_artist_name: 'Csillagrablók',
+            current_track_title: 'Rem�nytelen T�nc',
+            true_track_title: 'Reménytelen Tánc',
+          },
+        ])
+      )
+      // Guard-specific fragment.
+    ).rejects.toThrow('NFC-equal but byte-distinct');
+
+    // Rolled back -- this run's own UPDATE to the unrelated corrupt row is
+    // undone (the recovery shape every guard in this script uses), even
+    // though the duplicate it flagged predates this run and is NOT undone by
+    // the rollback -- the guard's own message says as much.
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrablók');
+    expect(row.track_title).toBe('Rem�nytelen T�nc');
+    expect(await ctaCount(libraryId)).toBe(3);
   });
 });

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -46,7 +46,9 @@ const EXPECTED_BLOCKS = [
   'guard-placeholder-scrub',
   'guard-replacement-specified',
   'guard-capture-sanity',
+  'guard-nfc-form',
   'build-targets',
+  'guard-post-fix-fffd',
   'guard-ambiguous-match',
   'guard-converging-pending',
   'repoint-twin-identity',
@@ -239,11 +241,13 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       await reservedSql.unsafe(blocks['guard-placeholder-scrub']);
       await reservedSql.unsafe(blocks['guard-replacement-specified']);
       await reservedSql.unsafe(blocks['guard-capture-sanity']);
+      await reservedSql.unsafe(blocks['guard-nfc-form']);
 
       await reservedSql.unsafe('BEGIN');
       inTransaction = true;
       await reservedSql.unsafe("SET LOCAL statement_timeout = '30s'");
       await reservedSql.unsafe(blocks['build-targets']);
+      await reservedSql.unsafe(blocks['guard-post-fix-fffd']);
       await reservedSql.unsafe(blocks['guard-ambiguous-match']);
       await reservedSql.unsafe(blocks['guard-converging-pending']);
       await reservedSql.unsafe(blocks['repoint-twin-identity']);
@@ -307,16 +311,65 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].n;
   }
 
-  test('extracts exactly the 12 expected STMT blocks, in order', () => {
+  test('extracts exactly the 14 expected STMT blocks, in order', () => {
     expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
     for (const name of EXPECTED_BLOCKS) {
       expect(blocks[name].trim().length).toBeGreaterThan(0);
     }
   });
 
-  test('the file carries a literal BEGIN; and COMMIT; outside any STMT block (pinned so the runner above stays honest)', () => {
-    expect(scriptText).toMatch(/^BEGIN;$/m);
-    expect(scriptText).toMatch(/^COMMIT;$/m);
+  test('the transaction boundary is positioned correctly: BEGIN; precedes build-targets, COMMIT; precedes the final ANALYZE (MEDIUM finding, PR #2154 review round 2 -- a prior version of this test only asserted BEGIN;/COMMIT; existed SOMEWHERE in the file, which cannot detect either boundary moving to the wrong side of a STMT block; verified against the review-cited regression: a verbatim revert of round 1\'s "classify inside the transaction" fix, or moving ANALYZE inside the transaction, both left the old assertion-only-existence version of this test green)', () => {
+    const beginIdx = scriptText.indexOf('\nBEGIN;\n');
+    const buildTargetsIdx = scriptText.indexOf('-- === STMT: build-targets ===');
+    const commitIdx = scriptText.indexOf('\nCOMMIT;\n');
+    const analyzeStmtIdx = scriptText.indexOf('-- === STMT: analyze ===');
+    const analyzeSqlIdx = scriptText.indexOf('ANALYZE wxyc_schema.compilation_track_artist;');
+
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(buildTargetsIdx).toBeGreaterThan(-1);
+    expect(commitIdx).toBeGreaterThan(-1);
+    expect(analyzeStmtIdx).toBeGreaterThan(-1);
+    expect(analyzeSqlIdx).toBeGreaterThan(-1);
+
+    expect(beginIdx).toBeLessThan(buildTargetsIdx);
+    expect(commitIdx).toBeGreaterThan(buildTargetsIdx);
+    expect(commitIdx).toBeLessThan(analyzeStmtIdx);
+    expect(commitIdx).toBeLessThan(analyzeSqlIdx);
+  });
+
+  test('the post-amble residual-count reads sit BEFORE COMMIT;, not after (MEDIUM finding, PR #2154 review round 2 -- pins the fix for the broken "swap COMMIT; for ROLLBACK;" dry-run recipe the header documents: with these reads after COMMIT;, a ROLLBACK undoes the CREATE TEMP TABLE cta_repair_targets they depend on and the whole script aborts)', () => {
+    const updateNoTwinsEndIdx = scriptText.indexOf(
+      '-- === END STMT ===',
+      scriptText.indexOf('-- === STMT: update-no-twins ===')
+    );
+    const postAmbleIdx = scriptText.indexOf('post-amble: residual count per targeted row');
+    const commitIdx = scriptText.indexOf('\nCOMMIT;\n');
+
+    expect(updateNoTwinsEndIdx).toBeGreaterThan(-1);
+    expect(postAmbleIdx).toBeGreaterThan(-1);
+    expect(commitIdx).toBeGreaterThan(-1);
+
+    expect(postAmbleIdx).toBeGreaterThan(updateNoTwinsEndIdx);
+    expect(postAmbleIdx).toBeLessThan(commitIdx);
+  });
+
+  test('the shipped insert-pending-rows block carries no quoted string literals in its SQL -- i.e. it is still just the all-NULL placeholder (the missing enforcement gate, PR #2154 review round 2)', () => {
+    // The deferred byte-exact codepoint assertion (Phase 4's
+    // scriptUsesTheRightCodepoints analogue, see the header's "Known gap,
+    // deliberately deferred" note) can't be written until an operator has
+    // actually captured and pasted the 14 real rows. The INVERSE is
+    // checkable today: as long as the shipped VALUES list is still just the
+    // placeholder, that gap is inert. Every real captured row has at least
+    // one single-quoted string (an artist_name or track_title); the
+    // placeholder and its scrub DELETE have none. This goes red the moment
+    // real data lands, forcing whoever adds it to add the codepoint
+    // assertion in the SAME change (see the header note this test is
+    // pointed at).
+    const sqlOnly = blocks['insert-pending-rows']
+      .split('\n')
+      .map((line) => line.replace(/--.*$/, ''))
+      .join('\n');
+    expect(sqlOnly).not.toMatch(/'/);
   });
 
   test('the shipped insert-pending-rows block (as committed) is a genuine no-op', async () => {
@@ -589,7 +642,12 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
           },
         ])
       )
-    ).rejects.toThrow(/BS#2152 guard/);
+      // Guard-specific fragment (LOW/MEDIUM finding, PR #2154 review round 2
+      // -- every guard test previously asserted only the shared /BS#2152
+      // guard/ prefix, which any OTHER guard's exception also satisfies; see
+      // the mutation-test table in the PR description for which tests this
+      // silently under-covered).
+    ).rejects.toThrow('specify no replacement');
   });
 
   test('the guard-ambiguous-match block rejects a duplicate entry in the pending block', async () => {
@@ -613,8 +671,12 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       true_artist_name: 'Csillagrablók',
     };
 
+    // Guard-specific fragment (PR #2154 review round 2, finding 4): the
+    // generic /BS#2152 guard/ prefix a prior version of this test asserted
+    // is shared by all seven guards, so it cannot tell this apart from
+    // guard-converging-pending, guard-capture-sanity, etc. firing instead.
     await expect(runRepairScript(withSyntheticPendingRows([dupPendingRow, { ...dupPendingRow }]))).rejects.toThrow(
-      /BS#2152 guard/
+      'live compilation_track_artist rows'
     );
   });
 
@@ -646,7 +708,8 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
           },
         ])
       )
-    ).rejects.toThrow(/BS#2152 guard/);
+      // Guard-specific fragment (PR #2154 review round 2, finding 4).
+    ).rejects.toThrow('looks transposed or uncorrupted');
 
     // Nothing was written -- the guard fires before BEGIN, and even if it
     // had fired inside the transaction, the ROLLBACK in runRepairScript's
@@ -694,7 +757,8 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       // The named guard message, NOT a raw postgres 23505 unique-violation
       // error -- proves guard-converging-pending caught this before either
       // write statement ran, rather than the write failing safe by accident.
-    ).rejects.toThrow(/BS#2152 guard/);
+      // Guard-specific fragment (PR #2154 review round 2, finding 4).
+    ).rejects.toThrow('converge on the same post-fix');
 
     // Both original corrupt rows survive untouched -- the transaction rolled
     // back before delete-twins/update-no-twins ever executed.
@@ -739,7 +803,8 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
           },
         ])
       )
-    ).rejects.toThrow(/BS#2152 guard/);
+      // Guard-specific fragment (PR #2154 review round 2, finding 4).
+    ).rejects.toThrow('already been scrubbed');
   });
 
   test("MEDIUM: the DELETE branch repoints the corrupt row's identity link + track_position onto the surviving twin before deleting it", async () => {
@@ -819,5 +884,215 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     expect(twin.track_artist_link_confidence).toBeCloseTo(0.99);
     expect(twin.track_artist_link_method).toBe('librarian');
     expect(twin.track_position).toBe('2');
+  });
+
+  // ==========================================================================
+  // Round 2 review findings (PR #2154 review, second pass against a live
+  // Postgres via `psql -f`).
+  // ==========================================================================
+
+  test('HIGH: silent row destruction (round 2 repro) -- a row corrupt in BOTH columns but captured with only ONE true_* replacement aborts via guard-post-fix-fffd, BOTH rows survive intact', async () => {
+    // Exact reviewer reproduction: two live rows share the SAME corrupt
+    // artist_name ('Hermanos Guti<U+FFFD>rrez') -- row 1 is corrupt ONLY in
+    // artist_name (its track_title is already clean), row 2 is corrupt in
+    // BOTH columns. The pending capture fixes row 2's track_title but
+    // (the operator slip) leaves true_artist_name NULL even though row 2's
+    // artist_name is ALSO corrupt. Unguarded: new_artist_name stays
+    // 'Hermanos Guti<U+FFFD>rrez' (untouched), new_track_title becomes the
+    // fixed 'Sonido Cósmico' -- which is now BYTE-IDENTICAL to row 1's
+    // existing (artist_name, track_title) tuple, so row 1 resolves as row
+    // 2's "twin" and gets DELETEd, destroying the row that was actually
+    // targeted for repair while row 1's corruption survives untouched.
+    const libraryId = await seedLibrary(90022);
+    const row1Id = await seedCta(libraryId, 'Hermanos Guti�rrez', 'Sonido Cósmico', '2');
+    const row2Id = await seedCta(libraryId, 'Hermanos Guti�rrez', 'Sonido C�smico', '7');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90022,
+            track_position: '7',
+            current_artist_name: 'Hermanos Guti�rrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico',
+            // true_artist_name deliberately omitted, even though row 2's
+            // artist_name is ALSO corrupt -- the exact capture slip finding
+            // 1 (round 2) reproduced.
+          },
+        ])
+      )
+      // Guard-specific fragment.
+    ).rejects.toThrow('still carries U+FFFD in its post-fix tuple');
+
+    // Both rows survive, byte for byte -- the guard fires before BEGIN's
+    // writes run (and even if it fired later, the ROLLBACK in
+    // runRepairScript's catch block would undo it).
+    const row1 = await ctaRow(row1Id);
+    expect(row1.artist_name).toBe('Hermanos Guti�rrez');
+    expect(row1.track_title).toBe('Sonido Cósmico');
+    const row2 = await ctaRow(row2Id);
+    expect(row2.artist_name).toBe('Hermanos Guti�rrez');
+    expect(row2.track_title).toBe('Sonido C�smico');
+    expect(await ctaCount(libraryId)).toBe(2);
+  });
+
+  test('HIGH: silent partial repair (round 2 repro) -- a row corrupt in BOTH columns, no twin, captured with only ONE true_* replacement aborts via guard-post-fix-fffd instead of half-writing', async () => {
+    // Exact reviewer reproduction: no twin exists anywhere for this credit,
+    // so unguarded the UPDATE branch would run and write only the supplied
+    // column -- exit 0, the per-row postlude residual would read 0 against
+    // this row's OLD tuple (which no longer exists), but the overall
+    // residual counter would still show 1 with no row-level indication of
+    // which row is still wrong.
+    const libraryId = await seedLibrary(90023);
+    const corruptId = await seedCta(libraryId, 'Csillagrabl�k', 'Rem�nytelen T�nc', '4');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90023,
+            track_position: '4',
+            current_artist_name: 'Csillagrabl�k',
+            current_track_title: 'Rem�nytelen T�nc',
+            true_track_title: 'Reménytelen Tánc',
+            // true_artist_name omitted, even though artist_name is ALSO corrupt.
+          },
+        ])
+      )
+    ).rejects.toThrow('still carries U+FFFD in its post-fix tuple');
+
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrabl�k'); // untouched -- not half-written
+    expect(row.track_title).toBe('Rem�nytelen T�nc');
+  });
+
+  test('a row corrupt in BOTH columns, captured CORRECTLY as one pending row with BOTH true_* values, repairs cleanly (the shape step 4 of the header now documents)', async () => {
+    const libraryId = await seedLibrary(90024);
+    const corruptId = await seedCta(libraryId, 'Csillagrabl�k', 'Rem�nytelen T�nc', '4');
+
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90024,
+          track_position: '4',
+          current_artist_name: 'Csillagrabl�k',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_artist_name: 'Csillagrablók',
+          true_track_title: 'Reménytelen Tánc',
+        },
+      ])
+    );
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(1);
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrablók');
+    expect(row.track_title).toBe('Reménytelen Tánc');
+  });
+
+  test('MEDIUM: guard-nfc-form rejects a true_* replacement pasted in a non-NFC Unicode normalization form', async () => {
+    await seedLibrary(90025);
+    // NFD: a bare 'o' followed by a standalone COMBINING ACUTE ACCENT
+    // (U+0301), rather than the precomposed 'ó' (U+00F3) every other test in
+    // this file uses -- exactly the shape a MySQL client or a different OS
+    // clipboard normalization can hand an operator without either of them
+    // noticing, since both render identically.
+    const nfdTrackTitle = 'Sonido Cósmico';
+    expect(nfdTrackTitle.normalize('NFC')).not.toBe(nfdTrackTitle);
+    expect(nfdTrackTitle.normalize('NFC')).toBe('Sonido Cósmico');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90025,
+            track_position: '1',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: nfdTrackTitle,
+          },
+        ])
+      )
+      // Guard-specific fragment.
+    ).rejects.toThrow('not NFC-normalized');
+  });
+
+  test("MEDIUM: repoint-twin-identity re-checks the corrupt row is unchanged before repointing, mirroring delete-twins' own re-check", async () => {
+    // A concurrent edit to the corrupt row's artist_name landing AFTER
+    // build-targets but BEFORE repoint-twin-identity -- e.g. a same-cycle
+    // library-etl write, or a librarian hand-edit -- means the corrupt row
+    // no longer matches its captured old_artist_name/old_track_title.
+    // delete-twins' own re-check already skips deleting it in that case;
+    // before this fix, repoint-twin-identity had no equivalent re-check, so
+    // it would still repoint the twin's identity link even though the
+    // corrupt row it came from was never actually deleted -- silently
+    // duplicating the identity link across two live rows.
+    const libraryId = await seedLibrary(90026);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', null, {
+      track_artist_id: null,
+      track_artist_link_confidence: null,
+      track_artist_link_method: null,
+    });
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '4', {
+      track_artist_id: 4242,
+      track_artist_link_confidence: 0.93,
+      track_artist_link_method: 'lml_backfill',
+    });
+
+    const reservedSql = await sql.reserve();
+    try {
+      await reservedSql.unsafe(blocks['create-pending-table']);
+      await insertSyntheticPendingRows(reservedSql, [
+        {
+          legacy_release_id: 90026,
+          track_position: '4',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico',
+        },
+      ]);
+      await reservedSql.unsafe(blocks['guard-placeholder-scrub']);
+      await reservedSql.unsafe(blocks['guard-replacement-specified']);
+      await reservedSql.unsafe(blocks['guard-capture-sanity']);
+      await reservedSql.unsafe(blocks['guard-nfc-form']);
+
+      await reservedSql.unsafe('BEGIN');
+      await reservedSql.unsafe("SET LOCAL statement_timeout = '30s'");
+      await reservedSql.unsafe(blocks['build-targets']);
+      await reservedSql.unsafe(blocks['guard-post-fix-fffd']);
+      await reservedSql.unsafe(blocks['guard-ambiguous-match']);
+      await reservedSql.unsafe(blocks['guard-converging-pending']);
+
+      // Simulate the concurrent edit from a SECOND session. READ COMMITTED
+      // means this ordinary UPDATE is not blocked by the open transaction
+      // above -- build-targets' CREATE TEMP TABLE ... AS SELECT took no row
+      // lock.
+      await sql`
+        UPDATE ${sql(TEST_SCHEMA)}.compilation_track_artist
+           SET artist_name = 'Somebody Else Entirely'
+         WHERE id = ${corruptId}
+      `;
+
+      await reservedSql.unsafe(blocks['repoint-twin-identity']);
+      await reservedSql.unsafe(blocks['delete-twins']);
+      await reservedSql.unsafe(blocks['update-no-twins']);
+      await reservedSql.unsafe('COMMIT');
+    } finally {
+      reservedSql.release();
+    }
+
+    // The twin's identity link was NOT repointed -- the re-check in
+    // repoint-twin-identity found the corrupt row no longer matched its
+    // captured old_artist_name and skipped.
+    const twin = await ctaRow(twinId);
+    expect(twin.track_artist_id).toBeNull();
+    expect(twin.track_artist_link_confidence).toBeNull();
+    expect(twin.track_artist_link_method).toBeNull();
+
+    // The concurrently-edited row survives untouched by this run (delete-
+    // twins' own pre-existing re-check already covered this half).
+    const corrupt = await ctaRow(corruptId);
+    expect(corrupt.artist_name).toBe('Somebody Else Entirely');
   });
 });

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -1,0 +1,505 @@
+/**
+ * Correctness pin for scripts/audit/bs_replacement_char_cta.sql (BS#2152).
+ *
+ * Unlike its three predecessors (bs_replacement_char_recovery.sql,
+ * _phase35.sql, _phase4.spec.js), the CTA script's 14 real corrupt/correct
+ * pairs cannot be enumerated locally -- dev_env/seed-clone.sql carries no
+ * `compilation_track_artist` rows at all (see the script's own header), so
+ * the script ships with a `pending_cta_repair` block holding zero real rows.
+ * That means the verification burden here is entirely on THIS spec: it runs
+ * the REAL mechanism statements extracted from the script file (schema-
+ * substituted into a throwaway schema, same technique as
+ * bs-replacement-char-phase4.spec.js's `extractUpdates`), then feeds them
+ * synthetic pending rows built from WXYC-representative fixture data so the
+ * twin-aware DELETE/UPDATE branching, the idempotency guarantee, and the
+ * NULL-track_title loophole (migration 0099 / `cta_unique_null_track_idx`)
+ * are all exercised against the actual DDL/DML the operator will run --
+ * only the pending DATA differs between this spec and prod.
+ *
+ * The throwaway `compilation_track_artist` table replicates BOTH production
+ * unique indexes (`cta_unique_idx` and its NULL-track_title complement) --
+ * unlike bs-replacement-char-phase4.spec.js's plain `text` columns, that
+ * replication is load-bearing here: the whole point of the twin-aware design
+ * is "never let a write hit a unique violation", and that claim is only
+ * actually tested if the constraint exists to violate.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getTestDb } = require('../utils/db');
+
+const TEST_SCHEMA = 'bs2152_cta_mojibake_test';
+const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_replacement_char_cta.sql');
+
+// The exact block names the script must carry, in the order the mechanism
+// requires them to run. A future edit that adds/removes/renames a block
+// fails this extraction loudly instead of silently testing a stale shape.
+const EXPECTED_BLOCKS = [
+  'create-pending-table',
+  'insert-pending-rows',
+  'guard-replacement-specified',
+  'build-targets',
+  'guard-ambiguous-match',
+  'delete-twins',
+  'update-no-twins',
+  'analyze',
+];
+
+/**
+ * Pull the `-- === STMT: <name> === ... -- === END STMT ===`-delimited
+ * blocks out of the operator script and retarget every `wxyc_schema.`
+ * reference at the throwaway schema. Each block is executed verbatim via
+ * `sql.unsafe` -- no re-parsing of individual statements, so a block
+ * containing a `DO $$ ... $$;` (whose body has its own internal semicolons)
+ * is never mis-split. The explicit `END STMT` marker (rather than "runs
+ * until the next STMT marker") matters: several blocks in this script are
+ * followed by unmarked prose/SELECTs -- including a bare `BEGIN;` starting
+ * the transactional write section -- that must NOT be swept into the
+ * preceding block. Executing a literal `BEGIN;` over this spec's pooled
+ * connection trips postgres-js's own cross-connection-transaction guard
+ * (`UNSAFE_TRANSACTION: Only use sql.begin, sql.reserved or max: 1`), which
+ * is exactly what caught this the first time this extractor was written
+ * without END markers.
+ */
+function extractStmtBlocks(scriptText, targetSchema) {
+  const startRe = /^--\s*===\s*STMT:\s*([a-z-]+)\s*===\s*$/gm;
+  const endRe = /^--\s*===\s*END STMT\s*===\s*$/gm;
+  const starts = [];
+  let m;
+  while ((m = startRe.exec(scriptText)) !== null) {
+    starts.push({ name: m[1], contentStart: m.index + m[0].length });
+  }
+  const names = starts.map((s) => s.name);
+  if (JSON.stringify(names) !== JSON.stringify(EXPECTED_BLOCKS)) {
+    throw new Error(
+      `expected bs_replacement_char_cta.sql STMT blocks ${JSON.stringify(EXPECTED_BLOCKS)}, found ${JSON.stringify(names)}`
+    );
+  }
+
+  const blocks = {};
+  for (const { name, contentStart } of starts) {
+    endRe.lastIndex = contentStart;
+    const endMatch = endRe.exec(scriptText);
+    if (!endMatch) {
+      throw new Error(`STMT block "${name}" has no matching "-- === END STMT ===" marker`);
+    }
+    blocks[name] = scriptText.slice(contentStart, endMatch.index).replace(/wxyc_schema\./g, `${targetSchema}.`);
+  }
+  return blocks;
+}
+
+describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
+  let sql;
+  let blocks;
+
+  beforeAll(async () => {
+    sql = getTestDb();
+    const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    blocks = extractStmtBlocks(scriptText, TEST_SCHEMA);
+
+    await sql.unsafe(`CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}`);
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS ${TEST_SCHEMA}.library (
+        id serial PRIMARY KEY,
+        legacy_release_id integer UNIQUE NOT NULL
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS ${TEST_SCHEMA}.compilation_track_artist (
+        id serial PRIMARY KEY,
+        library_id integer NOT NULL,
+        artist_name text NOT NULL,
+        track_title text,
+        track_position text
+      )
+    `);
+    // Replicates BOTH production unique constraints (schema.ts:731 +
+    // migration 0099) so "no unique violation is raised" is a real assertion,
+    // not a vacuous one -- a bug that ran UPDATE instead of DELETE on a twin
+    // row would actually throw 23505 against this schema.
+    await sql.unsafe(`
+      CREATE UNIQUE INDEX IF NOT EXISTS cta_test_unique_idx
+        ON ${TEST_SCHEMA}.compilation_track_artist (library_id, artist_name, track_title)
+    `);
+    await sql.unsafe(`
+      CREATE UNIQUE INDEX IF NOT EXISTS cta_test_unique_null_track_idx
+        ON ${TEST_SCHEMA}.compilation_track_artist (library_id, artist_name)
+        WHERE track_title IS NULL
+    `);
+  });
+
+  afterAll(async () => {
+    await sql.unsafe(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(
+      `TRUNCATE ${TEST_SCHEMA}.library, ${TEST_SCHEMA}.compilation_track_artist RESTART IDENTITY CASCADE`
+    );
+  });
+
+  /**
+   * Run the script's actual mechanism (every block except the script's own
+   * literal `insert-pending-rows`, which -- as shipped -- inserts nothing)
+   * against whatever fixture rows the caller has already seeded, using
+   * `pendingRows` as this run's captured-pairs block.
+   *
+   * `pending_cta_repair` and `cta_repair_targets` are TEMP TABLEs -- session
+   * scoped, exactly like they are when an operator runs this script through
+   * one `psql -f` connection. `getTestDb()` returns a POOL (max: 5), so
+   * spreading these statements across ordinary pooled queries would create
+   * the temp table on one physical connection and then fail to find it on
+   * another. `sql.reserve()` pins one connection for the whole run, the same
+   * single-session guarantee prod gets.
+   */
+  async function runRepairScript(pendingRows) {
+    const reservedSql = await sql.reserve();
+    try {
+      await reservedSql.unsafe(blocks['create-pending-table']);
+      if (pendingRows.length > 0) {
+        // Unqualified, deliberately -- `pending_cta_repair` is a TEMP TABLE,
+        // so it lives in this session's `pg_temp_N` schema, not
+        // `TEST_SCHEMA`. Schema-qualifying it here would look identical to
+        // qualifying an ordinary table and fail with "relation does not
+        // exist" despite the table genuinely existing on this connection.
+        //
+        // `sql(array, ...columns)` generates the WHOLE `(columns…) VALUES
+        // (…), (…)` fragment as one unit -- it is not just a values-list
+        // helper. Writing an explicit column list before it (as a plain
+        // `sql` tagged-template author would reasonably try first) silently
+        // produces a mismatched column/value count ("INSERT has more target
+        // columns than expressions"), because postgres-js then emits its
+        // own column list a second time inside the substitution.
+        await reservedSql`
+          INSERT INTO pending_cta_repair ${reservedSql(
+            pendingRows.map((r) => ({
+              legacy_release_id: r.legacy_release_id,
+              track_position: r.track_position ?? null,
+              current_artist_name: r.current_artist_name,
+              current_track_title: r.current_track_title ?? null,
+              true_artist_name: r.true_artist_name ?? null,
+              true_track_title: r.true_track_title ?? null,
+            })),
+            'legacy_release_id',
+            'track_position',
+            'current_artist_name',
+            'current_track_title',
+            'true_artist_name',
+            'true_track_title'
+          )}
+        `;
+      }
+      await reservedSql.unsafe(blocks['guard-replacement-specified']);
+      await reservedSql.unsafe(blocks['build-targets']);
+      await reservedSql.unsafe(blocks['guard-ambiguous-match']);
+      const deleteResult = await reservedSql.unsafe(blocks['delete-twins']);
+      const updateResult = await reservedSql.unsafe(blocks['update-no-twins']);
+      return { deleted: deleteResult.count, updated: updateResult.count };
+    } finally {
+      reservedSql.release();
+    }
+  }
+
+  async function seedLibrary(legacyReleaseId) {
+    const rows = await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.library (legacy_release_id) VALUES (${legacyReleaseId})
+      RETURNING id
+    `;
+    return rows[0].id;
+  }
+
+  async function seedCta(libraryId, artistName, trackTitle, trackPosition) {
+    const rows = await sql`
+      INSERT INTO ${sql(TEST_SCHEMA)}.compilation_track_artist (library_id, artist_name, track_title, track_position)
+      VALUES (${libraryId}, ${artistName}, ${trackTitle}, ${trackPosition})
+      RETURNING id
+    `;
+    return rows[0].id;
+  }
+
+  async function ctaRow(id) {
+    const rows = await sql`
+      SELECT artist_name, track_title FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${id}
+    `;
+    return rows[0];
+  }
+
+  async function ctaCount(libraryId) {
+    const rows = await sql`
+      SELECT COUNT(*)::int AS n FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE library_id = ${libraryId}
+    `;
+    return rows[0].n;
+  }
+
+  test('extracts exactly the 8 expected STMT blocks, in order', () => {
+    expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
+    for (const name of EXPECTED_BLOCKS) {
+      expect(blocks[name].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('corrupt track_title WITH a clean twin: DELETEs the corrupt row, raises no unique violation', async () => {
+    const libraryId = await seedLibrary(90001);
+    // The clean twin -- what the ETL's insert-only writer left behind
+    // alongside the corrupt paste.
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2');
+    // The corrupt row: same artist, corrupted track_title, different position.
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '7');
+
+    const result = await runRepairScript([
+      {
+        legacy_release_id: 90001,
+        track_position: '7',
+        current_artist_name: 'Hermanos Gutiérrez',
+        current_track_title: 'Sonido C�smico',
+        true_track_title: 'Sonido Cósmico',
+      },
+    ]);
+
+    expect(result.deleted).toBe(1);
+    expect(result.updated).toBe(0);
+    // The corrupt row is gone...
+    const remaining = await sql`
+      SELECT id FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${corruptId}
+    `;
+    expect(remaining).toHaveLength(0);
+    // ...the twin is untouched and is now the sole holder of the truth.
+    const twin = await ctaRow(twinId);
+    expect(twin.track_title).toBe('Sonido Cósmico');
+    expect(await ctaCount(libraryId)).toBe(1);
+  });
+
+  test('corrupt track_title WITHOUT a twin: UPDATEs to the exact expected string', async () => {
+    const libraryId = await seedLibrary(90002);
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    const result = await runRepairScript([
+      {
+        legacy_release_id: 90002,
+        track_position: '4',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Rem�nytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+    ]);
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(1);
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrablók');
+    expect(row.track_title).toBe('Reménytelen Tánc');
+  });
+
+  test('a clean row not named in the pending block is left untouched', async () => {
+    const libraryId = await seedLibrary(90003);
+    const cleanId = await seedCta(libraryId, 'Chuquimamani-Condori', 'Call Your Name', '1');
+
+    const result = await runRepairScript([]);
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(0);
+    const row = await ctaRow(cleanId);
+    expect(row.artist_name).toBe('Chuquimamani-Condori');
+    expect(row.track_title).toBe('Call Your Name');
+  });
+
+  test('a decoy row sharing the exact corrupt track_title under a DIFFERENT artist is left untouched', async () => {
+    // Same track title mis-transcribed identically for two different
+    // performers on the same compilation track (the multi-performer shape
+    // schema.ts's cta_unique_idx comment documents) -- the match must key on
+    // BOTH artist_name and track_title, not track_title alone.
+    const libraryId = await seedLibrary(90004);
+    const targetId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+    const decoyId = await seedCta(libraryId, 'Sonido Dueñez', 'Rem�nytelen T�nc', '5');
+
+    await runRepairScript([
+      {
+        legacy_release_id: 90004,
+        track_position: '4',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Rem�nytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+    ]);
+
+    const target = await ctaRow(targetId);
+    expect(target.track_title).toBe('Reménytelen Tánc');
+    const decoy = await ctaRow(decoyId);
+    expect(decoy.artist_name).toBe('Sonido Dueñez');
+    expect(decoy.track_title).toBe('Rem�nytelen T�nc'); // still corrupt -- untouched
+  });
+
+  test('NULL track_title, corrupt artist_name, WITH a twin: DELETEs, raises no unique violation under cta_unique_null_track_idx', async () => {
+    const libraryId = await seedLibrary(90005);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', null, null);
+    const corruptId = await seedCta(libraryId, 'Hermanos Guti�rrez', null, null);
+
+    const result = await runRepairScript([
+      {
+        legacy_release_id: 90005,
+        track_position: null,
+        current_artist_name: 'Hermanos Guti�rrez',
+        current_track_title: null,
+        true_artist_name: 'Hermanos Gutiérrez',
+      },
+    ]);
+
+    expect(result.deleted).toBe(1);
+    expect(result.updated).toBe(0);
+    const remaining = await sql`
+      SELECT id FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${corruptId}
+    `;
+    expect(remaining).toHaveLength(0);
+    const twin = await ctaRow(twinId);
+    expect(twin.artist_name).toBe('Hermanos Gutiérrez');
+    expect(twin.track_title).toBeNull();
+    expect(await ctaCount(libraryId)).toBe(1);
+  });
+
+  test('NULL track_title, corrupt artist_name, WITHOUT a twin: UPDATEs, track_title stays NULL', async () => {
+    const libraryId = await seedLibrary(90006);
+    const corruptId = await seedCta(libraryId, 'Csillagrabl�k', null, null);
+
+    const result = await runRepairScript([
+      {
+        legacy_release_id: 90006,
+        track_position: null,
+        current_artist_name: 'Csillagrabl�k',
+        current_track_title: null,
+        true_artist_name: 'Csillagrablók',
+      },
+    ]);
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(1);
+    const row = await ctaRow(corruptId);
+    expect(row.artist_name).toBe('Csillagrablók');
+    expect(row.track_title).toBeNull();
+  });
+
+  test('the U+FFFD predicate returns 0 across both columns after a run covering both corruption shapes', async () => {
+    const libA = await seedLibrary(90007);
+    await seedCta(libA, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+    const libB = await seedLibrary(90008);
+    await seedCta(libB, 'Csillagrabl�k', null, null);
+
+    await runRepairScript([
+      {
+        legacy_release_id: 90007,
+        track_position: '4',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Rem�nytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+      {
+        legacy_release_id: 90008,
+        track_position: null,
+        current_artist_name: 'Csillagrabl�k',
+        current_track_title: null,
+        true_artist_name: 'Csillagrablók',
+      },
+    ]);
+
+    const [{ remaining }] = await sql`
+      SELECT COUNT(*)::int AS remaining
+      FROM ${sql(TEST_SCHEMA)}.compilation_track_artist
+      WHERE artist_name LIKE '%' || chr(65533) || '%' OR track_title LIKE '%' || chr(65533) || '%'
+    `;
+    expect(remaining).toBe(0);
+  });
+
+  test('a second run is a genuine no-op once the first has landed (twin + no-twin together)', async () => {
+    const libA = await seedLibrary(90009);
+    const twinId = await seedCta(libA, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2');
+    const deletedId = await seedCta(libA, 'Hermanos Gutiérrez', 'Sonido C�smico', '7');
+    const libB = await seedLibrary(90010);
+    const updatedId = await seedCta(libB, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    const pending = [
+      {
+        legacy_release_id: 90009,
+        track_position: '7',
+        current_artist_name: 'Hermanos Gutiérrez',
+        current_track_title: 'Sonido C�smico',
+        true_track_title: 'Sonido Cósmico',
+      },
+      {
+        legacy_release_id: 90010,
+        track_position: '4',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Rem�nytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+    ];
+
+    const first = await runRepairScript(pending);
+    expect(first.deleted + first.updated).toBeGreaterThan(0);
+
+    const second = await runRepairScript(pending);
+    expect(second.deleted).toBe(0);
+    expect(second.updated).toBe(0);
+
+    // Values are still correct, not reverted or double-mangled.
+    const twin = await ctaRow(twinId);
+    expect(twin.track_title).toBe('Sonido Cósmico');
+    const updated = await ctaRow(updatedId);
+    expect(updated.track_title).toBe('Reménytelen Tánc');
+    const stillDeleted = await sql`
+      SELECT id FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${deletedId}
+    `;
+    expect(stillDeleted).toHaveLength(0);
+  });
+
+  test('is a no-op against an empty pending block (the script as shipped, pending prod capture)', async () => {
+    const libraryId = await seedLibrary(90011);
+    const cleanId = await seedCta(libraryId, 'Jessica Pratt', 'Back, Baby', '1');
+
+    const result = await runRepairScript([]);
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(await ctaCount(libraryId)).toBe(1);
+    const row = await ctaRow(cleanId);
+    expect(row.artist_name).toBe('Jessica Pratt');
+  });
+
+  test('the guard-replacement-specified block rejects a pending row that fixes nothing', async () => {
+    await seedLibrary(90012);
+    await expect(
+      runRepairScript([
+        {
+          legacy_release_id: 90012,
+          track_position: '1',
+          current_artist_name: 'Some Artist',
+          current_track_title: 'Some Title',
+          // both true_artist_name and true_track_title omitted -- nothing to fix
+        },
+      ])
+    ).rejects.toThrow(/BS#2152 guard/);
+  });
+
+  test('the guard-ambiguous-match block rejects a duplicate entry in the pending block', async () => {
+    // Two live CTA rows sharing (library_id, artist_name, track_title) is
+    // exactly what cta_unique_idx forbids in prod (and in this throwaway
+    // schema, which replicates it) -- so a pending row can never genuinely
+    // resolve to more than one live row. The guard's other purpose, an
+    // accidental duplicate entry in the pending capture block itself
+    // (the same real row pasted twice), is the reachable case: both
+    // duplicate pending rows resolve to the SAME single live row, so
+    // cta_repair_targets ends up with two rows sharing one identity, which
+    // is what the guard actually detects.
+    const libraryId = await seedLibrary(90013);
+    await seedCta(libraryId, 'Duplicate Artist', 'Duplicate Title', '1');
+
+    const dupPendingRow = {
+      legacy_release_id: 90013,
+      track_position: '1',
+      current_artist_name: 'Duplicate Artist',
+      current_track_title: 'Duplicate Title',
+      true_artist_name: 'Fixed Artist',
+    };
+
+    await expect(runRepairScript([dupPendingRow, { ...dupPendingRow }])).rejects.toThrow(/BS#2152 guard/);
+  });
+});

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -11,17 +11,23 @@
  * substituted into a throwaway schema, same technique as
  * bs-replacement-char-phase4.spec.js's `extractUpdates`), then feeds them
  * synthetic pending rows built from WXYC-representative fixture data so the
- * twin-aware DELETE/UPDATE branching, the idempotency guarantee, and the
- * NULL-track_title loophole (migration 0099 / `cta_unique_null_track_idx`)
- * are all exercised against the actual DDL/DML the operator will run --
- * only the pending DATA differs between this spec and prod.
+ * twin-aware DELETE/UPDATE branching, the idempotency guarantee, the
+ * NULL-track_title loophole (migration 0099 / `cta_unique_null_track_idx`),
+ * and every operator-error guard are all exercised against the actual
+ * DDL/DML the operator will run -- only the pending DATA differs between
+ * this spec and prod.
  *
  * The throwaway `compilation_track_artist` table replicates BOTH production
  * unique indexes (`cta_unique_idx` and its NULL-track_title complement) --
  * unlike bs-replacement-char-phase4.spec.js's plain `text` columns, that
  * replication is load-bearing here: the whole point of the twin-aware design
  * is "never let a write hit a unique violation", and that claim is only
- * actually tested if the constraint exists to violate.
+ * actually tested if the constraint exists to violate. It also carries the
+ * BS#1990 (#801 S1) identity-link columns (`track_artist_id` +
+ * `track_artist_link_confidence` + `track_artist_link_method`) with the same
+ * varchar(255)/varchar(20) lengths as prod (PR #2154 review NIT) -- plain
+ * `text` would silently accept a captured value too long for the real
+ * column.
  */
 
 const fs = require('fs');
@@ -37,9 +43,13 @@ const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_rep
 const EXPECTED_BLOCKS = [
   'create-pending-table',
   'insert-pending-rows',
+  'guard-placeholder-scrub',
   'guard-replacement-specified',
+  'guard-capture-sanity',
   'build-targets',
   'guard-ambiguous-match',
+  'guard-converging-pending',
+  'repoint-twin-identity',
   'delete-twins',
   'update-no-twins',
   'analyze',
@@ -60,9 +70,19 @@ const EXPECTED_BLOCKS = [
  * (`UNSAFE_TRANSACTION: Only use sql.begin, sql.reserved or max: 1`), which
  * is exactly what caught this the first time this extractor was written
  * without END markers.
+ *
+ * The start-marker name pattern is `[a-z0-9_-]+`, not just `[a-z-]+`
+ * (PR #2154 review, finding 5): the narrower pattern silently skips any
+ * future block named with a digit or underscore -- it simply never matches
+ * as a start, so that block's own content gets swept into whichever
+ * preceding block IS recognized, and the mis-shapen result would still pass
+ * the name-list assertion below as long as EXPECTED_BLOCKS was (wrongly)
+ * left in sync with the truncated `names` list. Widening the pattern makes
+ * that class of block silently disappearing structurally impossible instead
+ * of merely unlikely.
  */
 function extractStmtBlocks(scriptText, targetSchema) {
-  const startRe = /^--\s*===\s*STMT:\s*([a-z-]+)\s*===\s*$/gm;
+  const startRe = /^--\s*===\s*STMT:\s*([a-z0-9_-]+)\s*===\s*$/gm;
   const endRe = /^--\s*===\s*END STMT\s*===\s*$/gm;
   const starts = [];
   let m;
@@ -91,10 +111,11 @@ function extractStmtBlocks(scriptText, targetSchema) {
 describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
   let sql;
   let blocks;
+  let scriptText;
 
   beforeAll(async () => {
     sql = getTestDb();
-    const scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    scriptText = fs.readFileSync(SCRIPT_PATH, 'utf8');
     blocks = extractStmtBlocks(scriptText, TEST_SCHEMA);
 
     await sql.unsafe(`CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}`);
@@ -104,13 +125,22 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
         legacy_release_id integer UNIQUE NOT NULL
       )
     `);
+    // Column types match prod (shared/database/src/schema.ts:698) --
+    // varchar(255)/varchar(20), not `text` (PR #2154 review NIT) -- so a
+    // captured value too long for the real column would fail here the same
+    // way it would against prod, not silently succeed against a laxer
+    // throwaway shape. Also carries the BS#1990 (#801 S1) identity-link
+    // columns the repoint-twin-identity statement reads/writes.
     await sql.unsafe(`
       CREATE TABLE IF NOT EXISTS ${TEST_SCHEMA}.compilation_track_artist (
         id serial PRIMARY KEY,
         library_id integer NOT NULL,
-        artist_name text NOT NULL,
-        track_title text,
-        track_position text
+        artist_name varchar(255) NOT NULL,
+        track_title varchar(255),
+        track_position varchar(20),
+        track_artist_id integer,
+        track_artist_link_confidence real,
+        track_artist_link_method text
       )
     `);
     // Replicates BOTH production unique constraints (schema.ts:731 +
@@ -140,10 +170,55 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
   });
 
   /**
-   * Run the script's actual mechanism (every block except the script's own
-   * literal `insert-pending-rows`, which -- as shipped -- inserts nothing)
-   * against whatever fixture rows the caller has already seeded, using
-   * `pendingRows` as this run's captured-pairs block.
+   * Insert synthetic pending rows via a plain INSERT (NOT the script's own
+   * `insert-pending-rows` block, which as shipped only knows how to insert
+   * its own hardcoded placeholder). Unqualified, deliberately --
+   * `pending_cta_repair` is a TEMP TABLE, so it lives in this session's
+   * `pg_temp_N` schema, not `TEST_SCHEMA`. Schema-qualifying it here would
+   * look identical to qualifying an ordinary table and fail with "relation
+   * does not exist" despite the table genuinely existing on this connection.
+   *
+   * `sql(array, ...columns)` generates the WHOLE `(columns…) VALUES (…),
+   * (…)` fragment as one unit -- it is not just a values-list helper.
+   * Writing an explicit column list before it (as a plain `sql`
+   * tagged-template author would reasonably try first) silently produces a
+   * mismatched column/value count ("INSERT has more target columns than
+   * expressions"), because postgres-js then emits its own column list a
+   * second time inside the substitution.
+   */
+  async function insertSyntheticPendingRows(reservedSql, pendingRows) {
+    if (pendingRows.length === 0) return;
+    await reservedSql`
+      INSERT INTO pending_cta_repair ${reservedSql(
+        pendingRows.map((r) => ({
+          legacy_release_id: r.legacy_release_id,
+          track_position: r.track_position ?? null,
+          current_artist_name: r.current_artist_name,
+          current_track_title: r.current_track_title ?? null,
+          true_artist_name: r.true_artist_name ?? null,
+          true_track_title: r.true_track_title ?? null,
+        })),
+        'legacy_release_id',
+        'track_position',
+        'current_artist_name',
+        'current_track_title',
+        'true_artist_name',
+        'true_track_title'
+      )}
+    `;
+  }
+
+  /**
+   * Run the script's actual mechanism end to end -- every STMT block, plus
+   * the literal `BEGIN`/`SET LOCAL statement_timeout`/`COMMIT` control
+   * statements that sit between them in the file but aren't themselves
+   * STMT-tagged (PR #2154 review, finding 5: a prior version of this spec
+   * never executed those, so a bug that only manifested inside the real
+   * transaction boundary -- e.g. an aborted-transaction state leaking into
+   * the next statement -- had no coverage). `insertPhase` supplies whichever
+   * pending-row insertion the caller wants (synthetic fixture rows, or the
+   * literal shipped `insert-pending-rows` block) so both paths share the
+   * exact same guard/classify/write sequence.
    *
    * `pending_cta_repair` and `cta_repair_targets` are TEMP TABLEs -- session
    * scoped, exactly like they are when an operator runs this script through
@@ -151,55 +226,50 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
    * spreading these statements across ordinary pooled queries would create
    * the temp table on one physical connection and then fail to find it on
    * another. `sql.reserve()` pins one connection for the whole run, the same
-   * single-session guarantee prod gets.
+   * single-session guarantee prod gets -- which is also why running the
+   * real `BEGIN`/`COMMIT` here is safe: this is a dedicated reserved
+   * connection, not the shared pool the extractor's own comment warns about.
    */
-  async function runRepairScript(pendingRows) {
+  async function runRepairScript(insertPhase) {
     const reservedSql = await sql.reserve();
+    let inTransaction = false;
     try {
       await reservedSql.unsafe(blocks['create-pending-table']);
-      if (pendingRows.length > 0) {
-        // Unqualified, deliberately -- `pending_cta_repair` is a TEMP TABLE,
-        // so it lives in this session's `pg_temp_N` schema, not
-        // `TEST_SCHEMA`. Schema-qualifying it here would look identical to
-        // qualifying an ordinary table and fail with "relation does not
-        // exist" despite the table genuinely existing on this connection.
-        //
-        // `sql(array, ...columns)` generates the WHOLE `(columns…) VALUES
-        // (…), (…)` fragment as one unit -- it is not just a values-list
-        // helper. Writing an explicit column list before it (as a plain
-        // `sql` tagged-template author would reasonably try first) silently
-        // produces a mismatched column/value count ("INSERT has more target
-        // columns than expressions"), because postgres-js then emits its
-        // own column list a second time inside the substitution.
-        await reservedSql`
-          INSERT INTO pending_cta_repair ${reservedSql(
-            pendingRows.map((r) => ({
-              legacy_release_id: r.legacy_release_id,
-              track_position: r.track_position ?? null,
-              current_artist_name: r.current_artist_name,
-              current_track_title: r.current_track_title ?? null,
-              true_artist_name: r.true_artist_name ?? null,
-              true_track_title: r.true_track_title ?? null,
-            })),
-            'legacy_release_id',
-            'track_position',
-            'current_artist_name',
-            'current_track_title',
-            'true_artist_name',
-            'true_track_title'
-          )}
-        `;
-      }
+      await insertPhase(reservedSql);
+      await reservedSql.unsafe(blocks['guard-placeholder-scrub']);
       await reservedSql.unsafe(blocks['guard-replacement-specified']);
+      await reservedSql.unsafe(blocks['guard-capture-sanity']);
+
+      await reservedSql.unsafe('BEGIN');
+      inTransaction = true;
+      await reservedSql.unsafe("SET LOCAL statement_timeout = '30s'");
       await reservedSql.unsafe(blocks['build-targets']);
       await reservedSql.unsafe(blocks['guard-ambiguous-match']);
+      await reservedSql.unsafe(blocks['guard-converging-pending']);
+      await reservedSql.unsafe(blocks['repoint-twin-identity']);
       const deleteResult = await reservedSql.unsafe(blocks['delete-twins']);
       const updateResult = await reservedSql.unsafe(blocks['update-no-twins']);
+      await reservedSql.unsafe('COMMIT');
+      inTransaction = false;
+
+      await reservedSql.unsafe(blocks['analyze']);
       return { deleted: deleteResult.count, updated: updateResult.count };
+    } catch (err) {
+      // A guard RAISE EXCEPTION (or a real constraint violation) inside the
+      // transaction aborts it server-side; roll back explicitly so this
+      // reserved connection isn't handed back to the pool mid-aborted-
+      // transaction for the next test to trip over.
+      if (inTransaction) {
+        await reservedSql.unsafe('ROLLBACK');
+      }
+      throw err;
     } finally {
       reservedSql.release();
     }
   }
+
+  const withSyntheticPendingRows = (pendingRows) => (reservedSql) =>
+    insertSyntheticPendingRows(reservedSql, pendingRows);
 
   async function seedLibrary(legacyReleaseId) {
     const rows = await sql`
@@ -209,10 +279,14 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].id;
   }
 
-  async function seedCta(libraryId, artistName, trackTitle, trackPosition) {
+  async function seedCta(libraryId, artistName, trackTitle, trackPosition, identity = {}) {
     const rows = await sql`
-      INSERT INTO ${sql(TEST_SCHEMA)}.compilation_track_artist (library_id, artist_name, track_title, track_position)
-      VALUES (${libraryId}, ${artistName}, ${trackTitle}, ${trackPosition})
+      INSERT INTO ${sql(TEST_SCHEMA)}.compilation_track_artist
+        (library_id, artist_name, track_title, track_position, track_artist_id, track_artist_link_confidence, track_artist_link_method)
+      VALUES (
+        ${libraryId}, ${artistName}, ${trackTitle}, ${trackPosition},
+        ${identity.track_artist_id ?? null}, ${identity.track_artist_link_confidence ?? null}, ${identity.track_artist_link_method ?? null}
+      )
       RETURNING id
     `;
     return rows[0].id;
@@ -220,7 +294,8 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
 
   async function ctaRow(id) {
     const rows = await sql`
-      SELECT artist_name, track_title FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${id}
+      SELECT artist_name, track_title, track_position, track_artist_id, track_artist_link_confidence, track_artist_link_method
+      FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${id}
     `;
     return rows[0];
   }
@@ -232,11 +307,35 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].n;
   }
 
-  test('extracts exactly the 8 expected STMT blocks, in order', () => {
+  test('extracts exactly the 12 expected STMT blocks, in order', () => {
     expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
     for (const name of EXPECTED_BLOCKS) {
       expect(blocks[name].trim().length).toBeGreaterThan(0);
     }
+  });
+
+  test('the file carries a literal BEGIN; and COMMIT; outside any STMT block (pinned so the runner above stays honest)', () => {
+    expect(scriptText).toMatch(/^BEGIN;$/m);
+    expect(scriptText).toMatch(/^COMMIT;$/m);
+  });
+
+  test('the shipped insert-pending-rows block (as committed) is a genuine no-op', async () => {
+    const libraryId = await seedLibrary(90011);
+    const cleanId = await seedCta(libraryId, 'Jessica Pratt', 'Back, Baby', '1');
+
+    // Runs the LITERAL shipped block -- its own hardcoded placeholder INSERT
+    // plus its own scrub DELETE -- not a harness-constructed substitute
+    // (PR #2154 review, finding 5: the block an operator hand-edits with 14
+    // real rows previously had zero execution coverage).
+    const result = await runRepairScript(async (reservedSql) => {
+      await reservedSql.unsafe(blocks['insert-pending-rows']);
+    });
+
+    expect(result.deleted).toBe(0);
+    expect(result.updated).toBe(0);
+    expect(await ctaCount(libraryId)).toBe(1);
+    const row = await ctaRow(cleanId);
+    expect(row.artist_name).toBe('Jessica Pratt');
   });
 
   test('corrupt track_title WITH a clean twin: DELETEs the corrupt row, raises no unique violation', async () => {
@@ -247,15 +346,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     // The corrupt row: same artist, corrupted track_title, different position.
     const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '7');
 
-    const result = await runRepairScript([
-      {
-        legacy_release_id: 90001,
-        track_position: '7',
-        current_artist_name: 'Hermanos Gutiérrez',
-        current_track_title: 'Sonido C�smico',
-        true_track_title: 'Sonido Cósmico',
-      },
-    ]);
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90001,
+          track_position: '7',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico',
+        },
+      ])
+    );
 
     expect(result.deleted).toBe(1);
     expect(result.updated).toBe(0);
@@ -274,15 +375,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const libraryId = await seedLibrary(90002);
     const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
 
-    const result = await runRepairScript([
-      {
-        legacy_release_id: 90002,
-        track_position: '4',
-        current_artist_name: 'Csillagrablók',
-        current_track_title: 'Rem�nytelen T�nc',
-        true_track_title: 'Reménytelen Tánc',
-      },
-    ]);
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90002,
+          track_position: '4',
+          current_artist_name: 'Csillagrablók',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_track_title: 'Reménytelen Tánc',
+        },
+      ])
+    );
 
     expect(result.deleted).toBe(0);
     expect(result.updated).toBe(1);
@@ -295,7 +398,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const libraryId = await seedLibrary(90003);
     const cleanId = await seedCta(libraryId, 'Chuquimamani-Condori', 'Call Your Name', '1');
 
-    const result = await runRepairScript([]);
+    const result = await runRepairScript(withSyntheticPendingRows([]));
 
     expect(result.deleted).toBe(0);
     expect(result.updated).toBe(0);
@@ -313,15 +416,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const targetId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
     const decoyId = await seedCta(libraryId, 'Sonido Dueñez', 'Rem�nytelen T�nc', '5');
 
-    await runRepairScript([
-      {
-        legacy_release_id: 90004,
-        track_position: '4',
-        current_artist_name: 'Csillagrablók',
-        current_track_title: 'Rem�nytelen T�nc',
-        true_track_title: 'Reménytelen Tánc',
-      },
-    ]);
+    await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90004,
+          track_position: '4',
+          current_artist_name: 'Csillagrablók',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_track_title: 'Reménytelen Tánc',
+        },
+      ])
+    );
 
     const target = await ctaRow(targetId);
     expect(target.track_title).toBe('Reménytelen Tánc');
@@ -335,15 +440,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', null, null);
     const corruptId = await seedCta(libraryId, 'Hermanos Guti�rrez', null, null);
 
-    const result = await runRepairScript([
-      {
-        legacy_release_id: 90005,
-        track_position: null,
-        current_artist_name: 'Hermanos Guti�rrez',
-        current_track_title: null,
-        true_artist_name: 'Hermanos Gutiérrez',
-      },
-    ]);
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90005,
+          track_position: null,
+          current_artist_name: 'Hermanos Guti�rrez',
+          current_track_title: null,
+          true_artist_name: 'Hermanos Gutiérrez',
+        },
+      ])
+    );
 
     expect(result.deleted).toBe(1);
     expect(result.updated).toBe(0);
@@ -361,15 +468,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const libraryId = await seedLibrary(90006);
     const corruptId = await seedCta(libraryId, 'Csillagrabl�k', null, null);
 
-    const result = await runRepairScript([
-      {
-        legacy_release_id: 90006,
-        track_position: null,
-        current_artist_name: 'Csillagrabl�k',
-        current_track_title: null,
-        true_artist_name: 'Csillagrablók',
-      },
-    ]);
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90006,
+          track_position: null,
+          current_artist_name: 'Csillagrabl�k',
+          current_track_title: null,
+          true_artist_name: 'Csillagrablók',
+        },
+      ])
+    );
 
     expect(result.deleted).toBe(0);
     expect(result.updated).toBe(1);
@@ -384,22 +493,24 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     const libB = await seedLibrary(90008);
     await seedCta(libB, 'Csillagrabl�k', null, null);
 
-    await runRepairScript([
-      {
-        legacy_release_id: 90007,
-        track_position: '4',
-        current_artist_name: 'Csillagrablók',
-        current_track_title: 'Rem�nytelen T�nc',
-        true_track_title: 'Reménytelen Tánc',
-      },
-      {
-        legacy_release_id: 90008,
-        track_position: null,
-        current_artist_name: 'Csillagrabl�k',
-        current_track_title: null,
-        true_artist_name: 'Csillagrablók',
-      },
-    ]);
+    await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90007,
+          track_position: '4',
+          current_artist_name: 'Csillagrablók',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_track_title: 'Reménytelen Tánc',
+        },
+        {
+          legacy_release_id: 90008,
+          track_position: null,
+          current_artist_name: 'Csillagrabl�k',
+          current_track_title: null,
+          true_artist_name: 'Csillagrablók',
+        },
+      ])
+    );
 
     const [{ remaining }] = await sql`
       SELECT COUNT(*)::int AS remaining
@@ -433,10 +544,10 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       },
     ];
 
-    const first = await runRepairScript(pending);
+    const first = await runRepairScript(withSyntheticPendingRows(pending));
     expect(first.deleted + first.updated).toBeGreaterThan(0);
 
-    const second = await runRepairScript(pending);
+    const second = await runRepairScript(withSyntheticPendingRows(pending));
     expect(second.deleted).toBe(0);
     expect(second.updated).toBe(0);
 
@@ -451,11 +562,11 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     expect(stillDeleted).toHaveLength(0);
   });
 
-  test('is a no-op against an empty pending block (the script as shipped, pending prod capture)', async () => {
+  test('is a no-op against an empty pending block (zero synthetic rows, mirroring the shipped state)', async () => {
     const libraryId = await seedLibrary(90011);
     const cleanId = await seedCta(libraryId, 'Jessica Pratt', 'Back, Baby', '1');
 
-    const result = await runRepairScript([]);
+    const result = await runRepairScript(withSyntheticPendingRows([]));
 
     expect(result.deleted).toBe(0);
     expect(result.updated).toBe(0);
@@ -467,15 +578,17 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
   test('the guard-replacement-specified block rejects a pending row that fixes nothing', async () => {
     await seedLibrary(90012);
     await expect(
-      runRepairScript([
-        {
-          legacy_release_id: 90012,
-          track_position: '1',
-          current_artist_name: 'Some Artist',
-          current_track_title: 'Some Title',
-          // both true_artist_name and true_track_title omitted -- nothing to fix
-        },
-      ])
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90012,
+            track_position: '1',
+            current_artist_name: 'Some Artist',
+            current_track_title: 'Some Title',
+            // both true_artist_name and true_track_title omitted -- nothing to fix
+          },
+        ])
+      )
     ).rejects.toThrow(/BS#2152 guard/);
   });
 
@@ -490,16 +603,221 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     // cta_repair_targets ends up with two rows sharing one identity, which
     // is what the guard actually detects.
     const libraryId = await seedLibrary(90013);
-    await seedCta(libraryId, 'Duplicate Artist', 'Duplicate Title', '1');
+    await seedCta(libraryId, 'Csillagrabl�k', 'Duplicate Title', '1');
 
     const dupPendingRow = {
       legacy_release_id: 90013,
       track_position: '1',
-      current_artist_name: 'Duplicate Artist',
+      current_artist_name: 'Csillagrabl�k',
       current_track_title: 'Duplicate Title',
-      true_artist_name: 'Fixed Artist',
+      true_artist_name: 'Csillagrablók',
     };
 
-    await expect(runRepairScript([dupPendingRow, { ...dupPendingRow }])).rejects.toThrow(/BS#2152 guard/);
+    await expect(runRepairScript(withSyntheticPendingRows([dupPendingRow, { ...dupPendingRow }]))).rejects.toThrow(
+      /BS#2152 guard/
+    );
+  });
+
+  // ==========================================================================
+  // Required regression tests (PR #2154 review) -- the two HIGH findings.
+  // ==========================================================================
+
+  test('HIGH: a transposed capture (current/true swapped) aborts via guard-capture-sanity, BOTH rows survive intact', async () => {
+    // Exact reviewer reproduction: seed ('Csillagrablók','Tánc') and
+    // ('Csillagrablók','T<U+FFFD>nc'), then declare the pending row with
+    // current/true swapped -- current_track_title holds the CLEAN string,
+    // true_track_title holds the CORRUPT string. Unguarded, build-targets
+    // would match the clean row (its current_* equals the declared
+    // current_*), compute the corrupt string as the post-fix value, find the
+    // genuinely corrupt row as its "twin", and DELETE the clean row.
+    const libraryId = await seedLibrary(90015);
+    const cleanId = await seedCta(libraryId, 'Csillagrablók', 'Tánc', '1');
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'T�nc', '2');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90015,
+            track_position: '1',
+            current_artist_name: 'Csillagrablók',
+            current_track_title: 'Tánc', // TRANSPOSED: this is the CLEAN string
+            true_track_title: 'T�nc', // TRANSPOSED: this is the CORRUPT string
+          },
+        ])
+      )
+    ).rejects.toThrow(/BS#2152 guard/);
+
+    // Nothing was written -- the guard fires before BEGIN, and even if it
+    // had fired inside the transaction, the ROLLBACK in runRepairScript's
+    // catch block would undo it. Both rows survive with their original
+    // values, byte for byte.
+    const clean = await ctaRow(cleanId);
+    expect(clean.track_title).toBe('Tánc');
+    const corrupt = await ctaRow(corruptId);
+    expect(corrupt.track_title).toBe('T�nc');
+    expect(await ctaCount(libraryId)).toBe(2);
+  });
+
+  test('HIGH: two pending rows converging on the same post-fix tuple abort via guard-converging-pending, not a raw 23505', async () => {
+    // Exact reviewer reproduction: two differently-corrupted copies of the
+    // SAME real credit, with NO existing clean twin for either individually
+    // -- ('Hermanos Guti<U+FFFD>rrez','Sonido Cósmico') and
+    // ('Hermanos Gutiérrez','Sonido C<U+FFFD>smico'). Fixed independently,
+    // both resolve to the identical (library_id, 'Hermanos Gutiérrez',
+    // 'Sonido Cósmico') tuple -- has_twin=false for both (no live row holds
+    // that tuple yet), so unguarded they'd both land in the single
+    // update-no-twins UPDATE and collide under cta_unique_idx.
+    const libraryId = await seedLibrary(90016);
+    const rowAId = await seedCta(libraryId, 'Hermanos Guti�rrez', 'Sonido Cósmico', '1');
+    const rowBId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '2');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90016,
+            track_position: '1',
+            current_artist_name: 'Hermanos Guti�rrez',
+            current_track_title: 'Sonido Cósmico',
+            true_artist_name: 'Hermanos Gutiérrez',
+          },
+          {
+            legacy_release_id: 90016,
+            track_position: '2',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico',
+          },
+        ])
+      )
+      // The named guard message, NOT a raw postgres 23505 unique-violation
+      // error -- proves guard-converging-pending caught this before either
+      // write statement ran, rather than the write failing safe by accident.
+    ).rejects.toThrow(/BS#2152 guard/);
+
+    // Both original corrupt rows survive untouched -- the transaction rolled
+    // back before delete-twins/update-no-twins ever executed.
+    const rowA = await ctaRow(rowAId);
+    expect(rowA.artist_name).toBe('Hermanos Guti�rrez');
+    expect(rowA.track_title).toBe('Sonido Cósmico');
+    const rowB = await ctaRow(rowBId);
+    expect(rowB.artist_name).toBe('Hermanos Gutiérrez');
+    expect(rowB.track_title).toBe('Sonido C�smico');
+    expect(await ctaCount(libraryId)).toBe(2);
+  });
+
+  // ==========================================================================
+  // Additional coverage for the MEDIUM findings.
+  // ==========================================================================
+
+  test('MEDIUM: guard-placeholder-scrub rejects a captured row with a blank legacy_release_id (distinguishes it from the placeholder)', async () => {
+    // Reviewer reproduction shape: a real captured row that lost its
+    // legacy_release_id to a paste slip. Previously this was silently swept
+    // by the same unconditional DELETE that scrubs the shipped placeholder,
+    // and pending_declared undercounted with no warning.
+    await seedLibrary(90017);
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90017,
+            track_position: '1',
+            current_artist_name: 'Csillagrabl�k',
+            current_track_title: null,
+            true_artist_name: 'Csillagrablók',
+          },
+          {
+            // Paste slip: every other column populated but legacy_release_id
+            // blank -- must NOT be silently swept as if it were the shipped
+            // all-NULL placeholder.
+            legacy_release_id: null,
+            track_position: '2',
+            current_artist_name: 'Some Other Artist',
+            current_track_title: 'Some Other Title',
+            true_artist_name: 'Fixed Other Artist',
+          },
+        ])
+      )
+    ).rejects.toThrow(/BS#2152 guard/);
+  });
+
+  test("MEDIUM: the DELETE branch repoints the corrupt row's identity link + track_position onto the surviving twin before deleting it", async () => {
+    // The corrupt row is the OLDER ingestion and is the one holding the
+    // lml_backfill identity link; the clean twin has none yet. Reproduces
+    // the review's repro shape (track_position='4', track_artist_id=4242) --
+    // asserts the link survives onto the twin rather than being discarded
+    // with the deleted row.
+    const libraryId = await seedLibrary(90018);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', null, {
+      track_artist_id: null,
+      track_artist_link_confidence: null,
+      track_artist_link_method: null,
+    });
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '4', {
+      track_artist_id: 4242,
+      track_artist_link_confidence: 0.93,
+      track_artist_link_method: 'lml_backfill',
+    });
+
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90018,
+          track_position: '4',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico',
+        },
+      ])
+    );
+
+    expect(result.deleted).toBe(1);
+    expect(result.updated).toBe(0);
+    const remaining = await sql`
+      SELECT id FROM ${sql(TEST_SCHEMA)}.compilation_track_artist WHERE id = ${corruptId}
+    `;
+    expect(remaining).toHaveLength(0);
+
+    const twin = await ctaRow(twinId);
+    expect(twin.track_title).toBe('Sonido Cósmico');
+    expect(twin.track_artist_id).toBe(4242);
+    expect(twin.track_artist_link_confidence).toBeCloseTo(0.93);
+    expect(twin.track_artist_link_method).toBe('lml_backfill');
+    expect(twin.track_position).toBe('4'); // COALESCEd from the corrupt row (twin's own was NULL)
+  });
+
+  test('MEDIUM: the DELETE branch never overwrites a twin that already holds its OWN identity link', async () => {
+    // The twin's own non-NULL values must win over the corrupt row's --
+    // COALESCE(twin.*, corrupt.*), not the reverse.
+    const libraryId = await seedLibrary(90019);
+    const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2', {
+      track_artist_id: 1111,
+      track_artist_link_confidence: 0.99,
+      track_artist_link_method: 'librarian',
+    });
+    await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '4', {
+      track_artist_id: 4242,
+      track_artist_link_confidence: 0.5,
+      track_artist_link_method: 'lml_backfill',
+    });
+
+    await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90019,
+          track_position: '4',
+          current_artist_name: 'Hermanos Gutiérrez',
+          current_track_title: 'Sonido C�smico',
+          true_track_title: 'Sonido Cósmico',
+        },
+      ])
+    );
+
+    const twin = await ctaRow(twinId);
+    expect(twin.track_artist_id).toBe(1111);
+    expect(twin.track_artist_link_confidence).toBeCloseTo(0.99);
+    expect(twin.track_artist_link_method).toBe('librarian');
+    expect(twin.track_position).toBe('2');
   });
 });

--- a/tests/integration/bs-replacement-char-cta.spec.js
+++ b/tests/integration/bs-replacement-char-cta.spec.js
@@ -53,6 +53,12 @@ const fs = require('fs');
 const path = require('path');
 const { getTestDb } = require('../utils/db');
 
+// PostgreSQL dollar-quote delimiters: `$$` or `$tag$`, where tag follows
+// identifier rules -- leading letter/underscore, then letters, DIGITS, or
+// underscores. The digits are the part round 5 found missing: the previous
+// `/\$[A-Za-z_]*\$/` could not match `$q1$` or `$tag1$`.
+const DOLLAR_QUOTE_PATTERN = /\$\$|\$[A-Za-z_][A-Za-z0-9_]*\$/;
+
 const TEST_SCHEMA = 'bs2152_cta_mojibake_test';
 const SCRIPT_PATH = path.join(__dirname, '..', '..', 'scripts', 'audit', 'bs_replacement_char_cta.sql');
 
@@ -74,6 +80,7 @@ const EXPECTED_BLOCKS = [
   'guard-post-fix-fffd',
   'guard-ambiguous-match',
   'guard-converging-pending',
+  'before-matched-rows',
   'repoint-twin-identity',
   'delete-twins',
   'update-no-twins',
@@ -278,9 +285,16 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
    * real `BEGIN`/`COMMIT` here is safe: this is a dedicated reserved
    * connection, not the shared pool the extractor's own comment warns about.
    */
+  // Rows the `before-matched-rows` operator print emitted on the most recent
+  // run, so a test can assert on what the OPERATOR actually sees rather than
+  // re-deriving it from cta_repair_targets (which outlives neither the
+  // transaction nor a guard abort).
+  let lastBeforeMatchedRows = [];
+
   async function runRepairScript(insertPhase, hooks = {}) {
     const reservedSql = await sql.reserve();
     let inTransaction = false;
+    lastBeforeMatchedRows = [];
     try {
       await reservedSql.unsafe(blocks['create-pending-table']);
       await insertPhase(reservedSql);
@@ -316,6 +330,16 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       if (hooks.afterGuards) {
         await hooks.afterGuards(reservedSql);
       }
+      // The operator-facing BEFORE print. Executed here, in its real
+      // position, because through round 4 it was untagged and therefore
+      // unexecuted -- a column typo in it passed the whole suite and then
+      // aborted the real prod run under ON_ERROR_STOP (round 5 finding).
+      // Two statements (the section label, then the projection), so
+      // postgres-js returns one result array per statement -- the rows are
+      // the SECOND. Verified against the driver rather than assumed:
+      // `[[{section}], [ ...rows ]]`.
+      const beforeMatched = await reservedSql.unsafe(blocks['before-matched-rows']);
+      lastBeforeMatchedRows = beforeMatched.length === 2 ? beforeMatched[1] : beforeMatched;
       await reservedSql.unsafe(blocks['repoint-twin-identity']);
       const deleteResult = await reservedSql.unsafe(blocks['delete-twins']);
       const updateResult = await reservedSql.unsafe(blocks['update-no-twins']);
@@ -327,7 +351,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
       inTransaction = false;
 
       await reservedSql.unsafe(blocks['analyze']);
-      return { deleted: deleteResult.count, updated: updateResult.count };
+      return { deleted: deleteResult.count, updated: updateResult.count, beforeMatched: lastBeforeMatchedRows };
     } catch (err) {
       // A guard RAISE EXCEPTION (or a real constraint violation) inside the
       // transaction aborts it server-side; roll back explicitly so this
@@ -381,7 +405,7 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     return rows[0].n;
   }
 
-  test('extracts exactly the 21 expected STMT blocks, in order', () => {
+  test('extracts exactly the 22 expected STMT blocks, in order', () => {
     expect(Object.keys(blocks)).toEqual(EXPECTED_BLOCKS);
     for (const name of EXPECTED_BLOCKS) {
       expect(blocks[name].trim().length).toBeGreaterThan(0);
@@ -492,7 +516,31 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     // the whole suite stays green -- so the header's "goes red the moment
     // real rows land" contract, and the byte-assertion gate it defers to,
     // would both be bypassable without this second assertion.
-    expect(sqlOnly).not.toMatch(/\$[A-Za-z_]*\$/);
+    expect(sqlOnly).not.toMatch(DOLLAR_QUOTE_PATTERN);
+  });
+
+  test('the dollar-quote paste gate catches tags containing digits', () => {
+    // Round 5 finding: the pattern was /\$[A-Za-z_]*\$/, which cannot match
+    // `$q1$` or `$tag1$` -- the character class excludes digits and there is
+    // no second class for the tail. A real 14-row paste using such a tag
+    // carries no apostrophe, so it slipped BOTH assertions and the header's
+    // "goes red the moment real rows land" contract (and the byte-exact
+    // codepoint assertion it defers to) was bypassable.
+    //
+    // Asserted against a realistic ACCENTED payload on purpose. With an
+    // ASCII-only value the old pattern matched by ACCIDENT -- in
+    // `$q1$Csillagrablok$q1$` the substring `$Csillagrablok$` is itself a
+    // valid `\$[A-Za-z_]*\$` match -- so an ASCII fixture reports the hole as
+    // already closed. The accent is what breaks that coincidence.
+    const realPastes = [
+      "(50340, 3, 'Csillagrablók', NULL)",
+      '(50340, 3, $$Csillagrablók$$, NULL)',
+      '(50340, 3, $q1$Csillagrablók$q1$, NULL)',
+      '(50340, 3, $tag1$Csillagrablók$tag1$, NULL)',
+    ];
+    for (const paste of realPastes) {
+      expect(paste.includes("'") || DOLLAR_QUOTE_PATTERN.test(paste)).toBe(true);
+    }
   });
 
   test('the shipped insert-pending-rows block (as committed) is a genuine no-op', async () => {
@@ -798,8 +846,13 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     // generic /BS#2152 guard/ prefix a prior version of this test asserted
     // is shared by all seven guards, so it cannot tell this apart from
     // guard-converging-pending, guard-capture-sanity, etc. firing instead.
+    // Round 5 re-pointed this fragment when the guard's message was corrected
+    // (it named a violated index that post-round-4 is not the likeliest
+    // cause). This test exercises cause (3) -- a duplicate entry in the
+    // PENDING block -- so it asserts on that clause specifically; the
+    // NFC-fan-out cause (2) has its own test below.
     await expect(runRepairScript(withSyntheticPendingRows([dupPendingRow, { ...dupPendingRow }]))).rejects.toThrow(
-      'live compilation_track_artist rows'
+      'a duplicate entry in the pending block'
     );
   });
 
@@ -1585,14 +1638,20 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
     expect(rows[1].track_title).toBe('Sonido C�smico');
   });
 
-  test('BS#2152 round 4: guard-post-write-nfc-duplicate fires when a touched library_id holds two NFC-equal, byte-distinct rows', async () => {
-    // The belt-and-braces half of the round 4 fix: this guard checks the
-    // OUTCOME (no two live rows in a touched library_id are NFC-equal but
-    // byte-distinct), not just the twin-join mechanism that is supposed to
-    // prevent it. Reproduced here via a pre-existing NFC/NFD pair the run
-    // never touches directly, sitting in a compilation this run otherwise
-    // repairs -- scope is "library_id in cta_repair_targets", deliberately
-    // broader than "rows this run wrote", per the guard's own comment.
+  // ==========================================================================
+  // Round 5 review findings.
+  // ==========================================================================
+
+  test('BS#2152 round 5: a pre-existing NFC/NFD duplicate this run never wrote does NOT block an unrelated repair in the same compilation', async () => {
+    // Round 4 shipped guard-post-write-nfc-duplicate scoped to "any
+    // library_id in cta_repair_targets", which made any pre-existing
+    // duplicate pair a hard blocker for the ENTIRE 14-row repair: the
+    // legitimate no-twin UPDATE below succeeded, the guard then fired on a
+    // pair it never touched, and the whole transaction rolled back. The
+    // repair could not complete until a human merged a duplicate that had
+    // nothing to do with it -- in the same table #1996 is separately blocked
+    // on. This test is the round-4 test inverted: same fixture, opposite
+    // expectation.
     const libraryId = await seedLibrary(90041);
     const nfdTitle = 'Sonido Cósmico'.normalize('NFD');
     await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '1'); // NFC
@@ -1600,28 +1659,270 @@ describe('bs_replacement_char_cta mojibake repair (BS#2152)', () => {
 
     const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
 
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90041,
+          track_position: '4',
+          current_artist_name: 'Csillagrablók',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_track_title: 'Reménytelen Tánc',
+        },
+      ])
+    );
+
+    expect(result.updated).toBe(1);
+    const row = await ctaRow(corruptId);
+    expect(row.track_title).toBe('Reménytelen Tánc');
+
+    // The pre-existing pair is still there, untouched. That is #1996's
+    // territory, not this script's -- what matters is that it no longer
+    // vetoes a U+FFFD repair.
+    expect(await ctaCount(libraryId)).toBe(3);
+  });
+
+  test('BS#2152 round 5: guard-post-write-nfc-duplicate still fires when a row THIS run wrote is half of the duplicate', async () => {
+    // The narrowing must not neuter the guard. A concurrent INSERT is the one
+    // shape lock-targets structurally cannot prevent -- it takes row locks on
+    // rows that EXIST at classification time, and a brand-new row has none to
+    // take. Injected through the afterGuards hook so it lands in the real
+    // window: after the twin join has already concluded "no twin", before
+    // update-no-twins writes.
+    const libraryId = await seedLibrary(90042);
+    const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
     await expect(
       runRepairScript(
         withSyntheticPendingRows([
           {
-            legacy_release_id: 90041,
+            legacy_release_id: 90042,
             track_position: '4',
             current_artist_name: 'Csillagrablók',
             current_track_title: 'Rem�nytelen T�nc',
             true_track_title: 'Reménytelen Tánc',
           },
-        ])
+        ]),
+        {
+          afterGuards: async (reservedSql) => {
+            await reservedSql.unsafe(
+              `INSERT INTO ${TEST_SCHEMA}.compilation_track_artist (library_id, artist_name, track_title, track_position)
+               VALUES (${libraryId}, 'Csillagrablók', normalize('Reménytelen Tánc', NFD), '9')`
+            );
+          },
+        }
       )
-      // Guard-specific fragment.
     ).rejects.toThrow('NFC-equal but byte-distinct');
 
-    // Rolled back -- this run's own UPDATE to the unrelated corrupt row is
-    // undone (the recovery shape every guard in this script uses), even
-    // though the duplicate it flagged predates this run and is NOT undone by
-    // the rollback -- the guard's own message says as much.
+    // And now the message's rollback advice is honest: undoing this run's
+    // write genuinely removes this run's half of the pair.
     const row = await ctaRow(corruptId);
-    expect(row.artist_name).toBe('Csillagrablók');
     expect(row.track_title).toBe('Rem�nytelen T�nc');
+  });
+
+  test('BS#2152 round 5: an NFC-folded twin join that fans out to TWO live twins aborts via guard-ambiguous-match, naming the fold rather than a violated index', async () => {
+    // Pre-round-4 the twin join was byte-exact on exactly cta_unique_idx's
+    // key, so it could structurally match at most one row and the guard's
+    // "cta_unique_idx should make this impossible" message was true. Folded
+    // to NFC, no unique index backs the compared key -- cta_unique_null_track_idx
+    // is precisely the index that cannot constrain two NFC-equal,
+    // byte-distinct names -- so a pre-existing NFD/NFC clean pair fans one
+    // pending row out to two target rows. Aborting is right; blaming an index
+    // that was never violated sends the operator looking for the wrong thing.
+    const libraryId = await seedLibrary(90043);
+    await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '1'); // NFC twin candidate
+    await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico'.normalize('NFD'), '2'); // NFD twin candidate
+    const corruptId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '4');
+
+    await expect(
+      runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: 90043,
+            track_position: '4',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico',
+          },
+        ])
+      )
+    ).rejects.toThrow('NFC-folded twin join matched MORE THAN ONE live twin');
+
+    const row = await ctaRow(corruptId);
+    expect(row.track_title).toBe('Sonido C�smico');
     expect(await ctaCount(libraryId)).toBe(3);
   });
+
+  test.each([
+    {
+      shape: 'twin linked, corrupt row carries a different link',
+      legacyReleaseId: 90044,
+      twin: { track_artist_id: 1111, track_artist_link_confidence: null, track_artist_link_method: 'librarian' },
+      corrupt: { track_artist_id: 4242, track_artist_link_confidence: 0.5, track_artist_link_method: 'lml_backfill' },
+      expected: { track_artist_id: 1111, track_artist_link_confidence: null, track_artist_link_method: 'librarian' },
+    },
+    {
+      shape: 'twin orphaned by ON DELETE SET NULL, corrupt row carries a whole link',
+      legacyReleaseId: 90045,
+      twin: { track_artist_id: null, track_artist_link_confidence: 0.93, track_artist_link_method: 'lml_backfill' },
+      corrupt: { track_artist_id: 4242, track_artist_link_confidence: 0.5, track_artist_link_method: 'lml_backfill' },
+      expected: { track_artist_id: 4242, track_artist_link_confidence: 0.5, track_artist_link_method: 'lml_backfill' },
+    },
+  ])(
+    'BS#2152 round 5: repoint-twin-identity moves the identity link as one TUPLE, not column-by-column ($shape)',
+    async ({ legacyReleaseId, twin, corrupt, expected }) => {
+      // Per-column COALESCE merges two DIFFERENT links into one incoherent
+      // row. Shape 1 previously produced (id=1111, confidence=0.5,
+      // method='librarian') -- a machine confidence computed for artist 4242,
+      // attached to artist 1111, labelled human-entered, which
+      // library-identity-consumer's librarian precedence then skips forever.
+      // Shape 2 previously produced (id=4242, confidence=0.93,
+      // method='lml_backfill') -- the corrupt row's artist under the twin's
+      // stale orphaned confidence. Both are reachable today: track_artist_id
+      // is ON DELETE SET NULL on artists.id (migration 0140), so any artist
+      // deletion leaves the partial shape behind.
+      //
+      // Neither existing repoint test covers this -- both seed the twin with
+      // all three columns NULL or all three set, the two shapes where
+      // per-column and per-tuple COALESCE agree.
+      const libraryId = await seedLibrary(legacyReleaseId);
+      const twinId = await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido Cósmico', '2', twin);
+      await seedCta(libraryId, 'Hermanos Gutiérrez', 'Sonido C�smico', '4', corrupt);
+
+      await runRepairScript(
+        withSyntheticPendingRows([
+          {
+            legacy_release_id: legacyReleaseId,
+            track_position: '4',
+            current_artist_name: 'Hermanos Gutiérrez',
+            current_track_title: 'Sonido C�smico',
+            true_track_title: 'Sonido Cósmico',
+          },
+        ])
+      );
+
+      const survivor = await ctaRow(twinId);
+      expect(survivor.track_artist_id).toBe(expected.track_artist_id);
+      expect(survivor.track_artist_link_method).toBe(expected.track_artist_link_method);
+      if (expected.track_artist_link_confidence === null) {
+        expect(survivor.track_artist_link_confidence).toBeNull();
+      } else {
+        expect(survivor.track_artist_link_confidence).toBeCloseTo(expected.track_artist_link_confidence);
+      }
+    }
+  );
+
+  test('BS#2152 round 5: the BEFORE print surfaces the twin bytes the DELETE branch keeps, so a discarded NFC capture is visible', async () => {
+    // On the widened DELETE branch the row that SURVIVES is the twin,
+    // byte-for-byte -- so an NFD twin against an NFC capture means the bytes
+    // the operator read out of Kattare are discarded. Exit 0, residual 0/0,
+    // no duplicate, and (through round 4) no signal of any kind: the print
+    // projected twin_id and the three twin_track_artist_* columns but not the
+    // twin's own name/title.
+    //
+    // This test also covers the mechanism half of the same finding: the block
+    // is EXECUTED here (it was untagged and therefore unexecuted through
+    // round 4 -- the one statement in the file whose reversion broke no test,
+    // while a real psql -f run exited 3 on a column typo).
+    const libraryId = await seedLibrary(90046);
+    const nfdTitle = 'Reménytelen Tánc'.normalize('NFD');
+    const twinId = await seedCta(libraryId, 'Csillagrablók', nfdTitle, '2');
+    await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+    const result = await runRepairScript(
+      withSyntheticPendingRows([
+        {
+          legacy_release_id: 90046,
+          track_position: '4',
+          current_artist_name: 'Csillagrablók',
+          current_track_title: 'Rem�nytelen T�nc',
+          true_track_title: 'Reménytelen Tánc', // NFC
+        },
+      ])
+    );
+
+    expect(result.deleted).toBe(1);
+
+    const printed = result.beforeMatched;
+    expect(printed).toHaveLength(1);
+    expect(printed[0].action).toBe('DELETE (twin exists)');
+    expect(printed[0].twin_track_title).toBe(nfdTitle);
+    expect(printed[0].new_track_title).toBe('Reménytelen Tánc');
+    // The whole point: the operator can see these differ before committing.
+    expect(printed[0].twin_is_byte_exact).toBe(false);
+
+    // And the survivor really does hold the NFD bytes, not the capture.
+    const survivor = await ctaRow(twinId);
+    expect(survivor.track_title).toBe(nfdTitle);
+    expect(survivor.track_title).not.toBe('Reménytelen Tánc');
+  });
+
+  test('BS#2152 round 5: guard-converging-pending tells the operator the both-captures-correct remedy, not just "resolve which is correct"', async () => {
+    // The guard is deliberately over-broad and fires on the shape the script
+    // itself calls the 98.5% case -- two differently-corrupted copies of ONE
+    // credit, both captures correct, neither a distinct real credit. The
+    // over-breadth is justified in the comment; the MESSAGE was not, and the
+    // workable remedy (split across two sequential invocations) appeared
+    // nowhere in the message, the comment, or the capture procedure.
+    const libraryId = await seedLibrary(90047);
+    await seedCta(libraryId, 'Csillagrablók', 'Reménytelen Tánc', '1'); // clean third row
+    await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+    await seedCta(libraryId, 'Csillagrablók', 'Reménytelen T�nc', '5');
+
+    const pending = [
+      {
+        legacy_release_id: 90047,
+        track_position: '4',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Rem�nytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+      {
+        legacy_release_id: 90047,
+        track_position: '5',
+        current_artist_name: 'Csillagrablók',
+        current_track_title: 'Reménytelen T�nc',
+        true_track_title: 'Reménytelen Tánc',
+      },
+    ];
+
+    await expect(runRepairScript(withSyntheticPendingRows(pending))).rejects.toThrow(
+      'split the converging rows across two sequential invocations'
+    );
+  });
+
+  test.each([
+    { legacyReleaseId: 90048, value: 'Reménytelen Tánc   ', label: 'trailing whitespace' },
+    { legacyReleaseId: 90049, value: '   Reménytelen Tánc', label: 'leading whitespace' },
+    { legacyReleaseId: 90050, value: '', label: 'empty string' },
+  ])(
+    'BS#2152 round 5: guard-capture-sanity rejects a true_* capture with $label',
+    async ({ legacyReleaseId, value }) => {
+      // Capture channel (a) trims and maps empty to NULL; channel (c) -- raw
+      // Kattare MySQL, which the header explicitly offers -- does not. The
+      // consequence is not cosmetic: library-etl's importCompilationTracks
+      // inserts the TRIMMED string and its ON CONFLICT DO NOTHING is keyed on
+      // cta_unique_idx, so a repaired row differing by whitespace no longer
+      // conflicts with it and the next 30-minute cycle re-creates the exact
+      // duplicate this script exists to avoid.
+      const libraryId = await seedLibrary(legacyReleaseId);
+      const corruptId = await seedCta(libraryId, 'Csillagrablók', 'Rem�nytelen T�nc', '4');
+
+      await expect(
+        runRepairScript(
+          withSyntheticPendingRows([
+            {
+              legacy_release_id: legacyReleaseId,
+              track_position: '4',
+              current_artist_name: 'Csillagrablók',
+              current_track_title: 'Rem�nytelen T�nc',
+              true_track_title: value,
+            },
+          ])
+        )
+      ).rejects.toThrow('leading/trailing whitespace or is empty');
+
+      const row = await ctaRow(corruptId);
+      expect(row.track_title).toBe('Rem�nytelen T�nc');
+    }
+  );
 });


### PR DESCRIPTION
## Summary

Adds `scripts/audit/bs_replacement_char_cta.sql`, the fourth script in the U+FFFD-recovery family (Phase 1/2, Phase 3.5, Phase 4), repairing the 14 `wxyc_schema.compilation_track_artist` values (11 `track_title`, 3 `artist_name`) that no prior script covers.

Refs #2152

## Why this one looks different from its predecessors

Phase 1/2/3.5/4 all bake exact corrupt/correct string literals straight into their UPDATE statements, because those rows were enumerable against the local dev clone. That path is closed here: `dev_env/seed-clone.sql` carries **no** `compilation_track_artist` rows at all — the table appears once, in the TRUNCATE list, with no `COPY … FROM stdin` block — and there is no prod database access available while writing this. So the script is **data-driven**: a clearly-marked "PENDING CAPTURE" block at the top (currently a single filtered-out placeholder row) that an operator fills in from a documented capture procedure (enumeration SQL against prod + ground-truth resolution via this repo's own charset-correct `fetchLegacyCompilationTracks`, a tubafrenzy-sourced `library.db` snapshot, or Kattare MySQL directly — both spelled out in the script header). **No row ids or replacement strings were invented or guessed** — none of the 14 real pairs are known yet.

I also checked the two local `library.db` snapshots under `lml-cutover-snapshots/` (`prod-20260719`, `staging-20260718`, both safely post-2026-04-24) for a usable ground-truth extract. Neither is useful: `library.db`'s only table is a flat per-release `library` table (title/artist/call numbers/genre/format/etc.) with no per-track or per-compilation-credit rows at all — there is nothing shaped like `compilation_track_artist` in either snapshot. No supporting CSV artifact was produced, because there is nothing to extract.

## Mechanism (twin-aware repair)

`cta_unique_idx` is UNIQUE on `(library_id, artist_name, track_title)` (schema.ts:731, permanent per #801 D7 — never touched here). A blanket UPDATE onto the true value would raise a unique violation whenever a corrupt row's correctly-spelled twin already exists in the same compilation — and #1996 measured that shape holds for 98.5% of this table's damaged rows. So every pending row is classified once, before any write:

- twin already exists at the post-fix `(artist_name, track_title)` tuple → **DELETE** the corrupt row
- no twin → **UPDATE** the corrupt row in place

Classification uses `IS NOT DISTINCT FROM` for `track_title`, so the migration-0099 NULL-`track_title` loophole (`cta_unique_null_track_idx`) is covered the same way a non-NULL twin is. `ANALYZE wxyc_schema.compilation_track_artist` runs at the end, outside any transaction (the #934 lesson). Idempotent by construction: every write re-checks the row still holds the captured corrupt value, so a second run against an already-repaired row is a genuine no-op.

## Testing

Since the real pairs aren't captured yet, the verification burden is on the paired integration spec, `tests/integration/bs-replacement-char-cta.spec.js`. It extracts the script's actual mechanism statements (schema-substituted into a throwaway schema that replicates **both** production unique indexes, so "no unique violation is raised" is a real assertion) and exercises:

- a corrupt row WITH a clean twin → DELETE, no unique violation
- a corrupt row WITHOUT a twin → UPDATE to the exact expected string
- a clean row not named in the pending block → untouched
- a decoy row sharing the exact corrupt string under a different artist → untouched (proves the match isn't a loose single-column match)
- NULL-`track_title` corruption, both WITH and WITHOUT a twin (the migration-0099 partial-index path)
- the U+FFFD predicate returning 0 across both columns after a run covering both corruption shapes
- idempotency (second run is a genuine no-op)
- the as-shipped empty pending block (a true no-op)
- every one of the ten operator-error guards, each asserted on its OWN message fragment rather than the shared `BS#2152 guard:` prefix

36/36 tests pass locally against the dev Postgres container (33/33 at round 3; +3 for round 4's Unicode-composition-form fix below). Local checks also run clean: lint (0 errors), format check, typecheck, the full unit suite (7348/7348), and `scripts/check-bulk-update-analyze.mjs --strict`. The three documented `psql -f` paths (read-only `awk` prelude, `COMMIT;`→`ROLLBACK;` dry run, and a real no-op run against the dev DB) all exit 0. (The round-3 landing point also ran the Docker CI mirror `npm run ci:testmock` — 104 suites / 1014 tests, 0 failures; not re-run for round 4.)

## Review rounds

Four review passes landed on top of the original script. The mechanism above is unchanged in shape; what follows is what the reviews found and where each fix is pinned.

**Round 1** moved classification (`build-targets`) inside the transaction, added `guard-capture-sanity` for a transposed capture, `guard-converging-pending` for two pending rows resolving to one post-fix tuple, and `repoint-twin-identity` so the DELETE branch carries the corrupt row's BS#1990 identity link onto the surviving twin instead of discarding it.

**Round 2** added `guard-post-fix-fffd` (a row corrupt in both columns but captured with one replacement), `guard-nfc-form`, made the placeholder scrub conditional on the full all-NULL shape, moved the post-amble residual reads inside the transaction so the documented `COMMIT;`→`ROLLBACK;` dry run works, and corrected the round-1 claim that the race window was closed.

**Round 3** is this latest commit, and its two substantive findings are both concurrency:

- **The write statements could disagree with each other.** Each carried a re-check that made it individually correct, but `repoint-twin-identity` could fire, a concurrent edit land, and `delete-twins` then correctly decline — committing the corrupt row's identity link live on *both* rows at exit 0. Fixed structurally rather than with another re-check: `lock-targets` now takes `SELECT … FOR UPDATE` row locks (ascending id, deadlock-safe) on every classified corrupt row **and** every twin, immediately after `build-targets`. The one remaining window on existing rows is `build-targets`→`lock-targets`, which is exactly what the re-checks defend. A concurrent INSERT of a brand-new twin can't be locked against and stays fail-safe: 23505, whole-transaction rollback, re-run reclassifies.
- **`delete-twins` could destroy the last copy of a credit.** It re-checked only the row it was about to delete, never the twin meant to carry the credit forward. `twin.id = t.twin_id` is a snapshot from classification, so a twin deleted or renamed in the window let the DELETE remove the only remaining row — committing at exit 0 with a per-row residual of **0**, because the residual counts the OLD tuple, which the delete genuinely did remove. Both write statements now re-check the twin still holds the post-fix tuple, and the new `guard-repair-complete` refuses to COMMIT any run where a targeted row still holds its corrupt tuple after the writes. That last guard exists because all three writes skip *silently* by design — correct individually, and what makes a re-run idempotent, but "skipped" and "repaired" produced the same exit code.

Also in round 3: a NULL `current_artist_name` now aborts unconditionally (the test previously sat inside the `true_artist_name IS NOT NULL` branch, so on the 11 track_title-only rows a NULLed artist name passed every guard, matched nothing, and committed as a silent no-op); new `guard-unknown-release` for a `legacy_release_id` matching no `library` row — the one unmatched shape that can never be an idempotent re-run; and the statement timeout is raised to 5min *after* the last write, because the AFTER residual counts are unindexable full-table scans running inside the write transaction, where a cold-cache stall past 30s would roll back a repair that had fully succeeded.

### Enforcement-chain gaps

Two findings were about the PR's own safety machinery rather than the repair:

- `scripts/audit/bs_replacement_char_cta.sql` was **not** in `test.yml`'s `tests` paths-filter. The future PR that pastes the 14 real rows touches only `scripts/audit/`, so the "no quoted string literals" gate — and the deferred byte-assertion it forces whoever pastes them to add — would never have run on the one change it exists to catch. Added alongside its three sibling verbatim-read scripts.
- That gate only rejected single quotes. Dollar quoting (`$$Csillagrablók$$`) is valid PostgreSQL containing zero apostrophes, and is exactly what you reach for to avoid escaping apostrophes in real track titles; traced end to end, real dollar-quoted rows left the entire suite green. Now rejected too.

### Test-suite gaps

- The read-only pre-amble and the post-amble residual reads were never **executed** — the spec only pinned their position with `indexOf`. A typo there passed the whole suite and would then have aborted the real prod run under `ON_ERROR_STOP` *after* the writes and *before* COMMIT. Both are tagged STMT blocks now and run in the exact order `psql -f` would.
- A **typo'd** END marker (unlike a missing one) was silent: the block absorbed its successor's SQL, and that successor then executed twice per run with every name and order assertion still green. The extractor now rejects a block containing a nested start marker.
- No test ran the shipped scrub DELETE with any row but its own placeholder, so reverting it to the unconditional `WHERE legacy_release_id IS NULL` form — the exact round-2 bug — left the suite green.
- The concurrent-edit test hand-inlined the whole block sequence without the helper's catch/ROLLBACK, which could hand an aborted-transaction connection back to the shared `max: 5` pool (postgres-js `release()` issues no ROLLBACK or DISCARD). It uses a `runRepairScript` injection hook now.

**Every round-3 fix was mutation-verified**: reverting it individually fails exactly one test, and the right one — including the two that matter most, where removing `delete-twins`' twin re-check makes the vanished-twin test report a *resolved* promise (i.e. the script commits the data loss at exit 0), and removing `FOR UPDATE` lets a concurrent writer reach both locked rows.

### Doc corrections

The transposed-capture narration claimed residual counts "go UP"; on the DELETE path it describes they stay **flat**, which is also what a successful idempotent re-run prints — the more insidious signal, not the milder one. The ETL's `.onConflictDoNothing()` is untargeted, and that is load-bearing: an arbiter on `cta_unique_idx` would not cover the NULL-`track_title` partial index, which is where 3 of the 14 rows live. The pending columns are not 1:1 with the enumeration query, which leads with `cta.library_id`. Added the two triggers that fire on these writes — the 0138/0143 catalog-export watermark (desirable; the repoint deliberately doesn't advance it, per 0143's `UPDATE OF` list) and 0046's row-level CDC notify (delivered at COMMIT, so consumers see one burst and the ROLLBACK dry run emits nothing). And `fetchLegacyCompilationTracks` is documented as the **preferred** capture channel: it passes `--default-character-set=utf8` structurally, is already keyed on `LIBRARY_RELEASE_ID`, and is the same reader whose output the post-#454 ETL wrote into the live column — so its values land in the trim/whitespace regime the byte-exact predicates compare against. Nothing in the script verifies a `true_*` value against tubafrenzy, which is now stated outright rather than left implicit.

### Round 4: Unicode composition-form defect

`guard-nfc-form` pins every captured `true_*` replacement to NFC, but a LIVE row carries no such invariant — this table has no fold trigger the way `artists` does (`fold_artist_name`, migration 0134) — so a genuinely NFD-stored clean twin is possible. The twin join compared bytes exactly, so an NFD twin against an NFC capture missed: the row classified no-twin, `update-no-twins` wrote the NFC value, and the table ended up holding two rows for one credit differing only in composition form — invisible to `cta_unique_idx` (the bytes genuinely differ) and to the postlude's U+FFFD residual, which correctly read 0/0, because the corruption really was gone; what was left behind was a duplicate, not a U+FFFD.

Fix: `build-targets`' twin join, and the matching re-checks in `delete-twins` and `repoint-twin-identity`, now compare `normalize(x, NFC)` rather than raw bytes. Detection widens; writes stay byte-exact — the three write statements still write the captured strings verbatim, never a normalized form. `guard-converging-pending`'s GROUP BY folds too: two pending rows can converge on one credit via the same form mismatch through their untouched COALESCE column, with no `true_*` value even involved in the mismatch. A new tenth guard, `guard-post-write-nfc-duplicate`, is the belt-and-braces half — after the writes, it asserts no two rows within a library_id this run touched are NFC-equal but byte-distinct, catching the class rather than just the one path the join fix closes. `normalize()` never lands in the full-table BEFORE/AFTER residual scans, which stay a plain `LIKE E'%�%'`.

Classification-semantics widening, called out deliberately rather than left for a reader to discover: an NFC-folded twin match now takes the DELETE branch in cases where no `cta_unique_idx` violation would ever have fired pre-fix. That is correct, not incidental — the corrupt row is removed, the NFD clean twin survives as the sole copy, the credit's identity link repoints onto it, and no duplicate is created.

All five round-4 changes were mutation-verified: reverting each individually fails exactly one test, and the right one. Reverting the twin join or either write-statement re-check is caught by the NFD-twin regression test (via the new belt-and-braces guard, `guard-repair-complete`, or a silently-unrepointed identity link, depending on which piece is reverted); reverting `guard-converging-pending`'s fold is caught by its own dedicated convergence test (distinguished from the belt-and-braces guard by asserting on the guard-specific message); reverting `guard-post-write-nfc-duplicate` is caught by its own dedicated test.

## This PR does not repair prod

Per #2152's own framing (and the mistake #2153 exists to fix): merging this PR does not touch a single production row. The follow-up steps, still to be done:

1. Run the capture procedure in the script header against prod to get the 14 real `(legacy_release_id, track_position, current value, true value)` tuples.
2. Fill in the PENDING CAPTURE block, human-review it.
3. Run the script against prod RDS via `psql -f`, and paste the postlude output onto #2152.

Closing #2152 requires that run + its recorded output — not this merge.

