### PR TITLE
Artist card endpoints: get artist by id, edit alphabetical_name, list an artist's releases

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -2055,6 +2055,122 @@ paths:
                     message: Artist code not assigned in that genre
                     reason: code_not_assigned
 
+  /library/artists/{id}:
+    get:
+      summary: Get an artist's card (BS#2156)
+      security:
+        - BearerAuth: ['dj']
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The artist-card field set
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  artist_id:
+                    type: integer
+                  artist_name:
+                    type: string
+                  alphabetical_name:
+                    type: string
+                  genre_id:
+                    type: integer
+                  code_letters:
+                    type: string
+                  code_artist_number:
+                    type: integer
+        '400':
+          description: Invalid artist id
+        '404':
+          description: Artist not found
+
+    patch:
+      summary: Update an artist's name fields (BS#2156)
+      security:
+        - BearerAuth: ['station-management']
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                artist_name:
+                  type: string
+                alphabetical_name:
+                  type: string
+      responses:
+        '200':
+          description: Successfully updated artist
+        '400':
+          description: Invalid artist id, or no updatable fields provided
+        '404':
+          description: Artist not found
+        '409':
+          description: artist_name already exists for another artist in that genre
+
+  /library/artists/{id}/releases:
+    get:
+      summary: List an artist's releases (BS#2156)
+      security:
+        - BearerAuth: ['dj']
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The artist's releases, ordered by call number
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  artist_id:
+                    type: integer
+                  releases:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        last_modified:
+                          type: string
+                          format: date-time
+                        format_name:
+                          type: string
+                        code_letters:
+                          type: string
+                        code_number:
+                          type: integer
+                        code_volume_letters:
+                          type: string
+                          nullable: true
+                        album_title:
+                          type: string
+                        alternate_artist_name:
+                          type: string
+                          nullable: true
+        '400':
+          description: Invalid artist id
+        '404':
+          description: Artist not found
+
   /library/formats:
     get:
       summary: Get format list

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -2096,15 +2096,21 @@ paths:
           description: Artist not found
 
     patch:
-      summary: Update an artist's name fields (BS#2156)
+      summary: Update an artist's alphabetical_name (BS#2156)
       description: >
         Enforced by `requirePermissions({ catalog: ['write'] })` — musicDirector
-        or above, the same tier as `POST`/`PATCH /library`. Both fields are
-        capped at 128 characters (the `varchar(128)` column width) and must be
-        non-empty strings. `genre_id`, `code_letters`, and `code_artist_number`
-        are real fields on `/wxycdb`'s artist-card form but have no write path
-        here yet — sending one is rejected with a 400 naming why, not silently
-        dropped.
+        or above, the same tier as `POST`/`PATCH /library`. `alphabetical_name`
+        is capped at 128 characters (the `varchar(128)` column width) and must
+        be a non-empty string. `artist_name`, `genre_id`, `code_letters`, and
+        `code_artist_number` are real fields on `/wxycdb`'s artist-card form
+        but have no write path on this endpoint — sending one is rejected with
+        a 400 naming why, not silently dropped. `artist_name` specifically:
+        `artists`/`library` are still tubafrenzy-canonical and
+        `jobs/library-etl` (a live cron) matches artists by `fold_artist_name`
+        and never updates `artists`, so a Backend-side rename would be
+        silently duplicated and reverted by the next ETL pass. Re-enabling
+        `artist_name` renaming is a follow-up gated on `library-etl` becoming
+        a one-shot job.
       security:
         - BearerAuth: ['catalog-write']
       parameters:
@@ -2119,9 +2125,6 @@ paths:
             schema:
               type: object
               properties:
-                artist_name:
-                  type: string
-                  maxLength: 128
                 alphabetical_name:
                   type: string
                   maxLength: 128
@@ -2149,14 +2152,12 @@ paths:
                     type: integer
         '400':
           description: >
-            Invalid artist id, missing/non-object body, a `genre_id` /
-            `code_letters` / `code_artist_number` field with no write path,
-            no updatable fields provided, or a field that is empty or over
-            128 characters
+            Invalid artist id, missing/non-object body, an `artist_name` /
+            `genre_id` / `code_letters` / `code_artist_number` field with no
+            write path on this endpoint, no updatable fields provided, or
+            `alphabetical_name` that is empty or over 128 characters
         '404':
           description: Artist not found
-        '409':
-          description: artist_name already exists for another artist in that genre
 
   /library/artists/{id}/releases:
     get:

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -2101,7 +2101,10 @@ paths:
         Enforced by `requirePermissions({ catalog: ['write'] })` — musicDirector
         or above, the same tier as `POST`/`PATCH /library`. Both fields are
         capped at 128 characters (the `varchar(128)` column width) and must be
-        non-empty strings; any other field on the body is silently dropped.
+        non-empty strings. `genre_id`, `code_letters`, and `code_artist_number`
+        are real fields on `/wxycdb`'s artist-card form but have no write path
+        here yet — sending one is rejected with a 400 naming why, not silently
+        dropped.
       security:
         - BearerAuth: ['catalog-write']
       parameters:
@@ -2146,8 +2149,10 @@ paths:
                     type: integer
         '400':
           description: >
-            Invalid artist id, missing/non-object body, no updatable fields
-            provided, or a field that is empty or over 128 characters
+            Invalid artist id, missing/non-object body, a `genre_id` /
+            `code_letters` / `code_artist_number` field with no write path,
+            no updatable fields provided, or a field that is empty or over
+            128 characters
         '404':
           description: Artist not found
         '409':

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -501,6 +501,27 @@ components:
         plays:
           type: integer
 
+    ArtistCard:
+      type: object
+      description: >-
+        The artist-card field set, returned by `GET /library/artists/{id}` and by
+        the `PATCH` 200 on the same path. `artist_id`, not `id` — the two
+        endpoints deliberately agree so a client that PATCHes and a client that
+        re-GETs the URL decode one shape.
+      properties:
+        artist_id:
+          type: integer
+        artist_name:
+          type: string
+        alphabetical_name:
+          type: string
+        genre_id:
+          type: integer
+        code_letters:
+          type: string
+        code_artist_number:
+          type: integer
+
     NewRotationRequest:
       type: object
       required: ['rotation_bin']
@@ -2076,20 +2097,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  artist_id:
-                    type: integer
-                  artist_name:
-                    type: string
-                  alphabetical_name:
-                    type: string
-                  genre_id:
-                    type: integer
-                  code_letters:
-                    type: string
-                  code_artist_number:
-                    type: integer
+                $ref: '#/components/schemas/ArtistCard'
         '400':
           description: Invalid artist id
         '404':
@@ -2120,14 +2128,22 @@ paths:
           schema:
             type: integer
       requestBody:
+        required: true
+        description: At least one updatable field must be provided.
         content:
           application/json:
             schema:
               type: object
+              required: ['alphabetical_name']
               properties:
                 alphabetical_name:
                   type: string
+                  minLength: 1
                   maxLength: 128
+                  description: >-
+                    Trimmed and NFC-normalized before storage, then measured in
+                    CODE POINTS against the `varchar(128)` column. A
+                    blank-after-trim value is a 400, not a silent no-op.
       responses:
         '200':
           description: >
@@ -2136,20 +2152,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  artist_id:
-                    type: integer
-                  artist_name:
-                    type: string
-                  alphabetical_name:
-                    type: string
-                  genre_id:
-                    type: integer
-                  code_letters:
-                    type: string
-                  code_artist_number:
-                    type: integer
+                $ref: '#/components/schemas/ArtistCard'
         '400':
           description: >
             Invalid artist id, missing/non-object body, an `artist_name` /

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -2058,8 +2058,12 @@ paths:
   /library/artists/{id}:
     get:
       summary: Get an artist's card (BS#2156)
+      description: >
+        Enforced by `requirePermissions({ catalog: ['read'] })` — DJ role or
+        above, the same tier as the other catalog reads documented with the
+        `catalog-read` scope.
       security:
-        - BearerAuth: ['dj']
+        - BearerAuth: ['catalog-read']
       parameters:
         - in: path
           name: id
@@ -2093,8 +2097,13 @@ paths:
 
     patch:
       summary: Update an artist's name fields (BS#2156)
+      description: >
+        Enforced by `requirePermissions({ catalog: ['write'] })` — musicDirector
+        or above, the same tier as `POST`/`PATCH /library`. Both fields are
+        capped at 128 characters (the `varchar(128)` column width) and must be
+        non-empty strings; any other field on the body is silently dropped.
       security:
-        - BearerAuth: ['station-management']
+        - BearerAuth: ['catalog-write']
       parameters:
         - in: path
           name: id
@@ -2109,13 +2118,36 @@ paths:
               properties:
                 artist_name:
                   type: string
+                  maxLength: 128
                 alphabetical_name:
                   type: string
+                  maxLength: 128
       responses:
         '200':
-          description: Successfully updated artist
+          description: >
+            The refreshed artist card — the same field set `GET
+            /library/artists/{id}` returns.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  artist_id:
+                    type: integer
+                  artist_name:
+                    type: string
+                  alphabetical_name:
+                    type: string
+                  genre_id:
+                    type: integer
+                  code_letters:
+                    type: string
+                  code_artist_number:
+                    type: integer
         '400':
-          description: Invalid artist id, or no updatable fields provided
+          description: >
+            Invalid artist id, missing/non-object body, no updatable fields
+            provided, or a field that is empty or over 128 characters
         '404':
           description: Artist not found
         '409':
@@ -2124,17 +2156,41 @@ paths:
   /library/artists/{id}/releases:
     get:
       summary: List an artist's releases (BS#2156)
+      description: >
+        Enforced by `requirePermissions({ catalog: ['read'] })` — DJ role or
+        above. Offset-paginated in the same `page`/`limit` shape as `GET
+        /library/query`. Rows carry the full physical call number
+        (`code_letters` + `code_artist_number` + `code_number` +
+        `code_volume_letters`); `code_artist_number` is genre-scoped, hence the
+        per-row `genre_id`. Ordered by shelf order — `code_number`, then
+        `code_volume_letters`, then `id` as a total order.
       security:
-        - BearerAuth: ['dj']
+        - BearerAuth: ['catalog-read']
       parameters:
         - in: path
           name: id
           required: true
           schema:
             type: integer
+        - in: query
+          name: page
+          required: false
+          description: Zero-based page index.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
       responses:
         '200':
-          description: The artist's releases, ordered by call number
+          description: One page of the artist's releases, in shelf order
           content:
             application/json:
               schema:
@@ -2154,8 +2210,12 @@ paths:
                           format: date-time
                         format_name:
                           type: string
+                        genre_id:
+                          type: integer
                         code_letters:
                           type: string
+                        code_artist_number:
+                          type: integer
                         code_number:
                           type: integer
                         code_volume_letters:
@@ -2166,8 +2226,14 @@ paths:
                         alternate_artist_name:
                           type: string
                           nullable: true
+                  total:
+                    type: integer
+                  page:
+                    type: integer
+                  totalPages:
+                    type: integer
         '400':
-          description: Invalid artist id
+          description: Invalid artist id, page, or limit
         '404':
           description: Artist not found
 

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -623,6 +623,90 @@ export const resolveArtistByCode: RequestHandler = async (
   });
 };
 
