### PR TITLE
Add a library-code resolution endpoint (BS#2149)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1965,9 +1965,10 @@ paths:
         code. The triple is not unique — the Various-Artists shelf files many distinct buckets
         (`Soundtracks - A`, `Soundtracks - B`, …) under one `V/A` code — so the response is
         always a list, ordered by `artist_name` then `id`. A code with a single owner returns a
-        one-element array. `code_letters` is trimmed and upper-cased before matching.
+        one-element array. `code_letters` must be 1-4 characters from A-Z, 0-9, or `/` (the
+        `artists.code_letters` column domain); it is trimmed and upper-cased before matching.
       security:
-        - BearerAuth: ['station-management']
+        - BearerAuth: ['catalog-read']
       parameters:
         - in: query
           name: genre_id
@@ -1981,6 +1982,7 @@ paths:
           required: true
           schema:
             type: string
+            pattern: '^[A-Za-z0-9/]{1,4}$'
         - in: query
           name: code_number
           required: true

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1957,6 +1957,53 @@ paths:
         '200':
           description: Next available artist code number
 
+  /library/artists/by-code:
+    get:
+      summary: Resolve a fully-specified library code to its owning artist
+      security:
+        - BearerAuth: ['station-management']
+      parameters:
+        - in: query
+          name: genre_id
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: code_letters
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: code_number
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The artist that owns this code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  artist:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      artist_name:
+                        type: string
+                      code_letters:
+                        type: string
+                      code_number:
+                        type: integer
+                      genre_id:
+                        type: integer
+        '400':
+          description: Invalid or missing genre_id, code_letters, or code_number
+        '404':
+          description: Genre not found, or the code is not assigned in that genre
+
   /library/formats:
     get:
       summary: Get format list

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1959,7 +1959,13 @@ paths:
 
   /library/artists/by-code:
     get:
-      summary: Resolve a fully-specified library code to its owning artist
+      summary: Resolve a fully-specified library code to the artists that own it
+      description: >-
+        Resolves `genre_id` + `code_letters` + `code_number` to every artist filed under that
+        code. The triple is not unique — the Various-Artists shelf files many distinct buckets
+        (`Soundtracks - A`, `Soundtracks - B`, …) under one `V/A` code — so the response is
+        always a list, ordered by `artist_name` then `id`. A code with a single owner returns a
+        one-element array. `code_letters` is trimmed and upper-cased before matching.
       security:
         - BearerAuth: ['station-management']
       parameters:
@@ -1968,6 +1974,8 @@ paths:
           required: true
           schema:
             type: integer
+            minimum: 1
+            maximum: 2147483647
         - in: query
           name: code_letters
           required: true
@@ -1976,33 +1984,64 @@ paths:
         - in: query
           name: code_number
           required: true
+          description: >-
+            Accepts 0 — the Various-Artists filings are stored with an artist genre code of 0.
           schema:
             type: integer
+            minimum: 0
+            maximum: 2147483647
       responses:
         '200':
-          description: The artist that owns this code
+          description: The artists that own this code, ordered by artist_name then id
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  artist:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                      artist_name:
-                        type: string
-                      code_letters:
-                        type: string
-                      code_number:
-                        type: integer
-                      genre_id:
-                        type: integer
+                  artists:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        artist_name:
+                          type: string
+                        code_letters:
+                          type: string
+                        code_number:
+                          type: integer
+                        genre_id:
+                          type: integer
         '400':
           description: Invalid or missing genre_id, code_letters, or code_number
         '404':
-          description: Genre not found, or the code is not assigned in that genre
+          description: >-
+            Two distinct outcomes, told apart by `reason`, never by the message text.
+            `genre_not_found` — no genre has that `genre_id`, so the client's genre list is
+            stale and the code was never evaluated. `code_not_assigned` — the genre exists and
+            the code is free within it, so it is safe to create an artist under it.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                    enum: [genre_not_found, code_not_assigned]
+              examples:
+                genre_not_found:
+                  summary: Unknown genre_id
+                  value:
+                    message: Genre not found
+                    reason: genre_not_found
+                code_not_assigned:
+                  summary: Known genre, unassigned code
+                  value:
+                    message: Artist code not assigned in that genre
+                    reason: code_not_assigned
 
   /library/formats:
     get:

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1982,7 +1982,7 @@ paths:
           required: true
           schema:
             type: string
-            pattern: '^[A-Za-z0-9/]{1,4}$'
+            pattern: '^\s*[A-Za-z0-9/]{1,4}\s*$'
         - in: query
           name: code_number
           required: true
@@ -2022,7 +2022,17 @@ paths:
             Two distinct outcomes, told apart by `reason`, never by the message text.
             `genre_not_found` — no genre has that `genre_id`, so the client's genre list is
             stale and the code was never evaluated. `code_not_assigned` — the genre exists and
-            the code is free within it, so it is safe to create an artist under it.
+            no artist is filed under that exact code.
+
+            `code_not_assigned` is NOT a guarantee that creating an artist under the code is
+            safe. This lookup upper-cases `code_letters` before matching, but `artists.code_letters`
+            is a plain `varchar(4)` with byte-exact equality and neither writer canonicalizes:
+            `insertArtist` only NFC-normalizes, and the tubafrenzy `library-etl` job writes its
+            source value verbatim. So a lower-case row filed under the same shelf code is
+            invisible here — and `POST /library/artists`, whose own conflict pre-check also
+            compares raw, will happily create one. Every row in the production catalog is
+            canonical today, so this is an open path rather than existing data; canonicalizing
+            on write (plus a backfill) is the real fix and is tracked separately.
           content:
             application/json:
               schema:

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -149,12 +149,6 @@ export const MAX_RANGE_MS = 8 * 24 * 60 * 60 * 1000;
 // `INT4_MAX` (imported above), for a different overflow.
 const MIN_EPOCH_MS = -62167219200000; // 0000-01-01T00:00:00.000Z
 const MAX_EPOCH_MS = 253402300799999; // 9999-12-31T23:59:59.999Z
-// flowsheet.id is a Postgres int4 column; a value outside this range parses
-// fine as a JS integer (passing Number.isInteger) but blows up downstream as
-// an unhandled "value out of range for type integer" Postgres error (BS#1800).
-// `INT4_MAX` itself now lives in `utils/constants.ts` (imported above) so
-// `library.controller.ts`'s `by-code` route can share this exact guard
-// instead of re-declaring it -- see that file's BS#2149 usage.
 // BS#1960 cost/DoS guard on `page * limit` (the OFFSET passed to
 // getEntriesByPage). This is not a correctness bound — it's a ceiling on how
 // much index-scanning a single request can ask for. A genuine deep-history

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -12,6 +12,7 @@ import { projectFlowsheetEntry, toDiscogsUnavailableWireFields } from '../utils/
 import { getDiscogsUnavailableFlagsById } from '../services/library.service.js';
 import { stashMirrorData } from '../middleware/legacy/mirror.middleware.js';
 import WxycError from '../utils/error.js';
+import { INT4_MAX } from '../utils/constants.js';
 
 export type QueryParams = {
   page?: string;
@@ -145,13 +146,15 @@ export const MAX_RANGE_MS = 8 * 24 * 60 * 60 * 1000;
 // exact instants where `toISOString()` flips form (verified: MIN-1 renders
 // `-000001-…`, MAX+1 renders `+010000-…`), which is ~34x tighter than the Date
 // range and still far wider than any flowsheet window. Same class of guard as
-// INT4_MAX below, for a different overflow.
+// `INT4_MAX` (imported above), for a different overflow.
 const MIN_EPOCH_MS = -62167219200000; // 0000-01-01T00:00:00.000Z
 const MAX_EPOCH_MS = 253402300799999; // 9999-12-31T23:59:59.999Z
 // flowsheet.id is a Postgres int4 column; a value outside this range parses
 // fine as a JS integer (passing Number.isInteger) but blows up downstream as
 // an unhandled "value out of range for type integer" Postgres error (BS#1800).
-const INT4_MAX = 2147483647;
+// `INT4_MAX` itself now lives in `utils/constants.ts` (imported above) so
+// `library.controller.ts`'s `by-code` route can share this exact guard
+// instead of re-declaring it -- see that file's BS#2149 usage.
 // BS#1960 cost/DoS guard on `page * limit` (the OFFSET passed to
 // getEntriesByPage). This is not a correctness bound — it's a ceiling on how
 // much index-scanning a single request can ask for. A genuine deep-history

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -479,10 +479,12 @@ const parseCodeQueryInt = (raw: string | undefined, name: string, min: number): 
   if (typeof raw !== 'string') {
     throw new WxycError(`Invalid ${name}: must be a single value`, 400);
   }
-  if (raw.trim() === '') {
-    throw new WxycError(`Invalid ${name}: must be an integer between ${min} and ${INT4_MAX}`, 400);
-  }
-  const value = Number(raw);
+  // Blank folds into the range check rather than throwing the identical
+  // message from its own branch: `Number('')` and `Number(' ')` are both 0,
+  // which would sail through `Number.isInteger` as a legitimate zero now that
+  // 0 is a valid `code_number`. Coercing blank to NaN first makes one
+  // comparison cover both cases.
+  const value = raw.trim() === '' ? NaN : Number(raw);
   if (!Number.isInteger(value) || value < min || value > INT4_MAX) {
     throw new WxycError(`Invalid ${name}: must be an integer between ${min} and ${INT4_MAX}`, 400);
   }
@@ -614,8 +616,6 @@ export const resolveArtistByCode: RequestHandler = async (
     artists: owners.map((owner) => ({
       id: owner.artist_id,
       artist_name: owner.artist_name,
-      // Echoes the row's own `code_letters`, not the locally normalized
-      // `codeLetters` variable used to query it.
       code_letters: owner.code_letters,
       code_number: codeNumber,
       genre_id: genreId,

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -499,12 +499,13 @@ const parseCodeQueryInt = (raw: string | undefined, name: string, min: number): 
  * one arbitrary row out of 27. A single owner is simply a one-element array.
  *
  * `code_number` accepts **0**: the whole Various-Artists surface is filed at
- * `artist_genre_code = 0` (68 rows in the production clone, all `code_letters =
- * 'V/A'`), and neither sibling route imposes a floor — `addArtist` passes the
- * value straight through and `peekArtistNumber` uses `Number.isFinite`. A `< 1`
- * floor here would have made the one filing class that most needs code-first
- * resolution (compilations have no artist name to search by) the one class this
- * route could not answer.
+ * `artist_genre_code = 0` — 68 such rows in the production clone, 66 of them
+ * `code_letters = 'V/A'` and the other two a `VA`-spelled "V/A" and an `UNK`
+ * "Unknown", both in genre 6. Neither sibling route imposes a floor: `addArtist`
+ * passes the value straight through and `peekArtistNumber` uses
+ * `Number.isFinite`. A `< 1` floor here made the one filing class that most
+ * needs code-first resolution (compilations have no artist name to search by)
+ * the one class this route could not answer.
  *
  * Two 404s, discriminated by `reason` rather than by prose the way `addArtist`
  * above discriminates its two 409s: `genre_not_found` means the client's genre

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -445,6 +445,62 @@ export const peekArtistNumber: RequestHandler = async (
   res.status(200).json({ next_code_number: nextCode });
 };
 
+type ArtistByCodeQuery = {
+  genre_id?: string;
+  code_letters?: string;
+  code_number?: string;
+};
+
+/**
+ * BS#2149: resolves a fully-specified library code to its owning artist --
+ * the `/wxycdb` "does this code already exist, and whose is it" question
+ * `peek-code` (next-free-number) and `search` (name query) cannot answer.
+ * `getArtistByCode` already backs `addArtist`'s code-conflict pre-check
+ * (BS#792-era), so this reuses that lookup rather than duplicating the query.
+ *
+ * An unknown `genre_id` and an unassigned code are distinct 404s (mirrors
+ * `searchArtistsInGenre`'s precedent below): the former means the client's
+ * genre dropdown is stale, the latter means the code is free to create.
+ */
+export const resolveArtistByCode: RequestHandler = async (
+  req: Request<object, object, object, ArtistByCodeQuery>,
+  res
+) => {
+  const { query } = req;
+  if (!query.genre_id || !query.code_letters || !query.code_number) {
+    throw new WxycError('Missing query parameters: genre_id, code_letters, and code_number', 400);
+  }
+
+  const genreId = Number(query.genre_id);
+  if (!Number.isInteger(genreId) || genreId < 1) {
+    throw new WxycError('Invalid genre_id: must be a positive integer', 400);
+  }
+
+  const codeNumber = Number(query.code_number);
+  if (!Number.isInteger(codeNumber) || codeNumber < 1) {
+    throw new WxycError('Invalid code_number: must be a positive integer', 400);
+  }
+
+  if (!(await libraryService.genreExists(genreId))) {
+    throw new WxycError('Genre not found', 404);
+  }
+
+  const artist = await libraryService.getArtistByCode(query.code_letters, genreId, codeNumber);
+  if (!artist) {
+    throw new WxycError('Artist code not assigned in that genre', 404);
+  }
+
+  res.status(200).json({
+    artist: {
+      id: artist.artist_id,
+      artist_name: artist.artist_name,
+      code_letters: artist.code_letters,
+      code_number: codeNumber,
+      genre_id: genreId,
+    },
+  });
+};
+
 export const getRotation: RequestHandler = async (req, res) => {
   const rotation = await libraryService.getRotationFromDB();
   res.status(200).json(rotation);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -25,6 +25,15 @@ import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import { getPostHogClient } from '../utils/posthog.js';
 import WxycError from '../utils/error.js';
 
+// `genres.id` and `genre_artist_crossreference.artist_genre_code` are Postgres
+// int4 columns. A query value outside that range parses fine as a JS integer
+// (passing `Number.isInteger`) but blows up downstream as an unhandled
+// "value out of range for type integer" Postgres error — SQLSTATE 22003, which
+// is not a `WxycError` and so answers a generic 500 plus a Sentry capture.
+// Same constant and same guard as `flowsheet.controller.ts` (BS#1800), which
+// hit this first on `start_id`/`end_id`.
+const INT4_MAX = 2147483647;
+
 // BS#1826 PR 2: `LIBRARY_LML_BUDGET_MS` retired. Budget for the add-album
 // insert + fire-and-forget canonical-entity paths now comes from the
 // per-caller policy layer (`@wxyc/lml-client` `policy.ts`) — `library-add-
@@ -452,61 +461,124 @@ type ArtistByCodeQuery = {
 };
 
 /**
- * BS#2149: resolves a fully-specified library code to its owning artist --
+ * Parses one required integer query parameter for `resolveArtistByCode`,
+ * bounded on both ends. The upper bound is the int4 guard described at
+ * `INT4_MAX`; the lower bound differs per parameter, so it is passed in.
+ *
+ * `Number('')` is 0 and `Number(' ')` is 0, so a present-but-empty parameter
+ * (`?code_number=`) would sail through `Number.isInteger` as a legitimate
+ * zero — which matters now that 0 is a valid `code_number`. Hence the explicit
+ * blank check before the numeric one.
+ */
+const parseCodeQueryInt = (raw: string | undefined, name: string, min: number): number => {
+  // Express's `simple` query parser yields string[] for repeated keys
+  // (`?genre_id=1&genre_id=2`), which `Number()` would collapse to NaN with a
+  // misleading message; name the real problem instead.
+  if (typeof raw !== 'string') {
+    throw new WxycError(`Invalid ${name}: must be a single value`, 400);
+  }
+  if (raw.trim() === '') {
+    throw new WxycError(`Invalid ${name}: must be an integer between ${min} and ${INT4_MAX}`, 400);
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > INT4_MAX) {
+    throw new WxycError(`Invalid ${name}: must be an integer between ${min} and ${INT4_MAX}`, 400);
+  }
+  return value;
+};
+
+/**
+ * BS#2149: resolves a fully-specified library code to the artists that own it --
  * the `/wxycdb` "does this code already exist, and whose is it" question
  * `peek-code` (next-free-number) and `search` (name query) cannot answer.
- * `getArtistByCode` already backs `addArtist`'s code-conflict pre-check
- * (BS#792-era), so this reuses that lookup rather than duplicating the query.
  *
- * An unknown `genre_id` and an unassigned code are distinct 404s (mirrors
- * `searchArtistsInGenre`'s precedent below): the former means the client's
- * genre dropdown is stale, the latter means the code is free to create.
+ * Answers a LIST, not a single artist. The `(code_letters, genre_id,
+ * code_number)` triple is not unique — see `getArtistsByCode` for the schema
+ * reason and the measured V/A collisions — so a librarian holding a compilation
+ * card gets every bucket that shares the code and picks, rather than being handed
+ * one arbitrary row out of 27. A single owner is simply a one-element array.
+ *
+ * `code_number` accepts **0**: the whole Various-Artists surface is filed at
+ * `artist_genre_code = 0` (68 rows in the production clone, all `code_letters =
+ * 'V/A'`), and neither sibling route imposes a floor — `addArtist` passes the
+ * value straight through and `peekArtistNumber` uses `Number.isFinite`. A `< 1`
+ * floor here would have made the one filing class that most needs code-first
+ * resolution (compilations have no artist name to search by) the one class this
+ * route could not answer.
+ *
+ * Two 404s, discriminated by `reason` rather than by prose the way `addArtist`
+ * above discriminates its two 409s: `genre_not_found` means the client's genre
+ * dropdown is stale, `code_not_assigned` means the code is free to create. A
+ * client that has to string-match `message` to tell those apart cannot act on
+ * either.
  */
 export const resolveArtistByCode: RequestHandler = async (
   req: Request<object, object, object, ArtistByCodeQuery>,
   res
 ) => {
   const { query } = req;
-  if (!query.genre_id || !query.code_letters || !query.code_number) {
-    throw new WxycError('Missing query parameters: genre_id, code_letters, and code_number', 400);
+  // Name only the parameters actually missing. A fixed string listing all three
+  // would satisfy any "the error mentions code_number" assertion even when the
+  // handler refused on a different parameter, which is exactly the blind spot
+  // the BS#2149 review found in this route's first test.
+  const missing = (['genre_id', 'code_letters', 'code_number'] as const).filter((name) => query[name] === undefined);
+  if (missing.length > 0) {
+    throw new WxycError(`Missing query parameters: ${missing.join(', ')}`, 400);
   }
 
-  // Express's `simple` query parser yields string[] for repeated keys
-  // (`?code_letters=B&code_letters=U`); reject before it reaches Drizzle's
-  // `eq(artists.code_letters, ...)`, which would otherwise bind a text[]
-  // against a text column and surface as a driver-level 500 instead of a 400
-  // (mirrors the same guard on `q` in searchArtistsInGenre above).
+  // The `string[]` guard here is the one `searchArtistsInGenre` applies to `q`:
+  // without it, `?code_letters=B&code_letters=U` binds a text[] against Drizzle's
+  // `eq(artists.code_letters, ...)` text column and surfaces as a driver-level
+  // 500 instead of a 400.
   if (typeof query.code_letters !== 'string') {
     throw new WxycError('Invalid code_letters: must be a single string value', 400);
   }
 
-  const genreId = Number(query.genre_id);
-  if (!Number.isInteger(genreId) || genreId < 1) {
-    throw new WxycError('Invalid genre_id: must be a positive integer', 400);
+  const genreId = parseCodeQueryInt(query.genre_id, 'genre_id', 1);
+  // Lower bound 0, not 1 — see the V/A note in this function's doc comment.
+  const codeNumber = parseCodeQueryInt(query.code_number, 'code_number', 0);
+
+  // Trim + upper-case before matching. `artists.code_letters` is matched
+  // byte-for-byte by the query below, and every one of the 24,078 artist rows in
+  // the production clone stores a trimmed, upper-case value — so normalizing can
+  // never turn a real hit into a miss, while NOT normalizing lets ` BU ` or `bu`
+  // answer the "this code is free" 404 and invite the librarian to mint a
+  // duplicate shelf code. (The sibling write path, `addArtist`, still compares
+  // raw; widening its pre-check is a separate change, deliberately not made here
+  // because it alters an existing route's 409 behavior.)
+  const codeLetters = query.code_letters.trim().toUpperCase();
+  if (codeLetters === '') {
+    throw new WxycError('Invalid code_letters: must be a non-empty string', 400);
   }
 
-  const codeNumber = Number(query.code_number);
-  if (!Number.isInteger(codeNumber) || codeNumber < 1) {
-    throw new WxycError('Invalid code_number: must be a positive integer', 400);
-  }
+  // Code lookup FIRST, genre check only to explain a miss: a hit proves the genre
+  // exists (the lookup inner-joins `genre_artist_crossreference.genre_id`), so
+  // probing `genreExists` up front would double the round-trips on every happy
+  // path to discriminate a 404 that isn't happening.
+  const owners = await libraryService.getArtistsByCode(codeLetters, genreId, codeNumber);
 
-  if (!(await libraryService.genreExists(genreId))) {
-    throw new WxycError('Genre not found', 404);
-  }
-
-  const artist = await libraryService.getArtistByCode(query.code_letters, genreId, codeNumber);
-  if (!artist) {
-    throw new WxycError('Artist code not assigned in that genre', 404);
+  if (owners.length === 0) {
+    if (!(await libraryService.genreExists(genreId))) {
+      res.status(404).json({ message: 'Genre not found', reason: 'genre_not_found' });
+      return;
+    }
+    res.status(404).json({
+      message: 'Artist code not assigned in that genre',
+      reason: 'code_not_assigned',
+    });
+    return;
   }
 
   res.status(200).json({
-    artist: {
-      id: artist.artist_id,
-      artist_name: artist.artist_name,
-      code_letters: artist.code_letters,
+    artists: owners.map((owner) => ({
+      id: owner.artist_id,
+      artist_name: owner.artist_name,
+      // The stored `code_letters`, not the normalized input: the row is the
+      // truth about how this code is filed.
+      code_letters: owner.code_letters,
       code_number: codeNumber,
       genre_id: genreId,
-    },
+    })),
   });
 };
 

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -471,6 +471,15 @@ export const resolveArtistByCode: RequestHandler = async (
     throw new WxycError('Missing query parameters: genre_id, code_letters, and code_number', 400);
   }
 
+  // Express's `simple` query parser yields string[] for repeated keys
+  // (`?code_letters=B&code_letters=U`); reject before it reaches Drizzle's
+  // `eq(artists.code_letters, ...)`, which would otherwise bind a text[]
+  // against a text column and surface as a driver-level 500 instead of a 400
+  // (mirrors the same guard on `q` in searchArtistsInGenre above).
+  if (typeof query.code_letters !== 'string') {
+    throw new WxycError('Invalid code_letters: must be a single string value', 400);
+  }
+
   const genreId = Number(query.genre_id);
   if (!Number.isInteger(genreId) || genreId < 1) {
     throw new WxycError('Invalid genre_id: must be a positive integer', 400);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -24,15 +24,17 @@ import { lmlLookupCoordinator } from '../services/lml/index.js';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import { getPostHogClient } from '../utils/posthog.js';
 import WxycError from '../utils/error.js';
+import { INT4_MAX } from '../utils/constants.js';
 
 // `genres.id` and `genre_artist_crossreference.artist_genre_code` are Postgres
 // int4 columns. A query value outside that range parses fine as a JS integer
 // (passing `Number.isInteger`) but blows up downstream as an unhandled
 // "value out of range for type integer" Postgres error — SQLSTATE 22003, which
 // is not a `WxycError` and so answers a generic 500 plus a Sentry capture.
-// Same constant and same guard as `flowsheet.controller.ts` (BS#1800), which
-// hit this first on `start_id`/`end_id`.
-const INT4_MAX = 2147483647;
+// `INT4_MAX` lives in `utils/constants.ts` and is imported, not re-declared --
+// `flowsheet.controller.ts` (BS#1800) hit this first on `start_id`/`end_id`
+// and owned the only copy until the BS#2149 review found this file had grown
+// a silently-drifting second one.
 
 // BS#1826 PR 2: `LIBRARY_LML_BUDGET_MS` retired. Budget for the add-album
 // insert + fire-and-forget canonical-entity paths now comes from the
@@ -488,6 +490,49 @@ const parseCodeQueryInt = (raw: string | undefined, name: string, min: number): 
 };
 
 /**
+ * `artists.code_letters` is a Postgres `varchar(4)` column (`shared/database/
+ * src/schema.ts:439`) storing a trimmed, upper-case, ASCII value -- every one
+ * of the 24,078 rows in the production clone matches that shape, with `/` the
+ * only non-alphanumeric character in use (the `V/A` filing). Neither writer
+ * enforces that shape, though: `insertArtist` (`library.service.ts`) only
+ * NFC-normalizes -- no trim, no upper-case -- and the tubafrenzy `library-etl`
+ * job writes `codeLetters ?? '??'` verbatim (`jobs/library-etl/job.ts:441`),
+ * so a row filed non-canonically can already be sitting in the table.
+ *
+ * `.trim().toUpperCase()` is not a safe repair for that gap: it is neither
+ * length- nor charset-preserving for non-ASCII input
+ * (`'ß'.toUpperCase() === 'SS'`, `'ı'.toUpperCase() === 'I'`), so silently
+ * folding an out-of-domain value could match a DIFFERENT real artist's shelf
+ * code with no precondition that the input was canonical to begin with. (An
+ * earlier version of this comment claimed normalizing "can never turn a real
+ * hit into a miss" -- true only of the measured production snapshot, not of
+ * every possible input, which is exactly the gap this validation closes.)
+ *
+ * Reject anything outside the column's real domain instead: ASCII letters,
+ * digits, or `/`, 1-4 characters. A 5+ character value can never match a row
+ * either (BS#2149 review finding 2) -- unvalidated, it used to fall through
+ * to the 404 branch, whose own docs called that "safe to create an artist
+ * under it," right up until `insertArtist`'s `varchar(4)` column threw
+ * SQLSTATE 22001 on the follow-up write and this route's sibling inherited a
+ * generic 500 plus a Sentry event. Restricted to this input charset,
+ * `.toUpperCase()` is always a deterministic, length- and charset-preserving
+ * map (`a`-`z` -> `A`-`Z`; digits and `/` are fixed points), so the fold
+ * hazard above cannot occur once this check has passed.
+ */
+const CANONICAL_CODE_LETTERS_PATTERN = /^[A-Za-z0-9/]{1,4}$/;
+
+const validateCanonicalCodeLetters = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!CANONICAL_CODE_LETTERS_PATTERN.test(trimmed)) {
+    throw new WxycError(
+      "Invalid code_letters: must be 1-4 characters from A-Z, 0-9, or '/' (artists.code_letters is varchar(4))",
+      400
+    );
+  }
+  return trimmed.toUpperCase();
+};
+
+/**
  * BS#2149: resolves a fully-specified library code to the artists that own it --
  * the `/wxycdb` "does this code already exist, and whose is it" question
  * `peek-code` (next-free-number) and `search` (name query) cannot answer.
@@ -539,18 +584,13 @@ export const resolveArtistByCode: RequestHandler = async (
   // Lower bound 0, not 1 — see the V/A note in this function's doc comment.
   const codeNumber = parseCodeQueryInt(query.code_number, 'code_number', 0);
 
-  // Trim + upper-case before matching. `artists.code_letters` is matched
-  // byte-for-byte by the query below, and every one of the 24,078 artist rows in
-  // the production clone stores a trimmed, upper-case value — so normalizing can
-  // never turn a real hit into a miss, while NOT normalizing lets ` BU ` or `bu`
-  // answer the "this code is free" 404 and invite the librarian to mint a
-  // duplicate shelf code. (The sibling write path, `addArtist`, still compares
-  // raw; widening its pre-check is a separate change, deliberately not made here
-  // because it alters an existing route's 409 behavior.)
-  const codeLetters = query.code_letters.trim().toUpperCase();
-  if (codeLetters === '') {
-    throw new WxycError('Invalid code_letters: must be a non-empty string', 400);
-  }
+  // Validate against the column's real domain, then trim + upper-case -- see
+  // `validateCanonicalCodeLetters` above for why a bare `.trim().toUpperCase()`
+  // is not a safe normalization on its own. (The sibling write path,
+  // `addArtist`, still compares raw; widening its pre-check is a separate
+  // change, deliberately not made here because it alters an existing route's
+  // 409 behavior.)
+  const codeLetters = validateCanonicalCodeLetters(query.code_letters);
 
   // Code lookup FIRST, genre check only to explain a miss: a hit proves the genre
   // exists (the lookup inner-joins `genre_artist_crossreference.genre_id`), so
@@ -574,8 +614,8 @@ export const resolveArtistByCode: RequestHandler = async (
     artists: owners.map((owner) => ({
       id: owner.artist_id,
       artist_name: owner.artist_name,
-      // The stored `code_letters`, not the normalized input: the row is the
-      // truth about how this code is filed.
+      // Echoes the row's own `code_letters`, not the locally normalized
+      // `codeLetters` variable used to query it.
       code_letters: owner.code_letters,
       code_number: codeNumber,
       genre_id: genreId,

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -137,9 +137,10 @@ library_route.get(
 library_route.get('/artists/peek-code', requirePermissions({ catalog: ['write'] }), libraryController.peekArtistNumber);
 
 // BS#2149: resolves a fully-specified code (genre_id + code_letters +
-// code_number) to its owning artist -- the /wxycdb "find" half of the JSP
+// code_number) to the artists that own it -- the /wxycdb "find" half of the JSP
 // code-lookup flow that `peek-code` (a "next free number" create helper)
-// cannot answer. Same `catalog: ['write']` tier as the two routes above:
+// cannot answer. Answers a list because the code triple is not unique; see
+// `getArtistsByCode`. Same `catalog: ['write']` tier as the two routes above:
 // though this is a pure read, it serves the same librarian-only surface, and
 // widening the tier for one of three siblings would be an inconsistency, not
 // a simplification. Registered in this same `/artists/*` block, ahead of

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -136,6 +136,22 @@ library_route.get(
 
 library_route.get('/artists/peek-code', requirePermissions({ catalog: ['write'] }), libraryController.peekArtistNumber);
 
+// BS#2149: resolves a fully-specified code (genre_id + code_letters +
+// code_number) to its owning artist -- the /wxycdb "find" half of the JSP
+// code-lookup flow that `peek-code` (a "next free number" create helper)
+// cannot answer. Same `catalog: ['write']` tier as the two routes above:
+// though this is a pure read, it serves the same librarian-only surface, and
+// widening the tier for one of three siblings would be an inconsistency, not
+// a simplification. Registered in this same `/artists/*` block, ahead of
+// where WXYC/Backend-Service#2156 adds a parameterized `/artists/:id` route,
+// so Express's path matching can't swallow it -- keep it here if that route
+// is ever reordered.
+library_route.get(
+  '/artists/by-code',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.resolveArtistByCode
+);
+
 library_route.get('/formats', requirePermissions({ catalog: ['read'] }), libraryController.getFormats);
 
 library_route.post('/formats', requirePermissions({ catalog: ['write'] }), libraryController.addFormat);

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -140,18 +140,28 @@ library_route.get('/artists/peek-code', requirePermissions({ catalog: ['write'] 
 // code_number) to the artists that own it -- the /wxycdb "find" half of the JSP
 // code-lookup flow that `peek-code` (a "next free number" create helper)
 // cannot answer. Answers a list because the code triple is not unique; see
-// `getArtistsByCode`. Same `catalog: ['write']` tier as the two routes above:
-// though this is a pure read, it serves the same librarian-only surface, and
-// widening the tier for one of three siblings would be an inconsistency, not
-// a simplification. Registered in this same `/artists/*` block, ahead of
-// where WXYC/Backend-Service#2156 adds a parameterized `/artists/:id` route,
-// so Express's path matching can't swallow it -- keep it here if that route
-// is ever reordered.
-library_route.get(
-  '/artists/by-code',
-  requirePermissions({ catalog: ['write'] }),
-  libraryController.resolveArtistByCode
-);
+// `getArtistsByCode`.
+//
+// `catalog: ['read']`, NOT `catalog: ['write']` like the two create-flow
+// helpers above (BS#2149 review finding 3). Shelf-code data is already
+// DJ-readable on two live endpoints: `GET /library/query` returns
+// `code_letters`/`code_number`/`code_artist_number` at `catalog: ['read']`
+// (`library-search.service.ts`), and `GET /djs/bin` returns the same at
+// `bin: ['read']` (`djs.service.ts`). A DJ needs the call number to pull a
+// record, and this route returns strictly LESS than `/library/query` already
+// does, so widening it leaks nothing. (An earlier version of this comment
+// argued the opposite -- that widening the tier for one of three siblings
+// would be an inconsistency. That's now falsified the other way: sibling PR
+// #2162 lands `catalog: ['read']` on `GET /artists/:id` and
+// `GET /artists/:id/releases`, so `write` here would be the inconsistency.)
+// `search` and `peek-code` stay at `catalog: ['write']` -- they back the
+// create-artist flow, not a plain lookup.
+//
+// Registered in this same `/artists/*` block, ahead of where
+// WXYC/Backend-Service#2156 adds a parameterized `/artists/:id` route, so
+// Express's path matching can't swallow it -- keep it here if that route is
+// ever reordered.
+library_route.get('/artists/by-code', requirePermissions({ catalog: ['read'] }), libraryController.resolveArtistByCode);
 
 library_route.get('/formats', requirePermissions({ catalog: ['read'] }), libraryController.getFormats);
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2100,12 +2100,29 @@ export const insertArtistGenreCrossreference = async (
  * fine here, because the caller only needs *an* owner to name in its 409. A
  * route whose contract is "who owns this code" must use the plural instead.
  */
-export const getArtistByCode = async (
-  code_letters: string,
-  genre_id: number,
-  artist_genre_code: number
-): Promise<{ artist_id: number; artist_name: string; code_letters: string } | null> => {
-  const response = await db
+/**
+ * The `{ artist_id, artist_name, code_letters }` shape every code-owner lookup
+ * answers in: `getArtistByCode`'s 409 conflict payload, `getArtistsByCode`'s
+ * full owner list, and `getArtistById`. Named so the three cannot drift apart
+ * silently — it is now the wire shape of a public endpoint, not just an
+ * internal conflict payload.
+ */
+export type ArtistCodeOwner = {
+  artist_id: number;
+  artist_name: string;
+  code_letters: string;
+};
+
+/**
+ * The shared body of the two code-owner lookups. They differ only in the tail
+ * (`.limit(1)` for the conflict probe, `.orderBy(...)` for the full list), so
+ * the projection and the three-clause join predicate live here — a change to
+ * either (filtering soft-deleted artists, say) can no longer land on one and
+ * miss the other, leaving the 409 pre-check and the lookup disagreeing about
+ * who owns a code.
+ */
+const artistCodeOwnerQuery = (code_letters: string, genre_id: number, artist_genre_code: number) =>
+  db
     .select({
       artist_id: genre_artist_crossreference.artist_id,
       artist_name: artists.artist_name,
@@ -2119,8 +2136,14 @@ export const getArtistByCode = async (
         eq(genre_artist_crossreference.genre_id, genre_id),
         eq(genre_artist_crossreference.artist_genre_code, artist_genre_code)
       )
-    )
-    .limit(1);
+    );
+
+export const getArtistByCode = async (
+  code_letters: string,
+  genre_id: number,
+  artist_genre_code: number
+): Promise<ArtistCodeOwner | null> => {
+  const response = await artistCodeOwnerQuery(code_letters, genre_id, artist_genre_code).limit(1);
 
   // return null if no artist found
   return response[0] ?? null;
@@ -2159,23 +2182,11 @@ export const getArtistsByCode = async (
   code_letters: string,
   genre_id: number,
   artist_genre_code: number
-): Promise<Array<{ artist_id: number; artist_name: string; code_letters: string }>> => {
-  return db
-    .select({
-      artist_id: genre_artist_crossreference.artist_id,
-      artist_name: artists.artist_name,
-      code_letters: artists.code_letters,
-    })
-    .from(genre_artist_crossreference)
-    .innerJoin(artists, eq(genre_artist_crossreference.artist_id, artists.id))
-    .where(
-      and(
-        eq(artists.code_letters, code_letters),
-        eq(genre_artist_crossreference.genre_id, genre_id),
-        eq(genre_artist_crossreference.artist_genre_code, artist_genre_code)
-      )
-    )
-    .orderBy(asc(artists.artist_name), asc(artists.id));
+): Promise<ArtistCodeOwner[]> => {
+  return artistCodeOwnerQuery(code_letters, genre_id, artist_genre_code).orderBy(
+    asc(artists.artist_name),
+    asc(artists.id)
+  );
 };
 
 /**
@@ -2183,9 +2194,7 @@ export const getArtistsByCode = async (
  * shape `getArtistByCode` returns, so a 409 conflict payload can carry either
  * lookup's result through one consistent wire shape.
  */
-export const getArtistById = async (
-  artist_id: number
-): Promise<{ artist_id: number; artist_name: string; code_letters: string } | null> => {
+export const getArtistById = async (artist_id: number): Promise<ArtistCodeOwner | null> => {
   const response = await db
     .select({
       artist_id: artists.id,

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2093,6 +2093,13 @@ export const insertArtistGenreCrossreference = async (
   return response[0];
 };
 
+/**
+ * Boolean-grade "is this code triple taken" probe backing `addArtist`'s
+ * code-conflict pre-check. The triple is NOT unique (see `getArtistsByCode`
+ * below), so the row this returns for a contested code is arbitrary — which is
+ * fine here, because the caller only needs *an* owner to name in its 409. A
+ * route whose contract is "who owns this code" must use the plural instead.
+ */
 export const getArtistByCode = async (
   code_letters: string,
   genre_id: number,
@@ -2117,6 +2124,53 @@ export const getArtistByCode = async (
 
   // return null if no artist found
   return response[0] ?? null;
+};
+
+/**
+ * BS#2149: EVERY artist that owns `(code_letters, genre_id, artist_genre_code)`,
+ * in a deterministic order.
+ *
+ * The triple is not unique and nothing in the schema makes it so: the only
+ * unique index on `genre_artist_crossreference` is `artist_genre_key
+ * (artist_id, genre_id)`, and `code_letters` lives on `artists`, one join away.
+ * The production clone holds 13 collisions, every one a Various-Artists filing —
+ * `V/A`/12/0 with 27 owners (`Soundtracks - <LETTER>`) and `V/A`/11/0 with 26
+ * (`Various Artists - Rock - <LETTER>`) among them. Those are distinct shelf
+ * buckets a librarian relies on staying separately reachable, so this returns
+ * all of them and lets the caller present a chooser; collapsing to one row would
+ * be stably wrong for the other 26.
+ *
+ * Ordered `artist_name` then `id`: name first because the collision case is a
+ * lettered V/A run whose alphabetical order IS its shelf order, and `id` as a
+ * tiebreaker so the order is total (two artists can share a name) and repeated
+ * calls agree.
+ *
+ * Deliberately a sibling of the singular `getArtistByCode` rather than a
+ * widening of it: that one is `addArtist`'s conflict pre-check, where an
+ * unordered LIMIT 1 is correct and cheaper, and re-pointing it would change the
+ * `artist` payload of an existing 409.
+ */
+export const getArtistsByCode = async (
+  code_letters: string,
+  genre_id: number,
+  artist_genre_code: number
+): Promise<Array<{ artist_id: number; artist_name: string; code_letters: string }>> => {
+  return db
+    .select({
+      artist_id: genre_artist_crossreference.artist_id,
+      artist_name: artists.artist_name,
+      code_letters: artists.code_letters,
+    })
+    .from(genre_artist_crossreference)
+    .innerJoin(artists, eq(genre_artist_crossreference.artist_id, artists.id))
+    .where(
+      and(
+        eq(artists.code_letters, code_letters),
+        eq(genre_artist_crossreference.genre_id, genre_id),
+        eq(genre_artist_crossreference.artist_genre_code, artist_genre_code)
+      )
+    )
+    .orderBy(asc(artists.artist_name), asc(artists.id));
 };
 
 /**

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2133,12 +2133,17 @@ export const getArtistByCode = async (
  * The triple is not unique and nothing in the schema makes it so: the only
  * unique index on `genre_artist_crossreference` is `artist_genre_key
  * (artist_id, genre_id)`, and `code_letters` lives on `artists`, one join away.
- * The production clone holds 13 collisions, every one a Various-Artists filing —
- * `V/A`/12/0 with 27 owners (`Soundtracks - <LETTER>`) and `V/A`/11/0 with 26
- * (`Various Artists - Rock - <LETTER>`) among them. Those are distinct shelf
- * buckets a librarian relies on staying separately reachable, so this returns
- * all of them and lets the caller present a chooser; collapsing to one row would
- * be stably wrong for the other 26.
+ * The production clone holds 13 collisions. The two largest are Various-Artists
+ * filings — `V/A`/12/0 with 27 owners (`Soundtracks - <LETTER>`) and `V/A`/11/0
+ * with 26 (`Various Artists - Rock - <LETTER>`) — and those are distinct shelf
+ * buckets a librarian relies on staying separately reachable, so collapsing to
+ * one row would be stably wrong for the other 26.
+ *
+ * But this is NOT a V/A-only phenomenon, and a V/A-only special case would not
+ * cover it: the remaining **11 of 13** are ordinary artist codes with 2–3 owners
+ * (`KU`/11/7 with 3; `WI`/7/31, `BL`/9/16, `PO`/15/22, `JE`/9/2, `AP`/11/24,
+ * `OR`/11/39, `WH`/11/75, `SA`/4/4, `NO`/8/3, `SI`/15/20 with 2 each). Any code
+ * can be contested, so every code gets the list treatment.
  *
  * Ordered `artist_name` then `id`: name first because the collision case is a
  * lettered V/A run whose alphabetical order IS its shelf order, and `id` as a

--- a/apps/backend/utils/constants.ts
+++ b/apps/backend/utils/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Upper bound for a Postgres int4 column. A query value outside this range
+ * parses fine as a JS integer (`Number.isInteger` returns true) but blows up
+ * downstream as an unhandled "value out of range for type integer" Postgres
+ * error -- SQLSTATE 22003, which is not a `WxycError` and so answers a
+ * generic 500 plus a Sentry capture.
+ *
+ * `flowsheet.controller.ts` hit this first, on `start_id`/`end_id`
+ * (BS#1800). `library.controller.ts`'s `GET /library/artists/by-code`
+ * (BS#2149) reuses it for `genre_id`/`code_number` rather than re-declaring
+ * a second copy -- the BS#2149 review found the two had drifted apart (one
+ * file's copy claimed to "reuse" a constant that was actually a duplicate).
+ * Import this one wherever an int4-bound query parameter needs the same
+ * guard; do not re-declare it locally.
+ */
+export const INT4_MAX = 2147483647;

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1698,6 +1698,14 @@ describe('Library Artists By Code', () => {
 
     expectErrorContains(res, 'code_number');
   });
+
+  test('returns 400 when code_letters is repeated (Express string[] parsing)', async () => {
+    const res = await auth
+      .get('/library/artists/by-code?genre_id=11&code_letters=B&code_letters=U&code_number=60')
+      .expect(400);
+
+    expectErrorContains(res, 'code_letters');
+  });
 });
 
 describe('Library Formats', () => {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1631,57 +1631,180 @@ describe('Library Artists Peek Code', () => {
     expect(res.body.next_code_number).toBe(61);
   });
 
-  test('does not change with an unrelated third query parameter present (BS#2149)', async () => {
-    // peek-code's two-parameter behavior must survive the addition of the
-    // sibling by-code resolution endpoint -- a stray code_number must not be
-    // interpreted as "resolve" mode by this handler.
+  // BS#2149 regression. `peekArtistNumber` reads exactly two query parameters,
+  // so this compares the responses to the two call shapes dj-site sends rather
+  // than re-asserting a constant: an implementation that started consuming
+  // `code_number` would make these two bodies differ.
+  test('answers identically with and without a stray code_number (BS#2149)', async () => {
+    const twoParam = await auth
+      .get('/library/artists/peek-code')
+      .query({ code_letters: 'BU', genre_id: 11 })
+      .expect(200);
+
+    const withStrayCodeNumber = await auth
+      .get('/library/artists/peek-code')
+      .query({ code_letters: 'BU', genre_id: 11, code_number: 60 })
+      .expect(200);
+
+    expect(withStrayCodeNumber.body).toEqual(twoParam.body);
+    // And the value is still the next FREE number, not the code that was passed.
+    expect(withStrayCodeNumber.body.next_code_number).toBe(61);
+  });
+
+  // peek-code answers "next free number" even for a code that IS assigned --
+  // the question by-code exists to answer instead. If peek-code ever started
+  // resolving the triple, this would return 60 (or an artist) rather than 61.
+  test('still reports the next free number for an already-assigned code (BS#2149)', async () => {
     const res = await auth
       .get('/library/artists/peek-code')
       .query({ code_letters: 'BU', genre_id: 11, code_number: 60 })
       .expect(200);
 
-    expect(res.body.next_code_number).toBe(61);
+    expect(res.body).toEqual({ next_code_number: 61 });
+    expect(res.body.artists).toBeUndefined();
   });
 });
 
 describe('Library Artists By Code', () => {
   let auth;
+  let sql;
 
-  beforeAll(() => {
+  // A code triple deliberately given TWO owners, mirroring the production V/A
+  // shape: `code_letters = 'V/A'` with `artist_genre_code = 0`, several distinct
+  // shelf buckets filed under it. Seeded directly because the write path
+  // (POST /library/artists) refuses a duplicate code triple by design, so the
+  // collision it cannot create is one only SQL can set up.
+  const CONTESTED = { genre_id: 11, code_letters: 'V/A', code_number: 0 };
+  const SEEDED_NAMES = ['BS2149 Various - B', 'BS2149 Various - A'];
+  const seededArtistIds = [];
+
+  beforeAll(async () => {
     auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+
+    // Inserted in reverse alphabetical order on purpose: the endpoint's ordering
+    // must come from its ORDER BY, not from insertion/physical row order.
+    for (const name of SEEDED_NAMES) {
+      const [row] = await sql`
+        INSERT INTO ${sql(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+        VALUES (${name}, ${name}, ${CONTESTED.code_letters})
+        RETURNING id`;
+      seededArtistIds.push(row.id);
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+        VALUES (${row.id}, ${CONTESTED.genre_id}, ${CONTESTED.code_number})`;
+    }
   });
 
-  test('resolves a fully-specified code to its owning artist', async () => {
+  afterAll(async () => {
+    if (seededArtistIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.genre_artist_crossreference WHERE artist_id IN ${sql(seededArtistIds)}`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id IN ${sql(seededArtistIds)}`;
+    }
+  });
+
+  test('resolves a fully-specified code to a one-element list when it has a single owner', async () => {
     // BU/11/60 is Built to Spill's seeded code triple.
     const res = await auth
       .get('/library/artists/by-code')
       .query({ genre_id: 11, code_letters: 'BU', code_number: 60 })
       .expect(200);
 
-    expect(res.body.artist).toBeDefined();
-    expectFields(res.body.artist, 'id', 'artist_name', 'code_letters', 'code_number', 'genre_id');
-    expect(res.body.artist.artist_name).toBe('Built to Spill');
-    expect(res.body.artist.code_letters).toBe('BU');
-    expect(res.body.artist.code_number).toBe(60);
-    expect(res.body.artist.genre_id).toBe(11);
+    expect(Array.isArray(res.body.artists)).toBe(true);
+    expect(res.body.artists).toHaveLength(1);
+    expectFields(res.body.artists[0], 'id', 'artist_name', 'code_letters', 'code_number', 'genre_id');
+    expect(res.body.artists[0].artist_name).toBe('Built to Spill');
+    expect(res.body.artists[0].code_letters).toBe('BU');
+    expect(res.body.artists[0].code_number).toBe(60);
+    expect(res.body.artists[0].genre_id).toBe(11);
   });
 
-  test('returns 404 for an unassigned code in a known genre', async () => {
+  // The V/A librarian invariant: each `Various Artists - <LETTER>` / `Soundtracks
+  // - <LETTER>` bucket sharing one code is a distinct shelf location, so all of
+  // them must stay reachable. An unordered LIMIT 1 answered one arbitrary owner.
+  test('returns EVERY owner of a contested code, not one arbitrary row', async () => {
+    const res = await auth.get('/library/artists/by-code').query(CONTESTED).expect(200);
+
+    // Compare against the database's own count for this triple, so the assertion
+    // holds whether or not the environment's fixture already carries V/A rows.
+    const [{ count }] = await sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${sql(SCHEMA)}.genre_artist_crossreference gac
+      JOIN ${sql(SCHEMA)}.artists a ON a.id = gac.artist_id
+      WHERE a.code_letters = ${CONTESTED.code_letters}
+        AND gac.genre_id = ${CONTESTED.genre_id}
+        AND gac.artist_genre_code = ${CONTESTED.code_number}`;
+
+    expect(count).toBeGreaterThanOrEqual(2);
+    expect(res.body.artists).toHaveLength(count);
+
+    const returnedNames = res.body.artists.map((a) => a.artist_name);
+    for (const name of SEEDED_NAMES) {
+      expect(returnedNames).toContain(name);
+    }
+    // Every owner carries a distinct id -- no row is duplicated to pad the list.
+    expect(new Set(res.body.artists.map((a) => a.id)).size).toBe(res.body.artists.length);
+  });
+
+  test('orders the owners deterministically by artist_name, then id', async () => {
+    const first = await auth.get('/library/artists/by-code').query(CONTESTED).expect(200);
+    const second = await auth.get('/library/artists/by-code').query(CONTESTED).expect(200);
+
+    // Repeated calls agree.
+    expect(second.body.artists).toEqual(first.body.artists);
+
+    // The two seeded buckets come back in alphabetical order, the reverse of the
+    // order they were inserted in.
+    const seededOrder = first.body.artists.map((a) => a.artist_name).filter((n) => SEEDED_NAMES.includes(n));
+    expect(seededOrder).toEqual(['BS2149 Various - A', 'BS2149 Various - B']);
+  });
+
+  // The whole Various-Artists surface is filed at artist_genre_code 0; a `< 1`
+  // floor made compilations -- the class with no artist name to search by, and
+  // so the class that most needs code-first resolution -- unanswerable.
+  test('accepts code_number 0 (the Various-Artists filing)', async () => {
+    const res = await auth.get('/library/artists/by-code').query(CONTESTED).expect(200);
+
+    expect(res.body.artists.length).toBeGreaterThan(0);
+    for (const artist of res.body.artists) {
+      expect(artist.code_number).toBe(0);
+      expect(artist.code_letters).toBe('V/A');
+    }
+  });
+
+  test('returns 404 with reason code_not_assigned for an unassigned code in a known genre', async () => {
     const res = await auth
       .get('/library/artists/by-code')
       .query({ genre_id: 11, code_letters: 'BU', code_number: 999999 })
       .expect(404);
 
+    expect(res.body.reason).toBe('code_not_assigned');
     expectErrorContains(res, 'not assigned');
   });
 
-  test('returns 404 for an unknown genre_id, distinct from an unassigned code', async () => {
+  test('returns 404 with reason genre_not_found for an unknown genre_id', async () => {
     const res = await auth
       .get('/library/artists/by-code')
       .query({ genre_id: 999999, code_letters: 'BU', code_number: 60 })
       .expect(404);
 
+    expect(res.body.reason).toBe('genre_not_found');
     expectErrorContains(res, 'Genre not found');
+  });
+
+  // The acceptance criterion is a *documented distinct outcome*, which means a
+  // machine-readable discriminant -- not two prose messages a client must parse.
+  test('gives the two 404s different reasons', async () => {
+    const unknownGenre = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 999999, code_letters: 'BU', code_number: 60 })
+      .expect(404);
+    const freeCode = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: 'BU', code_number: 999999 })
+      .expect(404);
+
+    expect(unknownGenre.body.reason).not.toBe(freeCode.body.reason);
   });
 
   test('returns 400 for a malformed code_number', async () => {
@@ -1693,18 +1816,70 @@ describe('Library Artists By Code', () => {
     expectErrorContains(res, 'code_number');
   });
 
-  test('returns 400 when a required parameter is missing', async () => {
-    const res = await auth.get('/library/artists/by-code').query({ genre_id: 11, code_letters: 'BU' }).expect(400);
+  test('returns 400 for a negative code_number', async () => {
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: 'BU', code_number: -1 })
+      .expect(400);
 
     expectErrorContains(res, 'code_number');
   });
 
-  test('returns 400 when code_letters is repeated (Express string[] parsing)', async () => {
-    const res = await auth
-      .get('/library/artists/by-code?genre_id=11&code_letters=B&code_letters=U&code_number=60')
-      .expect(400);
+  // BS#1800 class: both bind to int4 columns, so a value that passes
+  // Number.isInteger but overflows int4 used to reach Postgres and answer a
+  // generic 500 (SQLSTATE 22003) plus a Sentry capture.
+  test.each([
+    ['genre_id', { genre_id: 2147483648, code_letters: 'BU', code_number: 60 }],
+    ['code_number', { genre_id: 11, code_letters: 'BU', code_number: 2147483648 }],
+  ])('returns 400, not 500, for a %s above INT4_MAX', async (param, query) => {
+    const res = await auth.get('/library/artists/by-code').query(query).expect(400);
 
-    expectErrorContains(res, 'code_letters');
+    expectErrorContains(res, param);
+  });
+
+  // Without normalization, ` BU ` and `bu` answer the "this code is free" 404 and
+  // invite the librarian to mint a duplicate shelf code.
+  test.each([
+    ['lower-cased', 'bu'],
+    ['whitespace-padded', ' BU '],
+  ])('resolves a %s code_letters to the same artist', async (_label, codeLetters) => {
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: codeLetters, code_number: 60 })
+      .expect(200);
+
+    expect(res.body.artists).toHaveLength(1);
+    expect(res.body.artists[0].artist_name).toBe('Built to Spill');
+    // The response echoes the stored value, not the caller's spelling.
+    expect(res.body.artists[0].code_letters).toBe('BU');
+  });
+
+  // Each case omits exactly one parameter and asserts the message names THAT one
+  // and not the others -- a message listing all three would pass no matter which
+  // parameter the handler actually refused on.
+  test.each([['genre_id'], ['code_letters'], ['code_number']])(
+    'returns 400 naming %s, and only %s, when it is the one missing',
+    async (param) => {
+      const query = { genre_id: 11, code_letters: 'BU', code_number: 60 };
+      delete query[param];
+
+      const res = await auth.get('/library/artists/by-code').query(query).expect(400);
+
+      expectErrorContains(res, param);
+      for (const other of ['genre_id', 'code_letters', 'code_number'].filter((p) => p !== param)) {
+        expect(res.body.message).not.toContain(other);
+      }
+    }
+  );
+
+  test.each([
+    ['code_letters', '/library/artists/by-code?genre_id=11&code_letters=B&code_letters=U&code_number=60'],
+    ['genre_id', '/library/artists/by-code?genre_id=11&genre_id=12&code_letters=BU&code_number=60'],
+    ['code_number', '/library/artists/by-code?genre_id=11&code_letters=BU&code_number=60&code_number=61'],
+  ])('returns 400 when %s is repeated (Express string[] parsing)', async (param, path) => {
+    const res = await auth.get(path).expect(400);
+
+    expectErrorContains(res, param);
   });
 });
 

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1630,6 +1630,74 @@ describe('Library Artists Peek Code', () => {
     // BU is the code for Built to Spill and has artist_genre_code 60
     expect(res.body.next_code_number).toBe(61);
   });
+
+  test('does not change with an unrelated third query parameter present (BS#2149)', async () => {
+    // peek-code's two-parameter behavior must survive the addition of the
+    // sibling by-code resolution endpoint -- a stray code_number must not be
+    // interpreted as "resolve" mode by this handler.
+    const res = await auth
+      .get('/library/artists/peek-code')
+      .query({ code_letters: 'BU', genre_id: 11, code_number: 60 })
+      .expect(200);
+
+    expect(res.body.next_code_number).toBe(61);
+  });
+});
+
+describe('Library Artists By Code', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  test('resolves a fully-specified code to its owning artist', async () => {
+    // BU/11/60 is Built to Spill's seeded code triple.
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: 'BU', code_number: 60 })
+      .expect(200);
+
+    expect(res.body.artist).toBeDefined();
+    expectFields(res.body.artist, 'id', 'artist_name', 'code_letters', 'code_number', 'genre_id');
+    expect(res.body.artist.artist_name).toBe('Built to Spill');
+    expect(res.body.artist.code_letters).toBe('BU');
+    expect(res.body.artist.code_number).toBe(60);
+    expect(res.body.artist.genre_id).toBe(11);
+  });
+
+  test('returns 404 for an unassigned code in a known genre', async () => {
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: 'BU', code_number: 999999 })
+      .expect(404);
+
+    expectErrorContains(res, 'not assigned');
+  });
+
+  test('returns 404 for an unknown genre_id, distinct from an unassigned code', async () => {
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 999999, code_letters: 'BU', code_number: 60 })
+      .expect(404);
+
+    expectErrorContains(res, 'Genre not found');
+  });
+
+  test('returns 400 for a malformed code_number', async () => {
+    const res = await auth
+      .get('/library/artists/by-code')
+      .query({ genre_id: 11, code_letters: 'BU', code_number: 'not-a-number' })
+      .expect(400);
+
+    expectErrorContains(res, 'code_number');
+  });
+
+  test('returns 400 when a required parameter is missing', async () => {
+    const res = await auth.get('/library/artists/by-code').query({ genre_id: 11, code_letters: 'BU' }).expect(400);
+
+    expectErrorContains(res, 'code_number');
+  });
 });
 
 describe('Library Formats', () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -999,9 +999,15 @@ describe('library.controller', () => {
       it('rejects an overflowing parameter with a WxycError (400), never an unhandled error', async () => {
         const res = mockResponse();
 
-        await expect(resolveArtistByCode(req({ code_number: '9999999999' }), res, next)).rejects.toBeInstanceOf(
-          WxycError
+        // The status code is the whole point of the test's name: a
+        // `WxycError` carrying 500 would satisfy a bare `toBeInstanceOf` while
+        // being exactly the outcome this guard exists to prevent.
+        const thrown = await resolveArtistByCode(req({ code_number: '9999999999' }), res, next).then(
+          () => null,
+          (error: unknown) => error
         );
+        expect(thrown).toBeInstanceOf(WxycError);
+        expect((thrown as WxycError).statusCode).toBe(400);
       });
 
       it('still accepts values exactly at the INT4_MAX boundary', async () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -1078,15 +1078,74 @@ describe('library.controller', () => {
         await expect(resolveArtistByCode(req({ code_letters: '   ' }), res, next)).rejects.toThrow('code_letters');
         expect(mockGetArtistsByCode).not.toHaveBeenCalled();
       });
+    });
 
-      it('echoes the stored code_letters, not the normalized input', async () => {
-        mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill', 'BU')]);
-
+    // BS#2149 review findings 1 + 2: `artists.code_letters` is a Postgres
+    // varchar(4) column and neither writer (insertArtist, the tubafrenzy
+    // library-etl job) guarantees a trimmed/upper-case/ASCII-only value, so a
+    // bare `.trim().toUpperCase()` isn't a safe read-side repair -- it can
+    // fold a non-canonical input onto a DIFFERENT real artist's code (`ß` ->
+    // `SS`, `ı` -> `I`) with no precondition that the input was canonical.
+    // These pin the domain check that replaced the naive normalization.
+    describe('code_letters domain validation (BS#2149 review findings 1 + 2)', () => {
+      it('rejects a code_letters longer than 4 characters (varchar(4) domain)', async () => {
         const res = mockResponse();
-        await resolveArtistByCode(req({ code_letters: 'bu' }), res, next);
 
-        const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ artists: Array<{ code_letters: string }> }];
-        expect(payload.artists[0].code_letters).toBe('BU');
+        await expect(resolveArtistByCode(req({ code_letters: 'ABCDE' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('rejects a code_letters that is exactly 5 characters after trimming', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: ' ABCDE ' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('accepts a code_letters at the 4-character boundary', async () => {
+        mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill', 'ABCD')]);
+        const res = mockResponse();
+
+        await resolveArtistByCode(req({ code_letters: 'ABCD' }), res, next);
+
+        expect(mockGetArtistsByCode).toHaveBeenCalledWith('ABCD', 11, 60);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      // `'ß'.toUpperCase() === 'SS'` -- not length-preserving. Left
+      // unvalidated, this would silently query for 'SS' instead of rejecting
+      // an input the column's real (ASCII) domain never contains.
+      it('rejects a code_letters containing ß rather than silently folding it to SS', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: 'ß' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      // `'ı'.toUpperCase() === 'I'` (the Turkish dotless i) -- length-preserving
+      // but charset-changing, so a length check alone would miss this case.
+      it('rejects a code_letters containing the dotless-i (ı) rather than folding it to I', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: 'ı' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('accepts the V/A code, whose "/" is the one non-alphanumeric character in production use', async () => {
+        mockGetArtistsByCode.mockResolvedValue([owner(200, 'Various Artists', 'V/A')]);
+        const res = mockResponse();
+
+        await resolveArtistByCode(req({ code_letters: 'V/A' }), res, next);
+
+        expect(mockGetArtistsByCode).toHaveBeenCalledWith('V/A', 11, 60);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('rejects a code_letters containing a character outside A-Z, 0-9, and /', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: 'B-U' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
       });
     });
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -13,6 +13,11 @@ type ArtistConflictRow = { artist_id: number; artist_name: string; code_letters:
 const mockGetArtistByCode =
   jest.fn<(codeLetters: string, genreId: number, codeNumber: number) => Promise<ArtistConflictRow | null>>();
 const mockGetArtistById = jest.fn<(artistId: number) => Promise<ArtistConflictRow | null>>();
+// GET /library/artists/by-code (BS#2149).
+const mockGetArtistsByCode =
+  jest.fn<(codeLetters: string, genreId: number, codeNumber: number) => Promise<ArtistConflictRow[]>>();
+const mockGenreExists = jest.fn<(genreId: number) => Promise<boolean>>();
+const mockGenerateArtistNumber = jest.fn<(codeLetters: string, genreId: number) => Promise<number>>();
 const mockInsertArtist = jest.fn<(artist: Record<string, unknown>) => Promise<Record<string, unknown>>>();
 const mockInsertArtistGenreCrossreference =
   jest.fn<(artistId: number, genreId: number, codeNumber: number) => Promise<unknown>>();
@@ -120,9 +125,11 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertArtist: mockInsertArtist,
   insertArtistGenreCrossreference: mockInsertArtistGenreCrossreference,
   getArtistByCode: mockGetArtistByCode,
+  getArtistsByCode: mockGetArtistsByCode,
+  genreExists: mockGenreExists,
   getArtistById: mockGetArtistById,
   generateAlbumCodeNumber: mockGenerateAlbumCodeNumber,
-  generateArtistNumber: jest.fn(),
+  generateArtistNumber: mockGenerateArtistNumber,
   getGenresFromDB: jest.fn(),
   insertGenre: jest.fn(),
   insertFormat: jest.fn(),
@@ -201,6 +208,8 @@ import {
   searchForAlbum,
   addAlbum,
   addArtist,
+  resolveArtistByCode,
+  peekArtistNumber,
   getAlbum,
   getRotationTracks,
   updateAlbum,
@@ -212,6 +221,7 @@ import {
   linkRotationToAlbum,
   pickAddRotationFields,
 } from '../../../apps/backend/controllers/library.controller';
+import WxycError from '../../../apps/backend/utils/error';
 
 function mockResponse(): Response {
   const res = {} as Response;
@@ -839,6 +849,347 @@ describe('library.controller', () => {
       // Short-circuits before the name pre-check even runs.
       expect(mockArtistIdFromName).not.toHaveBeenCalled();
       expect(mockInsertArtist).not.toHaveBeenCalled();
+    });
+  });
+
+  // GET /library/artists/by-code (BS#2149).
+  describe('resolveArtistByCode', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetArtistsByCode.mockResolvedValue([]);
+      mockGenreExists.mockResolvedValue(true);
+    });
+
+    const req = (query: Record<string, unknown> = {}) =>
+      ({
+        query: {
+          genre_id: '11',
+          code_letters: 'BU',
+          code_number: '60',
+          ...query,
+        },
+      }) as unknown as Request;
+
+    const owner = (id: number, artist_name: string, code_letters = 'BU') => ({
+      artist_id: id,
+      artist_name,
+      code_letters,
+    });
+
+    it('returns the sole owner of an uncontested code as a one-element list', async () => {
+      mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill')]);
+
+      const res = mockResponse();
+      await resolveArtistByCode(req(), res, next);
+
+      expect(mockGetArtistsByCode).toHaveBeenCalledWith('BU', 11, 60);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        artists: [{ id: 9, artist_name: 'Built to Spill', code_letters: 'BU', code_number: 60, genre_id: 11 }],
+      });
+    });
+
+    // The V/A invariant: `V/A`/12/0 has 27 owners in the production clone and
+    // each is a distinct shelf bucket. Collapsing or arbitrarily picking one
+    // would be stably wrong for the other 26.
+    it('returns EVERY owner of a contested code, not just the first', async () => {
+      const buckets = [
+        owner(101, 'Soundtracks - A', 'V/A'),
+        owner(102, 'Soundtracks - B', 'V/A'),
+        owner(103, 'Soundtracks - C', 'V/A'),
+      ];
+      mockGetArtistsByCode.mockResolvedValue(buckets);
+
+      const res = mockResponse();
+      await resolveArtistByCode(req({ genre_id: '12', code_letters: 'V/A', code_number: '0' }), res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ artists: Array<{ id: number }> }];
+      expect(payload.artists).toHaveLength(3);
+      expect(payload.artists.map((a) => a.id)).toEqual([101, 102, 103]);
+      expect(payload.artists.map((a) => a.artist_name)).toEqual([
+        'Soundtracks - A',
+        'Soundtracks - B',
+        'Soundtracks - C',
+      ]);
+    });
+
+    // The entire Various-Artists surface is filed at artist_genre_code 0 (68
+    // rows in the production clone). A `< 1` floor made the one filing class
+    // that most needs code-first resolution unanswerable.
+    it('accepts code_number 0 (the Various-Artists filing) and passes it through unchanged', async () => {
+      mockGetArtistsByCode.mockResolvedValue([owner(200, 'Various Artists', 'V/A')]);
+
+      const res = mockResponse();
+      await resolveArtistByCode(req({ genre_id: '11', code_letters: 'V/A', code_number: '0' }), res, next);
+
+      expect(mockGetArtistsByCode).toHaveBeenCalledWith('V/A', 11, 0);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        artists: [{ id: 200, artist_name: 'Various Artists', code_letters: 'V/A', code_number: 0, genre_id: 11 }],
+      });
+    });
+
+    it('rejects a negative code_number', async () => {
+      const res = mockResponse();
+
+      await expect(resolveArtistByCode(req({ code_number: '-1' }), res, next)).rejects.toThrow('code_number');
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-integer code_number', async () => {
+      const res = mockResponse();
+
+      await expect(resolveArtistByCode(req({ code_number: '3.5' }), res, next)).rejects.toThrow('code_number');
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+    });
+
+    // `Number('')` is 0, which now passes Number.isInteger and the >= 0 floor,
+    // so a present-but-blank parameter would silently resolve as a V/A lookup.
+    it('rejects a present-but-blank code_number rather than reading it as 0', async () => {
+      const res = mockResponse();
+
+      await expect(resolveArtistByCode(req({ code_number: '' }), res, next)).rejects.toThrow('code_number');
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects genre_id 0 (genre ids start at 1)', async () => {
+      const res = mockResponse();
+
+      await expect(resolveArtistByCode(req({ genre_id: '0' }), res, next)).rejects.toThrow('genre_id');
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+    });
+
+    // BS#1800 class: parses as a JS integer, overflows the int4 column, and
+    // used to reach Postgres as SQLSTATE 22003 -> unhandled 500 + Sentry noise.
+    describe('int4-bounds validation (BS#1800 class)', () => {
+      it('rejects a genre_id above INT4_MAX with a 400 naming genre_id', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ genre_id: '2147483648' }), res, next)).rejects.toThrow('genre_id');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('rejects a code_number above INT4_MAX with a 400 naming code_number', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_number: '2147483648' }), res, next)).rejects.toThrow('code_number');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('rejects an overflowing parameter with a WxycError (400), never an unhandled error', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_number: '9999999999' }), res, next)).rejects.toBeInstanceOf(
+          WxycError
+        );
+      });
+
+      it('still accepts values exactly at the INT4_MAX boundary', async () => {
+        mockGetArtistsByCode.mockResolvedValue([owner(1, 'Edge Case')]);
+        const res = mockResponse();
+
+        await resolveArtistByCode(req({ genre_id: '2147483647', code_number: '2147483647' }), res, next);
+
+        expect(mockGetArtistsByCode).toHaveBeenCalledWith('BU', 2147483647, 2147483647);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+
+    describe('404 discrimination', () => {
+      it('answers reason: genre_not_found when the genre does not exist', async () => {
+        mockGetArtistsByCode.mockResolvedValue([]);
+        mockGenreExists.mockResolvedValue(false);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req({ genre_id: '999999' }), res, next);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Genre not found', reason: 'genre_not_found' });
+      });
+
+      it('answers reason: code_not_assigned when the genre exists but the code is free', async () => {
+        mockGetArtistsByCode.mockResolvedValue([]);
+        mockGenreExists.mockResolvedValue(true);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req({ code_number: '999999' }), res, next);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({
+          message: 'Artist code not assigned in that genre',
+          reason: 'code_not_assigned',
+        });
+      });
+
+      it('gives the two 404s different reasons, so a client never has to parse the message', async () => {
+        const missReasons: string[] = [];
+        for (const genreKnown of [false, true]) {
+          jest.clearAllMocks();
+          mockGetArtistsByCode.mockResolvedValue([]);
+          mockGenreExists.mockResolvedValue(genreKnown);
+          const res = mockResponse();
+          await resolveArtistByCode(req(), res, next);
+          const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ reason: string }];
+          missReasons.push(payload.reason);
+        }
+
+        expect(new Set(missReasons).size).toBe(2);
+      });
+    });
+
+    describe('code_letters normalization', () => {
+      it.each([
+        ['lower-cased', 'bu'],
+        ['whitespace-padded', ' BU '],
+        ['both', ' bu '],
+      ])('trims and upper-cases a %s code_letters before matching', async (_label, raw) => {
+        mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill')]);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req({ code_letters: raw }), res, next);
+
+        expect(mockGetArtistsByCode).toHaveBeenCalledWith('BU', 11, 60);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('rejects code_letters that is empty once trimmed', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: '   ' }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it('echoes the stored code_letters, not the normalized input', async () => {
+        mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill', 'BU')]);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req({ code_letters: 'bu' }), res, next);
+
+        const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ artists: Array<{ code_letters: string }> }];
+        expect(payload.artists[0].code_letters).toBe('BU');
+      });
+    });
+
+    describe('repeated-key (Express string[]) parsing', () => {
+      it('rejects a repeated code_letters before it can bind a text[] against a text column', async () => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ code_letters: ['B', 'U'] }), res, next)).rejects.toThrow('code_letters');
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+
+      it.each([['genre_id'], ['code_number']])('rejects a repeated %s by name', async (param) => {
+        const res = mockResponse();
+
+        await expect(resolveArtistByCode(req({ [param]: ['1', '2'] }), res, next)).rejects.toThrow(param);
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('missing parameters', () => {
+      const ALL_PARAMS = ['genre_id', 'code_letters', 'code_number'] as const;
+
+      // Each case omits exactly one parameter and asserts the message names THAT
+      // one and none of the others. A message listing all three would satisfy a
+      // `toContain('code_number')` assertion no matter which parameter the
+      // handler actually refused on -- the blind spot this suite had before.
+      it.each(ALL_PARAMS.map((p) => [p]))('names %s, and only %s, when it is the missing one', async (param) => {
+        const full: Array<[string, string]> = [
+          ['genre_id', '11'],
+          ['code_letters', 'BU'],
+          ['code_number', '60'],
+        ];
+        const query = Object.fromEntries(full.filter(([name]) => name !== param));
+        const res = mockResponse();
+
+        const thrown = await resolveArtistByCode({ query } as unknown as Request, res, next).then(
+          () => null,
+          (err: unknown) => err
+        );
+
+        expect(thrown).toBeInstanceOf(WxycError);
+        expect((thrown as WxycError).statusCode).toBe(400);
+        expect((thrown as WxycError).message).toContain(param);
+        for (const other of ALL_PARAMS.filter((p) => p !== param)) {
+          expect((thrown as WxycError).message).not.toContain(other);
+        }
+        expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      });
+    });
+
+    // Finding 6: genreExists is only needed to explain a miss. A hit proves the
+    // genre exists, because the lookup inner-joins on genre_artist_crossreference
+    // .genre_id -- so probing it up front doubles the round-trips on the path
+    // that is taken every time a librarian types a real code.
+    describe('round-trip discipline', () => {
+      it('does not probe genreExists on a hit', async () => {
+        mockGetArtistsByCode.mockResolvedValue([owner(9, 'Built to Spill')]);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req(), res, next);
+
+        expect(mockGenreExists).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('probes genreExists exactly once on a miss', async () => {
+        mockGetArtistsByCode.mockResolvedValue([]);
+
+        const res = mockResponse();
+        await resolveArtistByCode(req(), res, next);
+
+        expect(mockGenreExists).toHaveBeenCalledTimes(1);
+        expect(mockGenreExists).toHaveBeenCalledWith(11);
+      });
+    });
+  });
+
+  // The sibling this endpoint was NOT folded into. `peekArtistNumber` reads
+  // exactly two query parameters, and these pin that: it must call the service
+  // with (code_letters, genre_id) and nothing else, for every call shape
+  // dj-site sends -- including one carrying a stray `code_number`.
+  describe('peekArtistNumber two-parameter contract (BS#2149 regression)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGenerateArtistNumber.mockResolvedValue(61);
+    });
+
+    it('calls generateArtistNumber with exactly (code_letters, genre_id)', async () => {
+      const res = mockResponse();
+      await peekArtistNumber({ query: { code_letters: 'BU', genre_id: '11' } } as unknown as Request, res, next);
+
+      expect(mockGenerateArtistNumber).toHaveBeenCalledTimes(1);
+      expect(mockGenerateArtistNumber.mock.calls[0]).toEqual(['BU', 11]);
+      expect(res.json).toHaveBeenCalledWith({ next_code_number: 61 });
+    });
+
+    it('ignores a code_number the by-code sibling would consume — same service call, same response', async () => {
+      const res = mockResponse();
+      await peekArtistNumber(
+        { query: { code_letters: 'BU', genre_id: '11', code_number: '60' } } as unknown as Request,
+        res,
+        next
+      );
+
+      // Byte-identical to the two-parameter call above: the third parameter
+      // reaches neither the service nor the response.
+      expect(mockGenerateArtistNumber.mock.calls[0]).toEqual(['BU', 11]);
+      expect(res.json).toHaveBeenCalledWith({ next_code_number: 61 });
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+    });
+
+    it('does not route to the by-code resolver even when all three parameters are present', async () => {
+      const res = mockResponse();
+      await peekArtistNumber(
+        { query: { code_letters: 'V/A', genre_id: '12', code_number: '0' } } as unknown as Request,
+        res,
+        next
+      );
+
+      expect(mockGenerateArtistNumber).toHaveBeenCalledTimes(1);
+      expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+      expect(mockGenreExists).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -889,6 +889,25 @@ describe('library.controller', () => {
       });
     });
 
+    // Contested codes are NOT a V/A-only phenomenon: 11 of the 13 collisions in
+    // the production clone are ordinary artist codes (`KU`/11/7 has 3 owners).
+    // A V/A-gated special case would answer one arbitrary row for those, so the
+    // list treatment has to be unconditional.
+    it('returns every owner of a contested ORDINARY code, not only V/A codes', async () => {
+      mockGetArtistsByCode.mockResolvedValue([
+        owner(301, 'Kudzu', 'KU'),
+        owner(302, 'Kudzu Ranch', 'KU'),
+        owner(303, 'Kukuruza', 'KU'),
+      ]);
+
+      const res = mockResponse();
+      await resolveArtistByCode(req({ genre_id: '11', code_letters: 'KU', code_number: '7' }), res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const [payload] = (res.json as jest.Mock).mock.calls[0] as [{ artists: Array<{ id: number }> }];
+      expect(payload.artists.map((a) => a.id)).toEqual([301, 302, 303]);
+    });
+
     // The V/A invariant: `V/A`/12/0 has 27 owners in the production clone and
     // each is a distinct shelf bucket. Collapsing or arbitrarily picking one
     // would be stably wrong for the other 26.

--- a/tests/unit/routes/library-by-code-permissions.route.test.ts
+++ b/tests/unit/routes/library-by-code-permissions.route.test.ts
@@ -1,0 +1,179 @@
+// Set required env vars before module load (ts-jest transforms imports to
+// requires, so these execute before the auth middleware module's top-level
+// code runs). Mirrors tests/unit/routes/library-missing-found-permissions.route.test.ts.
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+// Mock jose so we can hand back an arbitrary role in the verified JWT payload
+// without a real JWKS endpoint. requirePermissions's non-bypass branch is
+// what actually enforces role/permission checks. Note: integration tests run
+// with AUTH_BYPASS=true, whose branch short-circuits to next() before any
+// permission check runs, so they cannot exercise this route's auth tier --
+// hence this real-middleware unit test.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+// jest.unit.config.ts's moduleNameMapper sends `@wxyc/authentication` to
+// tests/mocks/authentication.mock.ts (a stub that ignores the role/permission
+// argument entirely). library.route.ts imports requirePermissions from that
+// package specifier, so this route-wiring test needs the REAL implementation
+// wired back in to actually exercise the catalog:read gate.
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
+import express from 'express';
+import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
+
+// Collaborator mocks below mirror tests/unit/controllers/library.controller.test.ts
+// (the resolveArtistByCode coverage itself already lives there) -- only enough
+// is stubbed here to let library.route's import chain resolve without
+// touching a real DB, LML, or lru-cache.
+type ArtistConflictRow = { artist_id: number; artist_name: string; code_letters: string };
+const mockGetArtistsByCode = jestGlobals.fn<() => Promise<ArtistConflictRow[]>>();
+const mockGenreExists = jestGlobals.fn<() => Promise<boolean>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  getArtistsByCode: mockGetArtistsByCode,
+  genreExists: mockGenreExists,
+  // Stub out other exports referenced at import time by library.controller.
+  getAlbumFromDB: jest.fn(),
+  getAlbumByLegacyId: jest.fn(),
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  getArtistById: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: jest.fn(),
+  getRotationTracksFromRelease: jest.fn(),
+  getLibraryRowById: jest.fn(),
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+  recheckDiscogsAvailability: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => false,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+/**
+ * BS#2149 review finding 3: GET /library/artists/by-code was gated to
+ * catalog:write, the same bar as the create-flow helpers `search` and
+ * `peek-code`, even though it's a pure read. Relaxed to catalog:read --
+ * shelf-code data is already DJ-readable on `GET /library/query` and
+ * `GET /djs/bin`, and this route returns strictly less than `/library/query`
+ * already does. `search` and `peek-code` are unchanged (still catalog:write).
+ */
+describe('GET /library/artists/by-code — permission tier (BS#2149)', () => {
+  beforeEach(() => {
+    mockGetArtistsByCode
+      .mockReset()
+      .mockResolvedValue([{ artist_id: 9, artist_name: 'Built to Spill', code_letters: 'BU' }]);
+    mockGenreExists.mockReset().mockResolvedValue(true);
+  });
+
+  const query = { genre_id: '11', code_letters: 'BU', code_number: '60' };
+
+  test('a dj-role token (catalog:read) is authorized', async () => {
+    mockRole('dj');
+    const res = await request(app)
+      .get('/library/artists/by-code')
+      .query(query)
+      .set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(200);
+    expect(mockGetArtistsByCode).toHaveBeenCalledWith('BU', 11, 60);
+  });
+
+  test('a member-role token (catalog:read, same tier as dj) is authorized', async () => {
+    mockRole('member');
+    const res = await request(app)
+      .get('/library/artists/by-code')
+      .query(query)
+      .set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(200);
+  });
+
+  test('a musicDirector-role token (catalog:read+write) is authorized', async () => {
+    mockRole('musicDirector');
+    const res = await request(app)
+      .get('/library/artists/by-code')
+      .query(query)
+      .set('Authorization', 'Bearer test-token');
+    expect(res.status).toBe(200);
+  });
+
+  test('a request with no Authorization header is rejected', async () => {
+    const res = await request(app).get('/library/artists/by-code').query(query);
+    expect(res.status).toBe(401);
+    expect(mockGetArtistsByCode).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GET /library/artists/by-code`, resolving a fully-specified `genre_id` + `code_letters` + `code_number` to the artists filed under it -- the "find" half of the `/wxycdb` catalog-entry JSP flow. Neither existing artist route answers this: `peek-code` returns the next *free* number, and `search` takes a name, not a code.

## Contract

```
GET /library/artists/by-code?genre_id=<int>&code_letters=<str>&code_number=<int>
  200 -> { artists: [ { id, artist_name, code_letters, code_number, genre_id }, ... ] }
  404 -> { message, reason: 'genre_not_found' | 'code_not_assigned' }
  400 -> { message }   // missing / malformed / out-of-int4-range / non-canonical code_letters
```

**The response is a list, and `code_number` accepts 0.** Both follow from the data, per the review-gate decision recorded on #2149:

- **`(code_letters, genre_id, artist_genre_code)` is not unique**, and nothing in the schema makes it so: the only unique index on `genre_artist_crossreference` is `artist_genre_key (artist_id, genre_id)`, and `code_letters` lives on `artists`, one join away. The production clone holds **13 collisions**. The two largest are V/A: `V/A`/12/0 with **27 owners** and `V/A`/11/0 with **26**, each a distinct shelf bucket (`Soundtracks - A`, `Soundtracks - B`, …) a librarian relies on staying separately reachable, so collapsing them would be stably wrong for 26 of 27.

  **This is not a V/A-only phenomenon, which is worth flagging because the decision comment on #2149 frames it that way.** Re-measuring the clone: **11 of the 13** collisions are *ordinary* artist codes with 2–3 owners — `KU`/11/7 with 3, and `WI`/7/31, `BL`/9/16, `PO`/15/22, `JE`/9/2, `AP`/11/24, `OR`/11/39, `WH`/11/75, `SA`/4/4, `NO`/8/3, `SI`/15/20 with 2 apiece. So the list treatment is unconditional rather than gated on V/A; a V/A-gated version would answer one arbitrary row for those 11. There is a unit test pinning a contested ordinary code specifically so that gating breaks a test rather than a librarian's lookup.

  A single owner is simply a one-element array, and WXYC/dj-site#1198 routes straight to that card.
- **`code_number` accepts 0** because the entire Various-Artists surface is filed there: 68 rows in the production clone with `artist_genre_code = 0` — 66 of them `code_letters = 'V/A'`, the other two a `VA`-spelled "V/A" and an `UNK` "Unknown", both in genre 6. Neither sibling route imposed a floor (`addArtist` passes the value through unvalidated, `peekArtistNumber` uses `Number.isFinite`), and a `< 1` floor made compilations -- the class with no artist name to search by, and so the class that most needs code-first resolution -- the one class this route could not answer. Negatives and non-integers are still rejected.

**Ordering is `artists.artist_name` ASC, then `artists.id` ASC.** Name first because the collision case is a lettered V/A run whose alphabetical order *is* its shelf order, so the chooser reads in shelf sequence; `id` as a tiebreaker so the order is total (two artists can share a name) and repeated calls agree.

## Design choices

- **New service function, not a widened one.** `getArtistsByCode` returns every owner with an explicit `ORDER BY`. The existing singular `getArtistByCode` is untouched: it backs `addArtist`'s boolean "is this code taken" pre-check, where an unordered `LIMIT 1` is correct and cheaper, and re-pointing it would change that route's 409 payload. Both now carry doc comments saying which question each answers.
- **Two 404s with a machine-readable discriminant.** `reason: 'genre_not_found'` (the client's genre dropdown is stale) vs `'code_not_assigned'` (the code is free to create), following `addArtist`'s `artist_code_conflict` / `artist_name_conflict` precedent in the same controller. `WxycError` carries only `message` + `statusCode`, so both are answered directly rather than thrown -- the same shape `addArtist` uses for its 409s. Documented separately in `app.yaml`, each with its own example.
- **`INT4_MAX` bound on both integer parameters.** `Number.isInteger(2147483648)` is true, so an overflowing `genre_id` or `code_number` used to pass validation and reach Postgres as SQLSTATE 22003 -- not a `WxycError`, so a generic 500 plus a Sentry capture. Same guard shape `flowsheet.controller.ts` established for `start_id`/`end_id` (BS#1800) -- **and now the same constant**, not a second copy: `INT4_MAX` moved to `apps/backend/utils/constants.ts` and both controllers import it (review finding 5; the first version of this PR claimed to reuse the constant while actually re-declaring it).
- **One round-trip on the happy path.** The code lookup runs first and `genreExists` only runs to explain a miss -- a hit already proves the genre exists, since the lookup inner-joins `genre_artist_crossreference.genre_id`. Observable behavior is byte-identical on all three outcomes.
- **`code_letters` is validated against its real column domain, then trimmed and upper-cased.** `artists.code_letters` is `varchar(4)`, and the 24,078 rows in the production clone all store a trimmed, upper-case ASCII value -- but neither writer enforces that shape (`insertArtist` only NFC-normalizes; the tubafrenzy `library-etl` job writes `codeLetters ?? '??'` verbatim), so a bare `.trim().toUpperCase()` isn't a safe repair: it's neither length- nor charset-preserving for non-ASCII input (`'ß'.toUpperCase() === 'SS'`, `'ı'.toUpperCase() === 'I'`), so it could fold an out-of-domain input onto a *different* real artist's code with no precondition that the input was canonical. A 5+ character value had the same failure shape as the int4 case this PR already guards: it can never match a row, so it silently fell through to the `code_not_assigned` 404 -- whose own docs called that "safe to create an artist under it" -- right up until `insertArtist`'s `varchar(4)` column threw SQLSTATE 22001 on the follow-up write. Both are now one check: `codeLetters` must be 1-4 characters from `A-Z`/`0-9`/`/` (the `/` covers the `V/A` filing), or the route 400s instead of guessing. (Review findings 1 + 2. The original version of this comment claimed normalizing "can never turn a real hit into a miss" -- that was true of the measured production snapshot, not of every possible input; this validation closes the gap rather than just documenting it.) The sibling write path `addArtist` still compares raw; widening its pre-check changes an existing route's 409 behavior and is deliberately left out of this PR.
- **Permission tier: `catalog: ['read']`** (review finding 3; was `catalog: ['write']` in the first version of this PR). Shelf-code data is already DJ-readable on two live endpoints -- `GET /library/query` returns `code_letters`/`code_number`/`code_artist_number` at `catalog: ['read']`, and `GET /djs/bin` returns the same at `bin: ['read']` -- and this route returns strictly *less* than `/library/query` already does, so there's no new leak. A DJ needs the call number to pull a record. `search` and `peek-code` stay at `catalog: ['write']`; they back the create-artist flow, not a plain lookup. (The original comment argued widening one of three siblings would be an inconsistency -- that's now backwards: sibling PR #2162 lands `catalog: ['read']` on `GET /artists/:id` and `GET /artists/:id/releases`, so `write` here would have been the odd one out.)
- **Route ordering**: registered in the existing `/artists/*` block, ahead of where WXYC/Backend-Service#2156 will add a parameterized `/artists/:id` route.
- **No `wxyc-shared/api.yaml` change**, per the issue -- the sibling `search`/`peek-code` routes are already live in production and undocumented there; WXYC/wxyc-shared#352 closes that drift for the whole surface. This PR does update `apps/backend/app.yaml` (Swagger-UI display only, not a codegen source), since both siblings already have entries there; the by-code entry's `security` scope and `code_letters` pattern are updated to match.
- **`parseCodeQueryInt`'s bare `Number()` parsing is deliberately untouched.** A dedicated consolidation PR is collapsing all five id parsers in this controller file after this batch of BS#2149 review fixes lands; narrowing accepted input on a live endpoint's parsing helper inside this feature PR would pre-empt that cleanup and risk drifting from its sibling parsers.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` -- 436 suites / 7389 tests pass

Coverage added at both levels. Unit (`tests/unit/controllers/library.controller.test.ts`):

- every owner of a contested code is returned, in order -- not one arbitrary row, for both a V/A code and an ordinary one
- `code_number` 0 passes through to the service unchanged
- negative, non-integer, blank, and above-`INT4_MAX` `code_number`; `genre_id` 0 and above-`INT4_MAX`; boundary values exactly at `INT4_MAX` still accepted
- both 404 `reason`s, plus an assertion that the two differ
- `code_letters` trim/upper-case normalization
- repeated-key `string[]` rejection for all three parameters
- `genreExists` is not probed on a hit, and probed exactly once on a miss
- **new (review findings 1 + 2):** `code_letters` domain validation -- rejects 5+ characters (both raw and after trimming), rejects `ß` and the Turkish dotless-i `ı` rather than silently folding them (the length-changing and charset-changing cases the review flagged), accepts the 4-character boundary, and accepts `V/A`'s `/` as the one non-alphanumeric character in production use

New permissions test (review finding 3, `tests/unit/routes/library-by-code-permissions.route.test.ts`), using the `jest.requireActual` real-middleware pattern from `library-discogs-recheck-permissions.route.test.ts`: `dj`, `member`, and `musicDirector` tokens are all authorized under `catalog: ['read']`; a request with no `Authorization` header is rejected.

Integration (`tests/integration/library.spec.js`): the same surface end-to-end, with a **multi-owner fixture seeded directly in SQL** -- the write path refuses a duplicate code triple by design, so the collision it cannot create is one only SQL can set up. The multi-owner assertion compares the response length against the database's own count for that triple, so it holds whether or not the environment's fixture already carries V/A rows.

Two test defects the original review found are fixed rather than kept:

- The peek-code regression test was tautological -- `peekArtistNumber` destructures only `code_letters` and `genre_id` and has no code path that can observe `code_number`, so the assertion could not fail for any implementation. It now pins the two-parameter contract directly: the exact service-call arguments at unit level, and identical responses across the two call shapes dj-site sends at integration level.
- "returns 400 when a required parameter is missing" asserted on a string naming *every* parameter, so it passed while naming the wrong one. The handler now names only the parameters actually absent, and the tests omit one at a time and assert the message names that one and none of the others.

A third, newly-introduced one is removed in this round (review finding 4): `resolveArtistByCode`'s `getArtistsByCode` filters `eq(artists.code_letters, codeLetters)` against a deterministic-collation column, so any row it returns is necessarily byte-equal to the normalized input -- a unit test asserting "echoes the stored code_letters, not the normalized input" only looked meaningful because the mock was hand-fed a different value; it could not fail for any real implementation. Deleted; the real version of this behavior is already covered by the integration suite's `resolves a %s code_letters to the same artist` cases, which run against actual Postgres.

## Follow-up (not in this PR)

`searchForAlbum` (`library.controller.ts:287`) is still a 501 stub. Out of scope here -- worth its own ticket.

Closes #2149