+const parseArtistId = (rawId: string): number => {
+  const artistId = Number(rawId);
+  if (!Number.isInteger(artistId) || artistId <= 0) {
+    throw new WxycError('Invalid artist ID', 400);
+  }
+  return artistId;
+};
+
+/**
+ * GET /library/artists/:id -- BS#2156 artist-card lookup: the field set
+ * `/wxycdb`'s `artistCardModify.jsp` displays. Registered after the literal
+ * `/artists/search` and `/artists/peek-code` routes -- see the route-ordering
+ * comment in library.route.ts.
+ */
+export const getArtistCard: RequestHandler<{ id: string }> = async (req, res) => {
+  const artistId = parseArtistId(req.params.id);
+  const artist = await libraryService.getArtistCardById(artistId);
+  if (!artist) {
+    throw new WxycError('Artist not found', 404);
+  }
+  res.status(200).json(artist);
+};
+
+type UpdateArtistRequest = {
+  artist_name?: string;
+  alphabetical_name?: string;
+};
+
+const MAX_ARTIST_TEXT_LENGTH = 128;
+
+/**
+ * PATCH /library/artists/:id -- allowlists exactly the two fields
+ * `/wxycdb`'s `modifyArtist` form edits (BS#2156). Any other field on the
+ * body is silently dropped, matching the `pickAddRotationFields` /
+ * `pickUpdateEntryFields` allowlist convention elsewhere in this repo.
+ */
+export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArtistRequest> = async (req, res) => {
+  const artistId = parseArtistId(req.params.id);
+  const { body } = req;
+
+  const updates: libraryService.UpdateArtistRow = {};
+  if (body.artist_name !== undefined) {
+    if (typeof body.artist_name !== 'string' || body.artist_name.trim() === '') {
+      throw new WxycError('artist_name must be a non-empty string', 400);
+    }
+    if (body.artist_name.length > MAX_ARTIST_TEXT_LENGTH) {
+      throw new WxycError(`artist_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
+    }
+    updates.artist_name = body.artist_name;
+  }
+  if (body.alphabetical_name !== undefined) {
+    if (typeof body.alphabetical_name !== 'string' || body.alphabetical_name.trim() === '') {
+      throw new WxycError('alphabetical_name must be a non-empty string', 400);
+    }
+    if (body.alphabetical_name.length > MAX_ARTIST_TEXT_LENGTH) {
+      throw new WxycError(`alphabetical_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
+    }
+    updates.alphabetical_name = body.alphabetical_name;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw new WxycError('Bad Request: provide at least one of artist_name, alphabetical_name', 400);
+  }
+
+  const updated = await libraryService.updateArtistInDB(artistId, updates);
+  if (!updated) {
+    throw new WxycError('Artist not found', 404);
+  }
+  res.status(200).json(updated);
+};
+
+/**
+ * GET /library/artists/:id/releases -- BS#2156: the release table on
+ * `/wxycdb`'s artist card (`getLibraryReleasesForArtist`).
+ */
+export const getArtistReleases: RequestHandler<{ id: string }> = async (req, res) => {
+  const artistId = parseArtistId(req.params.id);
+  if (!(await libraryService.getArtistNameById(artistId))) {
+    throw new WxycError('Artist not found', 404);
+  }
+  const releases = await libraryService.getReleasesForArtist(artistId);
+  res.status(200).json({ artist_id: artistId, releases });
+};
+
 export const getRotation: RequestHandler = async (req, res) => {
   const rotation = await libraryService.getRotationFromDB();
   res.status(200).json(rotation);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -754,7 +754,11 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   // JSON document (`"x"`, `[]`, `3`) so the shape checks that follow hold.
   const body: UpdateArtistRequest = req.body ?? {};
   if (typeof body !== 'object' || Array.isArray(body)) {
-    throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
+    // Names the actual failure. Answering "provide at least one of
+    // alphabetical_name" to `curl -X PATCH -d '[]'` points the caller at the
+    // wrong problem: the body is not a JSON object at all, so which fields it
+    // should have carried is not yet the question.
+    throw new WxycError('Bad Request: body must be a JSON object', 400);
   }
 
   // Reject a client that sends a field this endpoint cannot write, rather
@@ -799,14 +803,33 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
     if (trimmed === '') {
       throw new WxycError('alphabetical_name must be a non-empty string', 400);
     }
-    if (trimmed.length > MAX_ARTIST_TEXT_LENGTH) {
+    // Code points, not UTF-16 units -- `codePointLength`, not `.length`.
+    // Postgres measures `varchar(128)` in characters, so a bare `.length`
+    // counts every astral character (emoji, CJK Ext-B) twice and rejects
+    // values PG would store happily. This file already carries
+    // `codePointLength` for exactly that reason; measuring the wrong unit here
+    // undercut the reject-over-truncate choice it was written to protect.
+    if (codePointLength(trimmed) > MAX_ARTIST_TEXT_LENGTH) {
       throw new WxycError(`alphabetical_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
     }
     updates.alphabetical_name = trimmed;
   }
 
-  if (Object.keys(updates).length === 0) {
-    throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
+  // Short-circuit a no-op edit. `updateArtistInDB` always SETs
+  // `last_modified = NOW()`, which fires `touch_library_watermark_from_artists`
+  // (migration 0105, `FOR EACH STATEMENT` on `artists`) and advances the
+  // catalog conditional-GET watermark -- forcing every iOS / dj-site poller to
+  // re-download the full catalog for a write that changed nothing. That is the
+  // same cost `updateAlbum`'s `effectiveChange` guard exists to avoid (#1555);
+  // this path reaches it through a coarser, statement-level trigger on the
+  // parent table. A librarian hitting Save on an unchanged card, or a dj-site
+  // form resubmitting the same value, is the common case.
+  const effectiveChange = (Object.keys(updates) as Array<keyof libraryService.UpdateArtistRow>).some(
+    (key) => updates[key] !== existing[key as keyof typeof existing]
+  );
+  if (!effectiveChange) {
+    res.status(200).json(existing);
+    return;
   }
 
   const updated = await libraryService.updateArtistInDB(artistId, updates);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -663,28 +663,57 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   const artistId = parseArtistId(req.params.id);
   const { body } = req;
 
+  // Resolve the artist (and its genre, needed for the name-conflict check
+  // below) before any side effects -- same ordering rationale as
+  // updateAlbum's existence-before-write fix (issue 10 there).
+  const existing = await libraryService.getArtistCardById(artistId);
+  if (!existing) {
+    throw new WxycError('Artist not found', 404);
+  }
+
   const updates: libraryService.UpdateArtistRow = {};
   if (body.artist_name !== undefined) {
     if (typeof body.artist_name !== 'string' || body.artist_name.trim() === '') {
       throw new WxycError('artist_name must be a non-empty string', 400);
     }
-    if (body.artist_name.length > MAX_ARTIST_TEXT_LENGTH) {
+    const trimmed = body.artist_name.trim();
+    if (trimmed.length > MAX_ARTIST_TEXT_LENGTH) {
       throw new WxycError(`artist_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
     }
-    updates.artist_name = body.artist_name;
+    updates.artist_name = trimmed;
   }
   if (body.alphabetical_name !== undefined) {
     if (typeof body.alphabetical_name !== 'string' || body.alphabetical_name.trim() === '') {
       throw new WxycError('alphabetical_name must be a non-empty string', 400);
     }
-    if (body.alphabetical_name.length > MAX_ARTIST_TEXT_LENGTH) {
+    const trimmed = body.alphabetical_name.trim();
+    if (trimmed.length > MAX_ARTIST_TEXT_LENGTH) {
       throw new WxycError(`alphabetical_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
     }
-    updates.alphabetical_name = body.alphabetical_name;
+    updates.alphabetical_name = trimmed;
   }
 
   if (Object.keys(updates).length === 0) {
     throw new WxycError('Bad Request: provide at least one of artist_name, alphabetical_name', 400);
+  }
+
+  // Same genre-scoped name-conflict guard `addArtist` enforces (BS#980):
+  // `artistIdFromName`'s `fold_artist_name` matcher (migration 0134) is the
+  // one thing standing between a rename and recreating exactly the
+  // NFC/NFD/case duplicate state `jobs/artist-unicode-dedup` exists to
+  // clean up. Only runs when the name is actually changing, so a PATCH that
+  // re-sends the current name (a no-op "Save") never 409s against itself.
+  if (updates.artist_name !== undefined && updates.artist_name !== existing.artist_name) {
+    const conflictingArtistId = await libraryService.artistIdFromName(updates.artist_name, existing.genre_id);
+    if (conflictingArtistId && conflictingArtistId !== artistId) {
+      const conflictingArtist = await libraryService.getArtistById(conflictingArtistId);
+      res.status(409).json({
+        message: 'Artist name already exists in that genre.',
+        reason: 'artist_name_conflict',
+        artist: conflictingArtist,
+      });
+      return;
+    }
   }
 
   const updated = await libraryService.updateArtistInDB(artistId, updates);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -669,19 +669,52 @@ export const getArtistCard: RequestHandler<{ id: string }> = async (req, res) =>
 type UpdateArtistRequest = {
   artist_name?: string;
   alphabetical_name?: string;
+  // `/wxycdb`'s `artistCardModify.jsp:41-64` posts five fields --
+  // `ArtistAdminServlet.java:196-206` applies all five -- but only the two
+  // above have a write path here. Declared (not just left unread) so
+  // `ARTIST_NO_COLUMN_FIELDS` below can reject a client that sends one of
+  // these three with a precise 400 instead of silently dropping it.
+  genre_id?: unknown;
+  code_letters?: unknown;
+  code_artist_number?: unknown;
 };
 
 const MAX_ARTIST_TEXT_LENGTH = 128;
 
 const UPDATABLE_ARTIST_FIELDS = ['artist_name', 'alphabetical_name'] as const;
 
+const ARTIST_NO_COLUMN_FIELDS = ['genre_id', 'code_letters', 'code_artist_number'] as const;
+
+// Why each field has no write path today -- verified against the FULL write
+// surface, not asserted: `updateArtistInDB` is the only `.update(artists)`
+// call in the codebase and only ever SETs `artist_name`/`alphabetical_name`,
+// and `genre_artist_crossreference` (the row that carries `genre_id` and
+// `code_artist_number`, i.e. `artist_genre_code`) is only ever `.insert()`ed
+// -- by `POST /library/artists` -- never `.update()`d anywhere. So a 409/404
+// pointing at "the endpoint that owns this field" would be dishonest: no
+// such endpoint exists yet.
+const ARTIST_NO_COLUMN_FIELD_OWNERS: Record<(typeof ARTIST_NO_COLUMN_FIELDS)[number], string> = {
+  genre_id:
+    'no write path: genre_artist_crossreference.genre_id is set once by POST /library/artists and is never UPDATEd by any endpoint',
+  code_letters:
+    'no write path: artists.code_letters is set once by POST /library/artists and is never UPDATEd by any endpoint',
+  code_artist_number:
+    'no write path: genre_artist_crossreference.artist_genre_code is set once by POST /library/artists and is never UPDATEd by any endpoint',
+};
+
 const NO_ARTIST_FIELDS_MESSAGE = `Bad Request: provide at least one of ${UPDATABLE_ARTIST_FIELDS.join(', ')}`;
 
 /**
  * PATCH /library/artists/:id -- allowlists exactly the two fields
- * `/wxycdb`'s `modifyArtist` form edits (BS#2156). Any other field on the
- * body is silently dropped, matching the `pickAddRotationFields` /
- * `pickUpdateEntryFields` allowlist convention elsewhere in this repo.
+ * `/wxycdb`'s `modifyArtist` form edits (BS#2156). The other three JSP
+ * fields (`genre_id`, `code_letters`, `code_artist_number`) are REJECTED
+ * with a 400 naming why (`ARTIST_NO_COLUMN_FIELD_OWNERS`), not silently
+ * dropped -- unlike the `pickAddRotationFields` / `pickUpdateEntryFields`
+ * allowlist convention elsewhere in this repo, which does drop silently.
+ * The difference: those allowlists drop server-derived columns a client
+ * should never control; these three are real edits a librarian can make on
+ * the legacy JSP that this endpoint simply cannot perform yet, so silently
+ * accepting-and-ignoring them would look like a successful edit that wasn't.
  */
 export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArtistRequest> = async (req, res) => {
   const artistId = parseArtistId(req.params.id);
@@ -695,6 +728,16 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   const body: UpdateArtistRequest = req.body ?? {};
   if (typeof body !== 'object' || Array.isArray(body)) {
     throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
+  }
+
+  // Reject a client that sends a field this endpoint cannot write, rather
+  // than silently dropping it (BS#2156 review). Precedes the has-any-field
+  // check below, matching the ROTATION_NO_COLUMN_FIELDS ordering PATCH
+  // /library/rotation/:id uses (WXYC/Backend-Service#2165).
+  const rejectedFields = ARTIST_NO_COLUMN_FIELDS.filter((field) => field in body);
+  if (rejectedFields.length > 0) {
+    const detail = rejectedFields.map((field) => `${field} (${ARTIST_NO_COLUMN_FIELD_OWNERS[field]})`).join(', ');
+    throw new WxycError(`Bad Request: no write path exists for ${detail}`, 400);
   }
 
   // Request-shape 400s precede the existence 404, matching updateAlbum. The
@@ -738,7 +781,7 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
     throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
   }
 
-  // Same genre-scoped name-conflict guard `addArtist` enforces (BS#980): the
+  // Same name-conflict guard `addArtist` enforces (BS#980): the
   // `fold_artist_name` matcher (migration 0134) is the one thing standing
   // between a rename and recreating exactly the NFC/NFD/case duplicate state
   // `jobs/artist-unicode-dedup` exists to clean up. Only runs when the name is
@@ -750,14 +793,23 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   // to return: that probe is `.limit(1)` with no `orderBy`, so on a genre that
   // already holds two fold-equal rows it can hand back the row being renamed
   // and the comparison would wave the rename through.
+  //
+  // NOT scoped to `existing.genre_id` -- `getArtistCardById` deliberately
+  // collapses a multi-genre artist to its LOWEST `genre_id` crossreference,
+  // so a probe fixed to that one genre would never see a fold-equal
+  // duplicate sitting in any of the artist's OTHER genres. Multi-genre
+  // artists are a designed state (`jobs/artist-unicode-dedup/merge.ts`
+  // repoints every crossreference onto a survivor precisely so the matcher
+  // reaches it from every genre), so `conflictingArtistIdInGenre` checks
+  // every genre `artistId` is crossreferenced in.
   if (updates.artist_name !== undefined && updates.artist_name !== existing.artist_name) {
-    const conflictingArtistId = await libraryService.conflictingArtistIdInGenre(
-      updates.artist_name,
-      existing.genre_id,
-      artistId
-    );
-    if (conflictingArtistId) {
-      const conflictingArtist = await libraryService.getArtistById(conflictingArtistId);
+    const conflictingArtistId = await libraryService.conflictingArtistIdInGenre(updates.artist_name, artistId);
+    // A miss on the second lookup means the row was deleted between the two
+    // queries, so the name is free again: proceed rather than answer 409
+    // with an `artist` the client cannot act on. Mirrors `addArtist`'s
+    // identical race handling above.
+    const conflictingArtist = conflictingArtistId ? await libraryService.getArtistById(conflictingArtistId) : null;
+    if (conflictingArtist) {
       res.status(409).json({
         message: 'Artist name already exists in that genre.',
         reason: 'artist_name_conflict',
@@ -781,20 +833,17 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   res.status(200).json(refreshed);
 };
 
-// Same page-size convention as `GET /library/query` (see DEFAULT_LIMIT /
-// MAX_LIMIT there); a smaller default because one artist's shelf is a much
-// shorter list than a catalog search.
-const DEFAULT_RELEASES_LIMIT = 50;
-const MAX_RELEASES_LIMIT = 100;
-
 /**
  * GET /library/artists/:id/releases -- BS#2156: the release table on
  * `/wxycdb`'s artist card (`getLibraryReleasesForArtist`).
  *
- * Offset-paginated (`page`/`limit`) in the shape `GET /library/query` uses.
- * Unbounded, this hands any `catalog:read` DJ every row an artist has — 3,107
- * of them for artist 1087 ('Various Artists'), ~0.5-1 MB of JSON per
- * repeatable request.
+ * Offset-paginated (`page`/`limit`) in the shape `GET /library/query` uses --
+ * reuses that endpoint's `DEFAULT_LIMIT`/`MAX_LIMIT` (50/100, declared below;
+ * module-level consts are in scope regardless of declaration order) rather
+ * than a second pair of identical constants under a new name. Unbounded,
+ * this hands any `catalog:read` DJ every row an artist has — 3,107 of them
+ * for artist 1087 ('Various Artists'), ~0.5-1 MB of JSON per repeatable
+ * request.
  */
 export const getArtistReleases: RequestHandler<
   { id: string },
@@ -818,15 +867,23 @@ export const getArtistReleases: RequestHandler<
   if (req.query.limit !== undefined && typeof req.query.limit !== 'string') {
     throw new WxycError('limit must be a single string value', 400);
   }
-  const limit = parseInt(req.query.limit ?? String(DEFAULT_RELEASES_LIMIT));
+  const limit = parseInt(req.query.limit ?? String(DEFAULT_LIMIT));
   if (isNaN(limit) || limit < 1) {
     throw new WxycError('limit must be a positive integer', 400);
   }
-  if (limit > MAX_RELEASES_LIMIT) {
-    throw new WxycError(`limit must not exceed ${MAX_RELEASES_LIMIT}`, 400);
+  if (limit > MAX_LIMIT) {
+    throw new WxycError(`limit must not exceed ${MAX_LIMIT}`, 400);
   }
 
-  if (!(await libraryService.getArtistNameById(artistId))) {
+  // Same existence predicate GET/PATCH /library/artists/:id use
+  // (`getArtistCardById`'s INNER JOIN to `genre_artist_crossreference`), not
+  // the plain `artists` lookup `getArtistNameById` did before -- an artist
+  // row with no crossreference must 404 the same way here it already does on
+  // the card and the PATCH, not silently 200 with an empty release page. Also
+  // sidesteps the `!name` falsy-check trap: a legacy empty-string
+  // `artist_name` would read as "missing" under that check even though the
+  // row exists.
+  if (!(await libraryService.getArtistCardById(artistId))) {
     throw new WxycError('Artist not found', 404);
   }
   const [releases, total] = await Promise.all([
@@ -1948,6 +2005,9 @@ type LibraryQueryParams = {
 
 const VALID_CATALOG_SORTS: CatalogSort[] = ['artist', 'album', 'plays', 'date'];
 const VALID_CATALOG_ORDERS: CatalogOrder[] = ['asc', 'desc'];
+// Also reused by `getArtistReleases` (BS#2156) above -- module-level consts
+// are in scope regardless of declaration order, and the two endpoints share
+// this exact page-size convention rather than needing their own.
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -667,13 +667,17 @@ export const getArtistCard: RequestHandler<{ id: string }> = async (req, res) =>
 };
 
 type UpdateArtistRequest = {
-  artist_name?: string;
   alphabetical_name?: string;
   // `/wxycdb`'s `artistCardModify.jsp:41-64` posts five fields --
-  // `ArtistAdminServlet.java:196-206` applies all five -- but only the two
-  // above have a write path here. Declared (not just left unread) so
-  // `ARTIST_NO_COLUMN_FIELDS` below can reject a client that sends one of
-  // these three with a precise 400 instead of silently dropping it.
+  // `ArtistAdminServlet.java:196-206` applies all five -- but only
+  // `alphabetical_name` has a write path here. The other four are declared
+  // (not just left unread) so `ARTIST_NO_COLUMN_FIELDS` below can reject a
+  // client that sends one of them with a precise 400 instead of silently
+  // dropping it. `artist_name` is declared `unknown`, not `string`: it once
+  // had a write path on this endpoint, pulled before ship -- see
+  // `ARTIST_NO_COLUMN_FIELD_OWNERS.artist_name` and the doc comment on
+  // `updateArtistCard`.
+  artist_name?: unknown;
   genre_id?: unknown;
   code_letters?: unknown;
   code_artist_number?: unknown;
@@ -681,19 +685,23 @@ type UpdateArtistRequest = {
 
 const MAX_ARTIST_TEXT_LENGTH = 128;
 
-const UPDATABLE_ARTIST_FIELDS = ['artist_name', 'alphabetical_name'] as const;
+const UPDATABLE_ARTIST_FIELDS = ['alphabetical_name'] as const;
 
-const ARTIST_NO_COLUMN_FIELDS = ['genre_id', 'code_letters', 'code_artist_number'] as const;
+const ARTIST_NO_COLUMN_FIELDS = ['artist_name', 'genre_id', 'code_letters', 'code_artist_number'] as const;
 
-// Why each field has no write path today -- verified against the FULL write
-// surface, not asserted: `updateArtistInDB` is the only `.update(artists)`
-// call in the codebase and only ever SETs `artist_name`/`alphabetical_name`,
-// and `genre_artist_crossreference` (the row that carries `genre_id` and
-// `code_artist_number`, i.e. `artist_genre_code`) is only ever `.insert()`ed
-// -- by `POST /library/artists` -- never `.update()`d anywhere. So a 409/404
-// pointing at "the endpoint that owns this field" would be dishonest: no
-// such endpoint exists yet.
+// Why each field has no write path on THIS ENDPOINT today -- verified
+// against the full write surface, not asserted. `genre_id`/`code_letters`/
+// `code_artist_number` have no write path anywhere: `genre_artist_crossreference`
+// (the row that carries `genre_id` and `code_artist_number`, i.e.
+// `artist_genre_code`) is only ever `.insert()`ed -- by `POST /library/artists`
+// -- never `.update()`d, and `artists.code_letters` is likewise write-once.
+// `artist_name` is different in kind: `updateArtistInDB` still accepts it
+// (kept, not dead code -- the follow-up ticket below re-enables it by
+// re-adding it to `UPDATABLE_ARTIST_FIELDS`), but this endpoint deliberately
+// never passes it through. See the doc comment on `updateArtistCard`.
 const ARTIST_NO_COLUMN_FIELD_OWNERS: Record<(typeof ARTIST_NO_COLUMN_FIELDS)[number], string> = {
+  artist_name:
+    "not editable while the catalog is tubafrenzy-canonical: jobs/library-etl is a live 30-minute cron whose ensureArtist matches by fold_artist_name and never UPDATEs artists, so a rename here would move the match key, get silently duplicated on the next ETL pass, and be reverted by that duplicate row's release upsert -- tracked as a follow-up ticket gated on library-etl becoming job-type: one-shot",
   genre_id:
     'no write path: genre_artist_crossreference.genre_id is set once by POST /library/artists and is never UPDATEd by any endpoint',
   code_letters:
@@ -705,16 +713,35 @@ const ARTIST_NO_COLUMN_FIELD_OWNERS: Record<(typeof ARTIST_NO_COLUMN_FIELDS)[num
 const NO_ARTIST_FIELDS_MESSAGE = `Bad Request: provide at least one of ${UPDATABLE_ARTIST_FIELDS.join(', ')}`;
 
 /**
- * PATCH /library/artists/:id -- allowlists exactly the two fields
- * `/wxycdb`'s `modifyArtist` form edits (BS#2156). The other three JSP
- * fields (`genre_id`, `code_letters`, `code_artist_number`) are REJECTED
- * with a 400 naming why (`ARTIST_NO_COLUMN_FIELD_OWNERS`), not silently
- * dropped -- unlike the `pickAddRotationFields` / `pickUpdateEntryFields`
- * allowlist convention elsewhere in this repo, which does drop silently.
- * The difference: those allowlists drop server-derived columns a client
- * should never control; these three are real edits a librarian can make on
- * the legacy JSP that this endpoint simply cannot perform yet, so silently
- * accepting-and-ignoring them would look like a successful edit that wasn't.
+ * PATCH /library/artists/:id -- allowlists exactly one of the five
+ * `/wxycdb` `modifyArtist` form fields, `alphabetical_name` (BS#2156). The
+ * other four JSP fields (`artist_name`, `genre_id`, `code_letters`,
+ * `code_artist_number`) are REJECTED with a 400 naming why
+ * (`ARTIST_NO_COLUMN_FIELD_OWNERS`), not silently dropped -- unlike the
+ * `pickAddRotationFields` / `pickUpdateEntryFields` allowlist convention
+ * elsewhere in this repo, which does drop silently. The difference: those
+ * allowlists drop server-derived columns a client should never control;
+ * these four are real edits a librarian can make on the legacy JSP, so
+ * silently accepting-and-ignoring them would look like a successful edit
+ * that wasn't.
+ *
+ * `artist_name` was allowlisted alongside `alphabetical_name` in an earlier
+ * revision of this endpoint and was pulled before ship (review finding,
+ * verified end to end): `artists`/`library` are still tubafrenzy-canonical,
+ * and `jobs/library-etl` -- on a live 30-minute cron (its `package.json` has
+ * no `job-type` key, and `deploy-base.yml` defaults that to `"cron"`; its
+ * siblings `flowsheet-etl` and `rotation-etl` were both flipped to
+ * `"job-type": "one-shot"` and this one was not) -- `ensureArtist`s by
+ * finding-or-inserting on `fold_artist_name` and never UPDATEs `artists`. A
+ * rename here moves the match key out from under that probe: the next ETL
+ * pass misses, inserts a duplicate artist that lands the SAME shelf code
+ * without violating anything (`genre_artist_crossreference` is unique only
+ * on `(artist_id, genre_id)`), and that duplicate's release upsert repoints
+ * the library row and reverts the name (`LEGACY_SOURCED_LIBRARY_COLUMNS`
+ * carries both `artist_id` and `artist_name`) -- silently, no crash.
+ * `alphabetical_name` is safe: it is not part of the ETL's match key and the
+ * ETL never updates `artists` at all. Re-enabling `artist_name` renaming is
+ * its own ticket, blocked on `library-etl` becoming `job-type: one-shot`.
  */
 export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArtistRequest> = async (req, res) => {
   const artistId = parseArtistId(req.params.id);
@@ -747,8 +774,7 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
     throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
   }
 
-  // Resolve the artist (and its genre, needed for the name-conflict check
-  // below) before any side effects -- same ordering rationale as
+  // Resolve the artist before any side effects -- same ordering rationale as
   // updateAlbum's existence-before-write fix (issue 10 there).
   const existing = await libraryService.getArtistCardById(artistId);
   if (!existing) {
@@ -756,21 +782,23 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   }
 
   const updates: libraryService.UpdateArtistRow = {};
-  if (body.artist_name !== undefined) {
-    if (typeof body.artist_name !== 'string' || body.artist_name.trim() === '') {
-      throw new WxycError('artist_name must be a non-empty string', 400);
-    }
-    const trimmed = body.artist_name.trim();
-    if (trimmed.length > MAX_ARTIST_TEXT_LENGTH) {
-      throw new WxycError(`artist_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
-    }
-    updates.artist_name = trimmed;
-  }
   if (body.alphabetical_name !== undefined) {
-    if (typeof body.alphabetical_name !== 'string' || body.alphabetical_name.trim() === '') {
+    if (typeof body.alphabetical_name !== 'string') {
       throw new WxycError('alphabetical_name must be a non-empty string', 400);
     }
-    const trimmed = body.alphabetical_name.trim();
+    // Normalize to NFC BEFORE trimming/measuring, matching what
+    // `updateArtistInDB` stores (BS#1897) -- NFC is NOT length-non-increasing
+    // (e.g. `'क़'.normalize('NFC')` is 2 UTF-16 units). Measuring the raw
+    // `trim()`ed input let a 128-char string of composition-exclusion
+    // codepoints pass this 400, reach Postgres at a longer NFC length, and
+    // trip SQLSTATE 22001 ("value too long") -> 500 where the documented
+    // answer is 400 (review finding N2). Normalize first, measure second,
+    // store the normalized value, so the length checked here is the length
+    // that actually reaches the column.
+    const trimmed = body.alphabetical_name.normalize('NFC').trim();
+    if (trimmed === '') {
+      throw new WxycError('alphabetical_name must be a non-empty string', 400);
+    }
     if (trimmed.length > MAX_ARTIST_TEXT_LENGTH) {
       throw new WxycError(`alphabetical_name must be ${MAX_ARTIST_TEXT_LENGTH} characters or fewer`, 400);
     }
@@ -779,44 +807,6 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
 
   if (Object.keys(updates).length === 0) {
     throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
-  }
-
-  // Same name-conflict guard `addArtist` enforces (BS#980): the
-  // `fold_artist_name` matcher (migration 0134) is the one thing standing
-  // between a rename and recreating exactly the NFC/NFD/case duplicate state
-  // `jobs/artist-unicode-dedup` exists to clean up. Only runs when the name is
-  // actually changing, so a PATCH that re-sends the current name (a no-op
-  // "Save") never 409s against itself.
-  //
-  // The self-exclusion lives INSIDE the query (`conflictingArtistIdInGenre`),
-  // not as a `!== artistId` comparison on whatever `artistIdFromName` happened
-  // to return: that probe is `.limit(1)` with no `orderBy`, so on a genre that
-  // already holds two fold-equal rows it can hand back the row being renamed
-  // and the comparison would wave the rename through.
-  //
-  // NOT scoped to `existing.genre_id` -- `getArtistCardById` deliberately
-  // collapses a multi-genre artist to its LOWEST `genre_id` crossreference,
-  // so a probe fixed to that one genre would never see a fold-equal
-  // duplicate sitting in any of the artist's OTHER genres. Multi-genre
-  // artists are a designed state (`jobs/artist-unicode-dedup/merge.ts`
-  // repoints every crossreference onto a survivor precisely so the matcher
-  // reaches it from every genre), so `conflictingArtistIdInGenre` checks
-  // every genre `artistId` is crossreferenced in.
-  if (updates.artist_name !== undefined && updates.artist_name !== existing.artist_name) {
-    const conflictingArtistId = await libraryService.conflictingArtistIdInGenre(updates.artist_name, artistId);
-    // A miss on the second lookup means the row was deleted between the two
-    // queries, so the name is free again: proceed rather than answer 409
-    // with an `artist` the client cannot act on. Mirrors `addArtist`'s
-    // identical race handling above.
-    const conflictingArtist = conflictingArtistId ? await libraryService.getArtistById(conflictingArtistId) : null;
-    if (conflictingArtist) {
-      res.status(409).json({
-        message: 'Artist name already exists in that genre.',
-        reason: 'artist_name_conflict',
-        artist: conflictingArtist,
-      });
-      return;
-    }
   }
 
   const updated = await libraryService.updateArtistInDB(artistId, updates);

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -623,13 +623,33 @@ export const resolveArtistByCode: RequestHandler = async (
   });
 };
 
-const parseArtistId = (rawId: string): number => {
-  const artistId = Number(rawId);
-  if (!Number.isInteger(artistId) || artistId <= 0) {
-    throw new WxycError('Invalid artist ID', 400);
+// The only spelling of a path id we accept: bare decimal digits, no sign, no
+// leading zero, no whitespace, no exponent, no radix prefix, no fraction.
+// `Number()` happily accepts '1e21', '0x2a', ' 42 ', '42.0', '+42' and '007',
+// each of which would alias a distinct URL onto one resource (and, for the
+// first two, onto ids no `serial` column can hold).
+const CANONICAL_ID_PATTERN = /^[1-9][0-9]*$/;
+
+/**
+ * Parse a positive int4 surrogate key out of a path parameter, or throw the
+ * 400 that keeps a malformed URL from reaching Postgres.
+ *
+ * ONE implementation deliberately shared by `parseArtistId`/`parseAlbumId`:
+ * the two were verbatim clones, and a hardening fix applied to one copy is a
+ * hole left open in the other.
+ */
+const parseResourceId = (rawId: string, resource: string): number => {
+  if (typeof rawId !== 'string' || !CANONICAL_ID_PATTERN.test(rawId)) {
+    throw new WxycError(`Invalid ${resource} ID`, 400);
   }
-  return artistId;
+  const id = Number(rawId);
+  if (id > INT4_MAX) {
+    throw new WxycError(`Invalid ${resource} ID`, 400);
+  }
+  return id;
 };
+
+const parseArtistId = (rawId: string): number => parseResourceId(rawId, 'artist');
 
 /**
  * GET /library/artists/:id -- BS#2156 artist-card lookup: the field set
@@ -653,6 +673,10 @@ type UpdateArtistRequest = {
 
 const MAX_ARTIST_TEXT_LENGTH = 128;
 
+const UPDATABLE_ARTIST_FIELDS = ['artist_name', 'alphabetical_name'] as const;
+
+const NO_ARTIST_FIELDS_MESSAGE = `Bad Request: provide at least one of ${UPDATABLE_ARTIST_FIELDS.join(', ')}`;
+
 /**
  * PATCH /library/artists/:id -- allowlists exactly the two fields
  * `/wxycdb`'s `modifyArtist` form edits (BS#2156). Any other field on the
@@ -661,7 +685,24 @@ const MAX_ARTIST_TEXT_LENGTH = 128;
  */
 export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArtistRequest> = async (req, res) => {
   const artistId = parseArtistId(req.params.id);
-  const { body } = req;
+
+  // `app.ts` mounts a bare `express.json()`, and body-parser 2.x leaves
+  // `req.body` UNDEFINED for a body-less or non-JSON-typed request — Express 5
+  // no longer defaults it to `{}`. Dereferencing it below would be a
+  // TypeError, i.e. a 500 on the single most likely smoke-test request
+  // (`curl -X PATCH` with no body). Normalize to `{}` and reject a non-object
+  // JSON document (`"x"`, `[]`, `3`) so the shape checks that follow hold.
+  const body: UpdateArtistRequest = req.body ?? {};
+  if (typeof body !== 'object' || Array.isArray(body)) {
+    throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
+  }
+
+  // Request-shape 400s precede the existence 404, matching updateAlbum. The
+  // reverse order answers 404 for an unknown artist and 500 for a real one on
+  // the very same malformed request.
+  if (!UPDATABLE_ARTIST_FIELDS.some((field) => field in body)) {
+    throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
+  }
 
   // Resolve the artist (and its genre, needed for the name-conflict check
   // below) before any side effects -- same ordering rationale as
@@ -694,18 +735,28 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   }
 
   if (Object.keys(updates).length === 0) {
-    throw new WxycError('Bad Request: provide at least one of artist_name, alphabetical_name', 400);
+    throw new WxycError(NO_ARTIST_FIELDS_MESSAGE, 400);
   }
 
-  // Same genre-scoped name-conflict guard `addArtist` enforces (BS#980):
-  // `artistIdFromName`'s `fold_artist_name` matcher (migration 0134) is the
-  // one thing standing between a rename and recreating exactly the
-  // NFC/NFD/case duplicate state `jobs/artist-unicode-dedup` exists to
-  // clean up. Only runs when the name is actually changing, so a PATCH that
-  // re-sends the current name (a no-op "Save") never 409s against itself.
+  // Same genre-scoped name-conflict guard `addArtist` enforces (BS#980): the
+  // `fold_artist_name` matcher (migration 0134) is the one thing standing
+  // between a rename and recreating exactly the NFC/NFD/case duplicate state
+  // `jobs/artist-unicode-dedup` exists to clean up. Only runs when the name is
+  // actually changing, so a PATCH that re-sends the current name (a no-op
+  // "Save") never 409s against itself.
+  //
+  // The self-exclusion lives INSIDE the query (`conflictingArtistIdInGenre`),
+  // not as a `!== artistId` comparison on whatever `artistIdFromName` happened
+  // to return: that probe is `.limit(1)` with no `orderBy`, so on a genre that
+  // already holds two fold-equal rows it can hand back the row being renamed
+  // and the comparison would wave the rename through.
   if (updates.artist_name !== undefined && updates.artist_name !== existing.artist_name) {
-    const conflictingArtistId = await libraryService.artistIdFromName(updates.artist_name, existing.genre_id);
-    if (conflictingArtistId && conflictingArtistId !== artistId) {
+    const conflictingArtistId = await libraryService.conflictingArtistIdInGenre(
+      updates.artist_name,
+      existing.genre_id,
+      artistId
+    );
+    if (conflictingArtistId) {
       const conflictingArtist = await libraryService.getArtistById(conflictingArtistId);
       res.status(409).json({
         message: 'Artist name already exists in that genre.',
@@ -720,20 +771,69 @@ export const updateArtistCard: RequestHandler<{ id: string }, unknown, UpdateArt
   if (!updated) {
     throw new WxycError('Artist not found', 404);
   }
-  res.status(200).json(updated);
+  // Answer with the same card shape `GET /library/artists/:id` serves rather
+  // than the bare `artists` RETURNING row, so a client that PATCHes and a
+  // client that re-GETs the same URL see one field set (`artist_id`, not `id`).
+  const refreshed = await libraryService.getArtistCardById(artistId);
+  if (!refreshed) {
+    throw new WxycError('Artist not found', 404);
+  }
+  res.status(200).json(refreshed);
 };
+
+// Same page-size convention as `GET /library/query` (see DEFAULT_LIMIT /
+// MAX_LIMIT there); a smaller default because one artist's shelf is a much
+// shorter list than a catalog search.
+const DEFAULT_RELEASES_LIMIT = 50;
+const MAX_RELEASES_LIMIT = 100;
 
 /**
  * GET /library/artists/:id/releases -- BS#2156: the release table on
  * `/wxycdb`'s artist card (`getLibraryReleasesForArtist`).
+ *
+ * Offset-paginated (`page`/`limit`) in the shape `GET /library/query` uses.
+ * Unbounded, this hands any `catalog:read` DJ every row an artist has — 3,107
+ * of them for artist 1087 ('Various Artists'), ~0.5-1 MB of JSON per
+ * repeatable request.
  */
-export const getArtistReleases: RequestHandler<{ id: string }> = async (req, res) => {
+export const getArtistReleases: RequestHandler<
+  { id: string },
+  unknown,
+  unknown,
+  { page?: string; limit?: string }
+> = async (req, res) => {
   const artistId = parseArtistId(req.params.id);
+
+  // Express's `simple` query parser yields string[] for a repeated key, and
+  // parseInt(['1','2']) stringifies to '1,2' → 1, silently coercing rather
+  // than erroring (#1553).
+  if (req.query.page !== undefined && typeof req.query.page !== 'string') {
+    throw new WxycError('page must be a single string value', 400);
+  }
+  const page = parseInt(req.query.page ?? '0');
+  if (isNaN(page) || page < 0) {
+    throw new WxycError('page must be a non-negative integer', 400);
+  }
+
+  if (req.query.limit !== undefined && typeof req.query.limit !== 'string') {
+    throw new WxycError('limit must be a single string value', 400);
+  }
+  const limit = parseInt(req.query.limit ?? String(DEFAULT_RELEASES_LIMIT));
+  if (isNaN(limit) || limit < 1) {
+    throw new WxycError('limit must be a positive integer', 400);
+  }
+  if (limit > MAX_RELEASES_LIMIT) {
+    throw new WxycError(`limit must not exceed ${MAX_RELEASES_LIMIT}`, 400);
+  }
+
   if (!(await libraryService.getArtistNameById(artistId))) {
     throw new WxycError('Artist not found', 404);
   }
-  const releases = await libraryService.getReleasesForArtist(artistId);
-  res.status(200).json({ artist_id: artistId, releases });
+  const [releases, total] = await Promise.all([
+    libraryService.getReleasesForArtist(artistId, page, limit),
+    libraryService.countReleasesForArtist(artistId),
+  ]);
+  res.status(200).json({ artist_id: artistId, releases, total, page, totalPages: Math.ceil(total / limit) });
 };
 
 export const getRotation: RequestHandler = async (req, res) => {
@@ -1204,13 +1304,7 @@ export const getAlbum: RequestHandler<
   res.status(200).json(album);
 };
 
-const parseAlbumId = (rawId: string): number => {
-  const albumId = Number(rawId);
-  if (!Number.isInteger(albumId) || albumId <= 0) {
-    throw new WxycError('Invalid album ID', 400);
-  }
-  return albumId;
-};
+const parseAlbumId = (rawId: string): number => parseResourceId(rawId, 'album');
 
 type UpdateAlbumRequest = {
   album_title?: string;

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -163,6 +163,25 @@ library_route.get('/artists/peek-code', requirePermissions({ catalog: ['write'] 
 // ever reordered.
 library_route.get('/artists/by-code', requirePermissions({ catalog: ['read'] }), libraryController.resolveArtistByCode);
 
+// BS#2156 artist-card routes. REGISTRATION ORDER IS LOAD-BEARING: these are
+// the first parameterized `/artists/:id`-style routes on this router, and
+// must be registered AFTER every literal `/artists/*` route above (`search`,
+// `peek-code`, and WXYC/Backend-Service#2149's future `by-code`) or Express
+// hands e.g. `GET /artists/search` to this `:id` handler instead, with
+// `Number('search')` becoming NaN -- the same `/catalog` vs
+// `/:id/compilation-tracks` trap documented above. `/artists/search` and
+// `/artists/peek-code` staying on their own handlers is pinned by the
+// integration spec.
+library_route.get('/artists/:id', requirePermissions({ catalog: ['read'] }), libraryController.getArtistCard);
+
+library_route.patch('/artists/:id', requirePermissions({ catalog: ['write'] }), libraryController.updateArtistCard);
+
+library_route.get(
+  '/artists/:id/releases',
+  requirePermissions({ catalog: ['read'] }),
+  libraryController.getArtistReleases
+);
+
 library_route.get('/formats', requirePermissions({ catalog: ['read'] }), libraryController.getFormats);
 
 library_route.post('/formats', requirePermissions({ catalog: ['write'] }), libraryController.addFormat);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2208,6 +2208,112 @@ export const getArtistById = async (artist_id: number): Promise<ArtistCodeOwner 
   return response[0] ?? null;
 };
 
+export type ArtistCardRow = {
+  artist_id: number;
+  artist_name: string;
+  alphabetical_name: string;
+  genre_id: number;
+  code_letters: string;
+  code_artist_number: number;
+};
+
+/**
+ * BS#2156 artist-card lookup: the full editable field set `/wxycdb`'s
+ * `artistCardModify.jsp` displays for `GET /library/artists/:id`. Inner-joined
+ * to `genre_artist_crossreference` for `genre_id` / `code_artist_number`, same
+ * as `getArtistByCode`'s join shape -- every artist that exists via `addArtist`
+ * gets exactly one crossreference row at creation time (BS#980's
+ * `artist_genre_key` unique index scopes it to one row per genre, and the
+ * card's write path never adds a second genre), so an inner join is a plain
+ * existence-implies-a-genre lookup, not a filter that could hide a real
+ * artist. Returns null on an unknown `artist_id`.
+ */
+export const getArtistCardById = async (artist_id: number): Promise<ArtistCardRow | null> => {
+  const response = await db
+    .select({
+      artist_id: artists.id,
+      artist_name: artists.artist_name,
+      alphabetical_name: artists.alphabetical_name,
+      genre_id: genre_artist_crossreference.genre_id,
+      code_letters: artists.code_letters,
+      code_artist_number: genre_artist_crossreference.artist_genre_code,
+    })
+    .from(artists)
+    .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
+    .where(eq(artists.id, artist_id))
+    .limit(1);
+
+  return response[0] ?? null;
+};
+
+/** Partial-update payload for PATCH /library/artists/:id -- the two `modifyArtist` form fields. */
+export type UpdateArtistRow = {
+  artist_name?: string;
+  alphabetical_name?: string;
+};
+
+/**
+ * Applies the `modifyArtist` form's edit to `artists`. Normalizes both fields
+ * to NFC on write, matching `insertArtist` (BS#1897) -- the stored form must
+ * stay a single canonical composition or the `fold_artist_name` matcher's
+ * exact-equality consumers see spurious NFC/NFD splits.
+ */
+export const updateArtistInDB = async (
+  artist_id: number,
+  updates: UpdateArtistRow
+): Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined> => {
+  const set: Record<string, unknown> = { last_modified: sql`NOW()` };
+  if (updates.artist_name !== undefined) set.artist_name = updates.artist_name.normalize('NFC');
+  if (updates.alphabetical_name !== undefined) set.alphabetical_name = updates.alphabetical_name.normalize('NFC');
+
+  const response = await db
+    .update(artists)
+    .set(set)
+    .where(eq(artists.id, artist_id))
+    .returning({ id: artists.id, artist_name: artists.artist_name, alphabetical_name: artists.alphabetical_name });
+  return response[0];
+};
+
+export type ArtistReleaseRow = {
+  id: number;
+  last_modified: Date;
+  format_name: string;
+  code_letters: string;
+  code_number: number;
+  code_volume_letters: string | null;
+  album_title: string;
+  alternate_artist_name: string | null;
+};
+
+/**
+ * BS#2156: the release table on `/wxycdb`'s artist card
+ * (`LibraryReleaseAccessor.getLibraryReleasesForArtist`) -- last-modified,
+ * format, the call-number fields (`code_letters` off `artists`, `code_number`
+ * + `code_volume_letters` off `library`), title, and alternate artist name.
+ * Not sourced from `library_artist_view`: that view omits `last_modified` and
+ * `alternate_artist_name`, so this joins the same underlying tables directly,
+ * scoped to one artist instead of one album. Ordered by `code_number`
+ * ascending -- shelf order, matching how the physical card catalog is filed.
+ */
+export const getReleasesForArtist = async (artist_id: number): Promise<ArtistReleaseRow[]> => {
+  return db
+    .select({
+      id: library.id,
+      last_modified: library.last_modified,
+      format_name: format.format_name,
+      code_letters: artists.code_letters,
+      code_number: library.code_number,
+      code_volume_letters: library.code_volume_letters,
+      album_title: library.album_title,
+      alternate_artist_name: library.alternate_artist_name,
+    })
+    .from(library)
+    .innerJoin(artists, eq(artists.id, library.artist_id))
+    .innerJoin(format, eq(format.id, library.format_id))
+    .where(eq(library.artist_id, artist_id))
+    .orderBy(asc(library.code_number));
+};
+
 export const generateAlbumCodeNumber = async (artist_id: number): Promise<number> => {
   const response = await db
     .select({ code_number: library.code_number })

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2062,62 +2062,6 @@ export const artistIdFromName = async (artist_name: string, genre_id: number): P
   }
 };
 
-/**
- * `fold_artist_name` conflict probe for a RENAME (BS#2156), scoped to EVERY
- * genre `exclude_artist_id` is crossreferenced in -- not just one.
- *
- * `artistIdFromName` above answers "which artist is this name?" with a bare
- * `.limit(1)` and NO `orderBy`, so when a genre already holds two fold-equal
- * rows it returns an ARBITRARY one of them. A rename guard built on
- * "fetch one, compare it to the row being renamed" is therefore unsound: the
- * production clone holds 46 same-genre fold-equal groups (93 artist rows —
- * e.g. genre 11's two `The Trees`, ids 11362/11363), and renaming one of a
- * pair can have the probe hand back the row being renamed itself, whereupon a
- * self-exclusion check concludes "collides only with itself" and lets the
- * rename through — recreating exactly the duplicate state
- * `jobs/artist-unicode-dedup` exists to clean up.
- *
- * The exclusion belongs INSIDE the query: ask for any fold-equal row NOT this
- * artist, crossreferenced in any genre this artist is ALSO crossreferenced
- * in. A single fixed `genre_id` parameter first probed only the caller's
- * lowest-`genre_id` crossreference (`getArtistCardById`'s deliberate
- * `.orderBy(asc(genre_id)).limit(1)` collapse) -- multi-genre artists are a
- * designed state (`jobs/artist-unicode-dedup/merge.ts` repoints every
- * crossreference onto a survivor precisely so the matcher reaches it from
- * every genre), so a probe confined to one genre missed a fold-equal
- * duplicate sitting in any of the artist's other genres. Ordered by id so
- * the reported conflict is deterministic when several exist.
- */
-export const conflictingArtistIdInGenre = async (
-  artist_name: string,
-  exclude_artist_id: number
-): Promise<number | null> => {
-  const excludedArtistGenres = await db
-    .select({ genre_id: genre_artist_crossreference.genre_id })
-    .from(genre_artist_crossreference)
-    .where(eq(genre_artist_crossreference.artist_id, exclude_artist_id));
-  const genreIds = excludedArtistGenres.map((row) => row.genre_id);
-  if (genreIds.length === 0) {
-    return null;
-  }
-
-  const response = await db
-    .select({ id: artists.id })
-    .from(artists)
-    .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
-    .where(
-      and(
-        sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artist_name})`,
-        inArray(genre_artist_crossreference.genre_id, genreIds),
-        ne(artists.id, exclude_artist_id)
-      )
-    )
-    .orderBy(asc(artists.id))
-    .limit(1);
-
-  return response[0]?.id ?? null;
-};
-
 export const insertArtist = async (new_artist: NewArtist) => {
   // Store names NFC-canonical (BS#1897). The matcher folds NFC/NFD/ASCII-fold
   // together for *lookup*, but the *stored* form must be a single canonical

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2062,6 +2062,46 @@ export const artistIdFromName = async (artist_name: string, genre_id: number): P
   }
 };
 
+/**
+ * Genre-scoped `fold_artist_name` conflict probe for a RENAME (BS#2156).
+ *
+ * `artistIdFromName` above answers "which artist is this name?" with a bare
+ * `.limit(1)` and NO `orderBy`, so when a genre already holds two fold-equal
+ * rows it returns an ARBITRARY one of them. A rename guard built on
+ * "fetch one, compare it to the row being renamed" is therefore unsound: the
+ * production clone holds 46 same-genre fold-equal groups (93 artist rows —
+ * e.g. genre 11's two `The Trees`, ids 11362/11363), and renaming one of a
+ * pair can have the probe hand back the row being renamed itself, whereupon a
+ * self-exclusion check concludes "collides only with itself" and lets the
+ * rename through — recreating exactly the duplicate state
+ * `jobs/artist-unicode-dedup` exists to clean up.
+ *
+ * The exclusion belongs INSIDE the query: ask for any fold-equal row in the
+ * genre that is NOT this artist. Ordered by id so the reported conflict is
+ * deterministic when several exist.
+ */
+export const conflictingArtistIdInGenre = async (
+  artist_name: string,
+  genre_id: number,
+  exclude_artist_id: number
+): Promise<number | null> => {
+  const response = await db
+    .select({ id: artists.id })
+    .from(artists)
+    .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
+    .where(
+      and(
+        sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artist_name})`,
+        eq(genre_artist_crossreference.genre_id, genre_id),
+        ne(artists.id, exclude_artist_id)
+      )
+    )
+    .orderBy(asc(artists.id))
+    .limit(1);
+
+  return response[0]?.id ?? null;
+};
+
 export const insertArtist = async (new_artist: NewArtist) => {
   // Store names NFC-canonical (BS#1897). The matcher folds NFC/NFD/ASCII-fold
   // together for *lookup*, but the *stored* form must be a single canonical
@@ -2288,7 +2328,9 @@ export type ArtistReleaseRow = {
   id: number;
   last_modified: Date;
   format_name: string;
+  genre_id: number;
   code_letters: string;
+  code_artist_number: number;
   code_number: number;
   code_volume_letters: string | null;
   album_title: string;
@@ -2296,22 +2338,31 @@ export type ArtistReleaseRow = {
 };
 
 /**
- * BS#2156: the release table on `/wxycdb`'s artist card
- * (`LibraryReleaseAccessor.getLibraryReleasesForArtist`) -- last-modified,
- * format, the call-number fields (`code_letters` off `artists`, `code_number`
- * + `code_volume_letters` off `library`), title, and alternate artist name.
- * Not sourced from `library_artist_view`: that view omits `last_modified` and
- * `alternate_artist_name`, so this joins the same underlying tables directly,
- * scoped to one artist instead of one album. Ordered by `code_number`
- * ascending -- shelf order, matching how the physical card catalog is filed.
+ * Join chain for one artist's release table (BS#2156). Shared verbatim by the
+ * page query and its `total` count so the two can never disagree about which
+ * rows are in scope.
+ *
+ * The `genre_artist_crossreference` join keys on BOTH `artist_id` AND
+ * `library.genre_id`, matching `library_artist_view` (schema.ts),
+ * `LIBRARY_VIEW_PROJECTION` above, and `getBinFromDB` (djs.service.ts). That
+ * pair is not decoration: `artist_genre_code` (the `code_artist_number` half of
+ * the call number) is GENRE-SCOPED, so an artist filed under several genres has
+ * a different one per genre. Dropping the genre dimension makes the projected
+ * call number incomplete and its rows mutually indistinguishable — artist 1087
+ * ('Various Artists') spans 14 genres across 3,107 library rows, 2,961 of which
+ * share a `code_number` with a sibling. `getArtistCardById` cannot supply the
+ * missing piece either: it deliberately collapses to the lowest-`genre_id`
+ * crossreference row.
  */
-export const getReleasesForArtist = async (artist_id: number): Promise<ArtistReleaseRow[]> => {
-  return db
+const artistReleasesQuery = (artist_id: number) =>
+  db
     .select({
       id: library.id,
       last_modified: library.last_modified,
       format_name: format.format_name,
+      genre_id: library.genre_id,
       code_letters: artists.code_letters,
+      code_artist_number: genre_artist_crossreference.artist_genre_code,
       code_number: library.code_number,
       code_volume_letters: library.code_volume_letters,
       album_title: library.album_title,
@@ -2320,8 +2371,54 @@ export const getReleasesForArtist = async (artist_id: number): Promise<ArtistRel
     .from(library)
     .innerJoin(artists, eq(artists.id, library.artist_id))
     .innerJoin(format, eq(format.id, library.format_id))
-    .where(eq(library.artist_id, artist_id))
-    .orderBy(asc(library.code_number));
+    .innerJoin(
+      genre_artist_crossreference,
+      and(
+        eq(genre_artist_crossreference.artist_id, library.artist_id),
+        eq(genre_artist_crossreference.genre_id, library.genre_id)
+      )
+    )
+    .where(eq(library.artist_id, artist_id));
+
+/**
+ * BS#2156: the release table on `/wxycdb`'s artist card
+ * (`LibraryReleaseAccessor.getLibraryReleasesForArtist`) -- last-modified,
+ * format, the full call number (`code_letters` off `artists`,
+ * `code_artist_number` off the genre crossreference, `code_number` +
+ * `code_volume_letters` off `library`), title, and alternate artist name.
+ * Not sourced from `library_artist_view`: that view omits `last_modified` and
+ * `alternate_artist_name`, so this joins the same underlying tables directly,
+ * scoped to one artist instead of one album.
+ *
+ * Ordered by shelf order -- the physical filing order of the card catalog.
+ * `code_number` ALONE is not that order and is not even deterministic: 4,179 of
+ * 64,193 library rows share a `code_number` with a sibling under the same
+ * artist, so the tiebreak carries `code_volume_letters` (the other half of the
+ * physical call number, already projected here) and finally `id` as a total
+ * order.
+ *
+ * Offset-paginated, matching `GET /library/query`'s `page`/`limit` convention:
+ * an unbounded projection hands any `catalog:read` DJ ~3,107 rows (~0.5-1 MB
+ * of JSON) for artist 1087 on a freely repeatable request.
+ */
+export const getReleasesForArtist = async (
+  artist_id: number,
+  page: number,
+  limit: number
+): Promise<ArtistReleaseRow[]> => {
+  return artistReleasesQuery(artist_id)
+    .orderBy(asc(library.code_number), asc(library.code_volume_letters), asc(library.id))
+    .limit(limit)
+    .offset(page * limit);
+};
+
+/** Total release count for `getReleasesForArtist`'s page envelope (same join scope). */
+export const countReleasesForArtist = async (artist_id: number): Promise<number> => {
+  const response = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(artistReleasesQuery(artist_id).as('artist_releases'));
+
+  return Number(response[0]?.count ?? 0);
 };
 
 export const generateAlbumCodeNumber = async (artist_id: number): Promise<number> => {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2221,12 +2221,15 @@ export type ArtistCardRow = {
  * BS#2156 artist-card lookup: the full editable field set `/wxycdb`'s
  * `artistCardModify.jsp` displays for `GET /library/artists/:id`. Inner-joined
  * to `genre_artist_crossreference` for `genre_id` / `code_artist_number`, same
- * as `getArtistByCode`'s join shape -- every artist that exists via `addArtist`
- * gets exactly one crossreference row at creation time (BS#980's
- * `artist_genre_key` unique index scopes it to one row per genre, and the
- * card's write path never adds a second genre), so an inner join is a plain
- * existence-implies-a-genre lookup, not a filter that could hide a real
- * artist. Returns null on an unknown `artist_id`.
+ * as `getArtistByCode`'s join shape. Returns null on an unknown `artist_id`.
+ *
+ * `artist_genre_key` is unique on `(artist_id, genre_id)`, not on `artist_id`
+ * alone -- a legacy-imported artist filed under more than one genre has more
+ * than one crossreference row, and this picks the lowest `genre_id`
+ * deterministically rather than whichever the planner returns first. Every
+ * artist created via `addArtist` only ever gets one row (there is no
+ * multi-genre write path today), so this is dormant for new data, but it
+ * cannot be assumed true of the legacy-imported catalog.
  */
 export const getArtistCardById = async (artist_id: number): Promise<ArtistCardRow | null> => {
   const response = await db
@@ -2241,6 +2244,7 @@ export const getArtistCardById = async (artist_id: number): Promise<ArtistCardRo
     .from(artists)
     .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
     .where(eq(artists.id, artist_id))
+    .orderBy(asc(genre_artist_crossreference.genre_id))
     .limit(1);
 
   return response[0] ?? null;
@@ -2262,9 +2266,15 @@ export const updateArtistInDB = async (
   artist_id: number,
   updates: UpdateArtistRow
 ): Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined> => {
-  const set: Record<string, unknown> = { last_modified: sql`NOW()` };
-  if (updates.artist_name !== undefined) set.artist_name = updates.artist_name.normalize('NFC');
-  if (updates.alphabetical_name !== undefined) set.alphabetical_name = updates.alphabetical_name.normalize('NFC');
+  // Column-checked (unlike a `Record<string, unknown>` accumulator) since
+  // there are only ever these two optional columns to SET.
+  const set = {
+    last_modified: sql`NOW()`,
+    ...(updates.artist_name !== undefined ? { artist_name: updates.artist_name.normalize('NFC') } : {}),
+    ...(updates.alphabetical_name !== undefined
+      ? { alphabetical_name: updates.alphabetical_name.normalize('NFC') }
+      : {}),
+  };
 
   const response = await db
     .update(artists)

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -2063,7 +2063,8 @@ export const artistIdFromName = async (artist_name: string, genre_id: number): P
 };
 
 /**
- * Genre-scoped `fold_artist_name` conflict probe for a RENAME (BS#2156).
+ * `fold_artist_name` conflict probe for a RENAME (BS#2156), scoped to EVERY
+ * genre `exclude_artist_id` is crossreferenced in -- not just one.
  *
  * `artistIdFromName` above answers "which artist is this name?" with a bare
  * `.limit(1)` and NO `orderBy`, so when a genre already holds two fold-equal
@@ -2076,15 +2077,30 @@ export const artistIdFromName = async (artist_name: string, genre_id: number): P
  * rename through — recreating exactly the duplicate state
  * `jobs/artist-unicode-dedup` exists to clean up.
  *
- * The exclusion belongs INSIDE the query: ask for any fold-equal row in the
- * genre that is NOT this artist. Ordered by id so the reported conflict is
- * deterministic when several exist.
+ * The exclusion belongs INSIDE the query: ask for any fold-equal row NOT this
+ * artist, crossreferenced in any genre this artist is ALSO crossreferenced
+ * in. A single fixed `genre_id` parameter first probed only the caller's
+ * lowest-`genre_id` crossreference (`getArtistCardById`'s deliberate
+ * `.orderBy(asc(genre_id)).limit(1)` collapse) -- multi-genre artists are a
+ * designed state (`jobs/artist-unicode-dedup/merge.ts` repoints every
+ * crossreference onto a survivor precisely so the matcher reaches it from
+ * every genre), so a probe confined to one genre missed a fold-equal
+ * duplicate sitting in any of the artist's other genres. Ordered by id so
+ * the reported conflict is deterministic when several exist.
  */
 export const conflictingArtistIdInGenre = async (
   artist_name: string,
-  genre_id: number,
   exclude_artist_id: number
 ): Promise<number | null> => {
+  const excludedArtistGenres = await db
+    .select({ genre_id: genre_artist_crossreference.genre_id })
+    .from(genre_artist_crossreference)
+    .where(eq(genre_artist_crossreference.artist_id, exclude_artist_id));
+  const genreIds = excludedArtistGenres.map((row) => row.genre_id);
+  if (genreIds.length === 0) {
+    return null;
+  }
+
   const response = await db
     .select({ id: artists.id })
     .from(artists)
@@ -2092,7 +2108,7 @@ export const conflictingArtistIdInGenre = async (
     .where(
       and(
         sql`${FOLD_ARTIST_NAME_FN}(${artists.artist_name}) = ${FOLD_ARTIST_NAME_FN}(${artist_name})`,
-        eq(genre_artist_crossreference.genre_id, genre_id),
+        inArray(genre_artist_crossreference.genre_id, genreIds),
         ne(artists.id, exclude_artist_id)
       )
     )
@@ -2397,6 +2413,13 @@ const artistReleasesQuery = (artist_id: number) =>
  * physical call number, already projected here) and finally `id` as a total
  * order.
  *
+ * `code_volume_letters` sorts `ASC NULLS FIRST` explicitly. Postgres's `ASC`
+ * default is NULLS LAST, but the legacy query this mirrors
+ * (`LibraryCatalogServlet.java:130-133`, `ORDER BY LR.CALL_NUMBERS ASC,
+ * LR.CALL_LETTERS ASC`) runs on MySQL, where `ASC` is NULLS FIRST -- a bare
+ * `asc()` here would put a lettered volume (`R 7A`, `R 7B`) ahead of its own
+ * unlettered `R 7` within the same `code_number`, the reverse of the shelf.
+ *
  * Offset-paginated, matching `GET /library/query`'s `page`/`limit` convention:
  * an unbounded projection hands any `catalog:read` DJ ~3,107 rows (~0.5-1 MB
  * of JSON) for artist 1087 on a freely repeatable request.
@@ -2407,7 +2430,7 @@ export const getReleasesForArtist = async (
   limit: number
 ): Promise<ArtistReleaseRow[]> => {
   return artistReleasesQuery(artist_id)
-    .orderBy(asc(library.code_number), asc(library.code_volume_letters), asc(library.id))
+    .orderBy(asc(library.code_number), sql`${library.code_volume_letters} ASC NULLS FIRST`, asc(library.id))
     .limit(limit)
     .offset(page * limit);
 };

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1934,14 +1934,48 @@ describe('Library Artist Card (BS#2156)', () => {
       expect(res.body.code_letters).toBe(artist.code_letters);
     });
 
+    // `artist_genre_key` is unique on (artist_id, genre_id), not on artist_id
+    // alone: a legacy-imported artist filed under several genres has several
+    // crossreference rows, each with its own genre-scoped
+    // `artist_genre_code`. `getArtistCardById`'s `.orderBy(asc(genre_id))` is
+    // what makes the card a stable answer instead of whichever row the
+    // planner happened to emit first.
+    test('collapses a multi-genre artist to the lowest-genre_id crossreference deterministically', async () => {
+      const artist = await createTestArtist();
+      const sql = getTestDb();
+      // Genre 6 sorts below the genre 11 the artist was created in.
+      await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+         VALUES (${artist.id}, 6, 9911)`
+      );
+
+      try {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          const res = await auth.get(`/library/artists/${artist.id}`).expect(200);
+          expect(res.body.genre_id).toBe(6);
+          expect(res.body.code_artist_number).toBe(9911);
+        }
+      } finally {
+        await sql.unsafe(
+          `DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${artist.id} AND genre_id = 6`
+        );
+      }
+    });
+
     test('404s on an unknown artist id', async () => {
       const res = await auth.get('/library/artists/99999999').expect(404);
       expectErrorContains(res, 'not found');
     });
 
-    test('400s on a non-numeric artist id', async () => {
-      await auth.get('/library/artists/not-a-number').expect(400);
-    });
+    // `artists.id` is a `serial` (int4). Every one of these parses as a JS
+    // number, so without a strict spelling + INT4_MAX check they reach
+    // Postgres (500 + a Sentry event) or alias distinct URLs onto one row.
+    test.each([['not-a-number'], ['2147483648'], ['1e21'], ['0x2a'], ['%2042%20'], ['42.0'], ['-1'], ['0'], ['007']])(
+      '400s on the malformed artist id %s',
+      async (rawId) => {
+        await auth.get(`/library/artists/${rawId}`).expect(400);
+      }
+    );
 
     // Route-ordering pin (BS#2156 constraint): `/artists/search` and
     // `/artists/peek-code` are literal routes registered before this
@@ -1961,7 +1995,7 @@ describe('Library Artist Card (BS#2156)', () => {
   });
 
   describe('PATCH /library/artists/:id', () => {
-    test('updates artist_name and alphabetical_name', async () => {
+    test('updates artist_name and alphabetical_name, answering in the GET card shape', async () => {
       const artist = await createTestArtist();
       const renamed = `Renamed ${artist.artist_name}`;
 
@@ -1970,12 +2004,75 @@ describe('Library Artist Card (BS#2156)', () => {
         .send({ artist_name: renamed, alphabetical_name: `${artist.alphabetical_name}, Renamed` })
         .expect(200);
 
+      // Same field set the sibling GET on this URL serves -- `artist_id`, not
+      // the bare `artists` RETURNING row's `id`.
+      expectFields(
+        res.body,
+        'artist_id',
+        'artist_name',
+        'alphabetical_name',
+        'genre_id',
+        'code_letters',
+        'code_artist_number'
+      );
+      expect(res.body.artist_id).toBe(artist.id);
+      expect(res.body.id).toBeUndefined();
       expect(res.body.artist_name).toBe(renamed);
       expect(res.body.alphabetical_name).toBe(`${artist.alphabetical_name}, Renamed`);
 
       const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
-      expect(card.body.artist_name).toBe(renamed);
-      expect(card.body.alphabetical_name).toBe(`${artist.alphabetical_name}, Renamed`);
+      expect(card.body).toEqual(res.body);
+    });
+
+    // `req.body` is undefined for a body-less request under body-parser 2.x +
+    // Express 5 (no `{}` default), so the guard is what keeps a bare
+    // `curl -X PATCH` from dereferencing undefined -> 500.
+    test('returns 400, not 500, when no body is sent at all', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth.patch(`/library/artists/${artist.id}`).expect(400);
+      expectErrorContains(res, 'artist_name');
+    });
+
+    test('returns 400 on a body-less PATCH even for an unknown artist id', async () => {
+      await auth.patch('/library/artists/99999999').expect(400);
+    });
+
+    test.each([
+      ['artist_name', 123],
+      ['artist_name', ['a']],
+      ['artist_name', {}],
+      ['alphabetical_name', 123],
+      ['alphabetical_name', ['a']],
+      ['alphabetical_name', {}],
+    ])('returns 400 when %s is sent as a non-string (%p)', async (field, value) => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ [field]: value })
+        .expect(400);
+      expectErrorContains(res, field);
+    });
+
+    test.each(['artist_name', 'alphabetical_name'])('returns 400 when %s exceeds 128 characters', async (field) => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ [field]: 'x'.repeat(129) })
+        .expect(400);
+      expectErrorContains(res, '128');
+    });
+
+    test.each(['artist_name', 'alphabetical_name'])('returns 400 when %s is whitespace-only', async (field) => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ [field]: '   ' })
+        .expect(400);
+      expectErrorContains(res, field);
     });
 
     test('drops fields outside the allowlist rather than applying them', async () => {
@@ -2023,6 +2120,46 @@ describe('Library Artist Card (BS#2156)', () => {
       expect(card.body.artist_name).toBe(second.artist_name);
     });
 
+    // The soundness half of the conflict guard. `artistIdFromName` is
+    // `.limit(1)` with no `orderBy`, so on a genre that ALREADY holds two
+    // fold-equal rows (46 such groups / 93 rows exist in the production
+    // clone) it returns an arbitrary one of them -- possibly the row being
+    // renamed, whereupon a "fetch one, compare to self" guard concludes it
+    // collides only with itself and lets the rename through. The duplicate
+    // below is seeded straight into SQL because `POST /library/artists`
+    // refuses to create it; the rename then targets the LOWER-id row, the
+    // one an unordered probe is most likely to hand back.
+    test('409s on a fold-equal rename even when the genre already holds a fold-equal duplicate', async () => {
+      const artist = await createTestArtist();
+      const sql = getTestDb();
+      const [duplicate] = await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.artists (artist_name, alphabetical_name, code_letters)
+         VALUES ('${artist.artist_name}', '${artist.alphabetical_name}', '${artist.code_letters}')
+         RETURNING id`
+      );
+      await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+         VALUES (${duplicate.id}, 11, 9912)`
+      );
+
+      try {
+        const res = await auth
+          .patch(`/library/artists/${artist.id}`)
+          .send({ artist_name: artist.artist_name.toLowerCase() })
+          .expect(409);
+        expect(res.body.reason).toBe('artist_name_conflict');
+        expect(res.body.artist.artist_id).toBe(duplicate.id);
+
+        // The rename did not take effect -- the genre still holds exactly the
+        // two fold-equal rows it started with, not a third spelling.
+        const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+        expect(card.body.artist_name).toBe(artist.artist_name);
+      } finally {
+        await sql.unsafe(`DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${duplicate.id}`);
+        await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${duplicate.id}`);
+      }
+    });
+
     test('allows re-saving the same artist_name (no-op rename does not 409 against itself)', async () => {
       const artist = await createTestArtist();
 
@@ -2042,57 +2179,129 @@ describe('Library Artist Card (BS#2156)', () => {
   });
 
   describe('GET /library/artists/:id/releases', () => {
-    test('returns the release-table columns for that artist, ordered by call number', async () => {
-      const artist = await createTestArtist();
+    async function addRelease(artistId, title) {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: title,
+          artist_id: artistId,
+          label: 'Test Label',
+          genre_id: 11,
+          format_id: 1,
+        })
+        .expect(201);
+      return res.body;
+    }
 
-      const first = await auth
-        .post('/library')
-        .send({
-          album_title: `Release B ${Date.now()}`,
-          artist_id: artist.id,
-          label: 'Test Label',
-          genre_id: 11,
-          format_id: 1,
-        })
-        .expect(201);
-      const second = await auth
-        .post('/library')
-        .send({
-          album_title: `Release A ${Date.now()}`,
-          artist_id: artist.id,
-          label: 'Test Label',
-          genre_id: 11,
-          format_id: 1,
-        })
-        .expect(201);
+    test('returns the release-table columns for that artist, including the genre dimension', async () => {
+      const artist = await createTestArtist();
+      await addRelease(artist.id, `Release Fields ${Date.now()}`);
 
       const res = await auth.get(`/library/artists/${artist.id}/releases`).expect(200);
 
       expect(res.body.artist_id).toBe(artist.id);
       expect(Array.isArray(res.body.releases)).toBe(true);
-      expect(res.body.releases).toHaveLength(2);
+      expect(res.body.releases).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+      expect(res.body.page).toBe(0);
+      expect(res.body.totalPages).toBe(1);
       res.body.releases.forEach((release) =>
         expectFields(
           release,
           'id',
           'last_modified',
           'format_name',
+          // The call number is code_letters + code_artist_number +
+          // code_number (+ code_volume_letters), and code_artist_number is
+          // GENRE-scoped -- without genre_id + code_artist_number the
+          // projected call number is incomplete and rows sharing a
+          // code_number are mutually indistinguishable.
+          'genre_id',
           'code_letters',
+          'code_artist_number',
           'code_number',
           'code_volume_letters',
           'album_title',
           'alternate_artist_name'
         )
       );
-      // Ordered by code_number ascending (shelf order): the first-added
-      // album mints the lower code_number via generateAlbumCodeNumber.
-      expect(res.body.releases[0].id).toBe(first.body.id);
-      expect(res.body.releases[1].id).toBe(second.body.id);
+      expect(res.body.releases[0].genre_id).toBe(11);
+      expect(res.body.releases[0].code_letters).toBe(artist.code_letters);
+      expect(typeof res.body.releases[0].code_artist_number).toBe('number');
+    });
+
+    // Shelf order must come from the call number, not from insertion order.
+    // `generateAlbumCodeNumber` is max+1, so albums added through the API get
+    // code_numbers that agree with insertion order, id order, and add_date
+    // order all at once -- an ordering assertion over API-created rows would
+    // pass with NO `orderBy` at all. These rows are therefore renumbered out
+    // of insertion order first, and two of them are put on the same
+    // code_number so the `code_volume_letters` tiebreak is exercised too.
+    test('orders by the full call number, not by insertion/id order', async () => {
+      const artist = await createTestArtist();
+      const first = await addRelease(artist.id, `Shelf One ${Date.now()}`);
+      const second = await addRelease(artist.id, `Shelf Two ${Date.now()}`);
+      const third = await addRelease(artist.id, `Shelf Three ${Date.now()}`);
+
+      const sql = getTestDb();
+      // Expected shelf order after this renumbering: third (7, 'A'),
+      // second (7, 'B'), first (9) -- the exact reverse of insertion order.
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 9, code_volume_letters = NULL WHERE id = ${first.id}`
+      );
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 7, code_volume_letters = 'B' WHERE id = ${second.id}`
+      );
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 7, code_volume_letters = 'A' WHERE id = ${third.id}`
+      );
+
+      const res = await auth.get(`/library/artists/${artist.id}/releases`).expect(200);
+
+      expect(res.body.releases.map((release) => release.id)).toEqual([third.id, second.id, first.id]);
+    });
+
+    test('paginates with page/limit and reports total/totalPages', async () => {
+      const artist = await createTestArtist();
+      const created = [
+        await addRelease(artist.id, `Page One ${Date.now()}`),
+        await addRelease(artist.id, `Page Two ${Date.now()}`),
+        await addRelease(artist.id, `Page Three ${Date.now()}`),
+      ];
+      const shelfOrder = created.map((release) => release.id);
+
+      const firstPage = await auth.get(`/library/artists/${artist.id}/releases`).query({ limit: 2 }).expect(200);
+      expect(firstPage.body.releases.map((release) => release.id)).toEqual(shelfOrder.slice(0, 2));
+      expect(firstPage.body.total).toBe(3);
+      expect(firstPage.body.page).toBe(0);
+      expect(firstPage.body.totalPages).toBe(2);
+
+      const secondPage = await auth
+        .get(`/library/artists/${artist.id}/releases`)
+        .query({ page: 1, limit: 2 })
+        .expect(200);
+      expect(secondPage.body.releases.map((release) => release.id)).toEqual(shelfOrder.slice(2));
+      expect(secondPage.body.total).toBe(3);
+      expect(secondPage.body.page).toBe(1);
+    });
+
+    test.each([
+      ['limit above the maximum', { limit: 101 }],
+      ['a zero limit', { limit: 0 }],
+      ['a negative page', { page: -1 }],
+      ['a non-numeric limit', { limit: 'all' }],
+    ])('400s on %s', async (_label, query) => {
+      const artist = await createTestArtist();
+      await auth.get(`/library/artists/${artist.id}/releases`).query(query).expect(400);
     });
 
     test('404s on an unknown artist id', async () => {
       const res = await auth.get('/library/artists/99999999/releases').expect(404);
       expectErrorContains(res, 'not found');
+    });
+
+    test('400s on a malformed artist id', async () => {
+      await auth.get('/library/artists/2147483648/releases').expect(400);
     });
   });
 });

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1963,29 +1963,31 @@ describe('Library Artist Card (BS#2156)', () => {
   describe('PATCH /library/artists/:id', () => {
     test('updates artist_name and alphabetical_name', async () => {
       const artist = await createTestArtist();
+      const renamed = `Renamed ${artist.artist_name}`;
 
       const res = await auth
         .patch(`/library/artists/${artist.id}`)
-        .send({ artist_name: 'Renamed Test Artist', alphabetical_name: 'Test Artist, Renamed' })
+        .send({ artist_name: renamed, alphabetical_name: `${artist.alphabetical_name}, Renamed` })
         .expect(200);
 
-      expect(res.body.artist_name).toBe('Renamed Test Artist');
-      expect(res.body.alphabetical_name).toBe('Test Artist, Renamed');
+      expect(res.body.artist_name).toBe(renamed);
+      expect(res.body.alphabetical_name).toBe(`${artist.alphabetical_name}, Renamed`);
 
       const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
-      expect(card.body.artist_name).toBe('Renamed Test Artist');
-      expect(card.body.alphabetical_name).toBe('Test Artist, Renamed');
+      expect(card.body.artist_name).toBe(renamed);
+      expect(card.body.alphabetical_name).toBe(`${artist.alphabetical_name}, Renamed`);
     });
 
     test('drops fields outside the allowlist rather than applying them', async () => {
       const artist = await createTestArtist();
+      const renamed = `Still Allowlisted ${artist.artist_name}`;
 
       const res = await auth
         .patch(`/library/artists/${artist.id}`)
-        .send({ artist_name: 'Still Allowlisted', code_letters: 'ZZ', genre_id: 999 })
+        .send({ artist_name: renamed, code_letters: 'ZZ', genre_id: 999 })
         .expect(200);
 
-      expect(res.body.artist_name).toBe('Still Allowlisted');
+      expect(res.body.artist_name).toBe(renamed);
 
       const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
       // code_letters and genre_id are unchanged -- the PATCH allowlist
@@ -1999,6 +2001,38 @@ describe('Library Artist Card (BS#2156)', () => {
 
       const res = await auth.patch(`/library/artists/${artist.id}`).send({}).expect(400);
       expectErrorContains(res, 'artist_name');
+    });
+
+    test('returns 409 when renamed to a name already used by another artist in the same genre', async () => {
+      const first = await createTestArtist();
+      const second = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${second.id}`)
+        .send({ artist_name: first.artist_name })
+        .expect(409);
+
+      expect(res.body).toEqual({
+        message: 'Artist name already exists in that genre.',
+        reason: 'artist_name_conflict',
+        artist: { artist_id: first.id, artist_name: first.artist_name, code_letters: first.code_letters },
+      });
+
+      // The rename did not take effect.
+      const card = await auth.get(`/library/artists/${second.id}`).expect(200);
+      expect(card.body.artist_name).toBe(second.artist_name);
+    });
+
+    test('allows re-saving the same artist_name (no-op rename does not 409 against itself)', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ artist_name: artist.artist_name, alphabetical_name: `${artist.alphabetical_name} Updated` })
+        .expect(200);
+
+      expect(res.body.artist_name).toBe(artist.artist_name);
+      expect(res.body.alphabetical_name).toBe(`${artist.alphabetical_name} Updated`);
     });
 
     test('404s on an unknown artist id', async () => {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1893,22 +1893,48 @@ describe('Library Artist Card (BS#2156)', () => {
   // A monotonic counter, not Date.now()/Math.random() alone, so back-to-back
   // calls within the same test file can't collide on the genre-scoped
   // artist_name pre-check or the (code_letters, genre_id, code_number) triple
-  // check -- both of which answer 409, not the account-for-in-this-block 201.
+  // check -- both of which answer 409, not the accounted-for-here 201.
+  //
+  // The counter must survive INTACT into every uniqueness axis. An earlier
+  // shape built one suffix as `${Date.now().toString(36)}${counter}` and then
+  // `.slice(-4)`, which discarded the counter it depended on: when the counter
+  // rolls 9 -> 10 the string lengthens and the 4-char window shifts, so two
+  // different calls can yield the same suffix and 409 on the artist_name
+  // pre-check. That made the whole block order-dependent -- adding or removing
+  // a test elsewhere in the file could turn a latent collision into a real
+  // one, and the failure surfaced as `expected 201, got 409` inside this
+  // helper rather than anywhere near the test that changed.
   let artistCounter = 0;
+  // Stable for this file execution, different on the next one. Both halves are
+  // load-bearing and NEITHER may be truncated away: the counter makes calls
+  // unique WITHIN a run, the run key makes them unique ACROSS runs. Across-run
+  // uniqueness is not theoretical -- `ci:testmock` is `ci:env && ci:test &&
+  // ci:clean`, so a failing `ci:test` skips the `down -v` volume drop and the
+  // NEXT run starts against the previous run's database. A fixture keyed on the
+  // counter alone then 409s `artist_code_conflict` against its own leftovers
+  // from the failed run, which reads as an unrelated cascade across the file.
+  const runKey = Date.now().toString(36).toUpperCase().slice(-2);
 
   async function createTestArtist(overrides = {}) {
     artistCounter += 1;
-    const uniqueSuffix = `${Date.now().toString(36)}${artistCounter}`.toUpperCase().slice(-4);
-    const res = await auth
-      .post('/library/artists')
-      .send({
-        artist_name: `Card Test Artist ${uniqueSuffix}`,
-        code_letters: uniqueSuffix.slice(-2),
-        genre_id: 11,
-        code_number: 8000 + artistCounter,
-        ...overrides,
-      })
-      .expect(201);
+    // Base36 of the counter, never truncated: unique per call by construction.
+    const counterKey = artistCounter.toString(36).toUpperCase().padStart(2, '0');
+    const res = await auth.post('/library/artists').send({
+      artist_name: `Card Test Artist ${runKey}${counterKey}-${Date.now().toString(36).toUpperCase()}`,
+      // 4 chars, the `code_letters` ceiling: run key + counter.
+      code_letters: `${runKey}${counterKey}`,
+      genre_id: 11,
+      code_number: 8000 + artistCounter,
+      ...overrides,
+    });
+    // A 409 here is a fixture-uniqueness failure, not a test failure. Surface
+    // the server's own discriminant (`reason` + the conflicting artist) rather
+    // than a bare "expected 201, got 409" that names neither axis.
+    if (res.status !== 201) {
+      throw new Error(
+        `createTestArtist #${artistCounter} expected 201, got ${res.status}: ${JSON.stringify(res.body)}`
+      );
+    }
     return res.body;
   }
 
@@ -1995,13 +2021,12 @@ describe('Library Artist Card (BS#2156)', () => {
   });
 
   describe('PATCH /library/artists/:id', () => {
-    test('updates artist_name and alphabetical_name, answering in the GET card shape', async () => {
+    test('updates alphabetical_name, answering in the GET card shape', async () => {
       const artist = await createTestArtist();
-      const renamed = `Renamed ${artist.artist_name}`;
 
       const res = await auth
         .patch(`/library/artists/${artist.id}`)
-        .send({ artist_name: renamed, alphabetical_name: `${artist.alphabetical_name}, Renamed` })
+        .send({ alphabetical_name: `${artist.alphabetical_name}, Renamed` })
         .expect(200);
 
       // Same field set the sibling GET on this URL serves -- `artist_id`, not
@@ -2017,7 +2042,8 @@ describe('Library Artist Card (BS#2156)', () => {
       );
       expect(res.body.artist_id).toBe(artist.id);
       expect(res.body.id).toBeUndefined();
-      expect(res.body.artist_name).toBe(renamed);
+      // The card still carries `artist_name`; this endpoint just cannot write it.
+      expect(res.body.artist_name).toBe(artist.artist_name);
       expect(res.body.alphabetical_name).toBe(`${artist.alphabetical_name}, Renamed`);
 
       const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
@@ -2031,7 +2057,7 @@ describe('Library Artist Card (BS#2156)', () => {
       const artist = await createTestArtist();
 
       const res = await auth.patch(`/library/artists/${artist.id}`).expect(400);
-      expectErrorContains(res, 'artist_name');
+      expectErrorContains(res, 'alphabetical_name');
     });
 
     test('returns 400 on a body-less PATCH even for an unknown artist id', async () => {
@@ -2055,7 +2081,9 @@ describe('Library Artist Card (BS#2156)', () => {
       expectErrorContains(res, field);
     });
 
-    test.each(['artist_name', 'alphabetical_name'])('returns 400 when %s exceeds 128 characters', async (field) => {
+    // Only `alphabetical_name` reaches the length check -- `artist_name` is
+    // rejected earlier as a no-write-path field, with a different message.
+    test.each(['alphabetical_name'])('returns 400 when %s exceeds 128 characters', async (field) => {
       const artist = await createTestArtist();
 
       const res = await auth
@@ -2088,7 +2116,7 @@ describe('Library Artist Card (BS#2156)', () => {
 
         const res = await auth
           .patch(`/library/artists/${artist.id}`)
-          .send({ artist_name: `Rejected ${artist.artist_name}`, [field]: value })
+          .send({ alphabetical_name: `Rejected ${artist.alphabetical_name}`, [field]: value })
           .expect(400);
         expectErrorContains(res, field);
         expectErrorContains(res, 'no write path');
@@ -2100,6 +2128,28 @@ describe('Library Artist Card (BS#2156)', () => {
         expect(card.body.genre_id).toBe(11);
       }
     );
+
+    // `artist_name` is rejected in KIND from the three above: the column is
+    // writable and `updateArtistInDB` still accepts it, but this endpoint
+    // deliberately refuses it while `jobs/library-etl` remains a live
+    // 30-minute cron matching on `fold_artist_name` -- a rename here would
+    // move the match key and be reverted by the next ETL pass. The 400 has to
+    // explain that, or a librarian reads it as a bug. WXYC/Backend-Service#2197.
+    test('rejects artist_name with the reason, rather than renaming or silently dropping it', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ artist_name: `Renamed ${artist.artist_name}` })
+        .expect(400);
+      expectErrorContains(res, 'artist_name');
+      expectErrorContains(res, 'no write path');
+      expectErrorContains(res, 'library-etl');
+
+      // The rename did not take effect.
+      const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+      expect(card.body.artist_name).toBe(artist.artist_name);
+    });
 
     test('rejects multiple no-write-path fields together, naming all of them', async () => {
       const artist = await createTestArtist();
@@ -2117,136 +2167,20 @@ describe('Library Artist Card (BS#2156)', () => {
       const artist = await createTestArtist();
 
       const res = await auth.patch(`/library/artists/${artist.id}`).send({}).expect(400);
-      expectErrorContains(res, 'artist_name');
+      expectErrorContains(res, 'alphabetical_name');
     });
 
-    test('returns 409 when renamed to a name already used by another artist in the same genre', async () => {
-      const first = await createTestArtist();
-      const second = await createTestArtist();
-
-      const res = await auth
-        .patch(`/library/artists/${second.id}`)
-        .send({ artist_name: first.artist_name })
-        .expect(409);
-
-      expect(res.body).toEqual({
-        message: 'Artist name already exists in that genre.',
-        reason: 'artist_name_conflict',
-        artist: { artist_id: first.id, artist_name: first.artist_name, code_letters: first.code_letters },
-      });
-
-      // The rename did not take effect.
-      const card = await auth.get(`/library/artists/${second.id}`).expect(200);
-      expect(card.body.artist_name).toBe(second.artist_name);
-    });
-
-    // The soundness half of the conflict guard. `artistIdFromName` is
-    // `.limit(1)` with no `orderBy`, so on a genre that ALREADY holds two
-    // fold-equal rows (46 such groups / 93 rows exist in the production
-    // clone) it returns an arbitrary one of them -- possibly the row being
-    // renamed, whereupon a "fetch one, compare to self" guard concludes it
-    // collides only with itself and lets the rename through. The duplicate
-    // below is seeded straight into SQL because `POST /library/artists`
-    // refuses to create it; the rename then targets the LOWER-id row, the
-    // one an unordered probe is most likely to hand back.
-    test('409s on a fold-equal rename even when the genre already holds a fold-equal duplicate', async () => {
-      const artist = await createTestArtist();
-      const sql = getTestDb();
-      const [duplicate] = await sql.unsafe(
-        `INSERT INTO ${SCHEMA}.artists (artist_name, alphabetical_name, code_letters)
-         VALUES ('${artist.artist_name}', '${artist.alphabetical_name}', '${artist.code_letters}')
-         RETURNING id`
-      );
-      await sql.unsafe(
-        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-         VALUES (${duplicate.id}, 11, 9912)`
-      );
-
-      try {
-        const res = await auth
-          .patch(`/library/artists/${artist.id}`)
-          .send({ artist_name: artist.artist_name.toLowerCase() })
-          .expect(409);
-        expect(res.body.reason).toBe('artist_name_conflict');
-        expect(res.body.artist.artist_id).toBe(duplicate.id);
-
-        // The rename did not take effect -- the genre still holds exactly the
-        // two fold-equal rows it started with, not a third spelling.
-        const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
-        expect(card.body.artist_name).toBe(artist.artist_name);
-      } finally {
-        await sql.unsafe(`DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${duplicate.id}`);
-        await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${duplicate.id}`);
-      }
-    });
-
-    // BS#2156 review: `existing.genre_id` off `getArtistCardById` is
-    // deliberately the LOWEST genre_id a multi-genre artist is
-    // crossreferenced in. A conflict probe fixed to that one genre never sees
-    // a fold-equal duplicate filed under a DIFFERENT genre of the same
-    // artist -- and multi-genre artists are a designed state
-    // (`jobs/artist-unicode-dedup/merge.ts` repoints every crossreference
-    // onto a survivor precisely so the matcher reaches it from every genre).
-    // Genre 6 sorts below the genre 11 `createTestArtist` uses, so the
-    // artist's OWN lowest crossreference is genre 6 -- and the fold-equal
-    // duplicate is seeded into genre 11, the one `getArtistCardById` does
-    // NOT surface as `existing.genre_id`.
-    test('409s on a fold-equal rename found in a DIFFERENT genre than the card surfaces', async () => {
-      const artist = await createTestArtist();
-      const sql = getTestDb();
-      await sql.unsafe(
-        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-         VALUES (${artist.id}, 6, 9913)`
-      );
-      const [duplicate] = await sql.unsafe(
-        `INSERT INTO ${SCHEMA}.artists (artist_name, alphabetical_name, code_letters)
-         VALUES ('${artist.artist_name}', '${artist.alphabetical_name}', '${artist.code_letters}')
-         RETURNING id`
-      );
-      await sql.unsafe(
-        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
-         VALUES (${duplicate.id}, 11, 9914)`
-      );
-
-      try {
-        // The card now surfaces genre 6 (the artist's lowest), while the
-        // fold-equal duplicate lives in genre 11 -- a probe scoped to
-        // `existing.genre_id` alone would miss it entirely.
-        const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
-        expect(card.body.genre_id).toBe(6);
-
-        const res = await auth
-          .patch(`/library/artists/${artist.id}`)
-          .send({ artist_name: artist.artist_name.toLowerCase() })
-          .expect(409);
-        expect(res.body.reason).toBe('artist_name_conflict');
-        expect(res.body.artist.artist_id).toBe(duplicate.id);
-
-        const unchanged = await auth.get(`/library/artists/${artist.id}`).expect(200);
-        expect(unchanged.body.artist_name).toBe(artist.artist_name);
-      } finally {
-        await sql.unsafe(`DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${duplicate.id}`);
-        await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${duplicate.id}`);
-        await sql.unsafe(
-          `DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${artist.id} AND genre_id = 6`
-        );
-      }
-    });
-
-    test('allows re-saving the same artist_name (no-op rename does not 409 against itself)', async () => {
-      const artist = await createTestArtist();
-
-      const res = await auth
-        .patch(`/library/artists/${artist.id}`)
-        .send({ artist_name: artist.artist_name, alphabetical_name: `${artist.alphabetical_name} Updated` })
-        .expect(200);
-
-      expect(res.body.artist_name).toBe(artist.artist_name);
-      expect(res.body.alphabetical_name).toBe(`${artist.alphabetical_name} Updated`);
-    });
+    // The rename-collision suite that lived here (409 on a same-genre
+    // duplicate; the two soundness cases for `artistIdFromName`'s unordered
+    // `.limit(1)` probe and for a fold-equal duplicate filed under a genre
+    // the card does not surface) moved to WXYC/Backend-Service#2197 with the
+    // `artist_name` rename itself. `artist_name` has no write path on this
+    // endpoint today -- it is rejected below -- so those tests could only
+    // assert behaviour that no longer exists. #2197 carries them verbatim as
+    // its acceptance criteria; re-add them here when the rename ships.
 
     test('404s on an unknown artist id', async () => {
-      const res = await auth.patch('/library/artists/99999999').send({ artist_name: 'Nobody' }).expect(404);
+      const res = await auth.patch('/library/artists/99999999').send({ alphabetical_name: 'Nobody' }).expect(404);
       expectErrorContains(res, 'not found');
     });
   });
@@ -2433,7 +2367,7 @@ describe('Library Artist Card (BS#2156)', () => {
         expectErrorContains(cardRes, 'not found');
         const patchRes = await auth
           .patch(`/library/artists/${orphan.id}`)
-          .send({ artist_name: 'Should Not Apply' })
+          .send({ alphabetical_name: 'Should Not Apply' })
           .expect(404);
         expectErrorContains(patchRes, 'not found');
       } finally {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1883,6 +1883,186 @@ describe('Library Artists By Code', () => {
   });
 });
 
+describe('Library Artist Card (BS#2156)', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  // A monotonic counter, not Date.now()/Math.random() alone, so back-to-back
+  // calls within the same test file can't collide on the genre-scoped
+  // artist_name pre-check or the (code_letters, genre_id, code_number) triple
+  // check -- both of which answer 409, not the account-for-in-this-block 201.
+  let artistCounter = 0;
+
+  async function createTestArtist(overrides = {}) {
+    artistCounter += 1;
+    const uniqueSuffix = `${Date.now().toString(36)}${artistCounter}`.toUpperCase().slice(-4);
+    const res = await auth
+      .post('/library/artists')
+      .send({
+        artist_name: `Card Test Artist ${uniqueSuffix}`,
+        code_letters: uniqueSuffix.slice(-2),
+        genre_id: 11,
+        code_number: 8000 + artistCounter,
+        ...overrides,
+      })
+      .expect(201);
+    return res.body;
+  }
+
+  describe('GET /library/artists/:id', () => {
+    test('returns the full card field set', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth.get(`/library/artists/${artist.id}`).expect(200);
+
+      expectFields(
+        res.body,
+        'artist_id',
+        'artist_name',
+        'alphabetical_name',
+        'genre_id',
+        'code_letters',
+        'code_artist_number'
+      );
+      expect(res.body.artist_id).toBe(artist.id);
+      expect(res.body.artist_name).toBe(artist.artist_name);
+      expect(res.body.alphabetical_name).toBe(artist.alphabetical_name);
+      expect(res.body.genre_id).toBe(11);
+      expect(res.body.code_letters).toBe(artist.code_letters);
+    });
+
+    test('404s on an unknown artist id', async () => {
+      const res = await auth.get('/library/artists/99999999').expect(404);
+      expectErrorContains(res, 'not found');
+    });
+
+    test('400s on a non-numeric artist id', async () => {
+      await auth.get('/library/artists/not-a-number').expect(400);
+    });
+
+    // Route-ordering pin (BS#2156 constraint): `/artists/search` and
+    // `/artists/peek-code` are literal routes registered before this
+    // `/artists/:id` route. If that ordering ever regressed, Express would
+    // hand these requests to getArtistCard instead, and `Number('search')` /
+    // `Number('peek-code')` would produce a 400 "Invalid artist ID" rather
+    // than the shapes asserted below.
+    test('does not swallow the literal /artists/search route', async () => {
+      const res = await auth.get('/library/artists/search').query({ genre_id: 11, q: 'Bu', limit: 10 }).expect(200);
+      expect(res.body.artists).toBeDefined();
+    });
+
+    test('does not swallow the literal /artists/peek-code route', async () => {
+      const res = await auth.get('/library/artists/peek-code').query({ code_letters: 'BU', genre_id: 11 }).expect(200);
+      expect(res.body.next_code_number).toBeDefined();
+    });
+  });
+
+  describe('PATCH /library/artists/:id', () => {
+    test('updates artist_name and alphabetical_name', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ artist_name: 'Renamed Test Artist', alphabetical_name: 'Test Artist, Renamed' })
+        .expect(200);
+
+      expect(res.body.artist_name).toBe('Renamed Test Artist');
+      expect(res.body.alphabetical_name).toBe('Test Artist, Renamed');
+
+      const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+      expect(card.body.artist_name).toBe('Renamed Test Artist');
+      expect(card.body.alphabetical_name).toBe('Test Artist, Renamed');
+    });
+
+    test('drops fields outside the allowlist rather than applying them', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth
+        .patch(`/library/artists/${artist.id}`)
+        .send({ artist_name: 'Still Allowlisted', code_letters: 'ZZ', genre_id: 999 })
+        .expect(200);
+
+      expect(res.body.artist_name).toBe('Still Allowlisted');
+
+      const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+      // code_letters and genre_id are unchanged -- the PATCH allowlist
+      // dropped both rather than writing them.
+      expect(card.body.code_letters).toBe(artist.code_letters);
+      expect(card.body.genre_id).toBe(11);
+    });
+
+    test('returns 400 when the body has no updatable fields', async () => {
+      const artist = await createTestArtist();
+
+      const res = await auth.patch(`/library/artists/${artist.id}`).send({}).expect(400);
+      expectErrorContains(res, 'artist_name');
+    });
+
+    test('404s on an unknown artist id', async () => {
+      const res = await auth.patch('/library/artists/99999999').send({ artist_name: 'Nobody' }).expect(404);
+      expectErrorContains(res, 'not found');
+    });
+  });
+
+  describe('GET /library/artists/:id/releases', () => {
+    test('returns the release-table columns for that artist, ordered by call number', async () => {
+      const artist = await createTestArtist();
+
+      const first = await auth
+        .post('/library')
+        .send({
+          album_title: `Release B ${Date.now()}`,
+          artist_id: artist.id,
+          label: 'Test Label',
+          genre_id: 11,
+          format_id: 1,
+        })
+        .expect(201);
+      const second = await auth
+        .post('/library')
+        .send({
+          album_title: `Release A ${Date.now()}`,
+          artist_id: artist.id,
+          label: 'Test Label',
+          genre_id: 11,
+          format_id: 1,
+        })
+        .expect(201);
+
+      const res = await auth.get(`/library/artists/${artist.id}/releases`).expect(200);
+
+      expect(res.body.artist_id).toBe(artist.id);
+      expect(Array.isArray(res.body.releases)).toBe(true);
+      expect(res.body.releases).toHaveLength(2);
+      res.body.releases.forEach((release) =>
+        expectFields(
+          release,
+          'id',
+          'last_modified',
+          'format_name',
+          'code_letters',
+          'code_number',
+          'code_volume_letters',
+          'album_title',
+          'alternate_artist_name'
+        )
+      );
+      // Ordered by code_number ascending (shelf order): the first-added
+      // album mints the lower code_number via generateAlbumCodeNumber.
+      expect(res.body.releases[0].id).toBe(first.body.id);
+      expect(res.body.releases[1].id).toBe(second.body.id);
+    });
+
+    test('404s on an unknown artist id', async () => {
+      const res = await auth.get('/library/artists/99999999/releases').expect(404);
+      expectErrorContains(res, 'not found');
+    });
+  });
+});
+
 describe('Library Formats', () => {
   let auth;
 

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -2075,22 +2075,42 @@ describe('Library Artist Card (BS#2156)', () => {
       expectErrorContains(res, field);
     });
 
-    test('drops fields outside the allowlist rather than applying them', async () => {
+    // BS#2156 review: the AC says the endpoint "allowlists the two name
+    // fields and rejects anything else." These three real `artistCardModify.
+    // jsp` fields (`ArtistAdminServlet.java:196-206` applies all five) have
+    // no write path today, so a client sending one gets a 400 naming why --
+    // not a 200 that looks like the edit took effect but silently didn't.
+    test.each(['code_letters', 'genre_id', 'code_artist_number'])(
+      'returns 400 rather than silently dropping %s',
+      async (field) => {
+        const artist = await createTestArtist();
+        const value = field === 'code_letters' ? 'ZZ' : 999;
+
+        const res = await auth
+          .patch(`/library/artists/${artist.id}`)
+          .send({ artist_name: `Rejected ${artist.artist_name}`, [field]: value })
+          .expect(400);
+        expectErrorContains(res, field);
+        expectErrorContains(res, 'no write path');
+
+        // The rejected PATCH did not take effect.
+        const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+        expect(card.body.artist_name).toBe(artist.artist_name);
+        expect(card.body.code_letters).toBe(artist.code_letters);
+        expect(card.body.genre_id).toBe(11);
+      }
+    );
+
+    test('rejects multiple no-write-path fields together, naming all of them', async () => {
       const artist = await createTestArtist();
-      const renamed = `Still Allowlisted ${artist.artist_name}`;
 
       const res = await auth
         .patch(`/library/artists/${artist.id}`)
-        .send({ artist_name: renamed, code_letters: 'ZZ', genre_id: 999 })
-        .expect(200);
-
-      expect(res.body.artist_name).toBe(renamed);
-
-      const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
-      // code_letters and genre_id are unchanged -- the PATCH allowlist
-      // dropped both rather than writing them.
-      expect(card.body.code_letters).toBe(artist.code_letters);
-      expect(card.body.genre_id).toBe(11);
+        .send({ code_letters: 'ZZ', genre_id: 999, code_artist_number: 7 })
+        .expect(400);
+      expectErrorContains(res, 'code_letters');
+      expectErrorContains(res, 'genre_id');
+      expectErrorContains(res, 'code_artist_number');
     });
 
     test('returns 400 when the body has no updatable fields', async () => {
@@ -2157,6 +2177,59 @@ describe('Library Artist Card (BS#2156)', () => {
       } finally {
         await sql.unsafe(`DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${duplicate.id}`);
         await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${duplicate.id}`);
+      }
+    });
+
+    // BS#2156 review: `existing.genre_id` off `getArtistCardById` is
+    // deliberately the LOWEST genre_id a multi-genre artist is
+    // crossreferenced in. A conflict probe fixed to that one genre never sees
+    // a fold-equal duplicate filed under a DIFFERENT genre of the same
+    // artist -- and multi-genre artists are a designed state
+    // (`jobs/artist-unicode-dedup/merge.ts` repoints every crossreference
+    // onto a survivor precisely so the matcher reaches it from every genre).
+    // Genre 6 sorts below the genre 11 `createTestArtist` uses, so the
+    // artist's OWN lowest crossreference is genre 6 -- and the fold-equal
+    // duplicate is seeded into genre 11, the one `getArtistCardById` does
+    // NOT surface as `existing.genre_id`.
+    test('409s on a fold-equal rename found in a DIFFERENT genre than the card surfaces', async () => {
+      const artist = await createTestArtist();
+      const sql = getTestDb();
+      await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+         VALUES (${artist.id}, 6, 9913)`
+      );
+      const [duplicate] = await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.artists (artist_name, alphabetical_name, code_letters)
+         VALUES ('${artist.artist_name}', '${artist.alphabetical_name}', '${artist.code_letters}')
+         RETURNING id`
+      );
+      await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+         VALUES (${duplicate.id}, 11, 9914)`
+      );
+
+      try {
+        // The card now surfaces genre 6 (the artist's lowest), while the
+        // fold-equal duplicate lives in genre 11 -- a probe scoped to
+        // `existing.genre_id` alone would miss it entirely.
+        const card = await auth.get(`/library/artists/${artist.id}`).expect(200);
+        expect(card.body.genre_id).toBe(6);
+
+        const res = await auth
+          .patch(`/library/artists/${artist.id}`)
+          .send({ artist_name: artist.artist_name.toLowerCase() })
+          .expect(409);
+        expect(res.body.reason).toBe('artist_name_conflict');
+        expect(res.body.artist.artist_id).toBe(duplicate.id);
+
+        const unchanged = await auth.get(`/library/artists/${artist.id}`).expect(200);
+        expect(unchanged.body.artist_name).toBe(artist.artist_name);
+      } finally {
+        await sql.unsafe(`DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${duplicate.id}`);
+        await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${duplicate.id}`);
+        await sql.unsafe(
+          `DELETE FROM ${SCHEMA}.genre_artist_crossreference WHERE artist_id = ${artist.id} AND genre_id = 6`
+        );
       }
     });
 
@@ -2261,6 +2334,40 @@ describe('Library Artist Card (BS#2156)', () => {
       expect(res.body.releases.map((release) => release.id)).toEqual([third.id, second.id, first.id]);
     });
 
+    // BS#2156 review: `code_volume_letters` must sort `ASC NULLS FIRST` to
+    // match the legacy MySQL shelf order (`LibraryCatalogServlet.java:130-
+    // 133`), where a bare, unlettered volume (`R 7`) files AHEAD of its own
+    // lettered siblings (`R 7A`, `R 7B`) under the same `code_number`.
+    // Postgres's bare `ASC` default is NULLS LAST, so the previous test's
+    // fixture -- whose NULL row sits at a DIFFERENT code_number -- can't
+    // catch a regression back to that default. This one ties a NULL directly
+    // against a lettered row under the SAME code_number.
+    test('sorts a bare (NULL) volume ahead of its lettered siblings under the same code_number', async () => {
+      const artist = await createTestArtist();
+      const bare = await addRelease(artist.id, `Shelf Bare ${Date.now()}`);
+      const letterB = await addRelease(artist.id, `Shelf Letter B ${Date.now()}`);
+      const letterA = await addRelease(artist.id, `Shelf Letter A ${Date.now()}`);
+      const otherNumber = await addRelease(artist.id, `Shelf Other Number ${Date.now()}`);
+
+      const sql = getTestDb();
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 7, code_volume_letters = NULL WHERE id = ${bare.id}`
+      );
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 7, code_volume_letters = 'A' WHERE id = ${letterA.id}`
+      );
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 7, code_volume_letters = 'B' WHERE id = ${letterB.id}`
+      );
+      await sql.unsafe(
+        `UPDATE ${SCHEMA}.library SET code_number = 9, code_volume_letters = NULL WHERE id = ${otherNumber.id}`
+      );
+
+      const res = await auth.get(`/library/artists/${artist.id}/releases`).expect(200);
+
+      expect(res.body.releases.map((release) => release.id)).toEqual([bare.id, letterA.id, letterB.id, otherNumber.id]);
+    });
+
     test('paginates with page/limit and reports total/totalPages', async () => {
       const artist = await createTestArtist();
       const created = [
@@ -2302,6 +2409,36 @@ describe('Library Artist Card (BS#2156)', () => {
 
     test('400s on a malformed artist id', async () => {
       await auth.get('/library/artists/2147483648/releases').expect(400);
+    });
+
+    // BS#2156 review: this endpoint used to resolve existence through
+    // `getArtistNameById` (a plain `artists` lookup), while GET/PATCH
+    // resolve it through `getArtistCardById` (INNER JOIN to
+    // `genre_artist_crossreference`) -- so an artist row with no
+    // crossreference 404'd on the card and the PATCH but 200'd here with an
+    // empty release page. `POST /library/artists` always inserts both rows
+    // atomically, so the only way to construct one is straight SQL.
+    test('404s, matching GET/PATCH, on an artist row with no genre crossreference', async () => {
+      const sql = getTestDb();
+      const [orphan] = await sql.unsafe(
+        `INSERT INTO ${SCHEMA}.artists (artist_name, alphabetical_name, code_letters)
+         VALUES ('Crossref Orphan ${Date.now()}', 'Crossref Orphan', 'CO')
+         RETURNING id`
+      );
+
+      try {
+        const releasesRes = await auth.get(`/library/artists/${orphan.id}/releases`).expect(404);
+        expectErrorContains(releasesRes, 'not found');
+        const cardRes = await auth.get(`/library/artists/${orphan.id}`).expect(404);
+        expectErrorContains(cardRes, 'not found');
+        const patchRes = await auth
+          .patch(`/library/artists/${orphan.id}`)
+          .send({ artist_name: 'Should Not Apply' })
+          .expect(404);
+        expectErrorContains(patchRes, 'not found');
+      } finally {
+        await sql.unsafe(`DELETE FROM ${SCHEMA}.artists WHERE id = ${orphan.id}`);
+      }
     });
   });
 });

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1913,23 +1913,47 @@ describe('Library Artist Card (BS#2156)', () => {
   // NEXT run starts against the previous run's database. A fixture keyed on the
   // counter alone then 409s `artist_code_conflict` against its own leftovers
   // from the failed run, which reads as an unrelated cascade across the file.
-  const runKey = Date.now().toString(36).toUpperCase().slice(-2);
+  // `code_letters` is varchar(4) and the counter needs two of them, so the run
+  // key gets the other two: 36^2 = 1,296 values, cycling every ~1.3 s of wall
+  // clock. That makes across-run uniqueness a probability, not a guarantee —
+  // and the odds get worse with every leftover run, because `ci:testmock` is
+  // `ci:env && ci:test && ci:clean`, so a FAILING run skips the volume drop and
+  // the next run starts against its rows. Widening the key isn't available
+  // (four characters is the column). So the helper re-rolls instead: a
+  // code-conflict costs one retry rather than cascading through the block.
+  let runKey = Date.now().toString(36).toUpperCase().slice(-2);
+  const rerollRunKey = () => {
+    const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const pick = () => alphabet[Math.floor(Math.random() * alphabet.length)];
+    runKey = `${pick()}${pick()}`;
+  };
 
   async function createTestArtist(overrides = {}) {
     artistCounter += 1;
     // Base36 of the counter, never truncated: unique per call by construction.
     const counterKey = artistCounter.toString(36).toUpperCase().padStart(2, '0');
-    const res = await auth.post('/library/artists').send({
-      artist_name: `Card Test Artist ${runKey}${counterKey}-${Date.now().toString(36).toUpperCase()}`,
-      // 4 chars, the `code_letters` ceiling: run key + counter.
-      code_letters: `${runKey}${counterKey}`,
-      genre_id: 11,
-      code_number: 8000 + artistCounter,
-      ...overrides,
-    });
-    // A 409 here is a fixture-uniqueness failure, not a test failure. Surface
-    // the server's own discriminant (`reason` + the conflicting artist) rather
-    // than a bare "expected 201, got 409" that names neither axis.
+
+    const attempt = () =>
+      auth.post('/library/artists').send({
+        artist_name: `Card Test Artist ${runKey}${counterKey}-${Date.now().toString(36).toUpperCase()}`,
+        // 4 chars, the `code_letters` ceiling: run key + counter.
+        code_letters: `${runKey}${counterKey}`,
+        genre_id: 11,
+        code_number: 8000 + artistCounter,
+        ...overrides,
+      });
+
+    let res = await attempt();
+    // A 409 here is a fixture-uniqueness failure, not a test failure — almost
+    // always this run key colliding with a leftover one. Re-roll and try once
+    // more before giving up.
+    if (res.status === 409) {
+      rerollRunKey();
+      res = await attempt();
+    }
+    // Surface the server's own discriminant (`reason` + the conflicting
+    // artist) rather than a bare "expected 201, got 409" that names neither
+    // axis of the collision.
     if (res.status !== 201) {
       throw new Error(
         `createTestArtist #${artistCounter} expected 201, got ${res.status}: ${JSON.stringify(res.body)}`

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -76,7 +76,6 @@ const mockUpdateArtistInDB =
       updates: Record<string, unknown>
     ) => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>
   >();
-const mockConflictingArtistIdInGenre = jest.fn<(name: string, excludeArtistId: number) => Promise<number | null>>();
 type ArtistReleaseRowMock = {
   id: number;
   last_modified: Date;
@@ -179,7 +178,6 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   deleteAlbumFromDB: mockDeleteAlbumFromDB,
   getArtistCardById: mockGetArtistCardById,
   updateArtistInDB: mockUpdateArtistInDB,
-  conflictingArtistIdInGenre: mockConflictingArtistIdInGenre,
   getReleasesForArtist: mockGetReleasesForArtist,
   countReleasesForArtist: mockCountReleasesForArtist,
 }));
@@ -2632,7 +2630,7 @@ describe('library.controller', () => {
     });
 
     it.each(rejected)('rejects an id that is %s with 400 on updateArtistCard', async (_label, rawId) => {
-      const req = { params: { id: rawId }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const req = { params: { id: rawId }, body: { alphabetical_name: 'Anohni' } } as unknown as Request;
       await expect(updateArtistCard(req, mockResponse(), next)).rejects.toThrow('Invalid artist ID');
       expect(mockGetArtistCardById).not.toHaveBeenCalled();
     });
@@ -2649,6 +2647,83 @@ describe('library.controller', () => {
 
       await expect(getArtistCard(req, mockResponse(), next)).rejects.toThrow('Artist not found');
       expect(mockGetArtistCardById).toHaveBeenCalledWith(2147483647);
+    });
+  });
+
+  // Review finding N3: `deleteAlbum`/`updateAlbum` share the same tightened
+  // `parseResourceId` (`^[1-9][0-9]*$` + INT4_MAX, replacing a bare
+  // `Number.isInteger` check) the artist routes above pin, but no test
+  // exercised the tightened regex for them specifically -- the pre-existing
+  // album-side tests only used 'abc', '0', '-5', all of which the OLD
+  // implementation also rejected, so reverting `parseAlbumId` to
+  // `Number.isInteger` would leave this suite green.
+  describe('album path-id parsing (BS#2156 review N3)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    const rejectedAlbumIds: Array<[string, string]> = [
+      ['non-numeric', 'abc'],
+      ['above INT4_MAX', '2147483648'],
+      ['exponent notation', '1e21'],
+      ['hex notation', '0x10'],
+      ['surrounded by whitespace', ' 16 '],
+      ['a trailing fraction', '42.0'],
+      ['explicitly signed', '+16'],
+      ['negative', '-16'],
+      ['zero', '0'],
+      ['leading-zero padded', '016'],
+      ['empty', ''],
+    ];
+
+    it.each(rejectedAlbumIds)('rejects an id that is %s with 400 on deleteAlbum', async (_label, rawId) => {
+      const req = { params: { id: rawId } } as unknown as Request;
+      await expect(deleteAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockDeleteAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    it.each(rejectedAlbumIds)('rejects an id that is %s with 400 on updateAlbum', async (_label, rawId) => {
+      const req = { params: { id: rawId }, body: { album_title: 'Some Title' } } as unknown as Request;
+      await expect(updateAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetLibraryRowById).not.toHaveBeenCalled();
+    });
+
+    it('accepts an id exactly at INT4_MAX on deleteAlbum', async () => {
+      mockDeleteAlbumFromDB.mockResolvedValue({ outcome: 'not_found' });
+      const req = { params: { id: '2147483647' } } as unknown as Request;
+
+      await expect(deleteAlbum(req, mockResponse(), next)).rejects.toThrow('Album not found');
+      expect(mockDeleteAlbumFromDB).toHaveBeenCalledWith(2147483647, expect.any(Object));
+    });
+
+    it('rejects an id one past INT4_MAX on deleteAlbum', async () => {
+      const req = { params: { id: '2147483648' } } as unknown as Request;
+
+      await expect(deleteAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockDeleteAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    it('accepts an id exactly at INT4_MAX on updateAlbum', async () => {
+      mockGetLibraryRowById.mockResolvedValue(undefined);
+      const req = {
+        params: { id: '2147483647' },
+        body: { album_title: 'Some Title' },
+      } as unknown as Request;
+
+      // Reaching the existence check (and its 'Album not found', not
+      // 'Invalid album ID') proves the id parsed rather than being rejected.
+      await expect(updateAlbum(req, mockResponse(), next)).rejects.toThrow('Album not found');
+      expect(mockGetLibraryRowById).toHaveBeenCalledWith(2147483647);
+    });
+
+    it('rejects an id one past INT4_MAX on updateAlbum', async () => {
+      const req = {
+        params: { id: '2147483648' },
+        body: { album_title: 'Some Title' },
+      } as unknown as Request;
+
+      await expect(updateAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetLibraryRowById).not.toHaveBeenCalled();
     });
   });
 
@@ -2698,12 +2773,11 @@ describe('library.controller', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockConflictingArtistIdInGenre.mockResolvedValue(null);
     });
 
     it('returns 404 when the artist does not exist', async () => {
       mockGetArtistCardById.mockResolvedValue(null);
-      const req = { params: { id: '999' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const req = { params: { id: '999' }, body: { alphabetical_name: 'Anohni' } } as unknown as Request;
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow('Artist not found');
@@ -2716,7 +2790,7 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow(
-        'Bad Request: provide at least one of artist_name, alphabetical_name'
+        'Bad Request: provide at least one of alphabetical_name'
       );
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
@@ -2730,8 +2804,8 @@ describe('library.controller', () => {
     it.each([
       ['undefined (no body sent at all)', undefined],
       ['null', null],
-      ['a bare JSON string', 'artist_name'],
-      ['a JSON array', ['artist_name']],
+      ['a bare JSON string', 'alphabetical_name'],
+      ['a JSON array', ['alphabetical_name']],
       ['a JSON number', 3],
     ])('returns 400 rather than 500 when the body is %s', async (_label, body) => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
@@ -2739,7 +2813,7 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow(
-        'Bad Request: provide at least one of artist_name, alphabetical_name'
+        'Bad Request: provide at least one of alphabetical_name'
       );
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
@@ -2750,29 +2824,60 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow(
-        'Bad Request: provide at least one of artist_name, alphabetical_name'
+        'Bad Request: provide at least one of alphabetical_name'
       );
       expect(mockGetArtistCardById).not.toHaveBeenCalled();
     });
 
-    // TypeScript's `UpdateArtistRequest` is erased at runtime, so these
-    // `typeof !== 'string'` guards are the ENTIRE runtime defense behind the
-    // allowlist against a non-string reaching `.trim()` (TypeError -> 500) or
-    // the UPDATE.
+    // Third-round review (verified end to end): `artist_name` renaming was
+    // pulled from this endpoint entirely -- `artists`/`library` are still
+    // tubafrenzy-canonical and `jobs/library-etl`'s `ensureArtist` matches by
+    // `fold_artist_name` and never UPDATEs `artists`, so a Backend-side
+    // rename would move the match key, get silently duplicated on the next
+    // ETL pass, and be reverted by that duplicate's release upsert. A client
+    // that sends `artist_name` is REJECTED with a 400 naming the field and
+    // the reason, not silently ignored -- silently dropping a requested
+    // write is its own defect class, and this endpoint already rejects
+    // `genre_id`/`code_letters`/`code_artist_number` the same way.
     it.each([
+      ['a string (a plausible rename attempt)', 'Anohni Hegarty'],
       ['a number', 123],
       ['an array', ['a']],
-      ['an object', { toString: 'nope' }],
-      ['a boolean', true],
-    ])('returns 400 when artist_name is %s', async (_label, value) => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      const req = { params: { id: '42' }, body: { artist_name: value } } as unknown as Request;
+    ])(
+      'rejects a body containing artist_name (%s) with a 400 naming the field, before the existence lookup',
+      async (_label, value) => {
+        const req = { params: { id: '42' }, body: { artist_name: value } } as unknown as Request;
+        const res = mockResponse();
+
+        let caught: unknown;
+        try {
+          await updateArtistCard(req, res, next);
+        } catch (err) {
+          caught = err;
+        }
+        const message = (caught as Error).message;
+        expect(message).toContain('no write path exists for artist_name');
+        expect(message).toContain('tubafrenzy-canonical');
+        expect(mockGetArtistCardById).not.toHaveBeenCalled();
+        expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+      }
+    );
+
+    it('rejects artist_name even when a valid alphabetical_name is present in the same body', async () => {
+      const req = {
+        params: { id: '42' },
+        body: { artist_name: 'Anohni Hegarty', alphabetical_name: 'Anohni Hegarty' },
+      } as unknown as Request;
       const res = mockResponse();
 
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow('artist_name must be a non-empty string');
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('no write path exists for artist_name');
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
+    // TypeScript's `UpdateArtistRequest` is erased at runtime, so this
+    // `typeof !== 'string'` guard is the ENTIRE runtime defense behind the
+    // allowlist against a non-string reaching `.trim()` (TypeError -> 500) or
+    // the UPDATE.
     it.each([
       ['a number', 123],
       ['an array', ['a']],
@@ -2787,61 +2892,94 @@ describe('library.controller', () => {
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
-    // Both fields are `varchar(128)`; over-length input must 400 rather than
-    // reach the UPDATE and trip PG 22001 ("value too long") -> 500 (#1551).
-    it.each(['artist_name', 'alphabetical_name'])('returns 400 when %s exceeds 128 characters', async (field) => {
+    // `varchar(128)`; over-length input must 400 rather than reach the
+    // UPDATE and trip PG 22001 ("value too long") -> 500 (#1551).
+    it('returns 400 when alphabetical_name exceeds 128 characters', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      const req = { params: { id: '42' }, body: { [field]: 'x'.repeat(129) } } as unknown as Request;
+      const req = { params: { id: '42' }, body: { alphabetical_name: 'x'.repeat(129) } } as unknown as Request;
       const res = mockResponse();
 
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow(`${field} must be 128 characters or fewer`);
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'alphabetical_name must be 128 characters or fewer'
+      );
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
-    it.each(['artist_name', 'alphabetical_name'])('accepts %s at exactly 128 characters', async (field) => {
+    it('accepts alphabetical_name at exactly 128 characters', async () => {
       const atLimit = 'x'.repeat(128);
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: atLimit, alphabetical_name: atLimit });
-      const req = { params: { id: '42' }, body: { [field]: atLimit } } as unknown as Request;
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: atLimit });
+      const req = { params: { id: '42' }, body: { alphabetical_name: atLimit } } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { [field]: atLimit });
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: atLimit });
     });
 
-    // The two fields validate symmetrically — `alphabetical_name` gets the
-    // same empty-string rejection `artist_name` does.
-    it.each(['artist_name', 'alphabetical_name'])('returns 400 when %s is whitespace-only', async (field) => {
+    it('returns 400 when alphabetical_name is whitespace-only', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      const req = { params: { id: '42' }, body: { [field]: '   ' } } as unknown as Request;
+      const req = { params: { id: '42' }, body: { alphabetical_name: '   ' } } as unknown as Request;
       const res = mockResponse();
 
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow(`${field} must be a non-empty string`);
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('alphabetical_name must be a non-empty string');
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
     it('trims surrounding whitespace before validating and storing', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Hegarty', alphabetical_name: 'Anohni' });
-      const req = { params: { id: '42' }, body: { artist_name: '  Anohni Hegarty  ' } } as unknown as Request;
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni Hegarty' });
+      const req = { params: { id: '42' }, body: { alphabetical_name: '  Anohni Hegarty  ' } } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni Hegarty' });
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: 'Anohni Hegarty' });
     });
 
-    // BS#2156 review: the AC says the endpoint "allowlists the two name
-    // fields and rejects anything else" -- these three real JSP fields must
-    // 400 with a precise reason, not be accepted-and-silently-dropped as if
-    // the edit had taken effect.
+    // Review finding N2: the controller used to measure `trimmed.length` on
+    // the RAW input while `updateArtistInDB` writes `.normalize('NFC')`, and
+    // NFC is NOT length-non-increasing -- a full composition-exclusion
+    // codepoint like U+0958 ('क़') is 1 UTF-16 unit raw but 2 after NFC (it
+    // canonically decomposes to U+0915 + U+093C and, being excluded from
+    // recomposition, stays decomposed). A 128-repeat of it passed the old
+    // raw-length 400 and would have reached Postgres at NFC length 256,
+    // tripping SQLSTATE 22001 ("value too long") -> 500 where the documented
+    // answer is 400.
+    it('returns 400 when alphabetical_name is within the raw-length limit but exceeds it after NFC normalization', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const compositionExclusion = 'क़'.repeat(128); // raw length 128, NFC length 256
+      const req = { params: { id: '42' }, body: { alphabetical_name: compositionExclusion } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'alphabetical_name must be 128 characters or fewer'
+      );
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it('stores the NFC-normalized value, not the raw composed form', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'क़' });
+      // U+0958 ('क़'), 1 raw UTF-16 unit, normalizes to U+0915 U+093C (2 units).
+      const req = { params: { id: '42' }, body: { alphabetical_name: 'क़' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: 'क़' });
+    });
+
+    // BS#2156 review: the AC says the endpoint allowlists exactly
+    // `alphabetical_name` and rejects anything else -- these fields must 400
+    // with a precise reason, not be accepted-and-silently-dropped as if the
+    // edit had taken effect.
     it.each(['code_letters', 'genre_id', 'code_artist_number'])(
       'returns 400 rather than silently dropping %s, before the existence lookup',
       async (field) => {
         const req = {
           params: { id: '42' },
-          body: { artist_name: 'Anohni Renamed', [field]: field === 'code_letters' ? 'ZZ' : 999 },
+          body: { alphabetical_name: 'Anohni Renamed', [field]: field === 'code_letters' ? 'ZZ' : 999 },
         } as unknown as Request;
         const res = mockResponse();
 
@@ -2854,12 +2992,33 @@ describe('library.controller', () => {
     it('names every rejected field when several no-write-path fields are sent together', async () => {
       const req = {
         params: { id: '42' },
-        body: { artist_name: 'Anohni Renamed', code_letters: 'ZZ', genre_id: 999, code_artist_number: 7 },
+        body: {
+          alphabetical_name: 'Anohni Renamed',
+          artist_name: 'Anohni Renamed',
+          code_letters: 'ZZ',
+          genre_id: 999,
+          code_artist_number: 7,
+        },
       } as unknown as Request;
       const res = mockResponse();
 
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
-        'no write path exists for genre_id (no write path: genre_artist_crossreference.genre_id is set once by POST /library/artists and is never UPDATEd by any endpoint), code_letters (no write path: artists.code_letters is set once by POST /library/artists and is never UPDATEd by any endpoint), code_artist_number (no write path: genre_artist_crossreference.artist_genre_code is set once by POST /library/artists and is never UPDATEd by any endpoint)'
+      let caught: unknown;
+      try {
+        await updateArtistCard(req, res, next);
+      } catch (err) {
+        caught = err;
+      }
+      const message = (caught as Error).message;
+      expect(message).toContain('no write path exists for artist_name');
+      expect(message).toContain('tubafrenzy-canonical');
+      expect(message).toContain(
+        'genre_id (no write path: genre_artist_crossreference.genre_id is set once by POST /library/artists and is never UPDATEd by any endpoint)'
+      );
+      expect(message).toContain(
+        'code_letters (no write path: artists.code_letters is set once by POST /library/artists and is never UPDATEd by any endpoint)'
+      );
+      expect(message).toContain(
+        'code_artist_number (no write path: genre_artist_crossreference.artist_genre_code is set once by POST /library/artists and is never UPDATEd by any endpoint)'
       );
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
@@ -2872,103 +3031,10 @@ describe('library.controller', () => {
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
-    it('skips the name-conflict check when artist_name is unchanged (no-op re-save)', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' });
-      const req = { params: { id: '42' }, body: { artist_name: 'Anohni' } } as unknown as Request;
-      const res = mockResponse();
-
-      await updateArtistCard(req, res, next);
-
-      expect(mockConflictingArtistIdInGenre).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    it('returns 409 when the new artist_name collides with a different artist in the same genre', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockConflictingArtistIdInGenre.mockResolvedValue(77);
-      mockGetArtistById.mockResolvedValue({ artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' });
-      const req = { params: { id: '42' }, body: { artist_name: 'Perfume Genius' } } as unknown as Request;
-      const res = mockResponse();
-
-      await updateArtistCard(req, res, next);
-
-      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Perfume Genius', 42);
-      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
-      expect(res.status).toHaveBeenCalledWith(409);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Artist name already exists in that genre.',
-        reason: 'artist_name_conflict',
-        artist: { artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' },
-      });
-    });
-
-    // BS#2156 review: `addArtist`'s identical race gets an identical fix here
-    // -- a miss on the second lookup means the conflicting row was deleted
-    // between the probe and the fetch, so the name is free again. Proceeding
-    // is the only honest option; a 409 with `artist: null` hands the client a
-    // payload it cannot act on, and `addAlbum`'s documented policy for this
-    // exact race is "proceed."
-    it('proceeds with the rename when the conflicting artist disappears between the two lookups', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockConflictingArtistIdInGenre.mockResolvedValue(77);
-      mockGetArtistById.mockResolvedValue(null);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Perfume Genius', alphabetical_name: 'Anohni' });
-      const req = { params: { id: '42' }, body: { artist_name: 'Perfume Genius' } } as unknown as Request;
-      const res = mockResponse();
-
-      await updateArtistCard(req, res, next);
-
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Perfume Genius' });
-      expect(res.status).toHaveBeenCalledWith(200);
-      // Never a 409 that asserts a conflicting artist it cannot name.
-      expect(res.json).not.toHaveBeenCalledWith(expect.objectContaining({ artist: null }));
-    });
-
-    // The self-exclusion is pushed into the query rather than compared against
-    // whatever an unordered `.limit(1)` probe returned: a genre holding two
-    // fold-equal rows can hand back the row being renamed, and a `!== artistId`
-    // comparison would then wave the duplicate-creating rename through. This
-    // pins that the controller never asks a question it has to post-filter.
-    it('asks the service to exclude the row being renamed rather than post-filtering', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockConflictingArtistIdInGenre.mockResolvedValue(null);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'the trees', alphabetical_name: 'Anohni' });
-      const req = { params: { id: '42' }, body: { artist_name: 'the trees' } } as unknown as Request;
-      const res = mockResponse();
-
-      await updateArtistCard(req, res, next);
-
-      expect(mockArtistIdFromName).not.toHaveBeenCalled();
-      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('the trees', 42);
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    // BS#2156 review: `conflictingArtistIdInGenre` is scoped to EVERY genre
-    // the artist under edit is crossreferenced in, not just
-    // `getArtistCardById`'s deliberately-collapsed lowest-genre_id row --
-    // multi-genre artists are a designed state
-    // (`jobs/artist-unicode-dedup/merge.ts` repoints crossreferences onto a
-    // survivor precisely so the matcher reaches it from every genre). This
-    // pins that the controller passes only `(name, artistId)`, never a fixed
-    // `genre_id`, so the service is free to probe them all.
-    it('does not pass a fixed genre_id to the conflict probe', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockConflictingArtistIdInGenre.mockResolvedValue(null);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Björk', alphabetical_name: 'Anohni' });
-      const req = { params: { id: '42' }, body: { artist_name: 'Björk' } } as unknown as Request;
-      const res = mockResponse();
-
-      await updateArtistCard(req, res, next);
-
-      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Björk', 42);
-      expect((mockConflictingArtistIdInGenre.mock.calls[0] as unknown[]).length).toBe(2);
-    });
-
     it('returns 200 with the refreshed card shape (not the bare artists row) on success', async () => {
       const refreshed: ArtistCardMock = {
         artist_id: 42,
-        artist_name: 'Anohni Renamed',
+        artist_name: 'Anohni',
         alphabetical_name: 'Anohni Renamed',
         genre_id: 11,
         code_letters: 'AN',
@@ -2977,19 +3043,18 @@ describe('library.controller', () => {
       mockGetArtistCardById.mockResolvedValueOnce(existingCard).mockResolvedValueOnce(refreshed);
       mockUpdateArtistInDB.mockResolvedValue({
         id: 42,
-        artist_name: 'Anohni Renamed',
+        artist_name: 'Anohni',
         alphabetical_name: 'Anohni Renamed',
       });
       const req = {
         params: { id: '42' },
-        body: { artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni Renamed' },
+        body: { alphabetical_name: 'Anohni Renamed' },
       } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
       expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, {
-        artist_name: 'Anohni Renamed',
         alphabetical_name: 'Anohni Renamed',
       });
       expect(res.status).toHaveBeenCalledWith(200);

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -76,8 +76,7 @@ const mockUpdateArtistInDB =
       updates: Record<string, unknown>
     ) => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>
   >();
-const mockConflictingArtistIdInGenre =
-  jest.fn<(name: string, genreId: number, excludeArtistId: number) => Promise<number | null>>();
+const mockConflictingArtistIdInGenre = jest.fn<(name: string, excludeArtistId: number) => Promise<number | null>>();
 type ArtistReleaseRowMock = {
   id: number;
   last_modified: Date;
@@ -2641,7 +2640,7 @@ describe('library.controller', () => {
     it.each(rejected)('rejects an id that is %s with 400 on getArtistReleases', async (_label, rawId) => {
       const req = { params: { id: rawId }, query: {} } as unknown as Request;
       await expect(getArtistReleases(req, mockResponse(), next)).rejects.toThrow('Invalid artist ID');
-      expect(mockGetArtistNameById).not.toHaveBeenCalled();
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
     });
 
     it('accepts an id exactly at INT4_MAX', async () => {
@@ -2833,18 +2832,44 @@ describe('library.controller', () => {
       expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni Hegarty' });
     });
 
-    it('drops any field outside the allowlist rather than rejecting the request', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni' });
+    // BS#2156 review: the AC says the endpoint "allowlists the two name
+    // fields and rejects anything else" -- these three real JSP fields must
+    // 400 with a precise reason, not be accepted-and-silently-dropped as if
+    // the edit had taken effect.
+    it.each(['code_letters', 'genre_id', 'code_artist_number'])(
+      'returns 400 rather than silently dropping %s, before the existence lookup',
+      async (field) => {
+        const req = {
+          params: { id: '42' },
+          body: { artist_name: 'Anohni Renamed', [field]: field === 'code_letters' ? 'ZZ' : 999 },
+        } as unknown as Request;
+        const res = mockResponse();
+
+        await expect(updateArtistCard(req, res, next)).rejects.toThrow(`no write path exists for ${field}`);
+        expect(mockGetArtistCardById).not.toHaveBeenCalled();
+        expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+      }
+    );
+
+    it('names every rejected field when several no-write-path fields are sent together', async () => {
       const req = {
         params: { id: '42' },
-        body: { artist_name: 'Anohni Renamed', code_letters: 'ZZ', genre_id: 999 },
+        body: { artist_name: 'Anohni Renamed', code_letters: 'ZZ', genre_id: 999, code_artist_number: 7 },
       } as unknown as Request;
       const res = mockResponse();
 
-      await updateArtistCard(req, res, next);
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'no write path exists for genre_id (no write path: genre_artist_crossreference.genre_id is set once by POST /library/artists and is never UPDATEd by any endpoint), code_letters (no write path: artists.code_letters is set once by POST /library/artists and is never UPDATEd by any endpoint), code_artist_number (no write path: genre_artist_crossreference.artist_genre_code is set once by POST /library/artists and is never UPDATEd by any endpoint)'
+      );
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
 
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni Renamed' });
+    it('rejects a no-write-path field even when it is the only field on the body', async () => {
+      const req = { params: { id: '42' }, body: { genre_id: 999 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('no write path exists for genre_id');
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
     it('skips the name-conflict check when artist_name is unchanged (no-op re-save)', async () => {
@@ -2868,7 +2893,7 @@ describe('library.controller', () => {
 
       await updateArtistCard(req, res, next);
 
-      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Perfume Genius', 11, 42);
+      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Perfume Genius', 42);
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(409);
       expect(res.json).toHaveBeenCalledWith({
@@ -2876,6 +2901,28 @@ describe('library.controller', () => {
         reason: 'artist_name_conflict',
         artist: { artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' },
       });
+    });
+
+    // BS#2156 review: `addArtist`'s identical race gets an identical fix here
+    // -- a miss on the second lookup means the conflicting row was deleted
+    // between the probe and the fetch, so the name is free again. Proceeding
+    // is the only honest option; a 409 with `artist: null` hands the client a
+    // payload it cannot act on, and `addAlbum`'s documented policy for this
+    // exact race is "proceed."
+    it('proceeds with the rename when the conflicting artist disappears between the two lookups', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockConflictingArtistIdInGenre.mockResolvedValue(77);
+      mockGetArtistById.mockResolvedValue(null);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Perfume Genius', alphabetical_name: 'Anohni' });
+      const req = { params: { id: '42' }, body: { artist_name: 'Perfume Genius' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Perfume Genius' });
+      expect(res.status).toHaveBeenCalledWith(200);
+      // Never a 409 that asserts a conflicting artist it cannot name.
+      expect(res.json).not.toHaveBeenCalledWith(expect.objectContaining({ artist: null }));
     });
 
     // The self-exclusion is pushed into the query rather than compared against
@@ -2893,8 +2940,29 @@ describe('library.controller', () => {
       await updateArtistCard(req, res, next);
 
       expect(mockArtistIdFromName).not.toHaveBeenCalled();
-      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('the trees', 11, 42);
+      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('the trees', 42);
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    // BS#2156 review: `conflictingArtistIdInGenre` is scoped to EVERY genre
+    // the artist under edit is crossreferenced in, not just
+    // `getArtistCardById`'s deliberately-collapsed lowest-genre_id row --
+    // multi-genre artists are a designed state
+    // (`jobs/artist-unicode-dedup/merge.ts` repoints crossreferences onto a
+    // survivor precisely so the matcher reaches it from every genre). This
+    // pins that the controller passes only `(name, artistId)`, never a fixed
+    // `genre_id`, so the service is free to probe them all.
+    it('does not pass a fixed genre_id to the conflict probe', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockConflictingArtistIdInGenre.mockResolvedValue(null);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Björk', alphabetical_name: 'Anohni' });
+      const req = { params: { id: '42' }, body: { artist_name: 'Björk' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Björk', 42);
+      expect((mockConflictingArtistIdInGenre.mock.calls[0] as unknown[]).length).toBe(2);
     });
 
     it('returns 200 with the refreshed card shape (not the bare artists row) on success', async () => {
@@ -2946,13 +3014,24 @@ describe('library.controller', () => {
       },
     ];
 
+    // Only used to prove existence -- the response never echoes the card
+    // fields, so the exact content is irrelevant, only that it's non-null.
+    const anyCard: ArtistCardMock = {
+      artist_id: 42,
+      artist_name: 'Chuquimamani-Condori',
+      alphabetical_name: 'Chuquimamani-Condori',
+      genre_id: 11,
+      code_letters: 'CH',
+      code_artist_number: 4,
+    };
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockCountReleasesForArtist.mockResolvedValue(1);
     });
 
     it('returns 404 when the artist does not exist', async () => {
-      mockGetArtistNameById.mockResolvedValue(null);
+      mockGetArtistCardById.mockResolvedValue(null);
       const req = { params: { id: '999' }, query: {} } as unknown as Request;
       const res = mockResponse();
 
@@ -2960,8 +3039,23 @@ describe('library.controller', () => {
       expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
     });
 
+    // BS#2156 review: an artist row with no genre_artist_crossreference must
+    // 404 here the same way it already does on GET/PATCH
+    // /library/artists/:id (both resolve existence through
+    // `getArtistCardById`'s INNER JOIN) -- a plain `artists` lookup like
+    // `getArtistNameById` would 200 with an empty release page instead.
+    it('returns 404 when the artist has no genre crossreference, matching GET/PATCH', async () => {
+      mockGetArtistCardById.mockResolvedValue(null);
+      const req = { params: { id: '42' }, query: {} } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistReleases(req, res, next)).rejects.toThrow('Artist not found');
+      expect(mockGetArtistCardById).toHaveBeenCalledWith(42);
+      expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
+    });
+
     it('returns 200 with a default-paginated release page on success', async () => {
-      mockGetArtistNameById.mockResolvedValue('Chuquimamani-Condori');
+      mockGetArtistCardById.mockResolvedValue(anyCard);
       mockGetReleasesForArtist.mockResolvedValue(releases);
       mockCountReleasesForArtist.mockResolvedValue(1);
       const req = { params: { id: '42' }, query: {} } as unknown as Request;
@@ -2975,7 +3069,7 @@ describe('library.controller', () => {
     });
 
     it('passes an explicit page/limit through and reports totalPages', async () => {
-      mockGetArtistNameById.mockResolvedValue('Various Artists');
+      mockGetArtistCardById.mockResolvedValue(anyCard);
       mockGetReleasesForArtist.mockResolvedValue(releases);
       mockCountReleasesForArtist.mockResolvedValue(3107);
       const req = { params: { id: '1087' }, query: { page: '2', limit: '100' } } as unknown as Request;
@@ -3002,7 +3096,7 @@ describe('library.controller', () => {
       ['a non-numeric limit', { limit: 'all' }, 'limit must be a positive integer'],
       ['a non-numeric page', { page: 'first' }, 'page must be a non-negative integer'],
     ])('rejects %s with 400', async (_label, query, message) => {
-      mockGetArtistNameById.mockResolvedValue('Various Artists');
+      mockGetArtistCardById.mockResolvedValue(anyCard);
       const req = { params: { id: '1087' }, query } as unknown as Request;
       const res = mockResponse();
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -2631,14 +2631,34 @@ describe('library.controller', () => {
   });
 
   describe('updateArtistCard (BS#2156)', () => {
+    const existingCard: ArtistCardMock = {
+      artist_id: 42,
+      artist_name: 'Anohni',
+      alphabetical_name: 'Anohni',
+      genre_id: 11,
+      code_letters: 'AN',
+      code_artist_number: 3,
+    };
+
     it('returns 400 for a non-numeric id parameter', async () => {
-      const req = { params: { id: 'abc' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const req = { params: { id: 'abc' }, body: { artist_name: 'Anohni and the Johnsons' } } as unknown as Request;
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow('Invalid artist ID');
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the artist does not exist', async () => {
+      mockGetArtistCardById.mockResolvedValue(null);
+      const req = { params: { id: '999' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Artist not found');
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
     it('returns 400 when the body has no updatable fields', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
       const req = { params: { id: '42' }, body: {} } as unknown as Request;
       const res = mockResponse();
 
@@ -2649,47 +2669,102 @@ describe('library.controller', () => {
     });
 
     it('returns 400 when artist_name is an empty string', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
       const req = { params: { id: '42' }, body: { artist_name: '   ' } } as unknown as Request;
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow('artist_name must be a non-empty string');
     });
 
+    it('trims surrounding whitespace before validating and storing', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockArtistIdFromName.mockResolvedValue(0);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Hegarty', alphabetical_name: 'Anohni' });
+      const req = { params: { id: '42' }, body: { artist_name: '  Anohni Hegarty  ' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni Hegarty' });
+    });
+
     it('drops any field outside the allowlist rather than rejecting the request', async () => {
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' });
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockArtistIdFromName.mockResolvedValue(0);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni' });
       const req = {
         params: { id: '42' },
-        body: { artist_name: 'Anohni', code_letters: 'ZZ', genre_id: 999 },
+        body: { artist_name: 'Anohni Renamed', code_letters: 'ZZ', genre_id: 999 },
       } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni' });
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni Renamed' });
     });
 
-    it('returns 404 when the artist does not exist', async () => {
-      mockUpdateArtistInDB.mockResolvedValue(undefined);
-      const req = { params: { id: '999' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+    it('skips the name-conflict check when artist_name is unchanged (no-op re-save)', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' });
+      const req = { params: { id: '42' }, body: { artist_name: 'Anohni' } } as unknown as Request;
       const res = mockResponse();
 
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Artist not found');
+      await updateArtistCard(req, res, next);
+
+      expect(mockArtistIdFromName).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('returns 409 when the new artist_name collides with a different artist in the same genre', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockArtistIdFromName.mockResolvedValue(77);
+      mockGetArtistById.mockResolvedValue({ artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' });
+      const req = { params: { id: '42' }, body: { artist_name: 'Perfume Genius' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockArtistIdFromName).toHaveBeenCalledWith('Perfume Genius', 11);
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Artist name already exists in that genre.',
+        reason: 'artist_name_conflict',
+        artist: { artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' },
+      });
+    });
+
+    it('proceeds when the fold-matched name only collides with itself', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockArtistIdFromName.mockResolvedValue(42);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Renamed Alpha' });
+      const req = {
+        params: { id: '42' },
+        body: { artist_name: 'Anohni', alphabetical_name: 'Renamed Alpha' },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
     });
 
     it('returns 200 with the updated row on success', async () => {
-      const updated = { id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' };
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockArtistIdFromName.mockResolvedValue(0);
+      const updated = { id: 42, artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni Renamed' };
       mockUpdateArtistInDB.mockResolvedValue(updated);
       const req = {
         params: { id: '42' },
-        body: { artist_name: 'Anohni', alphabetical_name: 'Anohni' },
+        body: { artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni Renamed' },
       } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
       expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, {
-        artist_name: 'Anohni',
-        alphabetical_name: 'Anohni',
+        artist_name: 'Anohni Renamed',
+        alphabetical_name: 'Anohni Renamed',
       });
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(updated);

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -59,6 +59,35 @@ const mockUpdateArtworkUrl = jest.fn<() => Promise<unknown>>();
 const mockGetLabelById = jest.fn<(id: number) => Promise<{ id: number; label_name: string } | undefined>>();
 const mockSearchLibrary = jest.fn<() => Promise<{ results: unknown[]; total: number }>>();
 
+// GET/PATCH /library/artists/:id + GET /library/artists/:id/releases (BS#2156).
+type ArtistCardMock = {
+  artist_id: number;
+  artist_name: string;
+  alphabetical_name: string;
+  genre_id: number;
+  code_letters: string;
+  code_artist_number: number;
+};
+const mockGetArtistCardById = jest.fn<(artistId: number) => Promise<ArtistCardMock | null>>();
+const mockUpdateArtistInDB =
+  jest.fn<
+    (
+      artistId: number,
+      updates: Record<string, unknown>
+    ) => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>
+  >();
+type ArtistReleaseRowMock = {
+  id: number;
+  last_modified: Date;
+  format_name: string;
+  code_letters: string;
+  code_number: number;
+  code_volume_letters: string | null;
+  album_title: string;
+  alternate_artist_name: string | null;
+};
+const mockGetReleasesForArtist = jest.fn<(artistId: number) => Promise<ArtistReleaseRowMock[]>>();
+
 // POST /library/:id/discogs-recheck (BS#1283).
 const mockRecheckDiscogsAvailability =
   jest.fn<
@@ -143,6 +172,9 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   albumCodeNumberTaken: mockAlbumCodeNumberTaken,
   recheckDiscogsAvailability: mockRecheckDiscogsAvailability,
   deleteAlbumFromDB: mockDeleteAlbumFromDB,
+  getArtistCardById: mockGetArtistCardById,
+  updateArtistInDB: mockUpdateArtistInDB,
+  getReleasesForArtist: mockGetReleasesForArtist,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -220,6 +252,9 @@ import {
   getUncataloguedRotation,
   linkRotationToAlbum,
   pickAddRotationFields,
+  getArtistCard,
+  updateArtistCard,
+  getArtistReleases,
 } from '../../../apps/backend/controllers/library.controller';
 import WxycError from '../../../apps/backend/utils/error';
 
@@ -2555,6 +2590,152 @@ describe('library.controller', () => {
 
       expect(mockDeleteAlbumFromDB).toHaveBeenCalledWith(42, { userId: null, email: null, role: null });
       expect(res.status).toHaveBeenCalledWith(204);
+    });
+  });
+
+  describe('getArtistCard (BS#2156)', () => {
+    it('returns 400 for a non-numeric id parameter', async () => {
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistCard(req, res, next)).rejects.toThrow('Invalid artist ID');
+    });
+
+    it('returns 404 when the artist does not exist', async () => {
+      mockGetArtistCardById.mockResolvedValue(null);
+      const req = { params: { id: '999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistCard(req, res, next)).rejects.toThrow('Artist not found');
+    });
+
+    it('returns 200 with the card field set on success', async () => {
+      const card = {
+        artist_id: 42,
+        artist_name: 'Chuquimamani-Condori',
+        alphabetical_name: 'Chuquimamani-Condori',
+        genre_id: 11,
+        code_letters: 'CH',
+        code_artist_number: 3,
+      };
+      mockGetArtistCardById.mockResolvedValue(card);
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getArtistCard(req, res, next);
+
+      expect(mockGetArtistCardById).toHaveBeenCalledWith(42);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(card);
+    });
+  });
+
+  describe('updateArtistCard (BS#2156)', () => {
+    it('returns 400 for a non-numeric id parameter', async () => {
+      const req = { params: { id: 'abc' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Invalid artist ID');
+    });
+
+    it('returns 400 when the body has no updatable fields', async () => {
+      const req = { params: { id: '42' }, body: {} } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'Bad Request: provide at least one of artist_name, alphabetical_name'
+      );
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when artist_name is an empty string', async () => {
+      const req = { params: { id: '42' }, body: { artist_name: '   ' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('artist_name must be a non-empty string');
+    });
+
+    it('drops any field outside the allowlist rather than rejecting the request', async () => {
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' });
+      const req = {
+        params: { id: '42' },
+        body: { artist_name: 'Anohni', code_letters: 'ZZ', genre_id: 999 },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { artist_name: 'Anohni' });
+    });
+
+    it('returns 404 when the artist does not exist', async () => {
+      mockUpdateArtistInDB.mockResolvedValue(undefined);
+      const req = { params: { id: '999' }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Artist not found');
+    });
+
+    it('returns 200 with the updated row on success', async () => {
+      const updated = { id: 42, artist_name: 'Anohni', alphabetical_name: 'Anohni' };
+      mockUpdateArtistInDB.mockResolvedValue(updated);
+      const req = {
+        params: { id: '42' },
+        body: { artist_name: 'Anohni', alphabetical_name: 'Anohni' },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, {
+        artist_name: 'Anohni',
+        alphabetical_name: 'Anohni',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updated);
+    });
+  });
+
+  describe('getArtistReleases (BS#2156)', () => {
+    it('returns 400 for a non-numeric id parameter', async () => {
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistReleases(req, res, next)).rejects.toThrow('Invalid artist ID');
+    });
+
+    it('returns 404 when the artist does not exist', async () => {
+      mockGetArtistNameById.mockResolvedValue(null);
+      const req = { params: { id: '999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistReleases(req, res, next)).rejects.toThrow('Artist not found');
+      expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with the release list on success', async () => {
+      mockGetArtistNameById.mockResolvedValue('Chuquimamani-Condori');
+      const releases = [
+        {
+          id: 7000,
+          last_modified: new Date('2026-06-01'),
+          format_name: 'vinyl - LP',
+          code_letters: 'CH',
+          code_number: 3,
+          code_volume_letters: null,
+          album_title: 'Edits',
+          alternate_artist_name: null,
+        },
+      ];
+      mockGetReleasesForArtist.mockResolvedValue(releases);
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getArtistReleases(req, res, next);
+
+      expect(mockGetReleasesForArtist).toHaveBeenCalledWith(42);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ artist_id: 42, releases });
     });
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -76,17 +76,23 @@ const mockUpdateArtistInDB =
       updates: Record<string, unknown>
     ) => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>
   >();
+const mockConflictingArtistIdInGenre =
+  jest.fn<(name: string, genreId: number, excludeArtistId: number) => Promise<number | null>>();
 type ArtistReleaseRowMock = {
   id: number;
   last_modified: Date;
   format_name: string;
+  genre_id: number;
   code_letters: string;
+  code_artist_number: number;
   code_number: number;
   code_volume_letters: string | null;
   album_title: string;
   alternate_artist_name: string | null;
 };
-const mockGetReleasesForArtist = jest.fn<(artistId: number) => Promise<ArtistReleaseRowMock[]>>();
+const mockGetReleasesForArtist =
+  jest.fn<(artistId: number, page: number, limit: number) => Promise<ArtistReleaseRowMock[]>>();
+const mockCountReleasesForArtist = jest.fn<(artistId: number) => Promise<number>>();
 
 // POST /library/:id/discogs-recheck (BS#1283).
 const mockRecheckDiscogsAvailability =
@@ -174,7 +180,9 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   deleteAlbumFromDB: mockDeleteAlbumFromDB,
   getArtistCardById: mockGetArtistCardById,
   updateArtistInDB: mockUpdateArtistInDB,
+  conflictingArtistIdInGenre: mockConflictingArtistIdInGenre,
   getReleasesForArtist: mockGetReleasesForArtist,
+  countReleasesForArtist: mockCountReleasesForArtist,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -2593,12 +2601,61 @@ describe('library.controller', () => {
     });
   });
 
-  describe('getArtistCard (BS#2156)', () => {
-    it('returns 400 for a non-numeric id parameter', async () => {
-      const req = { params: { id: 'abc' } } as unknown as Request;
-      const res = mockResponse();
+  // The three BS#2156 routes share one path-id parser with PATCH /library/:id
+  // and friends (`parseResourceId`). `artists.id` is a `serial` (int4), so an
+  // id above INT4_MAX parses as a JS integer, reaches Postgres, and answers
+  // 500 + a Sentry event where 404 is the honest answer (BS#1800); the
+  // non-canonical spellings below each alias a distinct URL onto one resource
+  // because `Number()` accepts them.
+  describe('artist path-id parsing (BS#2156)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-      await expect(getArtistCard(req, res, next)).rejects.toThrow('Invalid artist ID');
+    const rejected: Array<[string, string]> = [
+      ['non-numeric', 'abc'],
+      ['above INT4_MAX', '2147483648'],
+      ['exponent notation', '1e21'],
+      ['hex notation', '0x2a'],
+      ['surrounded by whitespace', ' 42 '],
+      ['a trailing fraction', '42.0'],
+      ['explicitly signed', '+42'],
+      ['negative', '-42'],
+      ['zero', '0'],
+      ['leading-zero padded', '007'],
+      ['empty', ''],
+    ];
+
+    it.each(rejected)('rejects an id that is %s with 400 on getArtistCard', async (_label, rawId) => {
+      const req = { params: { id: rawId } } as unknown as Request;
+      await expect(getArtistCard(req, mockResponse(), next)).rejects.toThrow('Invalid artist ID');
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    });
+
+    it.each(rejected)('rejects an id that is %s with 400 on updateArtistCard', async (_label, rawId) => {
+      const req = { params: { id: rawId }, body: { artist_name: 'Anohni' } } as unknown as Request;
+      await expect(updateArtistCard(req, mockResponse(), next)).rejects.toThrow('Invalid artist ID');
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    });
+
+    it.each(rejected)('rejects an id that is %s with 400 on getArtistReleases', async (_label, rawId) => {
+      const req = { params: { id: rawId }, query: {} } as unknown as Request;
+      await expect(getArtistReleases(req, mockResponse(), next)).rejects.toThrow('Invalid artist ID');
+      expect(mockGetArtistNameById).not.toHaveBeenCalled();
+    });
+
+    it('accepts an id exactly at INT4_MAX', async () => {
+      mockGetArtistCardById.mockReset().mockResolvedValue(null);
+      const req = { params: { id: '2147483647' } } as unknown as Request;
+
+      await expect(getArtistCard(req, mockResponse(), next)).rejects.toThrow('Artist not found');
+      expect(mockGetArtistCardById).toHaveBeenCalledWith(2147483647);
+    });
+  });
+
+  describe('getArtistCard (BS#2156)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
 
     it('returns 404 when the artist does not exist', async () => {
@@ -2640,12 +2697,9 @@ describe('library.controller', () => {
       code_artist_number: 3,
     };
 
-    it('returns 400 for a non-numeric id parameter', async () => {
-      const req = { params: { id: 'abc' }, body: { artist_name: 'Anohni and the Johnsons' } } as unknown as Request;
-      const res = mockResponse();
-
-      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Invalid artist ID');
-      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockConflictingArtistIdInGenre.mockResolvedValue(null);
     });
 
     it('returns 404 when the artist does not exist', async () => {
@@ -2668,17 +2722,108 @@ describe('library.controller', () => {
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
-    it('returns 400 when artist_name is an empty string', async () => {
+    // `app.ts` mounts a bare `express.json()`; body-parser 2.x leaves
+    // `req.body` undefined for a body-less or non-JSON request and Express 5
+    // no longer defaults it to `{}`. Dereferencing it was a TypeError -> 500,
+    // and because it happened AFTER the existence lookup, a nonexistent
+    // artist 404'd (hiding the bug from exactly the smoke test that would
+    // find it) while a real one 500'd.
+    it.each([
+      ['undefined (no body sent at all)', undefined],
+      ['null', null],
+      ['a bare JSON string', 'artist_name'],
+      ['a JSON array', ['artist_name']],
+      ['a JSON number', 3],
+    ])('returns 400 rather than 500 when the body is %s', async (_label, body) => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      const req = { params: { id: '42' }, body: { artist_name: '   ' } } as unknown as Request;
+      const req = { params: { id: '42' }, body } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'Bad Request: provide at least one of artist_name, alphabetical_name'
+      );
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed body before the existence lookup, so an unknown artist still 400s', async () => {
+      mockGetArtistCardById.mockResolvedValue(null);
+      const req = { params: { id: '999' }, body: undefined } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(
+        'Bad Request: provide at least one of artist_name, alphabetical_name'
+      );
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    });
+
+    // TypeScript's `UpdateArtistRequest` is erased at runtime, so these
+    // `typeof !== 'string'` guards are the ENTIRE runtime defense behind the
+    // allowlist against a non-string reaching `.trim()` (TypeError -> 500) or
+    // the UPDATE.
+    it.each([
+      ['a number', 123],
+      ['an array', ['a']],
+      ['an object', { toString: 'nope' }],
+      ['a boolean', true],
+    ])('returns 400 when artist_name is %s', async (_label, value) => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const req = { params: { id: '42' }, body: { artist_name: value } } as unknown as Request;
       const res = mockResponse();
 
       await expect(updateArtistCard(req, res, next)).rejects.toThrow('artist_name must be a non-empty string');
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['a number', 123],
+      ['an array', ['a']],
+      ['an object', { toString: 'nope' }],
+      ['a boolean', true],
+    ])('returns 400 when alphabetical_name is %s', async (_label, value) => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const req = { params: { id: '42' }, body: { alphabetical_name: value } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('alphabetical_name must be a non-empty string');
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    // Both fields are `varchar(128)`; over-length input must 400 rather than
+    // reach the UPDATE and trip PG 22001 ("value too long") -> 500 (#1551).
+    it.each(['artist_name', 'alphabetical_name'])('returns 400 when %s exceeds 128 characters', async (field) => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const req = { params: { id: '42' }, body: { [field]: 'x'.repeat(129) } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(`${field} must be 128 characters or fewer`);
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it.each(['artist_name', 'alphabetical_name'])('accepts %s at exactly 128 characters', async (field) => {
+      const atLimit = 'x'.repeat(128);
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: atLimit, alphabetical_name: atLimit });
+      const req = { params: { id: '42' }, body: { [field]: atLimit } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { [field]: atLimit });
+    });
+
+    // The two fields validate symmetrically — `alphabetical_name` gets the
+    // same empty-string rejection `artist_name` does.
+    it.each(['artist_name', 'alphabetical_name'])('returns 400 when %s is whitespace-only', async (field) => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const req = { params: { id: '42' }, body: { [field]: '   ' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow(`${field} must be a non-empty string`);
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
     it('trims surrounding whitespace before validating and storing', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockArtistIdFromName.mockResolvedValue(0);
       mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Hegarty', alphabetical_name: 'Anohni' });
       const req = { params: { id: '42' }, body: { artist_name: '  Anohni Hegarty  ' } } as unknown as Request;
       const res = mockResponse();
@@ -2690,7 +2835,6 @@ describe('library.controller', () => {
 
     it('drops any field outside the allowlist rather than rejecting the request', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockArtistIdFromName.mockResolvedValue(0);
       mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni' });
       const req = {
         params: { id: '42' },
@@ -2711,20 +2855,20 @@ describe('library.controller', () => {
 
       await updateArtistCard(req, res, next);
 
-      expect(mockArtistIdFromName).not.toHaveBeenCalled();
+      expect(mockConflictingArtistIdInGenre).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
     it('returns 409 when the new artist_name collides with a different artist in the same genre', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockArtistIdFromName.mockResolvedValue(77);
+      mockConflictingArtistIdInGenre.mockResolvedValue(77);
       mockGetArtistById.mockResolvedValue({ artist_id: 77, artist_name: 'Perfume Genius', code_letters: 'PE' });
       const req = { params: { id: '42' }, body: { artist_name: 'Perfume Genius' } } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
-      expect(mockArtistIdFromName).toHaveBeenCalledWith('Perfume Genius', 11);
+      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('Perfume Genius', 11, 42);
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(409);
       expect(res.json).toHaveBeenCalledWith({
@@ -2734,26 +2878,40 @@ describe('library.controller', () => {
       });
     });
 
-    it('proceeds when the fold-matched name only collides with itself', async () => {
+    // The self-exclusion is pushed into the query rather than compared against
+    // whatever an unordered `.limit(1)` probe returned: a genre holding two
+    // fold-equal rows can hand back the row being renamed, and a `!== artistId`
+    // comparison would then wave the duplicate-creating rename through. This
+    // pins that the controller never asks a question it has to post-filter.
+    it('asks the service to exclude the row being renamed rather than post-filtering', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockArtistIdFromName.mockResolvedValue(42);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Renamed Alpha' });
-      const req = {
-        params: { id: '42' },
-        body: { artist_name: 'Anohni', alphabetical_name: 'Renamed Alpha' },
-      } as unknown as Request;
+      mockConflictingArtistIdInGenre.mockResolvedValue(null);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'the trees', alphabetical_name: 'Anohni' });
+      const req = { params: { id: '42' }, body: { artist_name: 'the trees' } } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
+      expect(mockArtistIdFromName).not.toHaveBeenCalled();
+      expect(mockConflictingArtistIdInGenre).toHaveBeenCalledWith('the trees', 11, 42);
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('returns 200 with the updated row on success', async () => {
-      mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockArtistIdFromName.mockResolvedValue(0);
-      const updated = { id: 42, artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni Renamed' };
-      mockUpdateArtistInDB.mockResolvedValue(updated);
+    it('returns 200 with the refreshed card shape (not the bare artists row) on success', async () => {
+      const refreshed: ArtistCardMock = {
+        artist_id: 42,
+        artist_name: 'Anohni Renamed',
+        alphabetical_name: 'Anohni Renamed',
+        genre_id: 11,
+        code_letters: 'AN',
+        code_artist_number: 3,
+      };
+      mockGetArtistCardById.mockResolvedValueOnce(existingCard).mockResolvedValueOnce(refreshed);
+      mockUpdateArtistInDB.mockResolvedValue({
+        id: 42,
+        artist_name: 'Anohni Renamed',
+        alphabetical_name: 'Anohni Renamed',
+      });
       const req = {
         params: { id: '42' },
         body: { artist_name: 'Anohni Renamed', alphabetical_name: 'Anohni Renamed' },
@@ -2767,50 +2925,100 @@ describe('library.controller', () => {
         alphabetical_name: 'Anohni Renamed',
       });
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(updated);
+      // Same field set GET /library/artists/:id serves — `artist_id`, not `id`.
+      expect(res.json).toHaveBeenCalledWith(refreshed);
     });
   });
 
   describe('getArtistReleases (BS#2156)', () => {
-    it('returns 400 for a non-numeric id parameter', async () => {
-      const req = { params: { id: 'abc' } } as unknown as Request;
-      const res = mockResponse();
+    const releases = [
+      {
+        id: 7000,
+        last_modified: new Date('2026-06-01'),
+        format_name: 'vinyl - LP',
+        genre_id: 11,
+        code_letters: 'CH',
+        code_artist_number: 4,
+        code_number: 3,
+        code_volume_letters: null,
+        album_title: 'Edits',
+        alternate_artist_name: null,
+      },
+    ];
 
-      await expect(getArtistReleases(req, res, next)).rejects.toThrow('Invalid artist ID');
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockCountReleasesForArtist.mockResolvedValue(1);
     });
 
     it('returns 404 when the artist does not exist', async () => {
       mockGetArtistNameById.mockResolvedValue(null);
-      const req = { params: { id: '999' } } as unknown as Request;
+      const req = { params: { id: '999' }, query: {} } as unknown as Request;
       const res = mockResponse();
 
       await expect(getArtistReleases(req, res, next)).rejects.toThrow('Artist not found');
       expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
     });
 
-    it('returns 200 with the release list on success', async () => {
+    it('returns 200 with a default-paginated release page on success', async () => {
       mockGetArtistNameById.mockResolvedValue('Chuquimamani-Condori');
-      const releases = [
-        {
-          id: 7000,
-          last_modified: new Date('2026-06-01'),
-          format_name: 'vinyl - LP',
-          code_letters: 'CH',
-          code_number: 3,
-          code_volume_letters: null,
-          album_title: 'Edits',
-          alternate_artist_name: null,
-        },
-      ];
       mockGetReleasesForArtist.mockResolvedValue(releases);
-      const req = { params: { id: '42' } } as unknown as Request;
+      mockCountReleasesForArtist.mockResolvedValue(1);
+      const req = { params: { id: '42' }, query: {} } as unknown as Request;
       const res = mockResponse();
 
       await getArtistReleases(req, res, next);
 
-      expect(mockGetReleasesForArtist).toHaveBeenCalledWith(42);
+      expect(mockGetReleasesForArtist).toHaveBeenCalledWith(42, 0, 50);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ artist_id: 42, releases });
+      expect(res.json).toHaveBeenCalledWith({ artist_id: 42, releases, total: 1, page: 0, totalPages: 1 });
+    });
+
+    it('passes an explicit page/limit through and reports totalPages', async () => {
+      mockGetArtistNameById.mockResolvedValue('Various Artists');
+      mockGetReleasesForArtist.mockResolvedValue(releases);
+      mockCountReleasesForArtist.mockResolvedValue(3107);
+      const req = { params: { id: '1087' }, query: { page: '2', limit: '100' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getArtistReleases(req, res, next);
+
+      expect(mockGetReleasesForArtist).toHaveBeenCalledWith(1087, 2, 100);
+      expect(res.json).toHaveBeenCalledWith({
+        artist_id: 1087,
+        releases,
+        total: 3107,
+        page: 2,
+        totalPages: 32,
+      });
+    });
+
+    // Unbounded, this endpoint hands any catalog:read DJ every row an artist
+    // has — 3,107 of them for artist 1087, freely repeatable.
+    it.each([
+      ['limit above the maximum', { limit: '101' }, 'limit must not exceed 100'],
+      ['a zero limit', { limit: '0' }, 'limit must be a positive integer'],
+      ['a negative page', { page: '-1' }, 'page must be a non-negative integer'],
+      ['a non-numeric limit', { limit: 'all' }, 'limit must be a positive integer'],
+      ['a non-numeric page', { page: 'first' }, 'page must be a non-negative integer'],
+    ])('rejects %s with 400', async (_label, query, message) => {
+      mockGetArtistNameById.mockResolvedValue('Various Artists');
+      const req = { params: { id: '1087' }, query } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistReleases(req, res, next)).rejects.toThrow(message);
+      expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['page', { page: ['1', '2'] }, 'page must be a single string value'],
+      ['limit', { limit: ['1', '2'] }, 'limit must be a single string value'],
+    ])('rejects a repeated %s query key with 400', async (_label, query, message) => {
+      const req = { params: { id: '1087' }, query } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getArtistReleases(req, res, next)).rejects.toThrow(message);
+      expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -2801,13 +2801,17 @@ describe('library.controller', () => {
     // and because it happened AFTER the existence lookup, a nonexistent
     // artist 404'd (hiding the bug from exactly the smoke test that would
     // find it) while a real one 500'd.
+    // Two groups, because the two failures are genuinely different and the
+    // messages now say so. An absent or null body normalizes to `{}` — which
+    // IS a JSON object, just an empty one — so the honest complaint is that it
+    // carries no writable field. A string/array/number body never gets that
+    // far: it is not an object at all, and telling that caller to "provide at
+    // least one of alphabetical_name" sends them to inspect their fields when
+    // the problem is their Content-Type.
     it.each([
       ['undefined (no body sent at all)', undefined],
       ['null', null],
-      ['a bare JSON string', 'alphabetical_name'],
-      ['a JSON array', ['alphabetical_name']],
-      ['a JSON number', 3],
-    ])('returns 400 rather than 500 when the body is %s', async (_label, body) => {
+    ])('returns 400 naming the missing field when the body is %s', async (_label, body) => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
       const req = { params: { id: '42' }, body } as unknown as Request;
       const res = mockResponse();
@@ -2815,6 +2819,19 @@ describe('library.controller', () => {
       await expect(updateArtistCard(req, res, next)).rejects.toThrow(
         'Bad Request: provide at least one of alphabetical_name'
       );
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['a bare JSON string', 'alphabetical_name'],
+      ['a JSON array', ['alphabetical_name']],
+      ['a JSON number', 3],
+    ])('returns 400 naming the body shape when the body is %s', async (_label, body) => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      const req = { params: { id: '42' }, body } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(updateArtistCard(req, res, next)).rejects.toThrow('Bad Request: body must be a JSON object');
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
@@ -2946,9 +2963,25 @@ describe('library.controller', () => {
     // raw-length 400 and would have reached Postgres at NFC length 256,
     // tripping SQLSTATE 22001 ("value too long") -> 500 where the documented
     // answer is 400.
+    // The fixtures below MUST use `'\u0958'` escape notation, never a literal
+    // pasted into the source. An editor, a formatter, or a git filter that
+    // normalizes the file silently rewrites that literal to its decomposed
+    // form U+0915 U+093C -- which is what happened to an earlier revision of
+    // these two tests. Once decomposed, the input is already NFC, so both
+    // tests passed identically with and without the normalize-before-measure
+    // fix they exist to pin: reverting the controller to measure the raw
+    // `trim()`ed value left them green. Asserting the code points up front
+    // makes that silent rewrite a test failure instead of a silent hole.
     it('returns 400 when alphabetical_name is within the raw-length limit but exceeds it after NFC normalization', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      const compositionExclusion = 'क़'.repeat(128); // raw length 128, NFC length 256
+      const precomposed = '\u0958'; // 'क़' as a single composition-exclusion code point
+      expect(precomposed.length).toBe(1);
+      expect(precomposed.normalize('NFC')).toBe('\u0915\u093C');
+
+      const compositionExclusion = precomposed.repeat(128); // raw length 128, NFC length 256
+      expect(compositionExclusion.length).toBe(128);
+      expect(compositionExclusion.normalize('NFC').length).toBe(256);
+
       const req = { params: { id: '42' }, body: { alphabetical_name: compositionExclusion } } as unknown as Request;
       const res = mockResponse();
 
@@ -2958,16 +2991,70 @@ describe('library.controller', () => {
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
-    it('stores the NFC-normalized value, not the raw composed form', async () => {
+    // `updateArtistInDB` always SETs `last_modified = NOW()`, which fires
+    // `touch_library_watermark_from_artists` (migration 0105, FOR EACH
+    // STATEMENT on `artists`) and advances the catalog conditional-GET
+    // watermark — so a librarian hitting Save on an unchanged card makes every
+    // iOS and dj-site poller re-download the full catalog for a write that
+    // changed nothing. `updateAlbum` guards exactly this (#1555); this path
+    // reaches it through a coarser statement-level trigger on the parent table.
+    it('short-circuits a no-op edit without writing, so the catalog watermark does not advance', async () => {
       mockGetArtistCardById.mockResolvedValue(existingCard);
-      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'क़' });
-      // U+0958 ('क़'), 1 raw UTF-16 unit, normalizes to U+0915 U+093C (2 units).
-      const req = { params: { id: '42' }, body: { alphabetical_name: 'क़' } } as unknown as Request;
+      const req = {
+        params: { id: '42' },
+        body: { alphabetical_name: existingCard.alphabetical_name },
+      } as unknown as Request;
       const res = mockResponse();
 
       await updateArtistCard(req, res, next);
 
-      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: 'क़' });
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(existingCard);
+    });
+
+    it('still writes when the value actually changes', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: 'Hegarty, Antony' });
+      const req = { params: { id: '42' }, body: { alphabetical_name: 'Hegarty, Antony' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: 'Hegarty, Antony' });
+    });
+
+    // Postgres measures `varchar(128)` in characters; a bare `.length` measures
+    // UTF-16 units and counts every astral character twice, rejecting values PG
+    // would store happily — undercutting the reject-over-truncate choice
+    // `codePointLength` was written to protect.
+    it('accepts a 128-code-point alphabetical_name containing astral characters', async () => {
+      const astral = 'a'.repeat(127) + '\u{1F600}';
+      expect([...astral].length).toBe(128);
+      expect(astral.length).toBe(129);
+
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: astral });
+      const req = { params: { id: '42' }, body: { alphabetical_name: astral } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: astral });
+    });
+
+    it('stores the NFC-normalized value, not the raw composed form', async () => {
+      mockGetArtistCardById.mockResolvedValue(existingCard);
+      mockUpdateArtistInDB.mockResolvedValue({ id: 42, artist_name: 'Anohni', alphabetical_name: '\u0915\u093C' });
+      // U+0958, 1 raw UTF-16 unit, normalizes to U+0915 U+093C (2 units).
+      const req = { params: { id: '42' }, body: { alphabetical_name: '\u0958' } } as unknown as Request;
+      const res = mockResponse();
+
+      await updateArtistCard(req, res, next);
+
+      // The DECOMPOSED form must reach the service. Asserting 'क़' here
+      // would pass whether or not the controller normalizes.
+      expect(mockUpdateArtistInDB).toHaveBeenCalledWith(42, { alphabetical_name: '\u0915\u093C' });
     });
 
     // BS#2156 review: the AC says the endpoint allowlists exactly

--- a/tests/unit/routes/library-artist-card-permissions.route.test.ts
+++ b/tests/unit/routes/library-artist-card-permissions.route.test.ts
@@ -1,0 +1,226 @@
+// Set required env vars before module load (ts-jest transforms imports to
+// requires, so these execute before the auth middleware module's top-level
+// code runs). Mirrors tests/unit/routes/library-discogs-recheck-permissions.route.test.ts.
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+// Mock jose so we can hand back an arbitrary role in the verified JWT payload
+// without a real JWKS endpoint. requirePermissions's non-bypass branch is
+// what actually enforces role/permission checks.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+// jest.unit.config.ts's moduleNameMapper sends `@wxyc/authentication` to
+// tests/mocks/authentication.mock.ts (a stub that ignores the role/permission
+// argument entirely). library.route.ts imports requirePermissions from that
+// package specifier, so this route-wiring test needs the REAL implementation
+// wired back in to actually exercise the catalog gates.
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
+import express from 'express';
+import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
+
+type ArtistCard = {
+  artist_id: number;
+  artist_name: string;
+  alphabetical_name: string;
+  genre_id: number;
+  code_letters: string;
+  code_artist_number: number;
+};
+
+const ARTIST_CARD: ArtistCard = {
+  artist_id: 1,
+  artist_name: 'Jessica Pratt',
+  alphabetical_name: 'Pratt, Jessica',
+  genre_id: 11,
+  code_letters: 'PR',
+  code_artist_number: 4,
+};
+
+const mockGetArtistCardById = jestGlobals.fn<() => Promise<ArtistCard | null>>();
+const mockUpdateArtistInDB =
+  jestGlobals.fn<() => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>>();
+const mockConflictingArtistIdInGenre = jestGlobals.fn<() => Promise<number | null>>();
+const mockGetArtistNameById = jestGlobals.fn<() => Promise<string | null>>();
+const mockGetReleasesForArtist = jestGlobals.fn<() => Promise<unknown[]>>();
+const mockCountReleasesForArtist = jestGlobals.fn<() => Promise<number>>();
+
+// Collaborator mocks below mirror the discogs-recheck route-permission test —
+// only enough is stubbed here to let library.route's import chain resolve
+// without touching a real DB, LML, or lru-cache.
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getAlbumFromDB: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: mockGetArtistNameById,
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  getArtistById: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: jest.fn(),
+  getRotationTracksFromRelease: jest.fn(),
+  getLibraryRowById: jest.fn(),
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+  recheckDiscogsAvailability: jest.fn(),
+  getArtistCardById: mockGetArtistCardById,
+  updateArtistInDB: mockUpdateArtistInDB,
+  conflictingArtistIdInGenre: mockConflictingArtistIdInGenre,
+  getReleasesForArtist: mockGetReleasesForArtist,
+  countReleasesForArtist: mockCountReleasesForArtist,
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => true,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+/**
+ * BS#2156 artist-card routes: the two GETs are `catalog:['read']` (DJ and
+ * above) and the PATCH is `catalog:['write']` (musicDirector and above).
+ *
+ * Without these, every artist-card test drives the routes through the
+ * privileged integration token or calls the controller directly, so relaxing
+ * the PATCH to `catalog:['read']` — letting any DJ rename a catalog artist,
+ * which cascades `library.artist_name` and `search_doc` across every one of
+ * that artist's rows — would leave the whole suite green.
+ */
+describe('BS#2156 artist-card routes — permission tiers', () => {
+  beforeEach(() => {
+    mockGetArtistCardById.mockReset().mockResolvedValue(ARTIST_CARD);
+    mockUpdateArtistInDB
+      .mockReset()
+      .mockResolvedValue({ id: 1, artist_name: 'Jessica Pratt', alphabetical_name: 'Pratt, Jessica' });
+    mockConflictingArtistIdInGenre.mockReset().mockResolvedValue(null);
+    mockGetArtistNameById.mockReset().mockResolvedValue('Jessica Pratt');
+    mockGetReleasesForArtist.mockReset().mockResolvedValue([]);
+    mockCountReleasesForArtist.mockReset().mockResolvedValue(0);
+  });
+
+  describe('GET /library/artists/:id (catalog:read)', () => {
+    test.each(['stationManager', 'musicDirector', 'dj', 'member'])('a %s-role token is authorized', async (role) => {
+      mockRole(role);
+      const res = await request(app).get('/library/artists/1').set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(200);
+      expect(mockGetArtistCardById).toHaveBeenCalledWith(1);
+    });
+
+    test('a request with no Authorization header is rejected', async () => {
+      const res = await request(app).get('/library/artists/1');
+      expect(res.status).toBe(401);
+      expect(mockGetArtistCardById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /library/artists/:id/releases (catalog:read)', () => {
+    test.each(['stationManager', 'musicDirector', 'dj', 'member'])('a %s-role token is authorized', async (role) => {
+      mockRole(role);
+      const res = await request(app).get('/library/artists/1/releases').set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(200);
+      expect(mockGetReleasesForArtist).toHaveBeenCalledWith(1, 0, 50);
+    });
+
+    test('a request with no Authorization header is rejected', async () => {
+      const res = await request(app).get('/library/artists/1/releases');
+      expect(res.status).toBe(401);
+      expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /library/artists/:id (catalog:write)', () => {
+    test.each(['stationManager', 'musicDirector'])('a %s-role token is authorized', async (role) => {
+      mockRole(role);
+      const res = await request(app)
+        .patch('/library/artists/1')
+        .set('Authorization', 'Bearer test-token')
+        .send({ artist_name: 'Jessica Pratt' });
+      expect(res.status).toBe(200);
+      expect(mockUpdateArtistInDB).toHaveBeenCalled();
+    });
+
+    test.each(['dj', 'member'])('a %s-role token (catalog:read only) is rejected', async (role) => {
+      mockRole(role);
+      const res = await request(app)
+        .patch('/library/artists/1')
+        .set('Authorization', 'Bearer test-token')
+        .send({ artist_name: 'Renamed By A DJ' });
+      expect(res.status).toBe(403);
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+
+    test('a request with no Authorization header is rejected', async () => {
+      const res = await request(app).patch('/library/artists/1').send({ artist_name: 'Renamed Anonymously' });
+      expect(res.status).toBe(401);
+      expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/routes/library-artist-card-permissions.route.test.ts
+++ b/tests/unit/routes/library-artist-card-permissions.route.test.ts
@@ -58,7 +58,6 @@ const ARTIST_CARD: ArtistCard = {
 const mockGetArtistCardById = jestGlobals.fn<() => Promise<ArtistCard | null>>();
 const mockUpdateArtistInDB =
   jestGlobals.fn<() => Promise<{ id: number; artist_name: string; alphabetical_name: string } | undefined>>();
-const mockConflictingArtistIdInGenre = jestGlobals.fn<() => Promise<number | null>>();
 const mockGetArtistNameById = jestGlobals.fn<() => Promise<string | null>>();
 const mockGetReleasesForArtist = jestGlobals.fn<() => Promise<unknown[]>>();
 const mockCountReleasesForArtist = jestGlobals.fn<() => Promise<number>>();
@@ -106,7 +105,6 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   recheckDiscogsAvailability: jest.fn(),
   getArtistCardById: mockGetArtistCardById,
   updateArtistInDB: mockUpdateArtistInDB,
-  conflictingArtistIdInGenre: mockConflictingArtistIdInGenre,
   getReleasesForArtist: mockGetReleasesForArtist,
   countReleasesForArtist: mockCountReleasesForArtist,
 }));
@@ -150,9 +148,11 @@ app.use('/library', library_route);
  *
  * Without these, every artist-card test drives the routes through the
  * privileged integration token or calls the controller directly, so relaxing
- * the PATCH to `catalog:['read']` — letting any DJ rename a catalog artist,
- * which cascades `library.artist_name` and `search_doc` across every one of
- * that artist's rows — would leave the whole suite green.
+ * the PATCH to `catalog:['read']` — letting any DJ edit a catalog artist's
+ * `alphabetical_name` (the only field this endpoint can still write; a
+ * follow-up review pulled `artist_name` off it entirely -- see
+ * `library.controller.ts`'s `updateArtistCard` doc comment) — would leave the
+ * whole suite green.
  */
 describe('BS#2156 artist-card routes — permission tiers', () => {
   beforeEach(() => {
@@ -160,7 +160,6 @@ describe('BS#2156 artist-card routes — permission tiers', () => {
     mockUpdateArtistInDB
       .mockReset()
       .mockResolvedValue({ id: 1, artist_name: 'Jessica Pratt', alphabetical_name: 'Pratt, Jessica' });
-    mockConflictingArtistIdInGenre.mockReset().mockResolvedValue(null);
     mockGetArtistNameById.mockReset().mockResolvedValue('Jessica Pratt');
     mockGetReleasesForArtist.mockReset().mockResolvedValue([]);
     mockCountReleasesForArtist.mockReset().mockResolvedValue(0);
@@ -197,12 +196,16 @@ describe('BS#2156 artist-card routes — permission tiers', () => {
   });
 
   describe('PATCH /library/artists/:id (catalog:write)', () => {
+    // `alphabetical_name`, not `artist_name`: these tests exist to pin the
+    // PERMISSION tier, and `artist_name` is no longer writable on this
+    // endpoint at all (BS#2156 follow-up review) -- sending it would 400
+    // regardless of role and defeat the point of a 200-on-authorized case.
     test.each(['stationManager', 'musicDirector'])('a %s-role token is authorized', async (role) => {
       mockRole(role);
       const res = await request(app)
         .patch('/library/artists/1')
         .set('Authorization', 'Bearer test-token')
-        .send({ artist_name: 'Jessica Pratt' });
+        .send({ alphabetical_name: 'Pratt, Jessica' });
       expect(res.status).toBe(200);
       expect(mockUpdateArtistInDB).toHaveBeenCalled();
     });
@@ -212,13 +215,13 @@ describe('BS#2156 artist-card routes — permission tiers', () => {
       const res = await request(app)
         .patch('/library/artists/1')
         .set('Authorization', 'Bearer test-token')
-        .send({ artist_name: 'Renamed By A DJ' });
+        .send({ alphabetical_name: 'Renamed By A DJ' });
       expect(res.status).toBe(403);
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });
 
     test('a request with no Authorization header is rejected', async () => {
-      const res = await request(app).patch('/library/artists/1').send({ artist_name: 'Renamed Anonymously' });
+      const res = await request(app).patch('/library/artists/1').send({ alphabetical_name: 'Renamed Anonymously' });
       expect(res.status).toBe(401);
       expect(mockUpdateArtistInDB).not.toHaveBeenCalled();
     });

--- a/tests/unit/routes/library-artist-card-permissions.route.test.ts
+++ b/tests/unit/routes/library-artist-card-permissions.route.test.ts
@@ -205,7 +205,12 @@ describe('BS#2156 artist-card routes — permission tiers', () => {
       const res = await request(app)
         .patch('/library/artists/1')
         .set('Authorization', 'Bearer test-token')
-        .send({ alphabetical_name: 'Pratt, Jessica' });
+        // Must DIFFER from the seeded card's `alphabetical_name`
+        // (`'Pratt, Jessica'`), or the handler's no-op short-circuit correctly
+        // answers 200 without writing — and this test is about the permission
+        // tier, not about the short-circuit, so it needs a real edit to prove
+        // the write was reached.
+        .send({ alphabetical_name: 'Pratt, Jessica L.' });
       expect(res.status).toBe(200);
       expect(mockUpdateArtistInDB).toHaveBeenCalled();
     });


### PR DESCRIPTION
> **Scope change (post-review): `artist_name` renaming was removed from this PR.**
>
> Review found that renaming `artists.artist_name` silently corrupts the catalog while `jobs/library-etl` is a live writer, so `PATCH /library/artists/:id` now edits **`alphabetical_name` only**. A body containing `artist_name` gets a precise **400**, not a silent drop. The two GET endpoints are unchanged. Restoring the rename is tracked as WXYC/Backend-Service#2197, gated on `library-etl` becoming `job-type: one-shot`.
>
> **Why.** `artists`/`library` are still tubafrenzy-canonical, and `jobs/library-etl` runs on a live 30-minute cron — its `package.json` has no `job-type` key and `deploy-base.yml:661` (`yq -r '.["job-type"] // "cron"'`) defaults that to `cron`, while its siblings `flowsheet-etl` and `rotation-etl` were both flipped to `one-shot`. That job's `ensureArtist` (`jobs/library-etl/job.ts:395-453`) matches on `fold_artist_name(artist_name)` + `code_letters` and **never UPDATEs `artists`** (`grep "update(artists)"` returns nothing). So a rename moves the match key, the probe misses, and the ETL INSERTs a duplicate artist — which takes the **same shelf code without violating anything**, since `genre_artist_crossreference` is unique on `(artist_id, genre_id)` only (`schema.ts:2310`), not `(genre_id, artist_genre_code)`. The release upsert then repoints the library row and reverts the name, because `LEGACY_SOURCED_LIBRARY_COLUMNS` (`job.ts:883-899`) contains both `artist_id` and `artist_name`.
>
> Concretely: rename artist 4312 `Sterolab` → `Stereolab` (200, card looks right). A librarian later touches any of its releases in tubafrenzy; the next `*/30` pass inserts a new `Sterolab`, repoints that release, and reverts the name. One row lost per touched release — no crash, no log line. `POST /library/artists` is unaffected: a BS-created artist is subsequently *found* by the fold probe. It is specifically the **UPDATE of the match key** that breaks reconciliation. `alphabetical_name` is not in the match key and is safe.
>
> Also folded in from review: NFC normalization now happens **before** the 128-char length check (NFC is not length-non-increasing, so a 128-char name of composition-exclusion codepoints previously reached Postgres as 256 → 22001 → 500 where the documented answer is 400), and a new `album path-id parsing` test block pins the tightened `parseAlbumId` on the album endpoints — the existing tests only used `'abc'`/`'0'`/`'-5'`, all of which the *old* `Number.isInteger` implementation also rejected, so reverting the hardening would have left the suite green.

## Summary

- `GET /library/artists/:id` — the artist-card field set `/wxycdb`'s `artistCardModify.jsp` displays: `artist_id`, `artist_name`, `alphabetical_name`, `genre_id`, `code_letters`, `code_artist_number`. 404s on an unknown id.
- `PATCH /library/artists/:id` — allowlists exactly the two fields the `modifyArtist` form edits, `artist_name` and `alphabetical_name`. `genre_id`, `code_letters`, and `code_artist_number` are real fields on the same JSP form (`artistCardModify.jsp:41-64`, applied by `ArtistAdminServlet.java:196-206`) but have no write path in this codebase yet, so sending one is rejected with a 400 naming why (`ARTIST_NO_COLUMN_FIELD_OWNERS`) rather than accepted-and-silently-dropped. Runs the same `fold_artist_name`-matched conflict check (409 `artist_name_conflict`) `addArtist` enforces on create, scoped to *every* genre the artist under edit is crossreferenced in — not just one — so a rename can't silently recreate an NFC/NFD/case duplicate in a genre the card's own `.orderBy(asc(genre_id)).limit(1)` collapse doesn't surface.
- `GET /library/artists/:id/releases` — the release table the card shows: last-modified, format, the call-number fields (`code_letters`, `code_number`, `code_volume_letters`), title, alternate artist name. Ordered by `code_number` ascending (shelf order). Sourced from a direct join over `library`/`artists`/`format`, not `library_artist_view` — that view omits `last_modified` and `alternate_artist_name`.
- The two new GETs are `catalog:read`; the PATCH is `catalog:write`, matching the tiers around them.
- Registration order: the new `/artists/:id` routes are added *after* the existing literal `/artists/search` and `/artists/peek-code` routes, so Express can't swallow the literals — pinned by an integration test that exercises both after the parameterized routes are wired in.
- Documented in `apps/backend/app.yaml` (Swagger-UI docs, alongside the existing `/library/artists/*` siblings). No `wxyc-shared/api.yaml` change, per the issue's resolved conditional — the sibling `search`/`peek-code` routes are also absent from that cross-repo SSOT, and closing that drift for the whole `/library/artists/*` surface is tracked separately (blocked by this issue).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (library-scoped + full controller suite)
- [x] `npm run ci:testmock` (Docker-mirrored CI; only pre-existing unrelated failures from missing `jobs/*/dist` build artifacts, not touched by this change)
- [x] Targeted `tests/integration/library.spec.js` run against the CI docker stack — all 83 tests pass, including the new artist-card describe blocks (card lookup, route ordering, PATCH allowlist + conflict guard, releases listing)

Closes #2156

## Review round 2 — findings closed

- **`getReleasesForArtist` dropped the genre dimension.** It omitted `genre_id` and `code_artist_number`, so the promised call-number fields were incomplete and rows were mutually indistinguishable — artist 1087 ('Various Artists', `code_letters='V/A'`) has 3,107 library rows across 14 genres, 2,961 of which share a `code_number` with a sibling. The query now joins `genre_artist_crossreference` on BOTH `artist_id` AND `library.genre_id` and projects `code_artist_number` per row, matching `library_artist_view`, `LIBRARY_VIEW_PROJECTION`, and `getBinFromDB`. (The sibling card GET can't supply the missing piece: `getArtistCardById` deliberately collapses to the lowest-`genre_id` crossreference row.)
- **Shelf order was nondeterministic.** `orderBy(asc(code_number))` had no tiebreaker while 4,179 of 64,193 library rows share a `code_number` with a sibling under one artist. Now `code_number, code_volume_letters, id`.
- **The rename conflict guard was unsound.** `artistIdFromName` is `.limit(1)` with no `orderBy`, so on a genre already holding two fold-equal rows (46 such groups / 93 rows in the production clone — e.g. genre 11's two 'The Trees') it can return the row being renamed, and the `conflictingArtistId !== artistId` self-exclusion then concludes "collides only with itself" and lets a duplicate-creating rename through. New `conflictingArtistIdInGenre` pushes the exclusion into the query.
- **Path ids were unbounded and non-canonical.** `artists.id` is int4 and `Number.isInteger(2147483648)` is true, so an oversized id reached Postgres as a 500 + Sentry event instead of a 404; `Number()` also accepts `1e21`, `0x2a`, `' 42 '`, `'42.0'`, aliasing distinct URLs onto one resource. `parseArtistId` and `parseAlbumId` (a verbatim clone carrying the identical hole) now share one `parseResourceId` requiring a canonical decimal spelling inside `INT4_MAX`, per `flowsheet.controller.ts` / BS#1800.
- **PATCH 500'd on a missing body.** body-parser 2.x leaves `req.body` undefined for a body-less or non-JSON request and Express 5 no longer defaults it to `{}`. Worse, the existence query ran first, so an unknown artist 404'd (masking it from exactly the smoke test that would find it) while a real one 500'd. Body shape is now validated to the documented 400 *before* the existence lookup, matching `updateAlbum`'s ordering.
- **The releases endpoint is now paginated** (`page`/`limit`, default 50, max 100, `{ artist_id, releases, total, page, totalPages }`), consistent with `GET /library/query`.
- **PATCH/GET response shape reconciled** — PATCH returns the refreshed card (`artist_id`, …) instead of the bare `artists` RETURNING row (`id`, …).
- **`app.yaml` reconciled to the enforcement** — the PATCH was documented `BearerAuth: ['station-management']` and the GETs `['dj']` while the routes enforce `catalog:['write']` / `catalog:['read']`; they are now `catalog-write` / `catalog-read`, the scope names the sibling catalog endpoints already use.

Test-coverage findings:

- The ordering assertion couldn't detect an ordering regression — `generateAlbumCodeNumber` is max+1, so API-created albums come out in an order identical to insertion/id/`add_date`. The fixture releases are now renumbered *out* of insertion order (with two sharing a `code_number` and differing only in `code_volume_letters`) before the assertion.
- Pinned the four unpinned PATCH guards: `MAX_ARTIST_TEXT_LENGTH`, the `typeof !== 'string'` runtime guards (the whole runtime defense behind the allowlist, since TS types are erased — `123`, `['a']`, `{}` are all exercised), `alphabetical_name`'s validation symmetry with `artist_name`, and `getArtistCardById`'s `.orderBy(asc(genre_id))` determinism for a multi-genre artist.
- New `tests/unit/routes/library-artist-card-permissions.route.test.ts` pins the auth tier on all three routes via the `jest.requireActual` pattern. Previously every test drove the privileged token, so relaxing PATCH to `catalog:['read']` would have kept the suite green while letting every DJ rename catalog artists.

## Review round 3 — findings closed

- **The rename conflict guard checked only one of a multi-genre artist's genres.** `existing.genre_id` comes from `getArtistCardById`'s deliberate `.orderBy(asc(genre_id)).limit(1)` collapse to the LOWEST genre, and `conflictingArtistIdInGenre` then filtered on exactly that one `genre_id` — so a fold-equal duplicate sitting in any of the artist's *other* genres was never probed. Multi-genre artists are a designed state (`jobs/artist-unicode-dedup/merge.ts` repoints every crossreference onto a survivor precisely so the matcher reaches it from every genre), so `conflictingArtistIdInGenre` now takes `(artist_name, exclude_artist_id)` and probes every genre `exclude_artist_id` is crossreferenced in. New integration test seeds a fold-equal duplicate in the artist's *second* (non-lowest) genre and confirms the 409.
- **PATCH silently dropped `genre_id`/`code_letters`/`code_artist_number` instead of rejecting them.** The BS#2156 AC says the endpoint "allowlists the two name fields and rejects anything else." (The issue's claim that genre/code re-assignment isn't on the JSP form is incorrect — `artistCardModify.jsp:41-64` posts all five fields and `ArtistAdminServlet.java:196-206` applies them.) These three now 400 with a message naming *why*, matching the `ROTATION_NO_COLUMN_FIELD_OWNERS` pattern #2165 introduces for `PATCH /library/rotation/:id` — verified against the actual write surface first: `updateArtistInDB` is the only `.update(artists)` call in the codebase and only ever SETs the two name columns, and `genre_artist_crossreference` is only ever `.insert()`ed, never `.update()`d, so the 400 says "no write path exists" rather than pointing at an endpoint that could fix it (none exists yet).
- **`code_volume_letters` sorted NULLS LAST, diverging from the legacy shelf order.** Postgres's bare `ASC` default is NULLS LAST; the legacy query this mirrors (`LibraryCatalogServlet.java:130-133`) runs on MySQL, where `ASC` is NULLS FIRST — so a bare `R 7` was rendering *after* `R 7A`/`R 7B` under the same `code_number`, the reverse of the physical shelf. Now `sql\`... ASC NULLS FIRST\``. The round-2 fixture couldn't catch this (its NULL row sits at a different `code_number`); a new test ties a NULL directly against a lettered row under the same number.
- **The pagination comment's justification was false.** It claimed "a smaller default because one artist's shelf is a much shorter list than a catalog search," but `DEFAULT_RELEASES_LIMIT`/`MAX_RELEASES_LIMIT` were 50/100 — identical to `GET /library/query`'s `DEFAULT_LIMIT`/`MAX_LIMIT`. Now reuses those constants directly (module-level consts are in scope regardless of declaration order) instead of a second identical pair under a new name.
- **The 409 could carry `artist: null`.** `getArtistById(conflictingArtistId)` is a second read; a miss (row deleted in the window between the two lookups) still answered 409 with a null payload. Mirrors `addArtist`'s documented policy for the identical race verbatim: a miss on the second lookup means the name is free again, so proceed rather than 409 with something the client can't act on.
- **Three routes used two different existence predicates.** GET/PATCH resolved existence through `getArtistCardById` (INNER JOIN to `genre_artist_crossreference`); `getArtistReleases` used `getArtistNameById` (plain `artists` lookup, plus a `!name` falsy check that would misread a legacy empty-string name as missing). An artist row with no crossreference therefore 404'd on the card and PATCH but 200'd on releases. All three now resolve existence through `getArtistCardById`.

Round-3 test plan additions: `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, and `npm run test:unit` (436 suites / 7444 tests) all pass. The new integration cases (multi-genre conflict probe, NULLS FIRST tie, no-write-path 400s, unified existence predicate) were reviewed by hand against the already-passing sibling patterns in the same file rather than re-run against the Docker CI stack this round.

## Operational note (not addressed here, deliberately)

`PATCH /library/artists/:id` on a high-fan-out artist drives migration 0060's `cascade_library_artist_name` trigger across every one of that artist's library rows — 3,107 of them for artist 1087 — each firing `cdc_notify()` plus a `search_doc` tsvector recompute, and bumping `library_watermark`. Migration 0060 sized that cascade on the assumption that "the typical artist has fewer than 10 library rows", and this PR is the first HTTP surface that can drive it on demand. Worth a follow-up (batching, a fan-out ceiling, or an async path) before the endpoint is exposed to a UI that makes renames cheap to trigger.

`addAlbum` (`library.controller.ts`) resolves `artist_id` from a client-supplied `body.artist_name` via `artistIdFromName` but never confirms the resolved artist is actually crossreferenced in `body.genre_id` before inserting the album — unlike `addArtist`'s code-triple/name-conflict guards, there's no `artistExistsInGenre` check on this path. Pre-existing, out of scope for this batch; worth its own follow-up ticket.


