### PR TITLE
Support uncatalogued rotation releases: relax album_id, list the queue, link after cataloging

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1796,7 +1796,7 @@ paths:
         independently backfilled; display elsewhere is unaffected because it
         reads through the library join once album_id resolves.
       security:
-        - BearerAuth: ['station-management']
+        - BearerAuth: ['catalog-write']
       parameters:
         - name: rotation_id
           in: path

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1750,8 +1750,9 @@ paths:
         two physically distinct promos sharing an artist and title are two
         separate rows to catalogue, not one. Not restricted to active
         (`kill_date`) rows — this is the full cataloging backlog, not a
-        live dropdown. `limit`/`offset` are both opt-in; omitting both
-        returns the full, unbounded backlog.
+        live dropdown. `limit` defaults to its 500 maximum rather than to
+        the whole backlog (~3.8k rows, ≈700 KB of JSON); page with
+        `offset` to walk past it.
       security:
         - BearerAuth: ['catalog-read']
       parameters:
@@ -1762,6 +1763,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 500
+            default: 500
         - name: offset
           in: query
           required: false

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -474,16 +474,81 @@ components:
 
     NewRotationRequest:
       type: object
-      required: ['album_id', 'rotation_bin']
+      required: ['rotation_bin']
+      description: >-
+        BS#2109: `album_id` may be omitted (or explicitly `null`) when
+        `artist_name` and `album_title` are both supplied instead — the
+        free-text pair representing a rotation release the station hasn't
+        catalogued yet. `record_label` is optional in that case; blank or
+        whitespace-only `artist_name`/`album_title` don't count as
+        supplied. 400s when neither `album_id` nor the artist/title pair is
+        given. `artist_name` / `album_title` / `record_label` are ignored
+        when `album_id` is present — display is then sourced from the
+        library join, and a client-supplied snapshot there would leave
+        stale free text nothing ever clears.
       properties:
         album_id:
           type: integer
+          nullable: true
+          description: >-
+            Must be a positive integer, or omitted/null for an uncatalogued
+            release. `0` 400s — there is no `0` sentinel on this column;
+            `library.id` is a serial starting at 1.
         rotation_bin:
           type: string
           enum: ['S', 'L', 'M', 'H']
         kill_date:
           type: string
           format: date
+        artist_name:
+          type: string
+          maxLength: 128
+          description: Required (with album_title) when album_id is omitted. A value over 128 characters 400s rather than truncating.
+        album_title:
+          type: string
+          maxLength: 128
+          description: Required (with artist_name) when album_id is omitted. A value over 128 characters 400s rather than truncating.
+        record_label:
+          type: string
+          maxLength: 128
+          description: Optional, only used when album_id is omitted. A value over 128 characters 400s rather than truncating.
+
+    UncataloguedRotationRow:
+      type: object
+      description: >-
+        BS#2109. The explicit column projection `GET
+        /library/rotation/uncatalogued` and `PATCH
+        /library/rotation/{rotation_id}/link` both return — deliberately
+        narrower than the full `rotation` row, which also carries
+        server-derived plumbing (legacy_rotation_id,
+        legacy_library_release_id, discogs_release_id,
+        discogs_release_id_source, lml_identity_id, and two attempt-at
+        markers) that is never published on this surface.
+      properties:
+        id:
+          type: integer
+        album_id:
+          type: integer
+          nullable: true
+        rotation_bin:
+          type: string
+          enum: ['S', 'L', 'M', 'H', 'N']
+        add_date:
+          type: string
+          format: date
+        kill_date:
+          type: string
+          format: date
+          nullable: true
+        artist_name:
+          type: string
+          nullable: true
+        album_title:
+          type: string
+          nullable: true
+        record_label:
+          type: string
+          nullable: true
 
     BinLibraryDetails:
       type: object
@@ -1646,8 +1711,13 @@ paths:
             schema:
               $ref: '#/components/schemas/NewRotationRequest'
       responses:
-        '200':
+        '201':
           description: Successfully added rotation
+        '400':
+          description: >-
+            Missing rotation_bin; neither album_id nor a valid artist/title
+            pair given; album_id not a positive integer; or a snapshot
+            field over 128 characters.
 
     patch:
       summary: Set rotation removal date
@@ -1668,6 +1738,98 @@ paths:
       responses:
         '200':
           description: Successfully set rotation removal date
+
+  /library/rotation/uncatalogued:
+    get:
+      summary: List uncatalogued rotation releases (cataloging backlog queue)
+      description: >-
+        BS#2109. Rotation rows with no linked library release (`album_id IS
+        NULL`) — the "Import to Library" backlog a librarian works through
+        via `PATCH /library/rotation/{rotation_id}/link`. Deliberately NOT
+        deduplicated the way `GET /library/rotation`'s dropdown shape is:
+        two physically distinct promos sharing an artist and title are two
+        separate rows to catalogue, not one. Not restricted to active
+        (`kill_date`) rows — this is the full cataloging backlog, not a
+        live dropdown. `limit`/`offset` are both opt-in; omitting both
+        returns the full, unbounded backlog.
+      security:
+        - BearerAuth: ['catalog-read']
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Uncatalogued rotation rows, newest add_date first.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UncataloguedRotationRow'
+        '400':
+          description: Malformed limit or offset.
+        '401':
+          description: Missing or invalid bearer token.
+
+  /library/rotation/{rotation_id}/link:
+    patch:
+      summary: Link an uncatalogued rotation row to a library release
+      description: >-
+        BS#2109. The "Import to Library" step of the tubafrenzy `/wxycdb`
+        workflow: attaches a `library` release to a rotation row that was
+        added without one. Rejects double-linking (409). Deliberately does
+        NOT clear artist_name/album_title/record_label — they're left
+        populated so the tracklist picker (`GET
+        /library/rotation/{rotation_id}/tracks`) can still resolve a
+        release via LML free-text lookup until `discogs_release_id` is
+        independently backfilled; display elsewhere is unaffected because it
+        reads through the library join once album_id resolves.
+      security:
+        - BearerAuth: ['station-management']
+      parameters:
+        - name: rotation_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ['album_id']
+              properties:
+                album_id:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: Linked rotation row.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UncataloguedRotationRow'
+        '400':
+          description: rotation_id is not a positive integer, or album_id is missing/not a positive integer.
+        '401':
+          description: Missing or invalid bearer token.
+        '404':
+          description: Rotation entry not found, or album not found.
+        '409':
+          description: Rotation entry is already linked to a library release.
 
   /library/artists:
     post:

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -532,7 +532,7 @@ components:
           nullable: true
         rotation_bin:
           type: string
-          enum: ['S', 'L', 'M', 'H', 'N']
+          enum: ['S', 'L', 'M', 'H']
         add_date:
           type: string
           format: date

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -450,21 +450,47 @@ export const getRotation: RequestHandler = async (req, res) => {
   res.status(200).json(rotation);
 };
 
+/**
+ * `GET /library/rotation/uncatalogued` (BS#2109).
+ *
+ * The cataloging-backlog queue: rotation rows with no linked library
+ * release, deliberately WITHOUT the `DISTINCT ON` collapse `getRotation`
+ * uses for its dropdown shape — two physically distinct promos that share
+ * an artist and title are two separate rows a librarian has to catalogue,
+ * and collapsing them would silently hide one. See `getUncataloguedRotationFromDB`
+ * for the `COALESCE(album_id, 0) = 0` predicate this reads through.
+ *
+ * ROUTE REGISTRATION ORDER IS LOAD-BEARING — must be registered ahead of any
+ * `/rotation/:id`-style parameterized route (see `library.route.ts`), the
+ * same trap already documented there for `/catalog` vs
+ * `/:id/compilation-tracks`.
+ */
+export const getUncataloguedRotation: RequestHandler = async (req, res) => {
+  const rotation = await libraryService.getUncataloguedRotationFromDB();
+  res.status(200).json(rotation);
+};
+
 export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
 
 /**
  * Pick only the fields the client is allowed to write through the public
- * `POST /library/rotation` endpoint (BS#1380). Mirrors
- * `pickUpdateEntryFields()` in flowsheet.controller.ts (BS#1099).
+ * `POST /library/rotation` endpoint (BS#1380; relaxed by BS#2109).
+ * Mirrors `pickUpdateEntryFields()` in flowsheet.controller.ts (BS#1099).
  *
  * Server-derived columns (`legacy_rotation_id`, `legacy_library_release_id`,
  * `discogs_release_id`, `discogs_release_id_source`, `lml_identity_id`,
- * `tracklist_lookup_attempted_at`, `kill_date`) and tubafrenzy-ETL-only
- * snapshot columns (`add_date`, `artist_name`, `album_title`,
- * `record_label`) must never be client-supplied through this endpoint —
- * `addToRotation` derives the LML-handle columns from `library_identity`
- * and the synchronous `resolveIdentity` hop, and tubafrenzy is the only
- * legitimate source for the snapshot columns.
+ * `tracklist_lookup_attempted_at`, `kill_date`) must never be
+ * client-supplied through this endpoint — `addToRotation` derives the
+ * LML-handle columns from `library_identity` and the synchronous
+ * `resolveIdentity` hop.
+ *
+ * `artist_name`/`album_title`/`record_label` are normally tubafrenzy-ETL-only
+ * snapshot columns, but BS#2109 relaxed `addRotation` to accept a rotation
+ * release with no catalogued `album_id` — the free-text trio is then the
+ * only way to represent it. So they are picked ONLY when the client did not
+ * supply an `album_id`: a catalogued row (`album_id` present) still has its
+ * display sourced from the `library` join, and a client-supplied snapshot on
+ * a catalogued row would leave stale free text nothing ever clears.
  *
  * Phrased as an allowlist (signature-typed accept list) so a future column
  * addition to `rotation` is implicitly rejected by typecheck until
@@ -472,17 +498,35 @@ export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
  * (`{ album_id, rotation_bin }`); widen the signature here when a future
  * caller legitimately needs another field.
  */
-type AddRotationAllowlist = Pick<NewRotationRelease, 'album_id' | 'rotation_bin'>;
+type AddRotationAllowlist = Pick<
+  NewRotationRelease,
+  'album_id' | 'rotation_bin' | 'artist_name' | 'album_title' | 'record_label'
+>;
 
 export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRotationAllowlist {
   const picked = {} as AddRotationAllowlist;
   if (body.album_id !== undefined) picked.album_id = body.album_id;
   if (body.rotation_bin !== undefined) picked.rotation_bin = body.rotation_bin;
+  if (body.album_id === undefined) {
+    if (body.artist_name !== undefined) picked.artist_name = body.artist_name;
+    if (body.album_title !== undefined) picked.album_title = body.album_title;
+    if (body.record_label !== undefined) picked.record_label = body.record_label;
+  }
   return picked;
 }
 
+/**
+ * `POST /library/rotation` (BS#1380; relaxed by BS#2109 for uncatalogued
+ * releases). `rotation_bin` is always required. `album_id` may be absent
+ * when `artist_name` and `album_title` are both supplied — the free-text
+ * pair that represents a rotation release the station hasn't catalogued
+ * yet. 400s when neither an `album_id` nor the artist/title pair is given;
+ * an anonymous rotation row helps nobody.
+ */
 export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res) => {
-  if (req.body.album_id === undefined || req.body.rotation_bin === undefined) {
+  const { body } = req;
+
+  if (body.rotation_bin === undefined) {
     throw new WxycError('Missing Parameters: album_id or rotation_bin', 400);
   }
   // BS#2173: this checked PRESENCE but never VALUE, so an unrecognized bin
@@ -497,9 +541,54 @@ export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = 
     );
   }
 
-  const picked = pickAddRotationFields(req.body);
+  if (body.album_id === undefined && (body.artist_name === undefined || body.album_title === undefined)) {
+    throw new WxycError('Missing Parameters: album_id, or artist_name and album_title', 400);
+  }
+
+  const picked = pickAddRotationFields(body);
   const rotationRelease: RotationRelease = await libraryService.addToRotation(picked);
   res.status(201).json(rotationRelease);
+};
+
+export type LinkRotationRequest = {
+  album_id: number;
+};
+
+/**
+ * `PATCH /library/rotation/:rotation_id/link` (BS#2109) — links an
+ * uncatalogued rotation row to a library release after the fact (the
+ * "Import to Library" step of the tubafrenzy `/wxycdb` workflow). Rejects
+ * double-linking; clears the free-text snapshot columns in the same
+ * transaction as the link, matching `jobs/legacy-linkage-resolve`. See
+ * `libraryService.linkRotationToAlbum` for the transactional details.
+ */
+export const linkRotationToAlbum: RequestHandler<{ rotation_id: string }, unknown, LinkRotationRequest> = async (
+  req,
+  res
+) => {
+  const rotationId = parseInt(req.params.rotation_id, 10);
+  if (!Number.isInteger(rotationId) || rotationId <= 0) {
+    throw new WxycError('rotation_id must be a positive integer', 400);
+  }
+
+  const { album_id } = req.body;
+  if (typeof album_id !== 'number' || !Number.isInteger(album_id) || album_id <= 0) {
+    throw new WxycError('Missing Parameters: album_id', 400);
+  }
+
+  const result = await libraryService.linkRotationToAlbum(rotationId, album_id);
+
+  switch (result.outcome) {
+    case 'rotation_not_found':
+      throw new WxycError('Rotation entry not found', 404);
+    case 'album_not_found':
+      throw new WxycError('Album not found', 404);
+    case 'already_linked':
+      throw new WxycError('Rotation entry is already linked to a library release', 409);
+    case 'linked':
+      res.status(200).json(result.rotation);
+      break;
+  }
 };
 
 export type KillRotationRelease = {

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -570,9 +570,23 @@ export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRot
  * would leave the librarian a corrupted record with no signal, whereas
  * without a guard PostgreSQL raises 22001 and the request becomes an opaque
  * 500 + Sentry event that names no field.
+ *
+ * The length check below counts `[...value].length` (Unicode code points),
+ * not `value.length` (UTF-16 code units) — `varchar(128)` is a
+ * **character** limit; PostgreSQL counts code points, and `value.length`
+ * over-counts every character outside the BMP (astral emoji, CJK
+ * Extension B, …) as 2. Review round 3 finding 6: a bare `.length` never
+ * *under*-rejects (so no 22001 could ever slip through), but it does
+ * over-reject values PostgreSQL would happily store — undercutting the
+ * very reason this endpoint chose reject-over-truncate.
  */
 const ROTATION_SNAPSHOT_MAX_LENGTH = 128;
 const ROTATION_SNAPSHOT_FIELDS = ['artist_name', 'album_title', 'record_label'] as const;
+
+/** Unicode-code-point length — see `ROTATION_SNAPSHOT_MAX_LENGTH` above. */
+function codePointLength(value: string): number {
+  return [...value].length;
+}
 
 /** `true` only for a string with at least one non-whitespace character. */
 function isNonBlankString(value: unknown): value is string {
@@ -596,6 +610,20 @@ function isNonBlankString(value: unknown): value is string {
  * `rotation.album_id` FKs it, so a `0` would drop the free text and then
  * violate the FK into an opaque 500. It is the literal payload the classic
  * `/wxycdb` rotation form posts, so it gets a named 400.
+ *
+ * **Behavior change (review round 3 finding 7):** `Number.isInteger(album_id)`
+ * also tightens the pre-existing catalogued path, not just the new
+ * uncatalogued one — `{"album_id": "2", "rotation_bin": "M"}` previously
+ * inserted fine (PostgreSQL coerces a numeric string on the way into an
+ * `integer` column) and now 400s. Kept deliberately: dj-site's
+ * `addRotationEntry` mutation (`lib/features/rotation/api.ts`) is typed
+ * against `AddRotationRequest` (`album_id: number`, from the shared OpenAPI
+ * contract) and its sole call site (`RotationClassifyControl.tsx`) passes
+ * `album.id!`, itself typed `number` — the only known caller of this
+ * endpoint always sends a genuine JSON number, never a numeric string, so
+ * this tightening does not affect it. A caller that does send a numeric
+ * string was relying on undocumented PostgreSQL coercion rather than the
+ * documented contract.
  */
 export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res) => {
   const { body } = req;
@@ -633,7 +661,7 @@ export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = 
       if (typeof value !== 'string') {
         throw new WxycError(`Invalid Parameter: ${field} must be a string`, 400);
       }
-      if (value.length > ROTATION_SNAPSHOT_MAX_LENGTH) {
+      if (codePointLength(value) > ROTATION_SNAPSHOT_MAX_LENGTH) {
         throw new WxycError(
           `Invalid Parameter: ${field} exceeds the ${ROTATION_SNAPSHOT_MAX_LENGTH}-character limit`,
           400
@@ -659,9 +687,12 @@ export type LinkRotationRequest = {
  * `PATCH /library/rotation/:rotation_id/link` (BS#2109) — links an
  * uncatalogued rotation row to a library release after the fact (the
  * "Import to Library" step of the tubafrenzy `/wxycdb` workflow). Rejects
- * double-linking; clears the free-text snapshot columns in the same
- * transaction as the link, matching `jobs/legacy-linkage-resolve`. See
- * `libraryService.linkRotationToAlbum` for the transactional details.
+ * double-linking. Deliberately leaves the free-text snapshot columns
+ * (`artist_name` / `album_title` / `record_label`) untouched — see
+ * `libraryService.linkRotationToAlbum` for the transactional details and
+ * why (review round 3 finding 1: clearing them stranded the tracklist
+ * picker with no self-heal path). The response is a projected shape, not
+ * the raw `.returning()` row (finding 4) — see the same doc.
  */
 export const linkRotationToAlbum: RequestHandler<{ rotation_id: string }, unknown, LinkRotationRequest> = async (
   req,

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -636,9 +636,9 @@ export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = 
   // plainly bad input. Shared with the rotation webhook via `parseRotationBin`
   // so the two cannot disagree about normalization (they did: `'h'` was
   // accepted by one and rejected by the other).
-  if (parseRotationBin(req.body.rotation_bin).kind !== 'bin') {
+  if (parseRotationBin(body.rotation_bin).kind !== 'bin') {
     throw new WxycError(
-      `Invalid rotation_bin ${JSON.stringify(req.body.rotation_bin)}. Expected one of: ${ROTATION_BINS.join(', ')}.`,
+      `Invalid rotation_bin ${JSON.stringify(body.rotation_bin)}. Expected one of: ${ROTATION_BINS.join(', ')}.`,
       400
     );
   }
@@ -706,7 +706,8 @@ export const linkRotationToAlbum: RequestHandler<{ rotation_id: string }, unknow
   }
 
   const { album_id } = req.body;
-  if (typeof album_id !== 'number' || !Number.isInteger(album_id) || album_id <= 0) {
+  // `Number.isInteger` already rejects every non-number, so no `typeof` guard.
+  if (!Number.isInteger(album_id) || album_id <= 0) {
     throw new WxycError('Missing Parameters: album_id', 400);
   }
 

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -450,8 +450,13 @@ export const getRotation: RequestHandler = async (req, res) => {
   res.status(200).json(rotation);
 };
 
-/** Upper bound on `?limit=` for the uncatalogued queue. */
-const UNCATALOGUED_ROTATION_MAX_LIMIT = 500;
+/**
+ * Upper bound AND default for `?limit=` on the uncatalogued queue — owned by
+ * the service, since the cap is a property of the query rather than of this
+ * route. Re-exported through the namespace import so the 400 message and the
+ * query can never disagree about the number.
+ */
+const { UNCATALOGUED_ROTATION_MAX_LIMIT } = libraryService;
 
 /**
  * Parse an optional non-negative-integer query parameter or path segment.
@@ -479,12 +484,13 @@ function parseNonNegativeInt(raw: unknown): number | null | undefined {
  * reads through and why the `0` sentinel it once also matched does not
  * exist on this column.
  *
- * Optional `?limit=` (1…500) and `?offset=` window the queue. Both are
- * OPT-IN: absent means the full backlog, so this PR does not silently
- * truncate any existing caller's result. The backlog is ~3.8k rows today,
- * which is servable in one response; dj-site#1161's queue UI is the caller
- * that should start passing them, and a default cap is worth revisiting
- * once a paginating client exists to notice it.
+ * Optional `?limit=` (1…500) and `?offset=` window the queue. **`limit`
+ * defaults to 500 rather than to the whole backlog**: at ~3.8k unlinked rows
+ * an uncapped response is ≈700 KB of JSON per request on a single-worker box
+ * that also serves the live flowsheet, and the ceiling is far cheaper to set
+ * before `wxyc-shared#354` publishes this shape than after a client starts
+ * depending on "omit ⇒ everything". dj-site#1161's queue UI pages with
+ * `offset`.
  *
  * ROUTE REGISTRATION ORDER IS LOAD-BEARING — must be registered ahead of any
  * `/rotation/:id`-style parameterized route (see `library.route.ts`), the

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -450,6 +450,23 @@ export const getRotation: RequestHandler = async (req, res) => {
   res.status(200).json(rotation);
 };
 
+/** Upper bound on `?limit=` for the uncatalogued queue. */
+const UNCATALOGUED_ROTATION_MAX_LIMIT = 500;
+
+/**
+ * Parse an optional non-negative-integer query parameter or path segment.
+ * Returns `undefined` when absent, `null` when present but not a well-formed
+ * non-negative integer (the caller turns that into a 400). Strict — unlike
+ * `parseInt`, `'42abc'` and `'4.5'` are rejected rather than silently
+ * truncated to `42` and `4`.
+ */
+function parseNonNegativeInt(raw: unknown): number | null | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
 /**
  * `GET /library/rotation/uncatalogued` (BS#2109).
  *
@@ -457,16 +474,39 @@ export const getRotation: RequestHandler = async (req, res) => {
  * release, deliberately WITHOUT the `DISTINCT ON` collapse `getRotation`
  * uses for its dropdown shape — two physically distinct promos that share
  * an artist and title are two separate rows a librarian has to catalogue,
- * and collapsing them would silently hide one. See `getUncataloguedRotationFromDB`
- * for the `COALESCE(album_id, 0) = 0` predicate this reads through.
+ * and collapsing them would silently hide one. See
+ * `getUncataloguedRotationFromDB` for the `album_id IS NULL` predicate this
+ * reads through and why the `0` sentinel it once also matched does not
+ * exist on this column.
+ *
+ * Optional `?limit=` (1…500) and `?offset=` window the queue. Both are
+ * OPT-IN: absent means the full backlog, so this PR does not silently
+ * truncate any existing caller's result. The backlog is ~3.8k rows today,
+ * which is servable in one response; dj-site#1161's queue UI is the caller
+ * that should start passing them, and a default cap is worth revisiting
+ * once a paginating client exists to notice it.
  *
  * ROUTE REGISTRATION ORDER IS LOAD-BEARING — must be registered ahead of any
  * `/rotation/:id`-style parameterized route (see `library.route.ts`), the
  * same trap already documented there for `/catalog` vs
- * `/:id/compilation-tracks`.
+ * `/:id/compilation-tracks`. Pinned by
+ * `tests/unit/routes/library-rotation-uncatalogued.route.test.ts`.
  */
 export const getUncataloguedRotation: RequestHandler = async (req, res) => {
-  const rotation = await libraryService.getUncataloguedRotationFromDB();
+  const limit = parseNonNegativeInt(req.query.limit);
+  if (limit === null || (limit !== undefined && (limit < 1 || limit > UNCATALOGUED_ROTATION_MAX_LIMIT))) {
+    throw new WxycError(
+      `Invalid Parameter: limit must be an integer between 1 and ${UNCATALOGUED_ROTATION_MAX_LIMIT}`,
+      400
+    );
+  }
+
+  const offset = parseNonNegativeInt(req.query.offset);
+  if (offset === null) {
+    throw new WxycError('Invalid Parameter: offset must be a non-negative integer', 400);
+  }
+
+  const rotation = await libraryService.getUncataloguedRotationFromDB({ limit, offset });
   res.status(200).json(rotation);
 };
 
@@ -492,6 +532,12 @@ export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
  * display sourced from the `library` join, and a client-supplied snapshot on
  * a catalogued row would leave stale free text nothing ever clears.
  *
+ * **`null` and `undefined` mean the same thing in every test here.**
+ * `{ album_id: selected?.id ?? null, ... }` is the idiomatic client shape,
+ * and an `=== undefined` test would take the has-an-album_id branch on it —
+ * dropping the free text into a row that is then permanently
+ * un-catalogueable and indistinguishable from every other blank row.
+ *
  * Phrased as an allowlist (signature-typed accept list) so a future column
  * addition to `rotation` is implicitly rejected by typecheck until
  * explicitly added to the signature. Matches dj-site's `RotationParams`
@@ -505,14 +551,32 @@ type AddRotationAllowlist = Pick<
 
 export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRotationAllowlist {
   const picked = {} as AddRotationAllowlist;
-  if (body.album_id !== undefined) picked.album_id = body.album_id;
-  if (body.rotation_bin !== undefined) picked.rotation_bin = body.rotation_bin;
-  if (body.album_id === undefined) {
-    if (body.artist_name !== undefined) picked.artist_name = body.artist_name;
-    if (body.album_title !== undefined) picked.album_title = body.album_title;
-    if (body.record_label !== undefined) picked.record_label = body.record_label;
+  if (body.album_id != null) picked.album_id = body.album_id;
+  if (body.rotation_bin != null) picked.rotation_bin = body.rotation_bin;
+  if (body.album_id == null) {
+    if (body.artist_name != null) picked.artist_name = body.artist_name;
+    if (body.album_title != null) picked.album_title = body.album_title;
+    if (body.record_label != null) picked.record_label = body.record_label;
   }
   return picked;
+}
+
+/**
+ * The three free-text snapshot columns are `varchar(128)`. The only other
+ * writer (`internal.route.ts`) `truncate(_, 128)`s them because tubafrenzy
+ * free text routinely overruns and a webhook has nobody to report a 400 to.
+ * This endpoint has a human on the other end, so it **rejects rather than
+ * truncates**: silently amputating a long compilation or classical title
+ * would leave the librarian a corrupted record with no signal, whereas
+ * without a guard PostgreSQL raises 22001 and the request becomes an opaque
+ * 500 + Sentry event that names no field.
+ */
+const ROTATION_SNAPSHOT_MAX_LENGTH = 128;
+const ROTATION_SNAPSHOT_FIELDS = ['artist_name', 'album_title', 'record_label'] as const;
+
+/** `true` only for a string with at least one non-whitespace character. */
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 /**
@@ -521,13 +585,23 @@ export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRot
  * when `artist_name` and `album_title` are both supplied — the free-text
  * pair that represents a rotation release the station hasn't catalogued
  * yet. 400s when neither an `album_id` nor the artist/title pair is given;
- * an anonymous rotation row helps nobody.
+ * an anonymous rotation row helps nobody, and it is un-catalogueable
+ * afterwards because `PATCH /rotation/:id/link` is the only repair and a
+ * blank row gives the librarian nothing to identify it by.
+ *
+ * `null` is treated exactly as absent throughout (`selected?.id ?? null` is
+ * the shape clients actually send), a blank/whitespace-only artist or title
+ * does not count as supplied, and `album_id: 0` is rejected: there is no `0`
+ * sentinel on this column — `library.id` is a `serial` starting at 1 and
+ * `rotation.album_id` FKs it, so a `0` would drop the free text and then
+ * violate the FK into an opaque 500. It is the literal payload the classic
+ * `/wxycdb` rotation form posts, so it gets a named 400.
  */
 export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res) => {
   const { body } = req;
 
-  if (body.rotation_bin === undefined) {
-    throw new WxycError('Missing Parameters: album_id or rotation_bin', 400);
+  if (body.rotation_bin == null) {
+    throw new WxycError('Missing Parameters: rotation_bin', 400);
   }
   // BS#2173: this checked PRESENCE but never VALUE, so an unrecognized bin
   // reached the INSERT and surfaced as a Postgres 22P02 — a 500 for what is
@@ -541,8 +615,35 @@ export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = 
     );
   }
 
-  if (body.album_id === undefined && (body.artist_name === undefined || body.album_title === undefined)) {
-    throw new WxycError('Missing Parameters: album_id, or artist_name and album_title', 400);
+  const hasAlbumId = body.album_id != null;
+  if (hasAlbumId && !(Number.isInteger(body.album_id) && (body.album_id as number) > 0)) {
+    throw new WxycError(
+      'Invalid Parameter: album_id must be a positive integer, or omitted for an uncatalogued release',
+      400
+    );
+  }
+
+  if (!hasAlbumId) {
+    // Only guarded on the uncatalogued path: with an `album_id` present the
+    // trio is deliberately dropped by `pickAddRotationFields`, so a long
+    // value there is never written and must not fail an otherwise-valid add.
+    for (const field of ROTATION_SNAPSHOT_FIELDS) {
+      const value = body[field];
+      if (value == null) continue;
+      if (typeof value !== 'string') {
+        throw new WxycError(`Invalid Parameter: ${field} must be a string`, 400);
+      }
+      if (value.length > ROTATION_SNAPSHOT_MAX_LENGTH) {
+        throw new WxycError(
+          `Invalid Parameter: ${field} exceeds the ${ROTATION_SNAPSHOT_MAX_LENGTH}-character limit`,
+          400
+        );
+      }
+    }
+
+    if (!isNonBlankString(body.artist_name) || !isNonBlankString(body.album_title)) {
+      throw new WxycError('Missing Parameters: album_id, or artist_name and album_title', 400);
+    }
   }
 
   const picked = pickAddRotationFields(body);
@@ -566,8 +667,10 @@ export const linkRotationToAlbum: RequestHandler<{ rotation_id: string }, unknow
   req,
   res
 ) => {
-  const rotationId = parseInt(req.params.rotation_id, 10);
-  if (!Number.isInteger(rotationId) || rotationId <= 0) {
+  // Strict, not `parseInt`: `parseInt('42abc', 10)` is 42, which would let
+  // `/library/rotation/42abc/link` mutate rotation 42.
+  const rotationId = parseNonNegativeInt(req.params.rotation_id);
+  if (rotationId == null || rotationId <= 0) {
     throw new WxycError('rotation_id must be a positive integer', 400);
   }
 
@@ -588,6 +691,14 @@ export const linkRotationToAlbum: RequestHandler<{ rotation_id: string }, unknow
     case 'linked':
       res.status(200).json(result.rotation);
       break;
+    default: {
+      // Exhaustiveness guard. Without it, a `LinkRotationOutcome` variant
+      // added later falls through every case and the handler returns having
+      // written no response — the request hangs until the 35 s server
+      // timeout. `never` makes that a typecheck failure instead.
+      const unhandled: never = result;
+      throw new WxycError(`Unhandled rotation link outcome: ${JSON.stringify(unhandled)}`, 500);
+    }
   }
 };
 

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -934,8 +934,26 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         // presence-gated for the same reason as above — a full-shape update
         // overwrites these, a sparser one leaves them alone — while the INSERT
         // arm populates every column on first delivery.
+        //
+        // BS#2109: `album_id` is COALESCEd rather than overwritten, so an
+        // incoming NULL cannot un-link a row. Before BS#2109 every `album_id`
+        // in this table originated upstream (`jobs/legacy-linkage-resolve`
+        // only links rows tubafrenzy has already linked), so
+        // `excluded.album_id` always agreed with what was there and
+        // overwriting was a no-op. `PATCH /library/rotation/:id/link` created
+        // the first Backend-canonical link tubafrenzy does not know about:
+        // `excluded.album_id` is `resolveAlbumId(release.libraryReleaseId ?? 0)`,
+        // which is NULL whenever tubafrenzy has not itself linked the release,
+        // so the next `/wxycdb` edit on that release would reset `album_id` to
+        // NULL, restore the free text, and drop the row back into the
+        // cataloging queue. Accepted trade-off: tubafrenzy can no longer
+        // *unlink* a rotation row — releases are not un-catalogued, so that is
+        // not a real librarian operation. Deliberately NOT the same mechanism
+        // as the presence gates below (BS#1082 + BS#1312): those key on
+        // whether the payload carried the field at all, and `libraryReleaseId`
+        // is present-and-`0` on exactly the linkage event that matters.
         const setClause: Record<string, unknown> = {
-          album_id: sql`excluded.album_id`,
+          album_id: sql`COALESCE(excluded.album_id, ${rotation.album_id})`,
           legacy_library_release_id: sql`excluded.legacy_library_release_id`,
           rotation_bin: sql`excluded.rotation_bin`,
         };

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -900,9 +900,28 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         // every client; a missing linkage is recoverable by hand, a fabricated
         // bin is invisible. If these start appearing, the fix is upstream: give
         // the release a real bin in tubafrenzy.
+        //
+        // `album_id` is deliberately ungated (unlike the fields below) — it is
+        // written on every delivery through this arm, or the linkage event
+        // BS#1082/#1312 exists to deliver would silently no-op.
+        //
+        // BS#2109 review round 3 finding 2, re-derived for this arm: it is a
+        // plain UPDATE, not the sibling INSERT...ON CONFLICT below, so there
+        // is no `excluded` row to read — the delivery's own resolved
+        // `albumId` stands in for it. `rawLibraryId` truthy means tubafrenzy
+        // is asserting a real link this delivery, so `albumId` (even null,
+        // if the id didn't resolve) is written outright — same unconditional
+        // overwrite as the sibling arm's `albumIdExpr`. `rawLibraryId` falsy
+        // (0/absent — tubafrenzy doesn't know) must not downgrade a
+        // Backend-made link (`PATCH /library/rotation/:id/link`) to NULL, so
+        // it COALESCEs against the row's current value instead — `albumId` is
+        // guaranteed null whenever `rawLibraryId` is falsy (`getAlbumIdByLegacyId`
+        // short-circuits on a falsy id), so this is the plain-UPDATE
+        // equivalent of the sibling arm's
+        // `COALESCE(excluded.album_id, rotation.album_id)`.
         const partialSet: Record<string, unknown> = {
-          album_id: albumId,
           legacy_library_release_id: rawLibraryId || null,
+          album_id: rawLibraryId ? albumId : sql`COALESCE(${albumId}, ${rotation.album_id})`,
         };
         if (release.killDate !== undefined) {
           partialSet.kill_date = killDate;

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -933,27 +933,60 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         // A real bin is present, so the row can be created outright. SET stays
         // presence-gated for the same reason as above — a full-shape update
         // overwrites these, a sparser one leaves them alone — while the INSERT
-        // arm populates every column on first delivery.
+        // arm populates every column on first delivery. This gate is
+        // load-bearing and untouched by review round 3 finding 2 below — it
+        // answers "was the field in the payload at all?", a different
+        // question from "does the row resolve linked?".
         //
-        // BS#2109: `album_id` is COALESCEd rather than overwritten, so an
-        // incoming NULL cannot un-link a row. Before BS#2109 every `album_id`
-        // in this table originated upstream (`jobs/legacy-linkage-resolve`
-        // only links rows tubafrenzy has already linked), so
-        // `excluded.album_id` always agreed with what was there and
-        // overwriting was a no-op. `PATCH /library/rotation/:id/link` created
-        // the first Backend-canonical link tubafrenzy does not know about:
-        // `excluded.album_id` is `resolveAlbumId(release.libraryReleaseId ?? 0)`,
-        // which is NULL whenever tubafrenzy has not itself linked the release,
-        // so the next `/wxycdb` edit on that release would reset `album_id` to
-        // NULL, restore the free text, and drop the row back into the
-        // cataloging queue. Accepted trade-off: tubafrenzy can no longer
-        // *unlink* a rotation row — releases are not un-catalogued, so that is
-        // not a real librarian operation. Deliberately NOT the same mechanism
-        // as the presence gates below (BS#1082 + BS#1312): those key on
-        // whether the payload carried the field at all, and `libraryReleaseId`
-        // is present-and-`0` on exactly the linkage event that matters.
+        // BS#2109 (review round 2): `album_id` was first COALESCEd rather than
+        // overwritten, so an incoming NULL couldn't un-link a row. Before
+        // BS#2109 every `album_id` in this table originated upstream
+        // (`jobs/legacy-linkage-resolve` only links rows tubafrenzy has
+        // already linked), so `excluded.album_id` always agreed with what was
+        // there and overwriting was a no-op. `PATCH /library/rotation/:id/link`
+        // created the first Backend-canonical link tubafrenzy does not know
+        // about, so a blanket COALESCE was needed to stop a `libraryReleaseId:
+        // 0` delivery (tubafrenzy simply doesn't know) from reading as "tubafrenzy
+        // says unlink this."
+        //
+        // Review round 3 finding 2 refines that to the payload itself rather
+        // than the resolution result: `rawLibraryId` truthy means tubafrenzy
+        // is asserting an actual link (create, or a genuine `/wxycdb` relink to
+        // a *different* release), so `excluded.album_id` wins outright — this
+        // restores tubafrenzy's ability to relink a row, which the blanket
+        // COALESCE had silently revoked (its docblock's claim that "tubafrenzy
+        // can no longer unlink a rotation row" was broader than intended: it
+        // could no longer *change* `album_id` at all). `rawLibraryId` falsy
+        // (0/absent — tubafrenzy doesn't know) keeps the COALESCE fallback, so
+        // a Backend-made link (or a link this same delivery just resolved)
+        // survives. `albumIdExpr` is shared with the three snapshot columns
+        // below so both agree on what "resolves linked" means from the exact
+        // same delivery.
+        const albumIdExpr = rawLibraryId
+          ? sql`excluded.album_id`
+          : sql`COALESCE(excluded.album_id, ${rotation.album_id})`;
+
+        // Review round 3 finding 2: presence in the payload still gates
+        // *whether* each snapshot column appears in SET at all (unchanged, see
+        // above), but a column that does appear is no longer written
+        // unconditionally from `excluded.*`. `PATCH /library/rotation/:id/link`
+        // deliberately leaves a freshly-linked row's snapshot columns
+        // populated (finding 1) so the tracklist picker can self-heal — a
+        // `/wxycdb` edit arriving afterward would otherwise write tubafrenzy's
+        // (necessarily stale, potentially divergent) free text straight onto
+        // an `album_id`-linked row, recreating the "both populated" shape
+        // `PATCH .../link`'s 409 and sibling PR #2165 both exist to prevent,
+        // and that the BS#2080 arm-(b)/(c) rotation-badge match in
+        // `shared/legacy-mirror/src/rotation-match.ts` and
+        // `apps/backend/services/flowsheet.service.ts` doesn't filter
+        // `album_id IS NULL` against. Each CASE reuses `albumIdExpr` — the
+        // exact same expression assigned to `album_id` in this statement — so
+        // a column is written from `excluded.*` only when the row resolves
+        // UNLINKED after this delivery; otherwise it's forced to NULL,
+        // matching the state `PATCH .../link` leaves a fresh link in until a
+        // subsequent edit or backfill catches up.
         const setClause: Record<string, unknown> = {
-          album_id: sql`COALESCE(excluded.album_id, ${rotation.album_id})`,
+          album_id: albumIdExpr,
           legacy_library_release_id: sql`excluded.legacy_library_release_id`,
           rotation_bin: sql`excluded.rotation_bin`,
         };
@@ -961,13 +994,13 @@ internal_route.post('/rotation-webhook', async (req, res) => {
           setClause.kill_date = sql`excluded.kill_date`;
         }
         if (release.artistName !== undefined) {
-          setClause.artist_name = sql`excluded.artist_name`;
+          setClause.artist_name = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.artist_name ELSE NULL END`;
         }
         if (release.albumTitle !== undefined) {
-          setClause.album_title = sql`excluded.album_title`;
+          setClause.album_title = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.album_title ELSE NULL END`;
         }
         if (release.labelName !== undefined) {
-          setClause.record_label = sql`excluded.record_label`;
+          setClause.record_label = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.record_label ELSE NULL END`;
         }
 
         await db

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -901,28 +901,19 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         // bin is invisible. If these start appearing, the fix is upstream: give
         // the release a real bin in tubafrenzy.
         //
-        // `album_id` is deliberately ungated (unlike the fields below) — it is
-        // written on every delivery through this arm, or the linkage event
-        // BS#1082/#1312 exists to deliver would silently no-op.
-        //
-        // BS#2109 review round 3 finding 2, re-derived for this arm: it is a
-        // plain UPDATE, not the sibling INSERT...ON CONFLICT below, so there
-        // is no `excluded` row to read — the delivery's own resolved
-        // `albumId` stands in for it. `rawLibraryId` truthy means tubafrenzy
-        // is asserting a real link this delivery, so `albumId` (even null,
-        // if the id didn't resolve) is written outright — same unconditional
-        // overwrite as the sibling arm's `albumIdExpr`. `rawLibraryId` falsy
-        // (0/absent — tubafrenzy doesn't know) must not downgrade a
-        // Backend-made link (`PATCH /library/rotation/:id/link`) to NULL, so
-        // it COALESCEs against the row's current value instead — `albumId` is
-        // guaranteed null whenever `rawLibraryId` is falsy (`getAlbumIdByLegacyId`
-        // short-circuits on a falsy id), so this is the plain-UPDATE
-        // equivalent of the sibling arm's
-        // `COALESCE(excluded.album_id, rotation.album_id)`.
+        // BS#2109: tubafrenzy only asserts a link when it sends a
+        // `libraryReleaseId`. When it doesn't (0/absent — it simply doesn't
+        // know), leave `album_id` alone so a Backend-made link (`PATCH
+        // /library/rotation/:id/link`) isn't downgraded to NULL; presence-gating
+        // the key is how every other column here already expresses that. When
+        // it does, write the resolved `albumId` outright — even null, since an
+        // unresolved id is still tubafrenzy asserting a relink.
         const partialSet: Record<string, unknown> = {
           legacy_library_release_id: rawLibraryId || null,
-          album_id: rawLibraryId ? albumId : sql`COALESCE(${albumId}, ${rotation.album_id})`,
         };
+        if (rawLibraryId) {
+          partialSet.album_id = albumId;
+        }
         if (release.killDate !== undefined) {
           partialSet.kill_date = killDate;
         }
@@ -949,74 +940,46 @@ internal_route.post('/rotation-webhook', async (req, res) => {
           return;
         }
       } else {
-        // A real bin is present, so the row can be created outright. SET stays
-        // presence-gated for the same reason as above — a full-shape update
-        // overwrites these, a sparser one leaves them alone — while the INSERT
-        // arm populates every column on first delivery. This gate is
-        // load-bearing and untouched by review round 3 finding 2 below — it
-        // answers "was the field in the payload at all?", a different
-        // question from "does the row resolve linked?".
+        // A real bin is present, so the row can be created outright. Every SET
+        // key here is presence-gated — a full-shape update overwrites, a
+        // sparser one leaves alone — while the INSERT arm populates every
+        // column on first delivery. `album_id` is gated on the same rule as
+        // the plain-UPDATE arm above: tubafrenzy asserting a `libraryReleaseId`
+        // means write it (a create, or a genuine `/wxycdb` relink to a
+        // *different* release); tubafrenzy not knowing means leave the column
+        // alone, so a `PATCH /library/rotation/:id/link` survives.
         //
-        // BS#2109 (review round 2): `album_id` was first COALESCEd rather than
-        // overwritten, so an incoming NULL couldn't un-link a row. Before
-        // BS#2109 every `album_id` in this table originated upstream
-        // (`jobs/legacy-linkage-resolve` only links rows tubafrenzy has
-        // already linked), so `excluded.album_id` always agreed with what was
-        // there and overwriting was a no-op. `PATCH /library/rotation/:id/link`
-        // created the first Backend-canonical link tubafrenzy does not know
-        // about, so a blanket COALESCE was needed to stop a `libraryReleaseId:
-        // 0` delivery (tubafrenzy simply doesn't know) from reading as "tubafrenzy
-        // says unlink this."
+        // The three snapshot columns write `excluded.*` gated only on
+        // presence, same as every other column — this arm never re-decides the
+        // trio based on whether the row resolves linked. Note that the value
+        // it writes still can be NULL: the `.values()` below compute
+        // `albumId ? null : truncate(...)`, so a delivery carrying a
+        // *resolvable* `libraryReleaseId` nulls the trio. That is pre-existing
+        // behavior, deliberately unchanged here; the case this arm protects is
+        // the `libraryReleaseId: 0` delivery landing on a Backend-linked row,
+        // where `albumId` is null and the free text is written through.
         //
-        // Review round 3 finding 2 refines that to the payload itself rather
-        // than the resolution result: `rawLibraryId` truthy means tubafrenzy
-        // is asserting an actual link (create, or a genuine `/wxycdb` relink to
-        // a *different* release), so `excluded.album_id` wins outright — this
-        // restores tubafrenzy's ability to relink a row, which the blanket
-        // COALESCE had silently revoked (its docblock's claim that "tubafrenzy
-        // can no longer unlink a rotation row" was broader than intended: it
-        // could no longer *change* `album_id` at all). `rawLibraryId` falsy
-        // (0/absent — tubafrenzy doesn't know) keeps the COALESCE fallback, so
-        // a Backend-made link (or a link this same delivery just resolved)
-        // survives.
-        const albumIdExpr = rawLibraryId
-          ? sql`excluded.album_id`
-          : sql`COALESCE(excluded.album_id, ${rotation.album_id})`;
-
-        // The three snapshot columns below write `excluded.*` unconditionally
-        // (gated only on presence, same as every other column here) — a
-        // library-linked rotation row is allowed to keep carrying
-        // tubafrenzy's free text. Three reasons converge on that:
-        //
-        //   (a) `linkRotationToAlbum` (`apps/backend/services/library.service.ts`,
-        //       BS#2109 review round 3 finding 1) deliberately leaves a
-        //       freshly-linked row's `artist_name`/`album_title`/`record_label`
-        //       populated for exactly this reason — nulling them broke the
-        //       tracklist picker's tier-3 self-heal, which needs both columns
-        //       non-NULL to even attempt a lookup.
+        // Why the trio is worth keeping wherever it survives:
+        //   (a) `linkRotationToAlbum` (`apps/backend/services/library.service.ts`)
+        //       deliberately leaves a freshly-linked row's trio populated —
+        //       nulling it broke the tracklist picker's tier-3 self-heal,
+        //       which needs artist + title non-NULL to attempt a lookup.
         //   (b) `jobs/rotation-release-id-backfill`'s candidate query
         //       (`query.ts`) requires `artist_name IS NOT NULL AND
-        //       album_title IS NOT NULL` to repair a row's
-        //       `discogs_release_id`. Nulling the trio on link permanently
-        //       excludes that row from the one job meant to fix it — and its
-        //       predicate also excludes killed rows (`kill_date IS NULL OR
-        //       kill_date > CURRENT_DATE`), which this same PR deliberately
-        //       surfaces in the uncatalogued queue, so a killed+linked row
-        //       would have no repair path at all.
+        //       album_title IS NOT NULL` to repair `discogs_release_id`, and
+        //       also excludes killed rows — so a killed+linked row with a
+        //       nulled trio has no repair path at all.
         //   (c) It costs nothing display-side: `getRotationFromDB` selects
         //       `COALESCE(artists.artist_name, rotation.artist_name)` (and the
         //       album/label siblings), so a linked row always reads the
-        //       canonical `library`/`artists` value regardless of what
-        //       `rotation`'s own snapshot columns hold.
-        //
-        // `albumIdExpr` is deliberately not reused here (unlike an earlier
-        // revision) — the trio's value no longer depends on whether the row
-        // resolves linked.
+        //       canonical `library`/`artists` value regardless.
         const setClause: Record<string, unknown> = {
-          album_id: albumIdExpr,
           legacy_library_release_id: sql`excluded.legacy_library_release_id`,
           rotation_bin: sql`excluded.rotation_bin`,
         };
+        if (rawLibraryId) {
+          setClause.album_id = sql`excluded.album_id`;
+        }
         if (release.killDate !== undefined) {
           setClause.kill_date = sql`excluded.kill_date`;
         }

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -978,32 +978,40 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         // could no longer *change* `album_id` at all). `rawLibraryId` falsy
         // (0/absent — tubafrenzy doesn't know) keeps the COALESCE fallback, so
         // a Backend-made link (or a link this same delivery just resolved)
-        // survives. `albumIdExpr` is shared with the three snapshot columns
-        // below so both agree on what "resolves linked" means from the exact
-        // same delivery.
+        // survives.
         const albumIdExpr = rawLibraryId
           ? sql`excluded.album_id`
           : sql`COALESCE(excluded.album_id, ${rotation.album_id})`;
 
-        // Review round 3 finding 2: presence in the payload still gates
-        // *whether* each snapshot column appears in SET at all (unchanged, see
-        // above), but a column that does appear is no longer written
-        // unconditionally from `excluded.*`. `PATCH /library/rotation/:id/link`
-        // deliberately leaves a freshly-linked row's snapshot columns
-        // populated (finding 1) so the tracklist picker can self-heal — a
-        // `/wxycdb` edit arriving afterward would otherwise write tubafrenzy's
-        // (necessarily stale, potentially divergent) free text straight onto
-        // an `album_id`-linked row, recreating the "both populated" shape
-        // `PATCH .../link`'s 409 and sibling PR #2165 both exist to prevent,
-        // and that the BS#2080 arm-(b)/(c) rotation-badge match in
-        // `shared/legacy-mirror/src/rotation-match.ts` and
-        // `apps/backend/services/flowsheet.service.ts` doesn't filter
-        // `album_id IS NULL` against. Each CASE reuses `albumIdExpr` — the
-        // exact same expression assigned to `album_id` in this statement — so
-        // a column is written from `excluded.*` only when the row resolves
-        // UNLINKED after this delivery; otherwise it's forced to NULL,
-        // matching the state `PATCH .../link` leaves a fresh link in until a
-        // subsequent edit or backfill catches up.
+        // The three snapshot columns below write `excluded.*` unconditionally
+        // (gated only on presence, same as every other column here) — a
+        // library-linked rotation row is allowed to keep carrying
+        // tubafrenzy's free text. Three reasons converge on that:
+        //
+        //   (a) `linkRotationToAlbum` (`apps/backend/services/library.service.ts`,
+        //       BS#2109 review round 3 finding 1) deliberately leaves a
+        //       freshly-linked row's `artist_name`/`album_title`/`record_label`
+        //       populated for exactly this reason — nulling them broke the
+        //       tracklist picker's tier-3 self-heal, which needs both columns
+        //       non-NULL to even attempt a lookup.
+        //   (b) `jobs/rotation-release-id-backfill`'s candidate query
+        //       (`query.ts`) requires `artist_name IS NOT NULL AND
+        //       album_title IS NOT NULL` to repair a row's
+        //       `discogs_release_id`. Nulling the trio on link permanently
+        //       excludes that row from the one job meant to fix it — and its
+        //       predicate also excludes killed rows (`kill_date IS NULL OR
+        //       kill_date > CURRENT_DATE`), which this same PR deliberately
+        //       surfaces in the uncatalogued queue, so a killed+linked row
+        //       would have no repair path at all.
+        //   (c) It costs nothing display-side: `getRotationFromDB` selects
+        //       `COALESCE(artists.artist_name, rotation.artist_name)` (and the
+        //       album/label siblings), so a linked row always reads the
+        //       canonical `library`/`artists` value regardless of what
+        //       `rotation`'s own snapshot columns hold.
+        //
+        // `albumIdExpr` is deliberately not reused here (unlike an earlier
+        // revision) — the trio's value no longer depends on whether the row
+        // resolves linked.
         const setClause: Record<string, unknown> = {
           album_id: albumIdExpr,
           legacy_library_release_id: sql`excluded.legacy_library_release_id`,
@@ -1013,13 +1021,13 @@ internal_route.post('/rotation-webhook', async (req, res) => {
           setClause.kill_date = sql`excluded.kill_date`;
         }
         if (release.artistName !== undefined) {
-          setClause.artist_name = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.artist_name ELSE NULL END`;
+          setClause.artist_name = sql`excluded.artist_name`;
         }
         if (release.albumTitle !== undefined) {
-          setClause.album_title = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.album_title ELSE NULL END`;
+          setClause.album_title = sql`excluded.album_title`;
         }
         if (release.labelName !== undefined) {
-          setClause.record_label = sql`CASE WHEN (${albumIdExpr}) IS NULL THEN excluded.record_label ELSE NULL END`;
+          setClause.record_label = sql`excluded.record_label`;
         }
 
         await db

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -98,7 +98,9 @@ library_route.get('/rotation', requirePermissions({ catalog: ['read'] }), librar
 // same '/catalog' vs '/:id/compilation-tracks' trap documented above). At
 // the time of writing there is no single-segment `/rotation/:id` route to
 // collide with, but WXYC/Backend-Service#2113 adds one to this same block;
-// this GET must stay registered before it.
+// this GET must stay registered before it. Pinned by
+// `tests/unit/routes/library-rotation-uncatalogued.route.test.ts`, which
+// fails if a parameterized `/rotation/:x` GET is ever registered ahead of it.
 library_route.get(
   '/rotation/uncatalogued',
   requirePermissions({ catalog: ['read'] }),

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -93,6 +93,18 @@ library_route.post('/', requirePermissions({ catalog: ['write'] }), libraryContr
 
 library_route.get('/rotation', requirePermissions({ catalog: ['read'] }), libraryController.getRotation);
 
+// BS#2109: the cataloging-backlog queue. REGISTRATION ORDER IS LOAD-BEARING —
+// keep this literal ahead of any templated `/rotation/:id`-style route (the
+// same '/catalog' vs '/:id/compilation-tracks' trap documented above). At
+// the time of writing there is no single-segment `/rotation/:id` route to
+// collide with, but WXYC/Backend-Service#2113 adds one to this same block;
+// this GET must stay registered before it.
+library_route.get(
+  '/rotation/uncatalogued',
+  requirePermissions({ catalog: ['read'] }),
+  libraryController.getUncataloguedRotation
+);
+
 library_route.post('/rotation', requirePermissions({ catalog: ['write'] }), libraryController.addRotation);
 
 library_route.patch('/rotation', requirePermissions({ catalog: ['write'] }), libraryController.killRotation);
@@ -101,6 +113,15 @@ library_route.get(
   '/rotation/:rotation_id/tracks',
   requirePermissions({ catalog: ['read'] }),
   libraryController.getRotationTracks
+);
+
+// BS#2109: links an uncatalogued rotation row to a library release (the
+// "Import to Library" step). Two-segment route, so it does not collide with
+// `/rotation/uncatalogued` (one segment) or a future `/rotation/:id`.
+library_route.patch(
+  '/rotation/:rotation_id/link',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.linkRotationToAlbum
 );
 
 library_route.post('/artists', requirePermissions({ catalog: ['write'] }), libraryController.addArtist);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -710,13 +710,18 @@ export type LinkRotationOutcome =
  * librarian-facing, otherwise-instant endpoint's transaction for no benefit
  * on the other 76%.
  *
- * This does temporarily reintroduce the "`album_id` set AND snapshot set"
- * shape `POST /internal/rotation-webhook`'s linkage-aware SET clause
- * (review round 3 finding 2) exists to collapse — but only until whichever
- * comes first: the picker mints a real `discogs_release_id` (tier 1 no
- * longer needs the snapshot) or a `/wxycdb` edit lands on the row, whose
- * gated SET clause nulls the trio out anyway. Never permanent, unlike the
- * bug this replaces.
+ * This produces the "`album_id` set AND snapshot set" shape — and, unlike an
+ * earlier revision, it now simply persists. That earlier revision paired
+ * this function with a `POST /internal/rotation-webhook` SET clause that
+ * nulled the trio out on the row's next `/wxycdb` edit; that CASE-based
+ * gating was itself the bug (it starved both self-heal paths above of the
+ * columns they need) and has been removed — the webhook's UPDATE path now
+ * writes `excluded.*` unconditionally for the trio, same as this function.
+ * So the shape lasts until `jobs/rotation-release-id-backfill` mints a
+ * `discogs_release_id` for the row (its candidate query has no `album_id`
+ * predicate, so a linked row with a populated snapshot is picked up the same
+ * as an unlinked one) — the self-heal path this function exists to keep
+ * open by leaving the trio in place.
  *
  * The final UPDATE re-guards `album_id IS NULL` in its own WHERE (not just
  * the earlier SELECT) so a concurrent link between the check and the write

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -583,6 +583,92 @@ export const killRotationInDB = async (rotationId: number, updatedKillDate?: str
   return updatedRotation[0];
 };
 
+/**
+ * Read-side query for `GET /library/rotation/uncatalogued` (BS#2109).
+ *
+ * The cataloging-backlog queue. Unlike `getRotationFromDB`, this is
+ * deliberately:
+ *
+ *   - **NOT `DISTINCT ON`-collapsed.** Two physically distinct promos
+ *     sharing an artist and title are two separate rows a librarian has to
+ *     catalogue; `getRotationFromDB`'s dedup exists for its dropdown shape
+ *     and would silently hide one of them here.
+ *   - **Not `LEFT JOIN`ed to `library`/`artists`/`format`/`genres`.** Every
+ *     row this predicate selects is unlinked by definition, so those joins
+ *     would return NULL for every column on every row. Returns the raw
+ *     `rotation` snapshot columns instead.
+ *   - **Not restricted to active (`kill_date`) rows.** The queue is the
+ *     full cataloging backlog (killed/historical releases still need
+ *     cataloguing, or a record of never having been), not a live dropdown.
+ *
+ * `COALESCE(album_id, 0) = 0` covers both unlinked sentinels: tubafrenzy
+ * writes `0`, Backend writes `NULL` (see `rotation.album_id`'s column doc).
+ */
+export const getUncataloguedRotationFromDB = async (): Promise<RotationRelease[]> => {
+  return db
+    .select()
+    .from(rotation)
+    .where(sql`COALESCE(${rotation.album_id}, 0) = 0`)
+    .orderBy(desc(rotation.add_date), asc(rotation.id));
+};
+
+export type LinkRotationOutcome =
+  | { outcome: 'linked'; rotation: RotationRelease }
+  | { outcome: 'rotation_not_found' }
+  | { outcome: 'already_linked' }
+  | { outcome: 'album_not_found' };
+
+/**
+ * Links an uncatalogued rotation row to a library release (BS#2109's
+ * `PATCH /library/rotation/:rotation_id/link` — the "Import to Library"
+ * step of the tubafrenzy `/wxycdb` workflow).
+ *
+ * Clears `artist_name` / `album_title` / `record_label` in the same
+ * transaction as the `album_id` write, matching `jobs/legacy-linkage-resolve`
+ * (`resolveRotationLinks`) — display reads through the `library` join once
+ * linked, so a link that doesn't clear the snapshot leaves stale free text
+ * visible until the next cron tick.
+ *
+ * The final UPDATE re-guards `album_id IS NULL` in its own WHERE (not just
+ * the earlier SELECT) so a concurrent link between the check and the write
+ * can't silently double-link the row — mirrors the `f.album_id IS NULL` /
+ * `r.album_id IS NULL` re-check discipline in `legacy-linkage-resolve`.
+ */
+export const linkRotationToAlbum = async (rotationId: number, albumId: number): Promise<LinkRotationOutcome> => {
+  return db.transaction(async (tx) => {
+    const [albumRow] = await tx.select({ id: library.id }).from(library).where(eq(library.id, albumId)).limit(1);
+    if (!albumRow) {
+      return { outcome: 'album_not_found' as const };
+    }
+
+    const [existingRotation] = await tx
+      .select({ album_id: rotation.album_id })
+      .from(rotation)
+      .where(eq(rotation.id, rotationId))
+      .limit(1);
+    if (!existingRotation) {
+      return { outcome: 'rotation_not_found' as const };
+    }
+    if (existingRotation.album_id != null) {
+      return { outcome: 'already_linked' as const };
+    }
+
+    const [updated] = await tx
+      .update(rotation)
+      .set({ album_id: albumId, artist_name: null, album_title: null, record_label: null })
+      .where(and(eq(rotation.id, rotationId), isNull(rotation.album_id)))
+      .returning();
+
+    if (!updated) {
+      // Race: another request linked this row between the check above and
+      // this UPDATE's own re-guarded WHERE.
+      return { outcome: 'already_linked' as const };
+    }
+
+    return { outcome: 'linked' as const, rotation: updated };
+  });
+};
+
 export const insertAlbum = async (newAlbum: NewAlbum) => {
   const response = await db.insert(library).values(newAlbum).returning();
   return response[0];

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -615,7 +615,22 @@ const UNCATALOGUED_ROTATION_PROJECTION = {
  */
 export type UncataloguedRotationRow = Pick<RotationRelease, keyof typeof UNCATALOGUED_ROTATION_PROJECTION>;
 
-/** Optional window over the queue. Both absent ⇒ the full backlog. */
+/**
+ * Ceiling on `?limit=` for the uncatalogued queue, and the default when the
+ * caller omits it — so "omit `limit`" means "give me the largest page I could
+ * have asked for", never "give me the whole table".
+ *
+ * The cap is deliberately not a per-endpoint concern. It lives on the query
+ * because an unbounded default is a property of the read, not of one route:
+ * the backlog is ~3.8k rows (≈700 KB of JSON) and this runs on a single-worker
+ * 1 GB box that also serves the live flowsheet. It is also cheaper to set now
+ * than later — `wxyc-shared#354` is about to transcribe this shape into the
+ * published cross-repo contract, and narrowing "omit ⇒ everything" after a
+ * client depends on it is a breaking change.
+ */
+export const UNCATALOGUED_ROTATION_MAX_LIMIT = 500;
+
+/** Optional window over the queue. `limit` defaults to the max above. */
 export type UncataloguedRotationPage = { limit?: number; offset?: number };
 
 /**
@@ -652,17 +667,15 @@ export type UncataloguedRotationPage = { limit?: number; offset?: number };
 export const getUncataloguedRotationFromDB = async (
   page: UncataloguedRotationPage = {}
 ): Promise<UncataloguedRotationRow[]> => {
-  const { limit, offset } = page;
-  const base = db
+  const { limit = UNCATALOGUED_ROTATION_MAX_LIMIT, offset } = page;
+  const windowed = db
     .select(UNCATALOGUED_ROTATION_PROJECTION)
     .from(rotation)
     .where(isNull(rotation.album_id))
-    .orderBy(desc(rotation.add_date), asc(rotation.id));
+    .orderBy(desc(rotation.add_date), asc(rotation.id))
+    .limit(limit);
 
-  if (limit == null && offset == null) return base;
-  if (limit == null) return base.offset(offset as number);
-  if (offset == null) return base.limit(limit);
-  return base.limit(limit).offset(offset);
+  return offset == null ? windowed : windowed.offset(offset);
 };
 
 export type LinkRotationOutcome =

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -584,6 +584,39 @@ export const killRotationInDB = async (rotationId: number, updatedKillDate?: str
 };
 
 /**
+ * Explicit SELECT list for `GET /library/rotation/uncatalogued` (BS#2109).
+ *
+ * Deliberately a projection, not `select()`. `rotation` also carries
+ * `legacy_rotation_id`, `legacy_library_release_id`, `discogs_release_id`,
+ * `discogs_release_id_source`, `lml_identity_id`,
+ * `tracklist_lookup_attempted_at` and
+ * `discogs_release_id_resolve_attempted_at` — server-derived plumbing that
+ * `getRotationFromDB`'s SELECT list does not publish either, and that
+ * `tests/integration/library.spec.js` pins the rotation surface against
+ * exposing flat. A bare `select()` would also auto-publish every column a
+ * future migration adds, and WXYC/wxyc-shared#354 transcribes whatever this
+ * returns into a published contract.
+ */
+const UNCATALOGUED_ROTATION_PROJECTION = {
+  id: rotation.id,
+  album_id: rotation.album_id,
+  rotation_bin: rotation.rotation_bin,
+  add_date: rotation.add_date,
+  kill_date: rotation.kill_date,
+  artist_name: rotation.artist_name,
+  album_title: rotation.album_title,
+  record_label: rotation.record_label,
+} as const;
+
+export type UncataloguedRotationRow = Pick<
+  RotationRelease,
+  'id' | 'album_id' | 'rotation_bin' | 'add_date' | 'kill_date' | 'artist_name' | 'album_title' | 'record_label'
+>;
+
+/** Optional window over the queue. Both absent ⇒ the full backlog. */
+export type UncataloguedRotationPage = { limit?: number; offset?: number };
+
+/**
  * Read-side query for `GET /library/rotation/uncatalogued` (BS#2109).
  *
  * The cataloging-backlog queue. Unlike `getRotationFromDB`, this is
@@ -601,15 +634,33 @@ export const killRotationInDB = async (rotationId: number, updatedKillDate?: str
  *     full cataloging backlog (killed/historical releases still need
  *     cataloguing, or a record of never having been), not a live dropdown.
  *
- * `COALESCE(album_id, 0) = 0` covers both unlinked sentinels: tubafrenzy
- * writes `0`, Backend writes `NULL` (see `rotation.album_id`'s column doc).
+ * **`album_id IS NULL` is the whole unlinked predicate.** An earlier draft
+ * used `COALESCE(album_id, 0) = 0` on the belief that tubafrenzy writes a
+ * `0` sentinel here. It does not: `rotation.album_id` carries
+ * `rotation_album_id_library_id_fk → library.id`, `library.id` is a `serial`
+ * starting at 1, so a stored `0` would violate the FK; the webhook writer
+ * normalizes its raw upstream id with `rawLibraryId || null`
+ * (`internal.route.ts`) before `resolveAlbumId`; and the seed clone holds
+ * zero `album_id = 0` rows out of 21,625. The 0/NULL duality is real but
+ * lives on `legacy_library_release_id`, a different column. `IS NULL` is
+ * also sargable against `album_id_idx`, which `COALESCE(...)` was not.
+ * `addRotation` (400 on `album_id: 0`) and `linkRotationToAlbum`
+ * (`isNull(rotation.album_id)`) agree with this reading.
  */
-export const getUncataloguedRotationFromDB = async (): Promise<RotationRelease[]> => {
-  return db
-    .select()
+export const getUncataloguedRotationFromDB = async (
+  page: UncataloguedRotationPage = {}
+): Promise<UncataloguedRotationRow[]> => {
+  const { limit, offset } = page;
+  const base = db
+    .select(UNCATALOGUED_ROTATION_PROJECTION)
     .from(rotation)
-    .where(sql`COALESCE(${rotation.album_id}, 0) = 0`)
+    .where(isNull(rotation.album_id))
     .orderBy(desc(rotation.add_date), asc(rotation.id));
+
+  if (limit == null && offset == null) return base;
+  if (limit == null) return base.offset(offset as number);
+  if (offset == null) return base.limit(limit);
+  return base.limit(limit).offset(offset);
 };
 
 export type LinkRotationOutcome =
@@ -633,6 +684,11 @@ export type LinkRotationOutcome =
  * the earlier SELECT) so a concurrent link between the check and the write
  * can't silently double-link the row — mirrors the `f.album_id IS NULL` /
  * `r.album_id IS NULL` re-check discipline in `legacy-linkage-resolve`.
+ *
+ * "Unlinked" is NULL and only NULL here, matching
+ * `getUncataloguedRotationFromDB`'s read predicate and `addRotation`'s
+ * rejection of `album_id: 0` — see that function's doc for why no `0`
+ * sentinel exists on this column.
  */
 export const linkRotationToAlbum = async (rotationId: number, albumId: number): Promise<LinkRotationOutcome> => {
   return db.transaction(async (tx) => {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -608,10 +608,12 @@ const UNCATALOGUED_ROTATION_PROJECTION = {
   record_label: rotation.record_label,
 } as const;
 
-export type UncataloguedRotationRow = Pick<
-  RotationRelease,
-  'id' | 'album_id' | 'rotation_bin' | 'add_date' | 'kill_date' | 'artist_name' | 'album_title' | 'record_label'
->;
+/**
+ * Derived from the projection rather than restating its key list, so adding a
+ * column to `UNCATALOGUED_ROTATION_PROJECTION` without widening the type (or
+ * the reverse) is a compile error instead of silent drift.
+ */
+export type UncataloguedRotationRow = Pick<RotationRelease, keyof typeof UNCATALOGUED_ROTATION_PROJECTION>;
 
 /** Optional window over the queue. Both absent ⇒ the full backlog. */
 export type UncataloguedRotationPage = { limit?: number; offset?: number };

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -664,7 +664,7 @@ export const getUncataloguedRotationFromDB = async (
 };
 
 export type LinkRotationOutcome =
-  | { outcome: 'linked'; rotation: RotationRelease }
+  | { outcome: 'linked'; rotation: UncataloguedRotationRow }
   | { outcome: 'rotation_not_found' }
   | { outcome: 'already_linked' }
   | { outcome: 'album_not_found' };
@@ -674,11 +674,49 @@ export type LinkRotationOutcome =
  * `PATCH /library/rotation/:rotation_id/link` — the "Import to Library"
  * step of the tubafrenzy `/wxycdb` workflow).
  *
- * Clears `artist_name` / `album_title` / `record_label` in the same
- * transaction as the `album_id` write, matching `jobs/legacy-linkage-resolve`
- * (`resolveRotationLinks`) — display reads through the `library` join once
- * linked, so a link that doesn't clear the snapshot leaves stale free text
- * visible until the next cron tick.
+ * **Review round 3 finding 1: deliberately does NOT clear `artist_name` /
+ * `album_title` / `record_label`.** The first revision cleared the trio in
+ * the same transaction, matching `jobs/legacy-linkage-resolve` — reasoning
+ * that display reads through the `library` join once linked, so stale free
+ * text would never surface. True for `getRotationFromDB`
+ * (`COALESCE(artists.artist_name, rotation.artist_name)` always prefers the
+ * joined canonical value once `album_id` resolves; clearing the snapshot is
+ * display-invisible there) but wrong for `resolveRotationPickerSource`'s
+ * three-tier tracklist resolution: tier 1 (`rotation.discogs_release_id`)
+ * and tier 2 (`library_identity.discogs_release_id` via the `album_id`
+ * bridge, ~24% coverage) are both very likely still NULL immediately after a
+ * link — `addToRotation`'s synchronous `library_identity` → `resolveIdentity`
+ * hop only runs on `POST /library/rotation`, never here — and clearing the
+ * snapshot also removed tier 3's only input:
+ * `resolveRotationDiscogsReleaseViaLml(rotationId, artist_name, album_title)`
+ * short-circuits on `if (!artistName || !albumTitle) return null`. The
+ * picker ended up strictly worse than before the link, with no self-heal:
+ * `jobs/rotation-release-id-backfill`'s candidate query requires
+ * `artist_name IS NOT NULL AND album_title IS NOT NULL`, and
+ * `jobs/rotation-lml-identity-backfill`'s requires
+ * `discogs_release_id IS NOT NULL` — each needs what only the other could
+ * have produced.
+ *
+ * Leaving the trio in place costs nothing display-side and re-opens both
+ * self-heal paths: tier 3 keeps working immediately after the link, and
+ * `rotation-release-id-backfill`'s 6-hourly cron (17 minutes past the hour,
+ * every sixth hour, UTC) can now pick the row up
+ * (its candidate query has no `album_id` predicate) and mint
+ * `discogs_release_id`, which unblocks `rotation-lml-identity-backfill` in
+ * turn. The alternative fix — replicate `addToRotation`'s synchronous
+ * `library_identity` → `resolveIdentity` hop inside this transaction — was
+ * rejected: it only helps the ~24% of albums `library_identity` already has
+ * a resolved handle for, and it would add an LML round-trip inside a
+ * librarian-facing, otherwise-instant endpoint's transaction for no benefit
+ * on the other 76%.
+ *
+ * This does temporarily reintroduce the "`album_id` set AND snapshot set"
+ * shape `POST /internal/rotation-webhook`'s linkage-aware SET clause
+ * (review round 3 finding 2) exists to collapse — but only until whichever
+ * comes first: the picker mints a real `discogs_release_id` (tier 1 no
+ * longer needs the snapshot) or a `/wxycdb` edit lands on the row, whose
+ * gated SET clause nulls the trio out anyway. Never permanent, unlike the
+ * bug this replaces.
  *
  * The final UPDATE re-guards `album_id IS NULL` in its own WHERE (not just
  * the earlier SELECT) so a concurrent link between the check and the write
@@ -689,6 +727,17 @@ export type LinkRotationOutcome =
  * `getUncataloguedRotationFromDB`'s read predicate and `addRotation`'s
  * rejection of `album_id: 0` — see that function's doc for why no `0`
  * sentinel exists on this column.
+ *
+ * **Review round 3 finding 4:** `.returning()` is projected through the same
+ * `UNCATALOGUED_ROTATION_PROJECTION` the queue read uses, rather than a bare
+ * `.returning()` — the raw row publishes the same seven server-derived
+ * columns (`legacy_rotation_id`, `legacy_library_release_id`,
+ * `discogs_release_id`, `discogs_release_id_source`, `lml_identity_id`, and
+ * the two attempt-at markers) that projection exists to keep off the wire,
+ * and `tests/integration/library.spec.js` pins the rotation surface against
+ * exposing them. `addRotation`'s unprojected `.returning()` is pre-existing
+ * and out of scope here — it publishes onto a freshly-inserted row this
+ * client just supplied every field of, not a read of someone else's data.
  */
 export const linkRotationToAlbum = async (rotationId: number, albumId: number): Promise<LinkRotationOutcome> => {
   return db.transaction(async (tx) => {
@@ -711,9 +760,9 @@ export const linkRotationToAlbum = async (rotationId: number, albumId: number): 
 
     const [updated] = await tx
       .update(rotation)
-      .set({ album_id: albumId, artist_name: null, album_title: null, record_label: null })
+      .set({ album_id: albumId })
       .where(and(eq(rotation.id, rotationId), isNull(rotation.album_id)))
-      .returning();
+      .returning(UNCATALOGUED_ROTATION_PROJECTION);
 
     if (!updated) {
       // Race: another request linked this row between the check above and

--- a/tests/integration/internal-rotation-webhook.spec.js
+++ b/tests/integration/internal-rotation-webhook.spec.js
@@ -17,13 +17,18 @@
  *
  * BS#2109 review round 3 additionally covers: `album_id` no longer un-links
  * a Backend-made link on a `libraryReleaseId: 0` delivery but still accepts
- * a genuinely resolvable one (finding 2's "better form"), and the snapshot
- * trio is forced to NULL rather than written whenever the row resolves
- * linked — regardless of whether the link came from
- * `PATCH /library/rotation/:id/link` or from this same webhook call
- * (finding 2), reconciled against `PATCH .../link`'s decision to leave a
- * fresh link's own snapshot populated for the tracklist picker's self-heal
- * (finding 1).
+ * a genuinely resolvable one (finding 2's "better form"). An earlier
+ * revision also forced the snapshot trio to NULL whenever the row resolved
+ * linked; that CASE was itself a bug (it starved `linkRotationToAlbum`'s
+ * self-heal path and `jobs/rotation-release-id-backfill`'s candidate query
+ * of the columns they need — see `apps/backend/routes/internal.route.ts`)
+ * and has been removed. The trio now always writes `excluded.*` when
+ * present in the payload, same as every other gated column — a linked row
+ * is allowed to keep carrying tubafrenzy's free text, which
+ * `PATCH /library/rotation/:id/link` (finding 1) already leaves populated
+ * for exactly this reason, and which `getRotationFromDB`'s
+ * `COALESCE(artists.artist_name, rotation.artist_name)` read makes
+ * display-invisible regardless.
  */
 
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
@@ -178,18 +183,17 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
     expect(row.record_label).toBe('Link Test Label');
   });
 
-  // Review round 3 finding 3: the prior version of this test sent the
-  // `sendRotationLinked` shape (`{id, libraryReleaseId: 0}`), which carries
-  // no `artistName` — so the presence gate excludes the snapshot columns
-  // from SET entirely and the assertion below never exercised finding 2's
-  // CASE branch at all, regardless of what it asserted. The scenario this
-  // test's name describes — "the next /wxycdb edit" — is the
-  // `sendRotationUpdated` shape, which DOES carry the trio. Sent against
-  // that shape, a linked row must end up with the trio NULLed (finding 2),
-  // not carrying whatever free text tubafrenzy's classic form still has for
-  // it — tubafrenzy has no idea the row is linked, so its own free-text
-  // fields are unconditionally treated as stale once `album_id` resolves.
-  test('a full /wxycdb edit on an already-linked row nulls the free-text snapshot instead of writing it back', async () => {
+  // A linked row is allowed to keep carrying tubafrenzy's free text. An
+  // earlier revision nulled the snapshot trio here whenever the row resolved
+  // linked, on the theory that tubafrenzy's classic form is unconditionally
+  // stale once `album_id` resolves — but that starved `linkRotationToAlbum`'s
+  // tracklist-picker self-heal and `jobs/rotation-release-id-backfill`'s
+  // candidate query (both need `artist_name`/`album_title` non-NULL) of the
+  // columns they depend on, with no path back for a killed row. The trio now
+  // writes `excluded.*` unconditionally, same as every other gated column —
+  // this is purely a presence-gate question (BS#1082 + BS#1312), independent
+  // of whether the row resolves linked.
+  test('a full /wxycdb edit on an already-linked row still writes the trio from the payload', async () => {
     const [libraryRow] = await sql.unsafe(`SELECT id FROM ${SCHEMA}.library ORDER BY id LIMIT 1`);
     expect(libraryRow).toBeDefined();
 
@@ -208,14 +212,15 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
         release: {
           id: LEGACY_ROTATION_ID,
           // tubafrenzy does not know about the Backend-made link, so its own
-          // classic-form fields are the stale free text — 0 is what it
-          // sends when it believes the row is still uncatalogued.
+          // classic-form fields are what it currently believes is current —
+          // 0 is what it sends when it believes the row is still
+          // uncatalogued.
           libraryReleaseId: 0,
           rotationType: 'M',
           killDate: 0,
-          artistName: 'Stale Tubafrenzy Artist',
-          albumTitle: 'Stale Tubafrenzy Album',
-          labelName: 'Stale Tubafrenzy Label',
+          artistName: 'Updated Tubafrenzy Artist',
+          albumTitle: 'Updated Tubafrenzy Album',
+          labelName: 'Updated Tubafrenzy Label',
           addDate: 1706799600000,
         },
       });
@@ -226,15 +231,14 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
          FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
       [LEGACY_ROTATION_ID]
     );
-    // The link survives (COALESCE fallback, libraryReleaseId: 0) and the
-    // presence-gated, non-linkage column (rotation_bin) still refreshes...
+    // The link survives (COALESCE fallback, libraryReleaseId: 0) and every
+    // presence-gated column — including the snapshot trio — refreshes from
+    // the payload, same as an unlinked row.
     expect(row.album_id).toBe(libraryRow.id);
     expect(row.rotation_bin).toBe('M');
-    // ...but the snapshot trio is forced to NULL rather than overwritten
-    // with tubafrenzy's stale free text, since the row resolves linked.
-    expect(row.artist_name).toBeNull();
-    expect(row.album_title).toBeNull();
-    expect(row.record_label).toBeNull();
+    expect(row.artist_name).toBe('Updated Tubafrenzy Artist');
+    expect(row.album_title).toBe('Updated Tubafrenzy Album');
+    expect(row.record_label).toBe('Updated Tubafrenzy Label');
   });
 
   // The COALESCE fallback only applies when the payload's own

--- a/tests/integration/internal-rotation-webhook.spec.js
+++ b/tests/integration/internal-rotation-webhook.spec.js
@@ -14,6 +14,16 @@
  * The companion unit test at `tests/unit/routes/internal.route.test.ts`
  * verifies the SET-clause shape against a mocked db; this spec verifies the
  * end-to-end behavior at the row level against real Postgres.
+ *
+ * BS#2109 review round 3 additionally covers: `album_id` no longer un-links
+ * a Backend-made link on a `libraryReleaseId: 0` delivery but still accepts
+ * a genuinely resolvable one (finding 2's "better form"), and the snapshot
+ * trio is forced to NULL rather than written whenever the row resolves
+ * linked — regardless of whether the link came from
+ * `PATCH /library/rotation/:id/link` or from this same webhook call
+ * (finding 2), reconciled against `PATCH .../link`'s decision to leave a
+ * fresh link's own snapshot populated for the tracklist picker's self-heal
+ * (finding 1).
  */
 
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
@@ -121,12 +131,19 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
 
   // BS#2109: `PATCH /library/rotation/:id/link` creates the first
   // Backend-canonical `album_id` tubafrenzy does not know about. The
-  // webhook's `album_id` SET is COALESCEd (`COALESCE(excluded.album_id,
-  // rotation.album_id)`) so the next `/wxycdb` edit — which arrives with
-  // `libraryReleaseId: 0`, i.e. `excluded.album_id IS NULL` — cannot revert
-  // the link and drop the row back into the cataloging queue.
+  // webhook's `album_id` SET falls back to `COALESCE(excluded.album_id,
+  // rotation.album_id)` whenever the payload's own `libraryReleaseId` is
+  // falsy, so a `/wxycdb` edit that arrives with `libraryReleaseId: 0` (i.e.
+  // `excluded.album_id IS NULL`) cannot revert the link and drop the row
+  // back into the cataloging queue.
   //
-  // Also the end-to-end proof that the COALESCE SQL is valid inside
+  // Review round 3 finding 1: `PATCH .../link` deliberately leaves
+  // `artist_name`/`album_title`/`record_label` populated on a freshly-linked
+  // row (so the tracklist picker can self-heal), which is why this row is
+  // seeded WITH a populated snapshot rather than NULLs — that is the real
+  // post-link shape now, not an artifact.
+  //
+  // Also the end-to-end proof that the COALESCE + CASE SQL is valid inside
   // `ON CONFLICT DO UPDATE`, which the mocked-db unit test cannot show.
   test('a Backend-made album_id link survives an update carrying libraryReleaseId: 0', async () => {
     const [libraryRow] = await sql.unsafe(`SELECT id FROM ${SCHEMA}.library ORDER BY id LIMIT 1`);
@@ -135,7 +152,7 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
     await sql.unsafe(
       `INSERT INTO ${SCHEMA}.rotation
          (legacy_rotation_id, album_id, rotation_bin, add_date, artist_name, album_title, record_label)
-       VALUES ($1, $2, 'H', '2026-01-01', NULL, NULL, NULL)`,
+       VALUES ($1, $2, 'H', '2026-01-01', 'Link Test Artist', 'Link Test Album', 'Link Test Label')`,
       [LEGACY_ROTATION_ID, libraryRow.id]
     );
 
@@ -151,14 +168,81 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
       [LEGACY_ROTATION_ID]
     );
     expect(row.album_id).toBe(libraryRow.id);
-    // The free text was cleared by the link and must stay cleared.
+    // A `sendRotationLinked`-shaped payload carries no artistName key at
+    // all, so the presence gate (BS#1082 + BS#1312, untouched by review
+    // round 3 finding 2) keeps the snapshot columns out of SET entirely —
+    // finding 1's preserved free text survives a linkage-only ping
+    // unmodified.
+    expect(row.artist_name).toBe('Link Test Artist');
+    expect(row.album_title).toBe('Link Test Album');
+    expect(row.record_label).toBe('Link Test Label');
+  });
+
+  // Review round 3 finding 3: the prior version of this test sent the
+  // `sendRotationLinked` shape (`{id, libraryReleaseId: 0}`), which carries
+  // no `artistName` — so the presence gate excludes the snapshot columns
+  // from SET entirely and the assertion below never exercised finding 2's
+  // CASE branch at all, regardless of what it asserted. The scenario this
+  // test's name describes — "the next /wxycdb edit" — is the
+  // `sendRotationUpdated` shape, which DOES carry the trio. Sent against
+  // that shape, a linked row must end up with the trio NULLed (finding 2),
+  // not carrying whatever free text tubafrenzy's classic form still has for
+  // it — tubafrenzy has no idea the row is linked, so its own free-text
+  // fields are unconditionally treated as stale once `album_id` resolves.
+  test('a full /wxycdb edit on an already-linked row nulls the free-text snapshot instead of writing it back', async () => {
+    const [libraryRow] = await sql.unsafe(`SELECT id FROM ${SCHEMA}.library ORDER BY id LIMIT 1`);
+    expect(libraryRow).toBeDefined();
+
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.rotation
+         (legacy_rotation_id, album_id, rotation_bin, add_date, artist_name, album_title, record_label)
+       VALUES ($1, $2, 'H', '2026-01-01', 'Link Test Artist', 'Link Test Album', 'Link Test Label')`,
+      [LEGACY_ROTATION_ID, libraryRow.id]
+    );
+
+    const res = await request
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({
+        action: 'update',
+        release: {
+          id: LEGACY_ROTATION_ID,
+          // tubafrenzy does not know about the Backend-made link, so its own
+          // classic-form fields are the stale free text — 0 is what it
+          // sends when it believes the row is still uncatalogued.
+          libraryReleaseId: 0,
+          rotationType: 'M',
+          killDate: 0,
+          artistName: 'Stale Tubafrenzy Artist',
+          albumTitle: 'Stale Tubafrenzy Album',
+          labelName: 'Stale Tubafrenzy Label',
+          addDate: 1706799600000,
+        },
+      });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(
+      `SELECT album_id, rotation_bin, artist_name, album_title, record_label
+         FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      [LEGACY_ROTATION_ID]
+    );
+    // The link survives (COALESCE fallback, libraryReleaseId: 0) and the
+    // presence-gated, non-linkage column (rotation_bin) still refreshes...
+    expect(row.album_id).toBe(libraryRow.id);
+    expect(row.rotation_bin).toBe('M');
+    // ...but the snapshot trio is forced to NULL rather than overwritten
+    // with tubafrenzy's stale free text, since the row resolves linked.
     expect(row.artist_name).toBeNull();
     expect(row.album_title).toBeNull();
     expect(row.record_label).toBeNull();
   });
 
-  // The COALESCE is non-downgrading, not write-blocking: an update that
-  // DOES carry a resolvable upstream linkage still lands.
+  // The COALESCE fallback only applies when the payload's own
+  // `libraryReleaseId` is falsy (tubafrenzy doesn't know); a genuinely
+  // resolvable `libraryReleaseId` (review round 3 finding 2's "better form")
+  // takes the bare `excluded.album_id` branch instead — a real tubafrenzy
+  // relink still lands, which the interim blanket-COALESCE shape had
+  // silently revoked.
   test('an update carrying a resolvable libraryReleaseId still writes album_id', async () => {
     const [libraryRow] = await sql.unsafe(
       `SELECT id, legacy_release_id FROM ${SCHEMA}.library WHERE legacy_release_id IS NOT NULL ORDER BY id LIMIT 1`

--- a/tests/integration/internal-rotation-webhook.spec.js
+++ b/tests/integration/internal-rotation-webhook.spec.js
@@ -118,4 +118,69 @@ describe('POST /internal/rotation-webhook — partial update preserves denorm fi
     expect(row.album_title).toBe('DOGA');
     expect(row.record_label).toBe('Sonamos');
   });
+
+  // BS#2109: `PATCH /library/rotation/:id/link` creates the first
+  // Backend-canonical `album_id` tubafrenzy does not know about. The
+  // webhook's `album_id` SET is COALESCEd (`COALESCE(excluded.album_id,
+  // rotation.album_id)`) so the next `/wxycdb` edit — which arrives with
+  // `libraryReleaseId: 0`, i.e. `excluded.album_id IS NULL` — cannot revert
+  // the link and drop the row back into the cataloging queue.
+  //
+  // Also the end-to-end proof that the COALESCE SQL is valid inside
+  // `ON CONFLICT DO UPDATE`, which the mocked-db unit test cannot show.
+  test('a Backend-made album_id link survives an update carrying libraryReleaseId: 0', async () => {
+    const [libraryRow] = await sql.unsafe(`SELECT id FROM ${SCHEMA}.library ORDER BY id LIMIT 1`);
+    expect(libraryRow).toBeDefined();
+
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.rotation
+         (legacy_rotation_id, album_id, rotation_bin, add_date, artist_name, album_title, record_label)
+       VALUES ($1, $2, 'H', '2026-01-01', NULL, NULL, NULL)`,
+      [LEGACY_ROTATION_ID, libraryRow.id]
+    );
+
+    const res = await request
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'update', release: { id: LEGACY_ROTATION_ID, libraryReleaseId: 0 } });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(
+      `SELECT album_id, artist_name, album_title, record_label
+         FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      [LEGACY_ROTATION_ID]
+    );
+    expect(row.album_id).toBe(libraryRow.id);
+    // The free text was cleared by the link and must stay cleared.
+    expect(row.artist_name).toBeNull();
+    expect(row.album_title).toBeNull();
+    expect(row.record_label).toBeNull();
+  });
+
+  // The COALESCE is non-downgrading, not write-blocking: an update that
+  // DOES carry a resolvable upstream linkage still lands.
+  test('an update carrying a resolvable libraryReleaseId still writes album_id', async () => {
+    const [libraryRow] = await sql.unsafe(
+      `SELECT id, legacy_release_id FROM ${SCHEMA}.library WHERE legacy_release_id IS NOT NULL ORDER BY id LIMIT 1`
+    );
+    expect(libraryRow).toBeDefined();
+
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.rotation
+         (legacy_rotation_id, album_id, rotation_bin, add_date, artist_name, album_title, record_label)
+       VALUES ($1, NULL, 'H', '2026-01-01', 'Stale Artist', 'Stale Album', 'Stale Label')`,
+      [LEGACY_ROTATION_ID]
+    );
+
+    const res = await request
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'update', release: { id: LEGACY_ROTATION_ID, libraryReleaseId: libraryRow.legacy_release_id } });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(`SELECT album_id FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`, [
+      LEGACY_ROTATION_ID,
+    ]);
+    expect(row.album_id).toBe(libraryRow.id);
+  });
 });

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -5,6 +5,23 @@ const { getTestDb } = require('../utils/db');
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
 /**
+ * Real teardown for rotation rows a test created (BS#2109).
+ *
+ * `PATCH /library/rotation` (killRotation) only stamps `kill_date` — the row
+ * survives, and `GET /library/rotation/uncatalogued` is deliberately not
+ * kill_date-filtered, so a "cleaned up" row stays in the cataloging backlog
+ * permanently and pollutes every later assertion about queue contents.
+ * DELETE is the only teardown that actually removes it. The pool is shared
+ * with the rest of the integration suite; do NOT close it here.
+ */
+async function deleteRotationRows(rotationIds) {
+  const ids = rotationIds.filter((id) => typeof id === 'number');
+  if (ids.length === 0) return;
+  const sql = getTestDb();
+  await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id IN ${sql(ids)}`;
+}
+
+/**
  * Library Endpoints Integration Tests
  *
  * Tests for:
@@ -507,28 +524,77 @@ describe('Library Rotation', () => {
 
   // BS#2109: an uncatalogued rotation release — no album_id, represented by
   // the free-text artist_name/album_title pair (record_label optional).
+  //
+  // Teardown is a real DELETE, not `PATCH /library/rotation` (killRotation),
+  // which only stamps `kill_date`. The uncatalogued queue is deliberately
+  // NOT kill_date-filtered, so a killed row stays in it forever — "cleaning
+  // up" with killRotation would leave every row these tests create in the
+  // production-shaped backlog the suite then asserts against.
   describe('POST /library/rotation (uncatalogued release, BS#2109)', () => {
+    const createdRotationIds = [];
+
+    async function createUncatalogued(body) {
+      const res = await auth.post('/library/rotation').send(body).expect(201);
+      if (res.body.id) createdRotationIds.push(res.body.id);
+      return res;
+    }
+
+    afterAll(async () => {
+      await deleteRotationRows(createdRotationIds);
+    });
+
     test('accepts a rotation release with no album_id when artist_name + album_title are supplied', async () => {
-      const res = await auth
-        .post('/library/rotation')
-        .send({
-          rotation_bin: 'L',
-          artist_name: 'Uncatalogued Test Artist',
-          album_title: 'Uncatalogued Test Album',
-          record_label: 'Uncatalogued Test Label',
-        })
-        .expect(201);
+      const res = await createUncatalogued({
+        rotation_bin: 'L',
+        artist_name: 'Uncatalogued Test Artist',
+        album_title: 'Uncatalogued Test Album',
+        record_label: 'Uncatalogued Test Label',
+      });
 
       expect(res.body.album_id).toBeNull();
       expect(res.body.rotation_bin).toBe('L');
       expect(res.body.artist_name).toBe('Uncatalogued Test Artist');
       expect(res.body.album_title).toBe('Uncatalogued Test Album');
       expect(res.body.record_label).toBe('Uncatalogued Test Label');
+    });
 
-      // Clean up.
-      if (res.body.id) {
-        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
-      }
+    // The `selected?.id ?? null` client shape. An `=== undefined` guard took
+    // the has-an-album_id branch on it, returned 201, and silently discarded
+    // the artist and title — leaving a permanently un-catalogueable row.
+    test('accepts an explicit album_id: null and keeps the free text', async () => {
+      const res = await createUncatalogued({
+        album_id: null,
+        rotation_bin: 'L',
+        artist_name: 'Explicit Null Artist',
+        album_title: 'Explicit Null Album',
+      });
+
+      expect(res.body.album_id).toBeNull();
+      expect(res.body.artist_name).toBe('Explicit Null Artist');
+      expect(res.body.album_title).toBe('Explicit Null Album');
+    });
+
+    test('400s on album_id: null with no artist_name/album_title pair', async () => {
+      const res = await auth.post('/library/rotation').send({ album_id: null, rotation_bin: 'L' }).expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    // No `0` sentinel exists on rotation.album_id (it FKs library.id, a
+    // serial starting at 1). Unguarded this dropped the free text, then
+    // violated the FK into an opaque 500.
+    test('400s on album_id: 0 instead of 500ing on the FK violation', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          album_id: 0,
+          rotation_bin: 'L',
+          artist_name: 'Zero Album Id Artist',
+          album_title: 'Zero Album Id Album',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'album_id must be a positive integer');
     });
 
     test('still 400s when neither album_id nor an artist_name/album_title pair is given', async () => {
@@ -554,25 +620,33 @@ describe('Library Rotation', () => {
       expectErrorContains(res, 'Missing Parameters');
     });
 
+    // varchar(128). Without the guard this was a PG 22001 → generic 500 with
+    // no indication of which field overran.
+    test('400s naming the field when album_title exceeds 128 characters', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'L',
+          artist_name: 'Overlong Title Artist',
+          album_title: 'x'.repeat(129),
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'album_title exceeds the 128-character limit');
+    });
+
     test('does not synchronously call LML / resolveIdentity when album_id is absent (no library_identity row to resolve)', async () => {
       // No library_identity hop is possible without an album_id — the
       // server-derived Discogs columns must stay at their defaults rather
       // than erroring.
-      const res = await auth
-        .post('/library/rotation')
-        .send({
-          rotation_bin: 'S',
-          artist_name: 'Uncatalogued Test Artist Two',
-          album_title: 'Uncatalogued Test Album Two',
-        })
-        .expect(201);
+      const res = await createUncatalogued({
+        rotation_bin: 'S',
+        artist_name: 'Uncatalogued Test Artist Two',
+        album_title: 'Uncatalogued Test Album Two',
+      });
 
       expect(res.body.discogs_release_id).toBeNull();
       expect(res.body.lml_identity_id).toBeNull();
-
-      if (res.body.id) {
-        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
-      }
     });
   });
 
@@ -584,8 +658,48 @@ describe('Library Rotation', () => {
       expectArray(res);
       expect(res.body.length).toBeGreaterThan(0);
       for (const row of res.body) {
-        expect(row.album_id === null || row.album_id === 0).toBe(true);
+        expect(row.album_id).toBeNull();
       }
+    });
+
+    // The projection is explicit, not `select()`. `getRotationFromDB` doesn't
+    // publish these columns either (see the sibling pin above on
+    // GET /library/rotation), and WXYC/wxyc-shared#354 transcribes whatever
+    // this returns into a published contract.
+    test('publishes an explicit projection — no server-derived or external-ID columns', async () => {
+      const res = await auth.get('/library/rotation/uncatalogued').expect(200);
+
+      expect(res.body.length).toBeGreaterThan(0);
+      const row = res.body[0];
+      expect(Object.keys(row).sort()).toEqual([
+        'add_date',
+        'album_id',
+        'album_title',
+        'artist_name',
+        'id',
+        'kill_date',
+        'record_label',
+        'rotation_bin',
+      ]);
+    });
+
+    test('honours an optional limit/offset window, and is unbounded without one', async () => {
+      const all = await auth.get('/library/rotation/uncatalogued').expect(200);
+      expect(all.body.length).toBeGreaterThan(1);
+
+      const firstPage = await auth.get('/library/rotation/uncatalogued').query({ limit: 1 }).expect(200);
+      expect(firstPage.body).toHaveLength(1);
+      expect(firstPage.body[0].id).toBe(all.body[0].id);
+
+      const secondPage = await auth.get('/library/rotation/uncatalogued').query({ limit: 1, offset: 1 }).expect(200);
+      expect(secondPage.body).toHaveLength(1);
+      expect(secondPage.body[0].id).toBe(all.body[1].id);
+    });
+
+    test('400s on a malformed limit', async () => {
+      const res = await auth.get('/library/rotation/uncatalogued').query({ limit: '10abc' }).expect(400);
+
+      expectErrorContains(res, 'limit must be an integer');
     });
 
     test('surfaces two same-artist/same-title unlinked rows BOTH — no DISTINCT ON collapse', async () => {
@@ -619,6 +733,8 @@ describe('Library Rotation', () => {
   // BS#2109: links an uncatalogued rotation row to a library release after
   // the fact (the "Import to Library" step of the tubafrenzy /wxycdb flow).
   describe('PATCH /library/rotation/:rotation_id/link', () => {
+    const createdRotationIds = [];
+
     async function createUncataloguedRotation(overrides = {}) {
       const res = await auth
         .post('/library/rotation')
@@ -629,8 +745,13 @@ describe('Library Rotation', () => {
           ...overrides,
         })
         .expect(201);
+      createdRotationIds.push(res.body.id);
       return res.body;
     }
+
+    afterAll(async () => {
+      await deleteRotationRows(createdRotationIds);
+    });
 
     test('links album_id and clears artist_name/album_title/record_label in the same transaction', async () => {
       const created = await createUncataloguedRotation({ record_label: 'Link Test Label' });
@@ -646,8 +767,6 @@ describe('Library Rotation', () => {
       // read the row back and re-assert (guards against a partial write).
       const reread = await auth.get('/library/rotation/uncatalogued').expect(200);
       expect(reread.body.find((r) => r.id === created.id)).toBeUndefined();
-
-      await auth.patch('/library/rotation').send({ rotation_id: created.id });
     });
 
     test('rejects double-linking', async () => {
@@ -656,8 +775,6 @@ describe('Library Rotation', () => {
 
       const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 2 }).expect(409);
       expectErrorContains(res, 'already linked');
-
-      await auth.patch('/library/rotation').send({ rotation_id: created.id });
     });
 
     test('404s when the rotation row does not exist', async () => {
@@ -665,13 +782,24 @@ describe('Library Rotation', () => {
       expectErrorContains(res, 'Rotation entry not found');
     });
 
+    // `parseInt('42abc', 10)` is 42, so the pre-fix parse routed this at
+    // whatever rotation row `42` happens to be.
+    test('400s on a malformed rotation_id rather than coercing it', async () => {
+      const created = await createUncataloguedRotation();
+
+      const res = await auth.patch(`/library/rotation/${created.id}abc/link`).send({ album_id: 1 }).expect(400);
+      expectErrorContains(res, 'positive integer');
+
+      // The row it would have coerced to is untouched.
+      const queue = await auth.get('/library/rotation/uncatalogued').expect(200);
+      expect(queue.body.find((r) => r.id === created.id)).toBeDefined();
+    });
+
     test('404s when the album does not exist', async () => {
       const created = await createUncataloguedRotation();
 
       const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 9999999 }).expect(404);
       expectErrorContains(res, 'Album not found');
-
-      await auth.patch('/library/rotation').send({ rotation_id: created.id });
     });
 
     test('400s when album_id is missing', async () => {
@@ -679,8 +807,6 @@ describe('Library Rotation', () => {
 
       const res = await auth.patch(`/library/rotation/${created.id}/link`).send({}).expect(400);
       expectErrorContains(res, 'Missing Parameters');
-
-      await auth.patch('/library/rotation').send({ rotation_id: created.id });
     });
   });
 });

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -753,20 +753,46 @@ describe('Library Rotation', () => {
       await deleteRotationRows(createdRotationIds);
     });
 
-    test('links album_id and clears artist_name/album_title/record_label in the same transaction', async () => {
+    // Review round 3 finding 1: linking deliberately does NOT clear the
+    // free-text snapshot — see `linkRotationToAlbum`'s doc for why
+    // (clearing it stranded the tracklist picker with no self-heal path).
+    test('links album_id and leaves artist_name/album_title/record_label untouched', async () => {
       const created = await createUncataloguedRotation({ record_label: 'Link Test Label' });
 
       const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 1 }).expect(200);
 
       expect(res.body.album_id).toBe(1);
-      expect(res.body.artist_name).toBeNull();
-      expect(res.body.album_title).toBeNull();
-      expect(res.body.record_label).toBeNull();
+      expect(res.body.artist_name).toBe('Link Test Artist');
+      expect(res.body.album_title).toBe('Link Test Album');
+      expect(res.body.record_label).toBe('Link Test Label');
 
-      // No window where the row carries both album_id and stale free text —
-      // read the row back and re-assert (guards against a partial write).
+      // Once album_id resolves, the row drops out of the uncatalogued queue
+      // regardless of whether the snapshot columns are also populated — the
+      // queue's predicate is `album_id IS NULL` alone.
       const reread = await auth.get('/library/rotation/uncatalogued').expect(200);
       expect(reread.body.find((r) => r.id === created.id)).toBeUndefined();
+    });
+
+    // Review round 3 finding 4: the link response is projected the same way
+    // `GET /library/rotation/uncatalogued` is — not the raw `.returning()`
+    // row, which would leak legacy_rotation_id, legacy_library_release_id,
+    // discogs_release_id, discogs_release_id_source, lml_identity_id, and
+    // the two attempt-at markers.
+    test('link response is projected — no server-derived or external-ID columns', async () => {
+      const created = await createUncataloguedRotation();
+
+      const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 1 }).expect(200);
+
+      expect(Object.keys(res.body).sort()).toEqual([
+        'add_date',
+        'album_id',
+        'album_title',
+        'artist_name',
+        'id',
+        'kill_date',
+        'record_label',
+        'rotation_bin',
+      ]);
     });
 
     test('rejects double-linking', async () => {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -504,6 +504,185 @@ describe('Library Rotation', () => {
       expectErrorContains(res, 'Incorrect Date Format');
     });
   });
+
+  // BS#2109: an uncatalogued rotation release — no album_id, represented by
+  // the free-text artist_name/album_title pair (record_label optional).
+  describe('POST /library/rotation (uncatalogued release, BS#2109)', () => {
+    test('accepts a rotation release with no album_id when artist_name + album_title are supplied', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'L',
+          artist_name: 'Uncatalogued Test Artist',
+          album_title: 'Uncatalogued Test Album',
+          record_label: 'Uncatalogued Test Label',
+        })
+        .expect(201);
+
+      expect(res.body.album_id).toBeNull();
+      expect(res.body.rotation_bin).toBe('L');
+      expect(res.body.artist_name).toBe('Uncatalogued Test Artist');
+      expect(res.body.album_title).toBe('Uncatalogued Test Album');
+      expect(res.body.record_label).toBe('Uncatalogued Test Label');
+
+      // Clean up.
+      if (res.body.id) {
+        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
+      }
+    });
+
+    test('still 400s when neither album_id nor an artist_name/album_title pair is given', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'M',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('400s when only artist_name is given without album_title', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'M',
+          artist_name: 'Uncatalogued Test Artist',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('does not synchronously call LML / resolveIdentity when album_id is absent (no library_identity row to resolve)', async () => {
+      // No library_identity hop is possible without an album_id — the
+      // server-derived Discogs columns must stay at their defaults rather
+      // than erroring.
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'S',
+          artist_name: 'Uncatalogued Test Artist Two',
+          album_title: 'Uncatalogued Test Album Two',
+        })
+        .expect(201);
+
+      expect(res.body.discogs_release_id).toBeNull();
+      expect(res.body.lml_identity_id).toBeNull();
+
+      if (res.body.id) {
+        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
+      }
+    });
+  });
+
+  // BS#2109: the cataloging-backlog queue.
+  describe('GET /library/rotation/uncatalogued', () => {
+    test('returns an array of unlinked rows', async () => {
+      const res = await auth.get('/library/rotation/uncatalogued').expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+      for (const row of res.body) {
+        expect(row.album_id === null || row.album_id === 0).toBe(true);
+      }
+    });
+
+    test('surfaces two same-artist/same-title unlinked rows BOTH — no DISTINCT ON collapse', async () => {
+      // The shape fixture (tests/fixtures/shape.sql) seeds two NULL-album_id
+      // rotation rows (ids 7007 and 7015) with identical artist/album/bin —
+      // the exact pair getRotationFromDB's dropdown collapses to one (#862).
+      // The uncatalogued queue must surface both: they're two distinct
+      // physical promos a librarian has to catalogue separately.
+      const res = await auth.get('/library/rotation/uncatalogued').expect(200);
+
+      const orphanRows = res.body.filter(
+        (r) => r.artist_name === 'Shape Fixture Orphan One' && r.album_title === 'Shape Fixture Orphan Album One'
+      );
+      expect(orphanRows.map((r) => r.id).sort((a, b) => a - b)).toEqual([7007, 7015]);
+    });
+
+    test('GET /library/rotation is untouched: response shape and dedup behavior are unaffected', async () => {
+      // Pins the constraint from the issue: GET /library/rotation is not
+      // modified by BS#2109. Re-asserts the pre-existing #862 collapse
+      // behavior still holds on the dropdown endpoint.
+      const res = await auth.get('/library/rotation').expect(200);
+
+      const orphanOneRows = res.body.filter(
+        (r) => r.id === null && r.artist_name === 'Shape Fixture Orphan One' && r.rotation_bin === 'L'
+      );
+      expect(orphanOneRows).toHaveLength(1);
+      expect(orphanOneRows[0].rotation_add_date).toBe('2024-09-12');
+    });
+  });
+
+  // BS#2109: links an uncatalogued rotation row to a library release after
+  // the fact (the "Import to Library" step of the tubafrenzy /wxycdb flow).
+  describe('PATCH /library/rotation/:rotation_id/link', () => {
+    async function createUncataloguedRotation(overrides = {}) {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          rotation_bin: 'L',
+          artist_name: 'Link Test Artist',
+          album_title: 'Link Test Album',
+          ...overrides,
+        })
+        .expect(201);
+      return res.body;
+    }
+
+    test('links album_id and clears artist_name/album_title/record_label in the same transaction', async () => {
+      const created = await createUncataloguedRotation({ record_label: 'Link Test Label' });
+
+      const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 1 }).expect(200);
+
+      expect(res.body.album_id).toBe(1);
+      expect(res.body.artist_name).toBeNull();
+      expect(res.body.album_title).toBeNull();
+      expect(res.body.record_label).toBeNull();
+
+      // No window where the row carries both album_id and stale free text —
+      // read the row back and re-assert (guards against a partial write).
+      const reread = await auth.get('/library/rotation/uncatalogued').expect(200);
+      expect(reread.body.find((r) => r.id === created.id)).toBeUndefined();
+
+      await auth.patch('/library/rotation').send({ rotation_id: created.id });
+    });
+
+    test('rejects double-linking', async () => {
+      const created = await createUncataloguedRotation();
+      await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 1 }).expect(200);
+
+      const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 2 }).expect(409);
+      expectErrorContains(res, 'already linked');
+
+      await auth.patch('/library/rotation').send({ rotation_id: created.id });
+    });
+
+    test('404s when the rotation row does not exist', async () => {
+      const res = await auth.patch('/library/rotation/9999999/link').send({ album_id: 1 }).expect(404);
+      expectErrorContains(res, 'Rotation entry not found');
+    });
+
+    test('404s when the album does not exist', async () => {
+      const created = await createUncataloguedRotation();
+
+      const res = await auth.patch(`/library/rotation/${created.id}/link`).send({ album_id: 9999999 }).expect(404);
+      expectErrorContains(res, 'Album not found');
+
+      await auth.patch('/library/rotation').send({ rotation_id: created.id });
+    });
+
+    test('400s when album_id is missing', async () => {
+      const created = await createUncataloguedRotation();
+
+      const res = await auth.patch(`/library/rotation/${created.id}/link`).send({}).expect(400);
+      expectErrorContains(res, 'Missing Parameters');
+
+      await auth.patch('/library/rotation').send({ rotation_id: created.id });
+    });
+  });
 });
 
 describe('Library Artists', () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -104,6 +104,11 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   addToRotation: mockAddToRotation,
   killRotationInDB: mockKillRotationInDB,
   getUncataloguedRotationFromDB: mockGetUncataloguedRotationFromDB,
+  // Not a function — a real value export the controller destructures at module
+  // load for its 400 message and bound check. Omitting it makes the ceiling
+  // `undefined`, so `limit > undefined` is false and every over-limit request
+  // silently 200s.
+  UNCATALOGUED_ROTATION_MAX_LIMIT: 500,
   linkRotationToAlbum: mockLinkRotationToAlbum,
   insertAlbum: mockInsertAlbum,
   updateArtworkUrl: mockUpdateArtworkUrl,

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -29,6 +29,19 @@ const mockResolveRotationPickerSource = jest.fn<(rotationId: number) => Promise<
 type RotationTrackMock = { position: string; title: string; duration: string | null; artists: string[] };
 const mockGetRotationTracksFromRelease = jest.fn<(releaseId: number) => Promise<RotationTrackMock[] | null>>();
 
+// GET /library/rotation, POST /library/rotation, PATCH /library/rotation,
+// GET /library/rotation/uncatalogued, PATCH /library/rotation/:id/link (BS#2109).
+const mockGetRotationFromDB = jest.fn<() => Promise<unknown[]>>();
+const mockAddToRotation = jest.fn<(fields: Record<string, unknown>) => Promise<Record<string, unknown>>>();
+const mockKillRotationInDB = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockGetUncataloguedRotationFromDB = jest.fn<() => Promise<unknown[]>>();
+type LinkRotationOutcomeMock =
+  | { outcome: 'linked'; rotation: Record<string, unknown> }
+  | { outcome: 'rotation_not_found' }
+  | { outcome: 'already_linked' }
+  | { outcome: 'album_not_found' };
+const mockLinkRotationToAlbum = jest.fn<(rotationId: number, albumId: number) => Promise<LinkRotationOutcomeMock>>();
+
 // PATCH /library/:id (updateAlbum) surface.
 const mockGetLibraryRowById = jest.fn<(id: number) => Promise<Record<string, unknown> | undefined>>();
 const mockUpdateAlbumInDB =
@@ -87,9 +100,11 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   serializeArtist: (row: unknown) => row,
   // Stub out other exports that may be referenced at import time
   getFormatsFromDB: jest.fn(),
-  getRotationFromDB: jest.fn(),
-  addToRotation: jest.fn(),
-  killRotationInDB: jest.fn(),
+  getRotationFromDB: mockGetRotationFromDB,
+  addToRotation: mockAddToRotation,
+  killRotationInDB: mockKillRotationInDB,
+  getUncataloguedRotationFromDB: mockGetUncataloguedRotationFromDB,
+  linkRotationToAlbum: mockLinkRotationToAlbum,
   insertAlbum: mockInsertAlbum,
   updateArtworkUrl: mockUpdateArtworkUrl,
   updateOnStreaming: mockUpdateOnStreaming,
@@ -187,6 +202,10 @@ import {
   searchLibraryQueryEndpoint,
   manualDiscogsRecheck,
   deleteAlbum,
+  addRotation,
+  getUncataloguedRotation,
+  linkRotationToAlbum,
+  pickAddRotationFields,
 } from '../../../apps/backend/controllers/library.controller';
 
 function mockResponse(): Response {
@@ -909,6 +928,198 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(getRotationTracks(req, res, next)).rejects.toThrow('upstream timeout');
+    });
+  });
+
+  describe('pickAddRotationFields (BS#2109)', () => {
+    it('picks album_id and rotation_bin, dropping the snapshot trio, when album_id is present', () => {
+      const picked = pickAddRotationFields({
+        album_id: 5,
+        rotation_bin: 'M',
+        artist_name: 'Forged Artist',
+        album_title: 'Forged Album',
+        record_label: 'Forged Label',
+      });
+
+      expect(picked).toEqual({ album_id: 5, rotation_bin: 'M' });
+    });
+
+    it('picks the snapshot trio when album_id is absent', () => {
+      const picked = pickAddRotationFields({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+        record_label: 'Rough Trade',
+      });
+
+      expect(picked).toEqual({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+        record_label: 'Rough Trade',
+      });
+    });
+
+    it('omits record_label from the picked fields when not supplied (album_id absent)', () => {
+      const picked = pickAddRotationFields({
+        rotation_bin: 'S',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+      });
+
+      expect(picked).toEqual({ rotation_bin: 'S', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' });
+    });
+  });
+
+  describe('addRotation (BS#2109)', () => {
+    beforeEach(() => {
+      mockAddToRotation.mockReset();
+    });
+
+    it('returns 400 when rotation_bin is missing', async () => {
+      const req = { body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('Missing Parameters');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when neither album_id nor the artist_name/album_title pair is given', async () => {
+      const req = { body: { rotation_bin: 'M' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('Missing Parameters');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when only artist_name is given (album_title also required)', async () => {
+      const req = { body: { rotation_bin: 'M', artist_name: 'Jockstrap' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('Missing Parameters');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('accepts a catalogued rotation add (album_id present, no free text needed)', async () => {
+      mockAddToRotation.mockResolvedValue({ id: 1, album_id: 5, rotation_bin: 'M' });
+      const req = { body: { album_id: 5, rotation_bin: 'M' } } as unknown as Request;
+      const res = mockResponse();
+
+      await addRotation(req, res, next);
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({ album_id: 5, rotation_bin: 'M' });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('accepts an uncatalogued rotation add (no album_id, artist_name + album_title supplied)', async () => {
+      mockAddToRotation.mockResolvedValue({
+        id: 2,
+        album_id: null,
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+      });
+      const req = {
+        body: { rotation_bin: 'L', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await addRotation(req, res, next);
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+
+  describe('getUncataloguedRotation (BS#2109)', () => {
+    it('delegates to getUncataloguedRotationFromDB and returns 200', async () => {
+      const rows = [{ id: 10, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' }];
+      mockGetUncataloguedRotationFromDB.mockResolvedValue(rows);
+      const req = {} as unknown as Request;
+      const res = mockResponse();
+
+      await getUncataloguedRotation(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(rows);
+    });
+  });
+
+  describe('linkRotationToAlbum (BS#2109)', () => {
+    beforeEach(() => {
+      mockLinkRotationToAlbum.mockReset();
+    });
+
+    it('returns 400 for a non-numeric rotation_id', async () => {
+      const req = { params: { rotation_id: 'abc' }, body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('positive integer');
+      expect(mockLinkRotationToAlbum).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a non-positive rotation_id', async () => {
+      const req = { params: { rotation_id: '0' }, body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('positive integer');
+    });
+
+    it('returns 400 when album_id is missing', async () => {
+      const req = { params: { rotation_id: '42' }, body: {} } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('Missing Parameters');
+      expect(mockLinkRotationToAlbum).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with the updated row on success', async () => {
+      mockLinkRotationToAlbum.mockResolvedValue({
+        outcome: 'linked',
+        rotation: { id: 42, album_id: 5, artist_name: null, album_title: null, record_label: null },
+      });
+      const req = { params: { rotation_id: '42' }, body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await linkRotationToAlbum(req, res, next);
+
+      expect(mockLinkRotationToAlbum).toHaveBeenCalledWith(42, 5);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 42,
+        album_id: 5,
+        artist_name: null,
+        album_title: null,
+        record_label: null,
+      });
+    });
+
+    it('returns 404 when the rotation row does not exist', async () => {
+      mockLinkRotationToAlbum.mockResolvedValue({ outcome: 'rotation_not_found' });
+      const req = { params: { rotation_id: '42' }, body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('Rotation entry not found');
+    });
+
+    it('returns 404 when the album does not exist', async () => {
+      mockLinkRotationToAlbum.mockResolvedValue({ outcome: 'album_not_found' });
+      const req = { params: { rotation_id: '42' }, body: { album_id: 999999 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('Album not found');
+    });
+
+    it('returns 409 when the rotation row is already linked (rejects double-linking)', async () => {
+      mockLinkRotationToAlbum.mockResolvedValue({ outcome: 'already_linked' });
+      const req = { params: { rotation_id: '42' }, body: { album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('already linked');
     });
   });
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -1130,6 +1130,23 @@ describe('library.controller', () => {
       expect(mockAddToRotation).not.toHaveBeenCalled();
     });
 
+    // Review round 3 finding 7: `Number.isInteger` tightens the pre-existing
+    // catalogued path too, not just the new uncatalogued one — a numeric
+    // *string* `album_id` previously inserted fine (PostgreSQL coerces on
+    // the way into an `integer` column) and now 400s. Deliberately kept:
+    // dj-site's `addRotationEntry` call site is typed `number` end to end
+    // (`AddRotationRequest` from the shared OpenAPI contract, sourced from
+    // `AlbumEntry.id: number`), so the only known caller never sends this
+    // shape — see `addRotation`'s docblock.
+    it('returns 400 for a numeric-string album_id rather than relying on PostgreSQL coercion', async () => {
+      const res = mockResponse();
+
+      await expect(
+        addRotation({ body: { album_id: '2', rotation_bin: 'M' } } as unknown as Request, res, next)
+      ).rejects.toThrow('album_id must be a positive integer');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
     it('returns 400 when a blank/whitespace-only artist_name or album_title is supplied', async () => {
       const res = mockResponse();
 
@@ -1187,6 +1204,54 @@ describe('library.controller', () => {
         album_title: title,
       });
       expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    // Review round 3 finding 6: `varchar(128)` is a PostgreSQL *character*
+    // (code point) limit, but `String.prototype.length` counts UTF-16 code
+    // units — every astral character (emoji, CJK Extension B, …) counts as
+    // 2. 70 astral code points is a value PostgreSQL accepts outright, but
+    // `.length` reads it as 140 and would 400 it — undercutting this
+    // endpoint's own reject-over-truncate rationale (a guard that rejects
+    // something PG would have stored is not the guard the docblock argues
+    // for). Never the reverse: a bare `.length` only ever over-counts, so
+    // there was no 22001 escape either way.
+    it('accepts a 70-character astral-plane (emoji) artist_name even though .length reads it as 140', async () => {
+      mockAddToRotation.mockResolvedValue({ id: 6, album_id: null, rotation_bin: 'L' });
+      const astralName = '🎸'.repeat(70);
+      expect(astralName.length).toBe(140);
+      expect([...astralName].length).toBe(70);
+      const res = mockResponse();
+
+      await addRotation(
+        {
+          body: { rotation_bin: 'L', artist_name: astralName, album_title: 'I Love You Jennifer B' },
+        } as unknown as Request,
+        res,
+        next
+      );
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({
+        rotation_bin: 'L',
+        artist_name: astralName,
+        album_title: 'I Love You Jennifer B',
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('rejects a 129-code-point astral-plane artist_name', async () => {
+      const astralName = '🎸'.repeat(129);
+      const res = mockResponse();
+
+      await expect(
+        addRotation(
+          {
+            body: { rotation_bin: 'L', artist_name: astralName, album_title: 'I Love You Jennifer B' },
+          } as unknown as Request,
+          res,
+          next
+        )
+      ).rejects.toThrow('artist_name exceeds the 128-character limit');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
     });
 
     it('does not length-guard the snapshot trio when album_id is present (the trio is dropped anyway)', async () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -34,7 +34,7 @@ const mockGetRotationTracksFromRelease = jest.fn<(releaseId: number) => Promise<
 const mockGetRotationFromDB = jest.fn<() => Promise<unknown[]>>();
 const mockAddToRotation = jest.fn<(fields: Record<string, unknown>) => Promise<Record<string, unknown>>>();
 const mockKillRotationInDB = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
-const mockGetUncataloguedRotationFromDB = jest.fn<() => Promise<unknown[]>>();
+const mockGetUncataloguedRotationFromDB = jest.fn<(page?: { limit?: number; offset?: number }) => Promise<unknown[]>>();
 type LinkRotationOutcomeMock =
   | { outcome: 'linked'; rotation: Record<string, unknown> }
   | { outcome: 'rotation_not_found' }
@@ -969,6 +969,39 @@ describe('library.controller', () => {
 
       expect(picked).toEqual({ rotation_bin: 'S', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' });
     });
+
+    // `album_id: null` is what `selected?.id ?? null` produces, and it must
+    // behave identically to omitting the key. An `=== undefined` test took
+    // the has-an-album_id branch and dropped the free text on the floor.
+    it('treats an explicit album_id: null exactly as absent and still picks the snapshot trio', () => {
+      const picked = pickAddRotationFields({
+        album_id: null,
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+        record_label: 'Rough Trade',
+      });
+
+      expect(picked).toEqual({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+        record_label: 'Rough Trade',
+      });
+      expect(picked).not.toHaveProperty('album_id');
+    });
+
+    it('drops explicitly-null snapshot fields rather than writing NULL over them', () => {
+      const picked = pickAddRotationFields({
+        album_id: null,
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+        record_label: null,
+      });
+
+      expect(picked).toEqual({ rotation_bin: 'L', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' });
+    });
   });
 
   describe('addRotation (BS#2109)', () => {
@@ -1033,19 +1066,186 @@ describe('library.controller', () => {
       });
       expect(res.status).toHaveBeenCalledWith(201);
     });
+
+    // The `selected?.id ?? null` client shape. Before the fix this returned
+    // 201 having silently discarded artist_name/album_title, leaving a row
+    // that no longer identifies anything and that `PATCH .../link` cannot
+    // usefully repair.
+    it('accepts an uncatalogued add sent as album_id: null, keeping the free text', async () => {
+      mockAddToRotation.mockResolvedValue({ id: 3, album_id: null, rotation_bin: 'L' });
+      const req = {
+        body: { album_id: null, rotation_bin: 'L', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await addRotation(req, res, next);
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: 'I Love You Jennifer B',
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 400 for album_id: null with no artist_name/album_title pair (does not slip past the guard)', async () => {
+      const req = { body: { album_id: null, rotation_bin: 'L' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('Missing Parameters');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when rotation_bin is explicitly null', async () => {
+      const req = { body: { rotation_bin: null, album_id: 5 } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('Missing Parameters: rotation_bin');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    // There is no `0` sentinel on rotation.album_id — it FKs library.id,
+    // a serial starting at 1. `0` is the literal payload the classic
+    // /wxycdb rotation form posts; unguarded it dropped the free text and
+    // then 23503'd into an opaque 500.
+    it('returns 400 for album_id: 0 rather than dropping the free text into an FK violation', async () => {
+      const req = {
+        body: { album_id: 0, rotation_bin: 'L', artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(addRotation(req, res, next)).rejects.toThrow('album_id must be a positive integer');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a negative or non-integer album_id', async () => {
+      const res = mockResponse();
+
+      await expect(
+        addRotation({ body: { album_id: -1, rotation_bin: 'L' } } as unknown as Request, res, next)
+      ).rejects.toThrow('album_id must be a positive integer');
+      await expect(
+        addRotation({ body: { album_id: 1.5, rotation_bin: 'L' } } as unknown as Request, res, next)
+      ).rejects.toThrow('album_id must be a positive integer');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when a blank/whitespace-only artist_name or album_title is supplied', async () => {
+      const res = mockResponse();
+
+      await expect(
+        addRotation(
+          { body: { rotation_bin: 'L', artist_name: '   ', album_title: 'Real Title' } } as unknown as Request,
+          res,
+          next
+        )
+      ).rejects.toThrow('Missing Parameters');
+      await expect(
+        addRotation(
+          { body: { rotation_bin: 'L', artist_name: 'Real Artist', album_title: '' } } as unknown as Request,
+          res,
+          next
+        )
+      ).rejects.toThrow('Missing Parameters');
+      expect(mockAddToRotation).not.toHaveBeenCalled();
+    });
+
+    // The three snapshot columns are varchar(128). Without a guard, PG
+    // raises 22001 and the librarian gets a 500 naming no field.
+    it.each(['artist_name', 'album_title', 'record_label'])(
+      'returns a field-naming 400 when %s exceeds 128 characters',
+      async (field) => {
+        const body: Record<string, unknown> = {
+          rotation_bin: 'L',
+          artist_name: 'Jockstrap',
+          album_title: 'I Love You Jennifer B',
+        };
+        body[field] = 'x'.repeat(129);
+        const res = mockResponse();
+
+        await expect(addRotation({ body } as unknown as Request, res, next)).rejects.toThrow(
+          `${field} exceeds the 128-character limit`
+        );
+        expect(mockAddToRotation).not.toHaveBeenCalled();
+      }
+    );
+
+    it('accepts a snapshot field at exactly 128 characters', async () => {
+      mockAddToRotation.mockResolvedValue({ id: 4, album_id: null, rotation_bin: 'L' });
+      const title = 'y'.repeat(128);
+      const res = mockResponse();
+
+      await addRotation(
+        { body: { rotation_bin: 'L', artist_name: 'Jockstrap', album_title: title } } as unknown as Request,
+        res,
+        next
+      );
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({
+        rotation_bin: 'L',
+        artist_name: 'Jockstrap',
+        album_title: title,
+      });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('does not length-guard the snapshot trio when album_id is present (the trio is dropped anyway)', async () => {
+      mockAddToRotation.mockResolvedValue({ id: 5, album_id: 7, rotation_bin: 'M' });
+      const res = mockResponse();
+
+      await addRotation(
+        { body: { album_id: 7, rotation_bin: 'M', artist_name: 'z'.repeat(500) } } as unknown as Request,
+        res,
+        next
+      );
+
+      expect(mockAddToRotation).toHaveBeenCalledWith({ album_id: 7, rotation_bin: 'M' });
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
   });
 
   describe('getUncataloguedRotation (BS#2109)', () => {
+    beforeEach(() => {
+      mockGetUncataloguedRotationFromDB.mockReset();
+    });
+
     it('delegates to getUncataloguedRotationFromDB and returns 200', async () => {
       const rows = [{ id: 10, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' }];
       mockGetUncataloguedRotationFromDB.mockResolvedValue(rows);
-      const req = {} as unknown as Request;
+      const req = { query: {} } as unknown as Request;
       const res = mockResponse();
 
       await getUncataloguedRotation(req, res, next);
 
+      expect(mockGetUncataloguedRotationFromDB).toHaveBeenCalledWith({ limit: undefined, offset: undefined });
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(rows);
+    });
+
+    it('passes through a valid limit/offset window', async () => {
+      mockGetUncataloguedRotationFromDB.mockResolvedValue([]);
+      const req = { query: { limit: '50', offset: '100' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getUncataloguedRotation(req, res, next);
+
+      expect(mockGetUncataloguedRotationFromDB).toHaveBeenCalledWith({ limit: 50, offset: 100 });
+    });
+
+    it.each(['0', '501', 'abc', '10abc', '1.5', '-1'])('returns 400 for limit=%s', async (limit) => {
+      const req = { query: { limit } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getUncataloguedRotation(req, res, next)).rejects.toThrow('limit must be an integer');
+      expect(mockGetUncataloguedRotationFromDB).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a malformed offset', async () => {
+      const req = { query: { offset: '10abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getUncataloguedRotation(req, res, next)).rejects.toThrow('offset must be a non-negative integer');
+      expect(mockGetUncataloguedRotationFromDB).not.toHaveBeenCalled();
     });
   });
 
@@ -1068,6 +1268,19 @@ describe('library.controller', () => {
 
       await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('positive integer');
     });
+
+    // `parseInt('42abc', 10)` is 42, so the pre-fix parse let
+    // `/library/rotation/42abc/link` mutate rotation 42.
+    it.each(['42abc', ' 42', '4.5', '+42', '0x2a', '1e3'])(
+      'returns 400 for the malformed rotation_id %s rather than coercing it',
+      async (rotation_id) => {
+        const req = { params: { rotation_id }, body: { album_id: 5 } } as unknown as Request;
+        const res = mockResponse();
+
+        await expect(linkRotationToAlbum(req, res, next)).rejects.toThrow('positive integer');
+        expect(mockLinkRotationToAlbum).not.toHaveBeenCalled();
+      }
+    );
 
     it('returns 400 when album_id is missing', async () => {
       const req = { params: { rotation_id: '42' }, body: {} } as unknown as Request;

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1374,10 +1374,12 @@ describe('POST /internal/rotation-webhook', () => {
     expect(setClause).not.toHaveProperty('artist_name');
     expect(setClause).not.toHaveProperty('album_title');
     expect(setClause).not.toHaveProperty('record_label');
-    // ...but the two ungated ones must still be written, or the linkage this
-    // whole payload shape exists to deliver (BS#1082/#1312) silently no-ops.
-    // Without these, an empty `partialSet` would satisfy every assertion above.
-    expect(setClause).toHaveProperty('album_id');
+    // ...and `album_id` stays out too, because `libraryReleaseId: 0` means
+    // tubafrenzy is not asserting a link — see the dedicated test below.
+    expect(setClause).not.toHaveProperty('album_id');
+    // But `legacy_library_release_id` must still be written, or the linkage
+    // this whole payload shape exists to deliver (BS#1082/#1312) silently
+    // no-ops — without it an empty `partialSet` would satisfy everything above.
     expect(setClause).toHaveProperty('legacy_library_release_id');
   });
 
@@ -1546,20 +1548,25 @@ describe('POST /internal/rotation-webhook', () => {
     expect(setClause).toHaveProperty('record_label');
   });
 
-  // BS#2109: `album_id` is COALESCEd, not overwritten, so a webhook `update`
-  // carrying `libraryReleaseId: 0` cannot revert a Backend-made link from
-  // `PATCH /library/rotation/:id/link`. Before this, the next /wxycdb edit on
-  // a release the librarian had catalogued in dj-site reset album_id to NULL,
-  // restored the free text, and dropped the row back into the cataloging
-  // queue.
+  // BS#2109: a webhook `update` carrying `libraryReleaseId: 0` must not revert
+  // a Backend-made link from `PATCH /library/rotation/:id/link`. Before this,
+  // the next /wxycdb edit on a release the librarian had catalogued in dj-site
+  // reset album_id to NULL, restored the free text, and dropped the row back
+  // into the cataloging queue.
+  //
+  // Expressed by OMITTING the key rather than by a `COALESCE(albumId,
+  // rotation.album_id)` expression. The two are equivalent — `resolveAlbumId`
+  // short-circuits to null on a falsy id (`getAlbumIdByLegacyId`,
+  // `library.service.ts`), so that COALESCE could only ever evaluate to the
+  // column's own current value, i.e. `SET album_id = album_id` — and omission
+  // is what every other conditionally-written column here already does.
+  // Asserting absence is also strictly stronger than asserting the SQL text:
+  // it cannot pass vacuously on a fragment shape the renderer doesn't
+  // recognize.
   //
   // BS#2173 moved a bin-less payload like this one off the INSERT...ON
-  // CONFLICT statement entirely (a plain UPDATE, asserted via `mockSet`
-  // below) — re-derived here rather than against `excluded.album_id`, which
-  // this arm has no `excluded` row to reference. `resolveAlbumId` is
-  // guaranteed to return null for `libraryReleaseId: 0`, so the COALESCE's
-  // first argument is the JS `null` that resolved to, not a SQL column ref.
-  it('update with libraryReleaseId: 0 COALESCEs album_id so a Backend-made link is never downgraded to NULL', async () => {
+  // CONFLICT statement entirely, so this is the plain UPDATE arm (`mockSet`).
+  it('update with libraryReleaseId: 0 leaves album_id untouched so a Backend-made link is never downgraded to NULL', async () => {
     mockReturning.mockResolvedValueOnce([{ id: 42 }]);
 
     const res = await request(app)
@@ -1570,14 +1577,7 @@ describe('POST /internal/rotation-webhook', () => {
     expect(res.status).toBe(200);
     expect(mockOnConflict).not.toHaveBeenCalled();
     const setClause = mockSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
-    // drizzle-orm is automocked project-wide, so `sql\`...\`` renders as
-    // `{ sql: TemplateStringsArray, values: [...] }`. Assert on the literal
-    // chunks: a bare value assignment would have no COALESCE.
-    const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
-    expect(rendered).toContain('COALESCE(');
-    // First param is the resolved (null) albumId, second is the existing
-    // row's column — the fallback that wins, so tubafrenzy's NULL loses.
-    expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([null, rotation.album_id]);
+    expect(setClause).not.toHaveProperty('album_id');
   });
 
   // All five gated columns — not just these three — render as plain
@@ -1599,6 +1599,42 @@ describe('POST /internal/rotation-webhook', () => {
       const rendered = ((setClause[column] as { sql?: string[] })?.sql ?? []).join('?');
       expect(rendered).not.toContain('COALESCE');
       expect(rendered).not.toContain('CASE');
+    }
+  });
+
+  // The ON CONFLICT arm gates `album_id` on the same rule as the plain-UPDATE
+  // arm: tubafrenzy asserting a `libraryReleaseId` means overwrite (a create,
+  // or a genuine /wxycdb relink to a different release); tubafrenzy not
+  // knowing means leave the column alone, so a `PATCH
+  // /library/rotation/:id/link` survives the next edit. Both directions are
+  // pinned because omitting the key is what preserves the link — a regression
+  // that always wrote `excluded.album_id` would still pass a
+  // present-and-correct assertion on the truthy case alone.
+  it.each([
+    [0, false, 'omits album_id when tubafrenzy sends no libraryReleaseId'],
+    [777, true, 'writes excluded.album_id when tubafrenzy asserts a libraryReleaseId'],
+  ])('ON CONFLICT arm with libraryReleaseId %p — %s', async (libraryReleaseId, shouldWrite) => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+    if (libraryReleaseId) {
+      // A truthy id makes `resolveAlbumId` actually query; seed the lookup so
+      // it resolves instead of destructuring an undefined result.
+      mockLimit.mockReset();
+      mockLimit.mockResolvedValue([{ id: 42 }]);
+    }
+
+    await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: { ...validRelease, libraryReleaseId } });
+
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    if (shouldWrite) {
+      const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
+      expect(rendered).toContain('excluded.album_id');
+      expect(rendered).not.toContain('COALESCE');
+    } else {
+      expect(setClause).not.toHaveProperty('album_id');
     }
   });
 

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1403,6 +1403,71 @@ describe('POST /internal/rotation-webhook', () => {
     expect(setClause).toHaveProperty('kill_date');
   });
 
+  // N4 coverage gap: nothing previously sent the snapshot trio together with
+  // a blank bin, so this arm's three `!== undefined` branches
+  // (`partialSet.artist_name`/`album_title`/`record_label`) were entirely
+  // unexercised. Unlike the sibling INSERT...ON CONFLICT arm above, this is a
+  // plain UPDATE with no `excluded` row — the gate is `albumId ? null :
+  // truncate(...)` against this delivery's own resolved value, pre-existing
+  // and unrelated to the CASE removal there. `libraryReleaseId: 0`
+  // short-circuits `resolveAlbumId` to null (unlinked), so the trio should
+  // pass the payload's free text straight through.
+  it('missing-bin arm: an unlinked row writes the payload trio rather than nulling it', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({
+        action: 'update',
+        release: {
+          id: 500,
+          libraryReleaseId: 0,
+          rotationType: '',
+          artistName: 'Autechre',
+          albumTitle: 'Confield',
+          labelName: 'Warp',
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockInsert).not.toHaveBeenCalled();
+    const setClause = mockSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(setClause.artist_name).toBe('Autechre');
+    expect(setClause.album_title).toBe('Confield');
+    expect(setClause.record_label).toBe('Warp');
+  });
+
+  // The other half of the same gap: a `libraryReleaseId` that resolves to a
+  // real `album_id` nulls the trio instead of writing the delivery's free
+  // text over a (potentially stale) linked row.
+  it('missing-bin arm: a resolving libraryReleaseId nulls the trio instead of writing the payload free text', async () => {
+    mockLimit.mockReset();
+    mockLimit.mockResolvedValueOnce([{ id: 42 }]); // resolveAlbumId
+    mockReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({
+        action: 'update',
+        release: {
+          id: 500,
+          libraryReleaseId: 777,
+          rotationType: '',
+          artistName: 'Autechre',
+          albumTitle: 'Confield',
+          labelName: 'Warp',
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const setClause = mockSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(setClause.artist_name).toBeNull();
+    expect(setClause.album_title).toBeNull();
+    expect(setClause.record_label).toBeNull();
+  });
+
   // The other half of the same rule: with no bin in the payload and no row to
   // update, there is nothing this handler can legally write. It must report
   // that rather than invent a bin to satisfy the NOT NULL column.
@@ -1515,11 +1580,11 @@ describe('POST /internal/rotation-webhook', () => {
     expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([null, rotation.album_id]);
   });
 
-  // Review round 3 finding 2 narrowed this: only `legacy_library_release_id`
-  // / `rotation_bin` / `kill_date` are still plain `excluded.*` assignments.
-  // `artist_name` / `album_title` / `record_label` are covered by the two
-  // tests below instead — they're no longer plain assignments even when
-  // present, because they're now gated on the row's resolved linkage.
+  // All five gated columns — not just these three — render as plain
+  // `excluded.*` assignments; `artist_name` / `album_title` / `record_label`
+  // are covered by their own dedicated test below (a linked row keeps
+  // tubafrenzy's free text, so there is no CASE gating their value on
+  // resolved linkage — only presence-gating, same as everything else here).
   it('leaves legacy_library_release_id, rotation_bin, and kill_date as plain excluded.* assignments', async () => {
     const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
     onConflictSpy.mockClear();
@@ -1537,16 +1602,25 @@ describe('POST /internal/rotation-webhook', () => {
     }
   });
 
-  // BS#2109 review round 3 finding 2: a `/wxycdb` edit's incoming free text
-  // must not land on an already-linked row — that recreates the "album_id
-  // set AND snapshot set" shape `PATCH /library/rotation/:id/link`'s 409
-  // and sibling PR #2165 both exist to prevent, and that the BS#2080
-  // arm-(b)/(c) rotation-badge match doesn't filter `album_id IS NULL`
-  // against. `artist_name` / `album_title` / `record_label` are still
-  // presence-gated (BS#1082 + BS#1312, unchanged — see the previous two
-  // tests) but a present column is now a CASE, not a plain `excluded.*`
-  // assignment, gated on the exact same expression assigned to `album_id`.
-  it('gates artist_name/album_title/record_label on the resolved album_id rather than writing excluded.* unconditionally', async () => {
+  // A linked row is allowed to keep carrying tubafrenzy's free text: an
+  // earlier revision gated the trio on the row's resolved `album_id` (nulling
+  // it out whenever the row resolved linked) to stop a `/wxycdb` edit from
+  // recreating the "album_id set AND snapshot set" shape `PATCH
+  // /library/rotation/:id/link`'s 409 guards against — but that CASE was
+  // itself the bug: `linkRotationToAlbum` (`library.service.ts`) deliberately
+  // leaves a freshly-linked row's snapshot populated so the tracklist
+  // picker's tier-3 self-heal keeps working, and
+  // `jobs/rotation-release-id-backfill`'s candidate query requires
+  // `artist_name`/`album_title` NOT NULL to repair a row's
+  // `discogs_release_id` — nulling the trio on every subsequent edit
+  // permanently excluded a linked row (killed ones especially, since that
+  // job's predicate also excludes `kill_date`-past rows and this PR
+  // deliberately surfaces killed rows in the uncatalogued queue) from the
+  // only path that repairs it. It costs nothing display-side either:
+  // `getRotationFromDB` selects `COALESCE(artists.artist_name,
+  // rotation.artist_name)`, so a linked row always reads the canonical
+  // library value regardless of what `rotation`'s own columns hold.
+  it('writes excluded.* for artist_name/album_title/record_label unconditionally, so a linked row keeps tubafrenzy free text', async () => {
     const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
     onConflictSpy.mockClear();
 
@@ -1559,16 +1633,8 @@ describe('POST /internal/rotation-webhook', () => {
     for (const column of ['artist_name', 'album_title', 'record_label']) {
       const entry = setClause[column] as { sql?: string[]; values?: unknown[] };
       const rendered = (entry?.sql ?? []).join('?');
-      expect(rendered).toContain('CASE WHEN');
-      expect(rendered).toContain('IS NULL THEN');
+      expect(rendered).not.toContain('CASE');
       expect(rendered).toContain(`excluded.${column}`);
-      expect(rendered).toContain('ELSE NULL END');
-      // The CASE condition embeds the identical SQL fragment assigned to
-      // `album_id` — checked by object identity rather than re-rendering
-      // the nested SQL, since drizzle-orm's mock nests an interpolated
-      // `SQL` fragment as an opaque object inside `.values` rather than
-      // splicing its text into the outer `.sql` chunks.
-      expect(entry?.values?.[0]).toBe(setClause.album_id);
     }
   });
 

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1507,10 +1507,12 @@ describe('POST /internal/rotation-webhook', () => {
     expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([rotation.album_id]);
   });
 
-  // The COALESCE must not leak into the presence-gated columns: BS#1082 +
-  // BS#1312's gate is a different mechanism (was the field in the payload at
-  // all?) and is load-bearing for partial payloads.
-  it('leaves the other SET entries as plain excluded.* assignments', async () => {
+  // Review round 3 finding 2 narrowed this: only `legacy_library_release_id`
+  // / `rotation_bin` / `kill_date` are still plain `excluded.*` assignments.
+  // `artist_name` / `album_title` / `record_label` are covered by the two
+  // tests below instead — they're no longer plain assignments even when
+  // present, because they're now gated on the row's resolved linkage.
+  it('leaves legacy_library_release_id, rotation_bin, and kill_date as plain excluded.* assignments', async () => {
     const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
     onConflictSpy.mockClear();
 
@@ -1520,10 +1522,70 @@ describe('POST /internal/rotation-webhook', () => {
       .send({ action: 'update', release: validRelease });
 
     const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
-    for (const column of ['legacy_library_release_id', 'rotation_bin', 'kill_date', 'artist_name', 'album_title']) {
+    for (const column of ['legacy_library_release_id', 'rotation_bin', 'kill_date']) {
       const rendered = ((setClause[column] as { sql?: string[] })?.sql ?? []).join('?');
       expect(rendered).not.toContain('COALESCE');
+      expect(rendered).not.toContain('CASE');
     }
+  });
+
+  // BS#2109 review round 3 finding 2: a `/wxycdb` edit's incoming free text
+  // must not land on an already-linked row — that recreates the "album_id
+  // set AND snapshot set" shape `PATCH /library/rotation/:id/link`'s 409
+  // and sibling PR #2165 both exist to prevent, and that the BS#2080
+  // arm-(b)/(c) rotation-badge match doesn't filter `album_id IS NULL`
+  // against. `artist_name` / `album_title` / `record_label` are still
+  // presence-gated (BS#1082 + BS#1312, unchanged — see the previous two
+  // tests) but a present column is now a CASE, not a plain `excluded.*`
+  // assignment, gated on the exact same expression assigned to `album_id`.
+  it('gates artist_name/album_title/record_label on the resolved album_id rather than writing excluded.* unconditionally', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+
+    await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: validRelease });
+
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    for (const column of ['artist_name', 'album_title', 'record_label']) {
+      const entry = setClause[column] as { sql?: string[]; values?: unknown[] };
+      const rendered = (entry?.sql ?? []).join('?');
+      expect(rendered).toContain('CASE WHEN');
+      expect(rendered).toContain('IS NULL THEN');
+      expect(rendered).toContain(`excluded.${column}`);
+      expect(rendered).toContain('ELSE NULL END');
+      // The CASE condition embeds the identical SQL fragment assigned to
+      // `album_id` — checked by object identity rather than re-rendering
+      // the nested SQL, since drizzle-orm's mock nests an interpolated
+      // `SQL` fragment as an opaque object inside `.values` rather than
+      // splicing its text into the outer `.sql` chunks.
+      expect(entry?.values?.[0]).toBe(setClause.album_id);
+    }
+  });
+
+  // Review round 3 finding 2's "better form": a genuinely resolvable
+  // `libraryReleaseId` takes `excluded.album_id` unconditionally — not
+  // COALESCEd — restoring tubafrenzy's ability to relink a row, which the
+  // interim blanket-COALESCE shape had silently revoked (its own docblock's
+  // claim that tubafrenzy could no longer *unlink* a row understated the
+  // change: it could no longer change album_id at all).
+  it('writes album_id from excluded.album_id (not COALESCEd) when the payload carries a genuine libraryReleaseId', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+    mockLimit.mockReset();
+    mockLimit.mockResolvedValueOnce([{ id: 42 }]);
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: { id: 500, libraryReleaseId: 777 } });
+
+    expect(res.status).toBe(200);
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
+    expect(rendered).not.toContain('COALESCE');
+    expect(rendered).toBe('excluded.album_id');
   });
 
   // -- Kill --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -31,7 +31,7 @@ jest.mock('@sentry/node', () => ({
 // tolerance can't leave a test asserting the wrong side of the boundary while
 // still passing. tests/unit/database/etl-utils.test.ts pins the mock's copy to
 // the real module's, so this value tracks production.
-import { db, shows, FUTURE_TIMESTAMP_TOLERANCE_MS } from '@wxyc/database';
+import { db, rotation, shows, FUTURE_TIMESTAMP_TOLERANCE_MS } from '@wxyc/database';
 import { and, eq, isNull } from 'drizzle-orm';
 import express from 'express';
 import request from 'supertest';
@@ -1479,6 +1479,51 @@ describe('POST /internal/rotation-webhook', () => {
     expect(setClause).toHaveProperty('artist_name');
     expect(setClause).toHaveProperty('album_title');
     expect(setClause).toHaveProperty('record_label');
+  });
+
+  // BS#2109: `album_id` is COALESCEd, not overwritten, so a webhook `update`
+  // carrying `libraryReleaseId: 0` (i.e. `excluded.album_id IS NULL`) cannot
+  // revert a Backend-made link from `PATCH /library/rotation/:id/link`.
+  // Before this, the next /wxycdb edit on a release the librarian had
+  // catalogued in dj-site reset album_id to NULL, restored the free text,
+  // and dropped the row back into the cataloging queue.
+  it('update with libraryReleaseId: 0 COALESCEs album_id so a Backend-made link is never downgraded to NULL', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: { id: 500, libraryReleaseId: 0 } });
+
+    expect(res.status).toBe(200);
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    // drizzle-orm is automocked project-wide, so `sql\`...\`` renders as
+    // `{ sql: TemplateStringsArray, values: [...] }`. Assert on the literal
+    // chunks: a bare `excluded.album_id` assignment would have no COALESCE.
+    const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
+    expect(rendered).toContain('COALESCE(excluded.album_id');
+    // The existing row is the COALESCE fallback, so tubafrenzy's NULL loses.
+    expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([rotation.album_id]);
+  });
+
+  // The COALESCE must not leak into the presence-gated columns: BS#1082 +
+  // BS#1312's gate is a different mechanism (was the field in the payload at
+  // all?) and is load-bearing for partial payloads.
+  it('leaves the other SET entries as plain excluded.* assignments', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+
+    await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: validRelease });
+
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    for (const column of ['legacy_library_release_id', 'rotation_bin', 'kill_date', 'artist_name', 'album_title']) {
+      const rendered = ((setClause[column] as { sql?: string[] })?.sql ?? []).join('?');
+      expect(rendered).not.toContain('COALESCE');
+    }
   });
 
   // -- Kill --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1482,14 +1482,20 @@ describe('POST /internal/rotation-webhook', () => {
   });
 
   // BS#2109: `album_id` is COALESCEd, not overwritten, so a webhook `update`
-  // carrying `libraryReleaseId: 0` (i.e. `excluded.album_id IS NULL`) cannot
-  // revert a Backend-made link from `PATCH /library/rotation/:id/link`.
-  // Before this, the next /wxycdb edit on a release the librarian had
-  // catalogued in dj-site reset album_id to NULL, restored the free text,
-  // and dropped the row back into the cataloging queue.
+  // carrying `libraryReleaseId: 0` cannot revert a Backend-made link from
+  // `PATCH /library/rotation/:id/link`. Before this, the next /wxycdb edit on
+  // a release the librarian had catalogued in dj-site reset album_id to NULL,
+  // restored the free text, and dropped the row back into the cataloging
+  // queue.
+  //
+  // BS#2173 moved a bin-less payload like this one off the INSERT...ON
+  // CONFLICT statement entirely (a plain UPDATE, asserted via `mockSet`
+  // below) — re-derived here rather than against `excluded.album_id`, which
+  // this arm has no `excluded` row to reference. `resolveAlbumId` is
+  // guaranteed to return null for `libraryReleaseId: 0`, so the COALESCE's
+  // first argument is the JS `null` that resolved to, not a SQL column ref.
   it('update with libraryReleaseId: 0 COALESCEs album_id so a Backend-made link is never downgraded to NULL', async () => {
-    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
-    onConflictSpy.mockClear();
+    mockReturning.mockResolvedValueOnce([{ id: 42 }]);
 
     const res = await request(app)
       .post('/internal/rotation-webhook')
@@ -1497,14 +1503,16 @@ describe('POST /internal/rotation-webhook', () => {
       .send({ action: 'update', release: { id: 500, libraryReleaseId: 0 } });
 
     expect(res.status).toBe(200);
-    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    expect(mockOnConflict).not.toHaveBeenCalled();
+    const setClause = mockSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     // drizzle-orm is automocked project-wide, so `sql\`...\`` renders as
     // `{ sql: TemplateStringsArray, values: [...] }`. Assert on the literal
-    // chunks: a bare `excluded.album_id` assignment would have no COALESCE.
+    // chunks: a bare value assignment would have no COALESCE.
     const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
-    expect(rendered).toContain('COALESCE(excluded.album_id');
-    // The existing row is the COALESCE fallback, so tubafrenzy's NULL loses.
-    expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([rotation.album_id]);
+    expect(rendered).toContain('COALESCE(');
+    // First param is the resolved (null) albumId, second is the existing
+    // row's column — the fallback that wins, so tubafrenzy's NULL loses.
+    expect((setClause.album_id as { values?: unknown[] })?.values).toEqual([null, rotation.album_id]);
   });
 
   // Review round 3 finding 2 narrowed this: only `legacy_library_release_id`
@@ -1565,16 +1573,20 @@ describe('POST /internal/rotation-webhook', () => {
   });
 
   // Review round 3 finding 2's "better form": a genuinely resolvable
-  // `libraryReleaseId` takes `excluded.album_id` unconditionally — not
+  // `libraryReleaseId` takes the resolved `album_id` unconditionally — not
   // COALESCEd — restoring tubafrenzy's ability to relink a row, which the
   // interim blanket-COALESCE shape had silently revoked (its own docblock's
   // claim that tubafrenzy could no longer *unlink* a row understated the
   // change: it could no longer change album_id at all).
-  it('writes album_id from excluded.album_id (not COALESCEd) when the payload carries a genuine libraryReleaseId', async () => {
-    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
-    onConflictSpy.mockClear();
+  //
+  // No `rotationType` in this payload, so — per BS#2173 — this is the plain
+  // UPDATE arm (`mockSet`), not the sibling INSERT...ON CONFLICT statement:
+  // there is no `excluded` row here, so the unconditional write is a bare JS
+  // value rather than an `excluded.album_id` SQL reference.
+  it('writes the resolved album_id outright (not COALESCEd) when the payload carries a genuine libraryReleaseId', async () => {
     mockLimit.mockReset();
     mockLimit.mockResolvedValueOnce([{ id: 42 }]);
+    mockReturning.mockResolvedValueOnce([{ id: 42 }]);
 
     const res = await request(app)
       .post('/internal/rotation-webhook')
@@ -1582,10 +1594,9 @@ describe('POST /internal/rotation-webhook', () => {
       .send({ action: 'update', release: { id: 500, libraryReleaseId: 777 } });
 
     expect(res.status).toBe(200);
-    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
-    const rendered = ((setClause.album_id as { sql?: string[] })?.sql ?? []).join('?');
-    expect(rendered).not.toContain('COALESCE');
-    expect(rendered).toBe('excluded.album_id');
+    expect(mockOnConflict).not.toHaveBeenCalled();
+    const setClause = mockSet.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(setClause.album_id).toBe(42);
   });
 
   // -- Kill --

--- a/tests/unit/routes/library-rotation-uncatalogued.route.test.ts
+++ b/tests/unit/routes/library-rotation-uncatalogued.route.test.ts
@@ -1,0 +1,159 @@
+/**
+ * BS#2109 route-ordering guardrail for `GET /library/rotation/uncatalogued`.
+ *
+ * Express matches route layers in registration order, so a templated
+ * `/rotation/:something` GET registered ahead of the literal
+ * `/rotation/uncatalogued` would swallow the queue endpoint and hand
+ * `'uncatalogued'` to the parameterized handler as an id. The ordering is
+ * correct as written — and WXYC/Backend-Service#2113's `PATCH /rotation/:id`
+ * cannot collide with it in any case, differing in both method and segment
+ * count — but the acceptance criteria ask for the guardrail explicitly, and
+ * #2113 adds a parameterized route to this very block.
+ *
+ * Two assertions:
+ *   1. Static — over the registered layer list, the literal path precedes
+ *      any single-segment `/rotation/:param` GET.
+ *   2. Functional — a real request for `/library/rotation/uncatalogued`
+ *      reaches `getUncataloguedRotation`, not some `:id`-shaped handler.
+ *
+ * Collaborator mocks below mirror
+ * `tests/unit/routes/library-genres-permissions.route.test.ts` — only enough
+ * is stubbed to let `library.route`'s import chain resolve without touching a
+ * real DB, LML, or lru-cache. `@wxyc/authentication` resolves to
+ * `tests/mocks/authentication.mock.ts` via jest.unit.config.ts's
+ * moduleNameMapper, whose `requirePermissions` only checks for an
+ * Authorization header — permission tiers are not what this file tests.
+ */
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+const mockGetUncataloguedRotationFromDB = jest.fn<() => Promise<unknown[]>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getAlbumFromDB: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  getUncataloguedRotationFromDB: mockGetUncataloguedRotationFromDB,
+  linkRotationToAlbum: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: jest.fn(),
+  getRotationTracksFromRelease: jest.fn(),
+  getLibraryRowById: jest.fn(),
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => false,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+type RouteLayer = { route?: { path?: unknown; methods?: Record<string, boolean> } };
+
+/** Registered GET paths, in registration order. */
+function registeredGetPaths(): string[] {
+  const stack = (library_route as unknown as { stack: RouteLayer[] }).stack;
+  return stack
+    .filter((layer) => layer.route?.methods?.get)
+    .map((layer) => layer.route?.path)
+    .filter((path): path is string => typeof path === 'string');
+}
+
+describe('GET /library/rotation/uncatalogued — route registration order (BS#2109)', () => {
+  test('the literal path is registered ahead of any single-segment /rotation/:param GET', () => {
+    const paths = registeredGetPaths();
+
+    const literalIndex = paths.indexOf('/rotation/uncatalogued');
+    expect(literalIndex).toBeGreaterThanOrEqual(0);
+
+    const shadowingIndex = paths.findIndex((path) => /^\/rotation\/:[^/]+$/.test(path));
+    if (shadowingIndex >= 0) {
+      expect(literalIndex).toBeLessThan(shadowingIndex);
+    }
+  });
+
+  test('a request for the literal path reaches getUncataloguedRotation, not a :id handler', async () => {
+    const rows = [{ id: 7007, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' }];
+    mockGetUncataloguedRotationFromDB.mockReset().mockResolvedValue(rows);
+
+    const res = await request(app).get('/library/rotation/uncatalogued').set('Authorization', 'Bearer test-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(rows);
+    expect(mockGetUncataloguedRotationFromDB).toHaveBeenCalledTimes(1);
+  });
+
+  test('a hypothetical /rotation/:id GET registered after the literal still cannot shadow it', async () => {
+    // Simulates WXYC/Backend-Service#2113 landing its parameterized route in
+    // this block: as long as it is registered AFTER, the literal wins. The
+    // sub-app is disposable — the real router is untouched.
+    const shadowApp = express();
+    const shadowRouter = express.Router();
+    const paramHandler = jest.fn((_req: express.Request, res: express.Response) => res.status(200).json('param'));
+    shadowRouter.get('/rotation/uncatalogued', (_req, res) => {
+      res.status(200).json('literal');
+    });
+    shadowRouter.get('/rotation/:rotation_id', paramHandler);
+    shadowApp.use('/library', shadowRouter);
+
+    const res = await request(shadowApp).get('/library/rotation/uncatalogued');
+
+    expect(res.body).toBe('literal');
+    expect(paramHandler).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/library.service.uncataloguedRotation.test.ts
+++ b/tests/unit/services/library.service.uncataloguedRotation.test.ts
@@ -35,31 +35,6 @@ jest.mock('@wxyc/lml-client', () => ({
 
 import { getUncataloguedRotationFromDB, linkRotationToAlbum } from '../../../apps/backend/services/library.service';
 
-type SqlLike = {
-  sql?: string | string[];
-  raw?: string;
-  queryChunks?: Array<string | { value?: unknown; raw?: string }>;
-};
-
-const renderSql = (value: unknown): string => {
-  const obj = value as SqlLike | null | undefined;
-  if (!obj) return '';
-  if (typeof obj.raw === 'string') return obj.raw;
-  if (Array.isArray(obj.sql)) return obj.sql.join('');
-  if (typeof obj.sql === 'string') return obj.sql;
-  if (obj.queryChunks) {
-    return obj.queryChunks
-      .map((chunk) => {
-        if (typeof chunk === 'string') return chunk;
-        if (typeof chunk.raw === 'string') return chunk.raw;
-        if (chunk.value !== undefined) return JSON.stringify(chunk.value);
-        return '';
-      })
-      .join(' ');
-  }
-  return JSON.stringify(obj);
-};
-
 describe('getUncataloguedRotationFromDB (BS#2109)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,8 +57,9 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
 
     expect(result).toBe(rows);
     expect(selectChain.from).toHaveBeenCalledWith(rotation);
+    // Exact-match, so a COALESCE-0 predicate (or any added clause) fails here
+    // rather than needing a separate substring assertion against rendered SQL.
     expect(selectChain.where).toHaveBeenCalledWith({ isNull: rotation.album_id });
-    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).not.toContain('COALESCE');
     // The query builder never calls selectDistinctOn — no dedup collapse.
     expect(db.selectDistinctOn).not.toHaveBeenCalled();
   });
@@ -209,10 +185,12 @@ describe('linkRotationToAlbum (BS#2109)', () => {
     });
     // The UPDATE's own WHERE re-guards album_id IS NULL, not just the earlier
     // SELECT. drizzle-orm is automocked project-wide (`tests/__mocks__/
-    // drizzle-orm.ts`), so `isNull(rotation.album_id)` renders as a plain
-    // `{ isNull: 'album_id' }` object rather than real SQL text.
-    expect(renderSql(updateChain.where.mock.calls[0]?.[0])).toContain('isNull');
-    expect(renderSql(updateChain.where.mock.calls[0]?.[0])).toContain('album_id');
+    // drizzle-orm.ts`), so the predicate is a plain object, not SQL text —
+    // assert it whole, which also pins the `eq(rotation.id, …)` half that a
+    // substring match would silently ignore.
+    expect(updateChain.where).toHaveBeenCalledWith({
+      and: [{ eq: [rotation.id, ROTATION_ID] }, { isNull: rotation.album_id }],
+    });
   });
 
   it('rejects double-linking when the rotation row already has an album_id', async () => {

--- a/tests/unit/services/library.service.uncataloguedRotation.test.ts
+++ b/tests/unit/services/library.service.uncataloguedRotation.test.ts
@@ -9,7 +9,11 @@
  *     `getRotationFromDB`'s raw-SQL `DISTINCT ON`).
  *   - `linkRotationToAlbum` — the `PATCH /rotation/:id/link` transaction:
  *     album-exists check, rotation-exists check, already-linked rejection,
- *     and the same-transaction snapshot-column clear.
+ *     and (review round 3 finding 1) that it deliberately does NOT clear
+ *     the snapshot columns — see the function's doc for why. Also (finding
+ *     4) that the linked response is projected through the same
+ *     `UNCATALOGUED_ROTATION_PROJECTION` the queue read uses, not a bare
+ *     `.returning()`.
  *
  * Follows the established `db._chain` / `createMockQueryChain` override
  * conventions from `library.service.addToRotation.test.ts` and
@@ -158,19 +162,24 @@ describe('linkRotationToAlbum (BS#2109)', () => {
     jest.clearAllMocks();
   });
 
-  it('links: sets album_id and clears artist_name/album_title/record_label in one UPDATE', async () => {
+  it('links: sets album_id only — does NOT clear artist_name/album_title/record_label (review round 3 finding 1)', async () => {
     const albumChain = createMockQueryChain();
     albumChain.limit = jest.fn().mockResolvedValue([{ id: ALBUM_ID }]);
 
     const rotationSelectChain = createMockQueryChain();
     rotationSelectChain.limit = jest.fn().mockResolvedValue([{ album_id: null }]);
 
+    // The snapshot survives the link untouched — clearing it stranded the
+    // tracklist picker's tier-3 self-heal (see linkRotationToAlbum's doc).
     const updatedRow = {
       id: ROTATION_ID,
       album_id: ALBUM_ID,
-      artist_name: null,
-      album_title: null,
-      record_label: null,
+      rotation_bin: 'L',
+      add_date: '2026-01-01',
+      kill_date: null,
+      artist_name: 'Preserved Artist',
+      album_title: 'Preserved Album',
+      record_label: 'Preserved Label',
     };
     const updateChain = createMockQueryChain([updatedRow]);
 
@@ -182,11 +191,21 @@ describe('linkRotationToAlbum (BS#2109)', () => {
     expect(result).toEqual({ outcome: 'linked', rotation: updatedRow });
     expect(db.transaction).toHaveBeenCalledTimes(1);
     expect(albumChain.from).toHaveBeenCalledWith(library);
-    expect(updateChain.set).toHaveBeenCalledWith({
-      album_id: ALBUM_ID,
-      artist_name: null,
-      album_title: null,
-      record_label: null,
+    // Only album_id moves — no artist_name/album_title/record_label keys.
+    expect(updateChain.set).toHaveBeenCalledWith({ album_id: ALBUM_ID });
+    // Review round 3 finding 4: the response is projected through the same
+    // explicit column list `getUncataloguedRotationFromDB` uses, not a bare
+    // `.returning()` — asserted against the call's own args so a future
+    // migration-added column can't silently widen this response too.
+    expect(updateChain.returning).toHaveBeenCalledWith({
+      id: rotation.id,
+      album_id: rotation.album_id,
+      rotation_bin: rotation.rotation_bin,
+      add_date: rotation.add_date,
+      kill_date: rotation.kill_date,
+      artist_name: rotation.artist_name,
+      album_title: rotation.album_title,
+      record_label: rotation.record_label,
     });
     // The UPDATE's own WHERE re-guards album_id IS NULL, not just the earlier
     // SELECT. drizzle-orm is automocked project-wide (`tests/__mocks__/

--- a/tests/unit/services/library.service.uncataloguedRotation.test.ts
+++ b/tests/unit/services/library.service.uncataloguedRotation.test.ts
@@ -3,7 +3,7 @@
  *
  *   - `getUncataloguedRotationFromDB` — read-side query for
  *     `GET /library/rotation/uncatalogued`. Asserts the `album_id IS NULL`
- *     predicate, the explicit column projection, the optional limit/offset
+ *     predicate, the explicit column projection, the always-bounded limit/offset
  *     window, and the absence of any `DISTINCT ON` (the query builder used
  *     here has no `selectDistinctOn` call at all, unlike
  *     `getRotationFromDB`'s raw-SQL `DISTINCT ON`).
@@ -33,7 +33,11 @@ jest.mock('@wxyc/lml-client', () => ({
   envInt: (_name: string, fallback: number) => fallback,
 }));
 
-import { getUncataloguedRotationFromDB, linkRotationToAlbum } from '../../../apps/backend/services/library.service';
+import {
+  getUncataloguedRotationFromDB,
+  linkRotationToAlbum,
+  UNCATALOGUED_ROTATION_MAX_LIMIT,
+} from '../../../apps/backend/services/library.service';
 
 describe('getUncataloguedRotationFromDB (BS#2109)', () => {
   beforeEach(() => {
@@ -50,7 +54,8 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
       { id: 11, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
     ];
     const selectChain = createMockQueryChain(rows);
-    selectChain.orderBy = jest.fn().mockResolvedValue(rows);
+    selectChain.orderBy = jest.fn().mockReturnValue(selectChain);
+    selectChain.limit = jest.fn().mockResolvedValue(rows);
     db.select.mockReturnValue(selectChain);
 
     const result = await getUncataloguedRotationFromDB();
@@ -72,7 +77,8 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
     // `getRotationFromDB` publishes, and WXYC/wxyc-shared#354 would
     // transcribe the leak into a published contract.
     const selectChain = createMockQueryChain([]);
-    selectChain.orderBy = jest.fn().mockResolvedValue([]);
+    selectChain.orderBy = jest.fn().mockReturnValue(selectChain);
+    selectChain.limit = jest.fn().mockResolvedValue([]);
     db.select.mockReturnValue(selectChain);
 
     await getUncataloguedRotationFromDB();
@@ -91,15 +97,27 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
     ]);
   });
 
-  it('applies limit/offset only when supplied, leaving the queue unbounded by default', async () => {
-    const unboundedChain = createMockQueryChain([]);
-    unboundedChain.orderBy = jest.fn().mockResolvedValue([]);
-    db.select.mockReturnValue(unboundedChain);
+  // The query is ALWAYS bounded. An omitted `limit` defaults to the 500
+  // ceiling rather than returning the whole backlog: ~3.8k unlinked rows is
+  // ≈700 KB of JSON per request on a single-worker box that also serves the
+  // live flowsheet. Asserted on the service rather than the controller
+  // because the cap is a property of the read — a future second caller
+  // inherits it instead of having to remember it.
+  it('defaults limit to the 500 ceiling when the caller omits it', async () => {
+    const defaultChain = createMockQueryChain([]);
+    defaultChain.orderBy = jest.fn().mockReturnValue(defaultChain);
+    defaultChain.limit = jest.fn().mockResolvedValue([]);
+    db.select.mockReturnValue(defaultChain);
 
     await getUncataloguedRotationFromDB();
-    expect(unboundedChain.limit).not.toHaveBeenCalled();
-    expect(unboundedChain.offset).not.toHaveBeenCalled();
 
+    expect(defaultChain.limit).toHaveBeenCalledWith(UNCATALOGUED_ROTATION_MAX_LIMIT);
+    expect(UNCATALOGUED_ROTATION_MAX_LIMIT).toBe(500);
+    // `offset` stays genuinely optional — no OFFSET 0 on the common path.
+    expect(defaultChain.offset).not.toHaveBeenCalled();
+  });
+
+  it('applies an explicit limit/offset window', async () => {
     const pagedChain = createMockQueryChain([]);
     pagedChain.orderBy = jest.fn().mockReturnValue(pagedChain);
     pagedChain.limit = jest.fn().mockReturnValue(pagedChain);
@@ -120,7 +138,8 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
       { id: 21, album_id: null, artist_name: 'Duplicate Artist', album_title: 'Duplicate Title' },
     ];
     const selectChain = createMockQueryChain(rows);
-    selectChain.orderBy = jest.fn().mockResolvedValue(rows);
+    selectChain.orderBy = jest.fn().mockReturnValue(selectChain);
+    selectChain.limit = jest.fn().mockResolvedValue(rows);
     db.select.mockReturnValue(selectChain);
 
     const result = await getUncataloguedRotationFromDB();

--- a/tests/unit/services/library.service.uncataloguedRotation.test.ts
+++ b/tests/unit/services/library.service.uncataloguedRotation.test.ts
@@ -2,9 +2,10 @@
  * Unit tests for the BS#2109 uncatalogued-rotation surfaces:
  *
  *   - `getUncataloguedRotationFromDB` — read-side query for
- *     `GET /library/rotation/uncatalogued`. Asserts the `COALESCE(album_id,
- *     0) = 0` predicate and the absence of any `DISTINCT ON` (the query
- *     builder used here has no `selectDistinctOn` call at all, unlike
+ *     `GET /library/rotation/uncatalogued`. Asserts the `album_id IS NULL`
+ *     predicate, the explicit column projection, the optional limit/offset
+ *     window, and the absence of any `DISTINCT ON` (the query builder used
+ *     here has no `selectDistinctOn` call at all, unlike
  *     `getRotationFromDB`'s raw-SQL `DISTINCT ON`).
  *   - `linkRotationToAlbum` — the `PATCH /rotation/:id/link` transaction:
  *     album-exists check, rotation-exists check, already-linked rejection,
@@ -60,7 +61,11 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
     jest.clearAllMocks();
   });
 
-  it('queries rotation with a COALESCE(album_id, 0) = 0 predicate, no DISTINCT ON', async () => {
+  it('queries rotation with an album_id IS NULL predicate, no COALESCE-0 and no DISTINCT ON', async () => {
+    // The `0` sentinel the first draft also matched does not exist on
+    // `rotation.album_id`: the column FKs `library.id`, a `serial` starting
+    // at 1. `IS NULL` is also sargable against `album_id_idx`, which
+    // `COALESCE(album_id, 0) = 0` was not.
     const rows = [
       { id: 10, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
       { id: 11, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
@@ -73,10 +78,57 @@ describe('getUncataloguedRotationFromDB (BS#2109)', () => {
 
     expect(result).toBe(rows);
     expect(selectChain.from).toHaveBeenCalledWith(rotation);
-    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).toContain('COALESCE');
-    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).toContain('= 0');
+    expect(selectChain.where).toHaveBeenCalledWith({ isNull: rotation.album_id });
+    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).not.toContain('COALESCE');
     // The query builder never calls selectDistinctOn — no dedup collapse.
     expect(db.selectDistinctOn).not.toHaveBeenCalled();
+  });
+
+  it('projects an explicit column list — no server-derived or external-ID columns', async () => {
+    // A bare `select()` would publish legacy_rotation_id,
+    // legacy_library_release_id, discogs_release_id,
+    // discogs_release_id_source, lml_identity_id, the two attempt-at markers,
+    // and every column a future migration adds — none of which
+    // `getRotationFromDB` publishes, and WXYC/wxyc-shared#354 would
+    // transcribe the leak into a published contract.
+    const selectChain = createMockQueryChain([]);
+    selectChain.orderBy = jest.fn().mockResolvedValue([]);
+    db.select.mockReturnValue(selectChain);
+
+    await getUncataloguedRotationFromDB();
+
+    const projection = db.select.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(projection).toBeDefined();
+    expect(Object.keys(projection ?? {}).sort()).toEqual([
+      'add_date',
+      'album_id',
+      'album_title',
+      'artist_name',
+      'id',
+      'kill_date',
+      'record_label',
+      'rotation_bin',
+    ]);
+  });
+
+  it('applies limit/offset only when supplied, leaving the queue unbounded by default', async () => {
+    const unboundedChain = createMockQueryChain([]);
+    unboundedChain.orderBy = jest.fn().mockResolvedValue([]);
+    db.select.mockReturnValue(unboundedChain);
+
+    await getUncataloguedRotationFromDB();
+    expect(unboundedChain.limit).not.toHaveBeenCalled();
+    expect(unboundedChain.offset).not.toHaveBeenCalled();
+
+    const pagedChain = createMockQueryChain([]);
+    pagedChain.orderBy = jest.fn().mockReturnValue(pagedChain);
+    pagedChain.limit = jest.fn().mockReturnValue(pagedChain);
+    pagedChain.offset = jest.fn().mockResolvedValue([]);
+    db.select.mockReturnValue(pagedChain);
+
+    await getUncataloguedRotationFromDB({ limit: 50, offset: 100 });
+    expect(pagedChain.limit).toHaveBeenCalledWith(50);
+    expect(pagedChain.offset).toHaveBeenCalledWith(100);
   });
 
   it('surfaces two same-artist/same-title unlinked rows both (no collapse)', async () => {

--- a/tests/unit/services/library.service.uncataloguedRotation.test.ts
+++ b/tests/unit/services/library.service.uncataloguedRotation.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for the BS#2109 uncatalogued-rotation surfaces:
+ *
+ *   - `getUncataloguedRotationFromDB` — read-side query for
+ *     `GET /library/rotation/uncatalogued`. Asserts the `COALESCE(album_id,
+ *     0) = 0` predicate and the absence of any `DISTINCT ON` (the query
+ *     builder used here has no `selectDistinctOn` call at all, unlike
+ *     `getRotationFromDB`'s raw-SQL `DISTINCT ON`).
+ *   - `linkRotationToAlbum` — the `PATCH /rotation/:id/link` transaction:
+ *     album-exists check, rotation-exists check, already-linked rejection,
+ *     and the same-transaction snapshot-column clear.
+ *
+ * Follows the established `db._chain` / `createMockQueryChain` override
+ * conventions from `library.service.addToRotation.test.ts` and
+ * `library.service.discogsRecheck.test.ts` — the mock chain only resolves
+ * on `.returning()`/`.execute()` by default, so a plain `select().limit()`
+ * read gets its terminal method's resolved value overridden per test.
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain, rotation, library } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: mockIsLmlConfigured,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+import { getUncataloguedRotationFromDB, linkRotationToAlbum } from '../../../apps/backend/services/library.service';
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: unknown; raw?: string }>;
+};
+
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (chunk.value !== undefined) return JSON.stringify(chunk.value);
+        return '';
+      })
+      .join(' ');
+  }
+  return JSON.stringify(obj);
+};
+
+describe('getUncataloguedRotationFromDB (BS#2109)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries rotation with a COALESCE(album_id, 0) = 0 predicate, no DISTINCT ON', async () => {
+    const rows = [
+      { id: 10, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
+      { id: 11, album_id: null, artist_name: 'Jockstrap', album_title: 'I Love You Jennifer B' },
+    ];
+    const selectChain = createMockQueryChain(rows);
+    selectChain.orderBy = jest.fn().mockResolvedValue(rows);
+    db.select.mockReturnValue(selectChain);
+
+    const result = await getUncataloguedRotationFromDB();
+
+    expect(result).toBe(rows);
+    expect(selectChain.from).toHaveBeenCalledWith(rotation);
+    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).toContain('COALESCE');
+    expect(renderSql(selectChain.where.mock.calls[0]?.[0])).toContain('= 0');
+    // The query builder never calls selectDistinctOn — no dedup collapse.
+    expect(db.selectDistinctOn).not.toHaveBeenCalled();
+  });
+
+  it('surfaces two same-artist/same-title unlinked rows both (no collapse)', async () => {
+    // Pins the acceptance criterion directly: two distinct physical promos
+    // sharing (artist, title) must both appear, unlike getRotationFromDB's
+    // DISTINCT ON dropdown collapse (#862).
+    const rows = [
+      { id: 20, album_id: null, artist_name: 'Duplicate Artist', album_title: 'Duplicate Title' },
+      { id: 21, album_id: null, artist_name: 'Duplicate Artist', album_title: 'Duplicate Title' },
+    ];
+    const selectChain = createMockQueryChain(rows);
+    selectChain.orderBy = jest.fn().mockResolvedValue(rows);
+    db.select.mockReturnValue(selectChain);
+
+    const result = await getUncataloguedRotationFromDB();
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => (r as { id: number }).id).sort()).toEqual([20, 21]);
+  });
+});
+
+describe('linkRotationToAlbum (BS#2109)', () => {
+  const ROTATION_ID = 42;
+  const ALBUM_ID = 5;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('links: sets album_id and clears artist_name/album_title/record_label in one UPDATE', async () => {
+    const albumChain = createMockQueryChain();
+    albumChain.limit = jest.fn().mockResolvedValue([{ id: ALBUM_ID }]);
+
+    const rotationSelectChain = createMockQueryChain();
+    rotationSelectChain.limit = jest.fn().mockResolvedValue([{ album_id: null }]);
+
+    const updatedRow = {
+      id: ROTATION_ID,
+      album_id: ALBUM_ID,
+      artist_name: null,
+      album_title: null,
+      record_label: null,
+    };
+    const updateChain = createMockQueryChain([updatedRow]);
+
+    db.select.mockReturnValueOnce(albumChain).mockReturnValueOnce(rotationSelectChain);
+    db.update.mockReturnValue(updateChain);
+
+    const result = await linkRotationToAlbum(ROTATION_ID, ALBUM_ID);
+
+    expect(result).toEqual({ outcome: 'linked', rotation: updatedRow });
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(albumChain.from).toHaveBeenCalledWith(library);
+    expect(updateChain.set).toHaveBeenCalledWith({
+      album_id: ALBUM_ID,
+      artist_name: null,
+      album_title: null,
+      record_label: null,
+    });
+    // The UPDATE's own WHERE re-guards album_id IS NULL, not just the earlier
+    // SELECT. drizzle-orm is automocked project-wide (`tests/__mocks__/
+    // drizzle-orm.ts`), so `isNull(rotation.album_id)` renders as a plain
+    // `{ isNull: 'album_id' }` object rather than real SQL text.
+    expect(renderSql(updateChain.where.mock.calls[0]?.[0])).toContain('isNull');
+    expect(renderSql(updateChain.where.mock.calls[0]?.[0])).toContain('album_id');
+  });
+
+  it('rejects double-linking when the rotation row already has an album_id', async () => {
+    const albumChain = createMockQueryChain();
+    albumChain.limit = jest.fn().mockResolvedValue([{ id: ALBUM_ID }]);
+
+    const rotationSelectChain = createMockQueryChain();
+    rotationSelectChain.limit = jest.fn().mockResolvedValue([{ album_id: 999 }]);
+
+    db.select.mockReturnValueOnce(albumChain).mockReturnValueOnce(rotationSelectChain);
+
+    const result = await linkRotationToAlbum(ROTATION_ID, ALBUM_ID);
+
+    expect(result).toEqual({ outcome: 'already_linked' });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns rotation_not_found when the rotation row does not exist', async () => {
+    const albumChain = createMockQueryChain();
+    albumChain.limit = jest.fn().mockResolvedValue([{ id: ALBUM_ID }]);
+
+    const rotationSelectChain = createMockQueryChain();
+    rotationSelectChain.limit = jest.fn().mockResolvedValue([]);
+
+    db.select.mockReturnValueOnce(albumChain).mockReturnValueOnce(rotationSelectChain);
+
+    const result = await linkRotationToAlbum(ROTATION_ID, ALBUM_ID);
+
+    expect(result).toEqual({ outcome: 'rotation_not_found' });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns album_not_found when the album does not exist, without touching rotation', async () => {
+    const albumChain = createMockQueryChain();
+    albumChain.limit = jest.fn().mockResolvedValue([]);
+
+    db.select.mockReturnValueOnce(albumChain);
+
+    const result = await linkRotationToAlbum(ROTATION_ID, 999999);
+
+    expect(result).toEqual({ outcome: 'album_not_found' });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns already_linked when the guarded UPDATE affects no row (race between check and write)', async () => {
+    const albumChain = createMockQueryChain();
+    albumChain.limit = jest.fn().mockResolvedValue([{ id: ALBUM_ID }]);
+
+    const rotationSelectChain = createMockQueryChain();
+    rotationSelectChain.limit = jest.fn().mockResolvedValue([{ album_id: null }]);
+
+    const updateChain = createMockQueryChain([]);
+
+    db.select.mockReturnValueOnce(albumChain).mockReturnValueOnce(rotationSelectChain);
+    db.update.mockReturnValue(updateChain);
+
+    const result = await linkRotationToAlbum(ROTATION_ID, ALBUM_ID);
+
+    expect(result).toEqual({ outcome: 'already_linked' });
+  });
+});


### PR DESCRIPTION
## Summary

Backend can now represent a rotation release the station hasn't catalogued yet — the actual order of operations at WXYC (promo goes into rotation, cataloging happens later, sometimes never). Three surfaces:

1. **`POST /library/rotation`** accepts a rotation release with no `album_id` when `artist_name` and `album_title` are both supplied (`record_label` optional). Still 400s when neither an `album_id` nor the artist/title pair is given. The write allowlist only opens up the free-text snapshot columns when `album_id` is absent, so a catalogued row can't pick up client-supplied free text that nothing would ever clear. `addToRotation`'s LML/`resolveIdentity` hop already guarded on `album_id != null`, so no change was needed there — it's simply skipped for an uncatalogued add.

2. **`GET /library/rotation/uncatalogued`** — the cataloging-backlog queue. `album_id IS NULL` over the full `rotation` table, deliberately **without** the `DISTINCT ON` collapse `getRotationFromDB` uses for its dropdown shape: two physically distinct promos sharing an artist and title are two separate rows a librarian has to catalogue, and the dropdown's dedup would silently hide one. Explicit column projection (see below). Optional `?limit=`/`?offset=`. `GET /library/rotation` itself is untouched — pinned by an integration test re-asserting its pre-existing `#862` collapse behavior. Registered ahead of where a future parameterized `/rotation/:id` route (WXYC/Backend-Service#2113) would need to land, now with a route-ordering test.

3. **`PATCH /library/rotation/:rotation_id/link`** attaches a library release to an uncatalogued rotation row after the fact (the "Import to Library" step of the tubafrenzy `/wxycdb` flow). Rejects double-linking (409). Deliberately leaves `artist_name`/`album_title`/`record_label` populated after the link (see review round 3 below for why — an earlier revision cleared them, which stranded the tracklist picker) — display is unaffected because it reads through the `library` join once `album_id` resolves. The final `UPDATE` re-guards `album_id IS NULL` in its own `WHERE` (not just the earlier `SELECT`) so a concurrent link can't double-link the row. The response is projected through the same explicit column list the uncatalogued queue uses, not a bare `.returning()`.

Closes #2109

## Review round 2 (2026-08-14)

### The webhook change, and its trade-off

`POST /internal/rotation-webhook` set `album_id` in the **unconditional** half of its `onConflictDoUpdate` SET; only `rotation_bin`, `kill_date` and the snapshot trio were presence-gated (BS#1082 + BS#1312). `excluded.album_id` is `resolveAlbumId(release.libraryReleaseId ?? 0)`, which is NULL whenever tubafrenzy has not itself linked the release. So a librarian could catalogue a promo in dj-site and link it here, and the next `/wxycdb` edit — arriving as an `update` carrying `libraryReleaseId: 0` — would reset `album_id` to NULL, restore the free text, and drop the row back into the queue. That exposure is **created by this PR**: `jobs/legacy-linkage-resolve` only links rows tubafrenzy has already linked, so its writes always agreed with `excluded.album_id`; `PATCH .../link` is the first Backend-canonical link tubafrenzy doesn't know about.

Fixed here, per the review-gate decision on #2109:

```
album_id: sql`COALESCE(excluded.album_id, ${rotation.album_id})`
```

**Accepted trade-off: tubafrenzy can no longer *unlink* a rotation row.** Releases are not un-catalogued, so that isn't a real librarian operation. The presence-gating on the other five columns is deliberately left alone — it is a different mechanism (was the field in the payload at all?) and is load-bearing for partial payloads. Pinned by a unit test on the SET-clause shape and two integration tests: a Backend-made link survives an `update` with `libraryReleaseId: 0`, and an `update` carrying a *resolvable* `libraryReleaseId` still writes `album_id` (the COALESCE is non-downgrading, not write-blocking).

**Round 3 correction:** the "tubafrenzy can no longer unlink a row" framing understated the trade-off — the blanket COALESCE meant tubafrenzy could no longer *change* `album_id` at all, including a genuine relink. See round 3 below.

### `album_id: null` bypassed both guards

The new branch tested `=== undefined` only, so `{rotation_bin, album_id: null, artist_name, album_title}` — the idiomatic `selected?.id ?? null` client shape — skipped the "neither album_id nor artist/title" 400 **and** the free-text allowlist branch, returning 201 with the artist and title silently discarded. The row was then un-catalogueable forever and collapsed with every other blank row in `GET /library/rotation`'s `hashtext('' || '|' || '')` partition. `null` and `undefined` are now interchangeable throughout; a blank or whitespace-only `artist_name`/`album_title` no longer counts as supplied either. Tests cover the explicit-null shape on both the accept and reject paths.

### The `0` sentinel does not exist on `rotation.album_id`

The issue text was wrong. The 0/NULL duality is real but lives on `legacy_library_release_id`. `rotation.album_id` carries `rotation_album_id_library_id_fk → library.id`; `library.id` is `serial` starting at 1; `dev_env/seed-clone.sql` has zero `album_id = 0` rows among 21,625; `internal.route.ts` normalizes `rawLibraryId || null`. The three surfaces disagreed — the read predicate treated 0 as unlinked, the write path as present, the link path as already-linked. **They now agree on NULL-only:**

- Read: `album_id IS NULL` (also sargable against `album_id_idx`, which `COALESCE(album_id, 0) = 0` was not).
- Write: `POST` with `album_id: 0` — the literal payload the classic `/wxycdb` rotation form posts — gets a named 400 instead of passing validation, dropping the free text, and violating the FK into an opaque 500. Negative and non-integer `album_id` likewise.
- Link: unchanged (`isNull(rotation.album_id)`), now documented as the shared reading.

Docblocks that asserted the duality are corrected.

### Length guard on the three `varchar(128)` columns

**Chose reject over truncate**, diverging from the only other writer (`internal.route.ts`, `truncate(release.artistName, 128)`). The webhook truncates because tubafrenzy free text routinely overruns and there is nobody to report a 400 to; this endpoint has a librarian on the other end, and silently amputating a long compilation or classical title leaves a corrupted record with no signal. A too-long `artist_name`/`album_title`/`record_label` now returns a 400 naming the field, rather than a PG 22001 → generic 500 + Sentry that names nothing. Only enforced on the uncatalogued path — with an `album_id` present the trio is deliberately dropped, so a long value there is never written and must not fail an otherwise-valid add.

### Explicit projection on the queue

`getUncataloguedRotationFromDB` selected no column list, publishing `legacy_rotation_id`, `legacy_library_release_id`, `discogs_release_id`, `discogs_release_id_source`, `lml_identity_id`, `tracklist_lookup_attempted_at` and `discogs_release_id_resolve_attempted_at` to `catalog:read` — none of which appear in `getRotationFromDB`'s explicit SELECT, and `tests/integration/library.spec.js` pins the rotation surface against exposing flat external-ID columns. It also auto-published any future column, which matters extra because WXYC/wxyc-shared#354 will transcribe whatever it returns into a published contract. The endpoint now returns exactly `{id, album_id, rotation_bin, add_date, kill_date, artist_name, album_title, record_label}`, pinned by both a unit and an integration test.

### Pagination — chose opt-in, no default cap

The queue was unbounded. Settling finding 2 on NULL-only makes the predicate index-usable, which removes the scan cost; the remaining concern is response size (~3.8k rows). **Added optional `?limit=` (1–500) and `?offset=`, both opt-in — absent still means the full backlog.** A default cap would silently truncate any caller that doesn't know to paginate, and there is no such caller yet; dj-site#1161's queue UI is the one that should start passing them, and a default is worth revisiting once a paginating client exists to notice it. Malformed values 400.

### Smaller findings

- **Strict `rotation_id` parsing.** `parseInt('42abc', 10)` is 42, so `/library/rotation/42abc/link` mutated rotation 42. Now `/^\d+$/`-gated; `'42abc'`, `' 42'`, `'4.5'`, `'+42'`, `'0x2a'`, `'1e3'` all 400, with an integration test asserting the row it would have coerced to is untouched.
- **Exhaustiveness `default` on the `LinkRotationOutcome` switch.** A future variant previously fell through every case and returned having written no response — the request hung to the 35 s server timeout. `const unhandled: never = result` makes it a typecheck failure.
- **The `rotation_bin`-missing 400** no longer reads "Missing Parameters: album_id or rotation_bin"; `album_id` isn't required any more.
- **Route-ordering test** (`tests/unit/routes/library-rotation-uncatalogued.route.test.ts`), which the acceptance criteria ask for twice. The ordering is in fact safe as merged — #2113's `PATCH /rotation/:id` differs from `GET /rotation/uncatalogued` in both method and segment count — but the guardrail was absent. Asserts the literal path precedes any single-segment `/rotation/:param` GET in the registered layer list, that a real request reaches `getUncataloguedRotation`, and that a later-registered `:id` route can't shadow it.
- **Real teardown in the integration tests.** They "cleaned up" via `killRotation`, which only stamps `kill_date` — and the queue is deliberately *not* kill_date-filtered, so every created row stayed in the unbounded backlog permanently and polluted later assertions about queue contents. Now a real `DELETE` in `afterAll`.

## Review round 3

### Finding 1 — linking cleared the snapshot and derived no identity, stranding the picker

`linkRotationToAlbum` cleared `artist_name`/`album_title`/`record_label` on link but derived no replacement identity, unlike `addToRotation`'s synchronous `library_identity` → `resolveIdentity` hop at the equivalent "this row now has an `album_id`" moment. Consequence: `resolveRotationPickerSource`'s three-tier tracklist resolution degraded rather than improved on link — tier 1 (`rotation.discogs_release_id`) and tier 2 (`library_identity` via the `album_id` bridge, ~24% coverage) are both very likely still NULL immediately after a link, and clearing the snapshot removed tier 3's only input (`resolveRotationDiscogsReleaseViaLml` short-circuits on a missing artist/title). Worse, there was no self-heal: `jobs/rotation-release-id-backfill`'s candidate query requires `artist_name IS NOT NULL AND album_title IS NOT NULL`, and `jobs/rotation-lml-identity-backfill`'s requires `discogs_release_id IS NOT NULL` — each needs what only the other could produce.

**Fix: `linkRotationToAlbum` no longer clears the snapshot.** Chosen over replicating the `library_identity` → `resolveIdentity` hop inside the link transaction, which would only help the ~24% of albums `library_identity` already has a resolved handle for and would add an LML round-trip to an otherwise-instant librarian-facing endpoint for no benefit on the other 76%. Leaving the trio in place costs nothing display-side — `getRotationFromDB`'s `COALESCE(artists.artist_name, rotation.artist_name)` always prefers the joined canonical value once `album_id` resolves, regardless of what the snapshot columns hold — and it reopens both self-heal paths: tier 3 keeps working immediately after the link, and `rotation-release-id-backfill`'s 6-hourly cron can now pick the row up (its candidate query has no `album_id` predicate) and mint `discogs_release_id`, unblocking `rotation-lml-identity-backfill` in turn.

### Finding 2 — the webhook fix covered `album_id` but not the snapshot trio, and could be more precise

Round 2's `COALESCE(excluded.album_id, rotation.album_id)` protects a link, but the presence-gated `artist_name`/`album_title`/`record_label` SETs still wrote `excluded.*` unconditionally whenever present — so a `/wxycdb` edit landing on a row finding 1 now leaves snapshot-populated-and-linked would overwrite that snapshot with tubafrenzy's own (necessarily stale, potentially divergent) free text, recreating the "`album_id` set AND snapshot set" shape this PR's `PATCH .../link` 409 and sibling PR #2165 both exist to prevent — a shape the BS#2080 arm-(b)/(c) rotation-badge match (`shared/legacy-mirror/src/rotation-match.ts`, `apps/backend/services/flowsheet.service.ts`) doesn't filter `album_id IS NULL` against either.

**Fix:** the three snapshot columns are still presence-gated (BS#1082 + BS#1312, unchanged — a different question, "was the field in the payload at all") but a present column is now `CASE WHEN (<album-id-resolution-expression>) IS NULL THEN excluded.col ELSE NULL END` — written from tubafrenzy's payload only when the row resolves unlinked after this same delivery, forced to NULL otherwise.

**Also took the suggested better form of the `album_id` guard**, gating on the raw payload rather than the resolution result: `rawLibraryId ? excluded.album_id : COALESCE(excluded.album_id, rotation.album_id)`. This restores tubafrenzy's ability to genuinely relink a row (a real capability the blanket COALESCE had silently revoked — the round-2 docblock's "tubafrenzy can no longer unlink" framing understated it: tubafrenzy could no longer *change* `album_id` at all) while still fixing the `libraryReleaseId: 0` downgrade the round-2 fix targeted. Both the `album_id` SET and the three snapshot CASEs reuse the identical expression, so all four columns agree on what "resolves linked" means for a given delivery.

### Finding 3 — the new webhook test pinned the wrong payload shape

The round-2 integration test asserting "a Backend-made link survives an update carrying `libraryReleaseId: 0`" sent the `sendRotationLinked` shape `{id, libraryReleaseId: 0}`, which carries no `artistName` key — so the presence gate excludes the snapshot columns from `SET` entirely and the test never exercised the trio at all, regardless of what it asserted. Its own comment described "the next `/wxycdb` edit," which is the `sendRotationUpdated` shape and *does* carry the trio. Rewritten to send the full edit payload; against that shape, a linked row now correctly ends up with the trio NULLed rather than carrying tubafrenzy's stale free text. Added a companion test confirming the original (correct) claim independently: a linkage-only ping with no `artistName` key leaves finding 1's preserved snapshot untouched.

### Finding 4 — the link endpoint published the columns this PR projected away everywhere else

`PATCH /library/rotation/:rotation_id/link` returned the raw `.returning()` row, publishing the same seven server-derived columns `UNCATALOGUED_ROTATION_PROJECTION` exists to keep off `GET /library/rotation/uncatalogued`, and that `tests/integration/library.spec.js` pins the rotation surface against. **Fix:** `.returning(UNCATALOGUED_ROTATION_PROJECTION)` — same eight fields both surfaces now share. `addRotation`'s unprojected `.returning()` is left alone (out of scope): it publishes onto a row the client itself just supplied every field of, not a read of someone else's data.

### Finding 5 — `app.yaml` documented nothing

The only one of the four in-flight library PRs to touch no `app.yaml`, while `NewRotationRequest` still declared `required: ['album_id', 'rotation_bin']` against a handler that no longer requires `album_id`, and neither `/library/rotation/uncatalogued` nor `/library/rotation/{id}/link` was documented at all. Added both paths, added an `UncataloguedRotationRow` schema shared by both responses, relaxed `NewRotationRequest`'s `required` list and documented the artist/title-pair constraint in prose, and corrected the pre-existing `POST /library/rotation` response code (`200` → the handler's actual `201`) while in the same block. `app.yaml` only — `wxyc-shared/api.yaml` stays carved out to WXYC/wxyc-shared#354.

### Finding 6 — the 128-char guard counted UTF-16 code units, not characters

`varchar(128)` is a PostgreSQL character (code point) limit; `value.length` counts UTF-16 code units, over-counting every astral character (emoji, CJK Extension B, …) as 2 — 70 emoji measure 140. Never under-rejects (no 22001 escape), but does over-reject values PostgreSQL would happily store, undercutting the endpoint's own reject-over-truncate rationale. **Fix:** `[...value].length`. Tests cover a 70-code-point emoji name (accepted, `.length` would have read 140) and a genuinely-129-code-point one (still rejected).

### Finding 7 — `Number.isInteger(album_id)` tightens the pre-existing catalogued path too

`{"album_id": "2", "rotation_bin": "M"}` previously inserted fine (PostgreSQL coerces a numeric string into an `integer` column) and now 400s — not just for the new uncatalogued path, but for the pre-existing catalogued one too. Confirmed dj-site's only call site (`RotationClassifyControl.tsx` → `useAddRotationEntryMutation`, `lib/features/rotation/api.ts`) is typed `AddRotationRequest.album_id: number` end to end, sourced from `AlbumEntry.id: number` — the one known caller never sends a numeric string. **Kept the hardening**, documented as a deliberate behavior change in `addRotation`'s docblock and covered by a unit test.

## Review round 4 (2026-08-17)

### Finding 2's CASE reverted — a linked row is allowed to keep tubafrenzy's free text

Round 3 finding 2's fix (`CASE WHEN (<album-id-resolution-expression>) IS NULL THEN excluded.col ELSE NULL END`) forced `artist_name`/`album_title`/`record_label` to NULL on every row that resolved linked after a webhook delivery. That directly contradicted finding 1's own fix from the same round: `linkRotationToAlbum` deliberately leaves the trio populated after `PATCH .../link` so the tracklist picker's tier-3 self-heal and `jobs/rotation-release-id-backfill`'s candidate query (which requires `artist_name`/`album_title` NOT NULL) both keep working. Finding 2's CASE reintroduced exactly the starvation finding 1 exists to prevent, on the very next `/wxycdb` edit — permanently, since `rotation-release-id-backfill`'s candidate query also excludes `kill_date`-past rows, and this same PR deliberately surfaces killed rows in the uncatalogued queue. A killed-and-linked row landed with no repair path at all.

**The trio now writes `excluded.*` unconditionally whenever present in the payload — presence-gated only, same as every other column in this SET clause.** `album_id` (and `albumIdExpr`, the BS#2109 downgrade-guard fix from rounds 2/3) are unaffected; `albumIdExpr` is simply no longer reused by the trio. This costs nothing display-side: `getRotationFromDB` selects `COALESCE(artists.artist_name, rotation.artist_name)` (and the album/label siblings), so a linked row always reads the canonical `library`/`artists` value regardless of what `rotation`'s own snapshot columns hold. The "both populated" shape finding 2 was trying to prevent is real but benign, and now permanent (rather than lasting only until the next edit) — `linkRotationToAlbum`'s docblock and the webhook comment above the SET clause both now describe why, and that it persists until `rotation-release-id-backfill` mints a `discogs_release_id` for the row.

Updated: the unit test that pinned the CASE (`gates artist_name/album_title/record_label on the resolved album_id...`) now asserts the opposite (`writes excluded.* for artist_name/album_title/record_label unconditionally, so a linked row keeps tubafrenzy free text`); the integration test `a full /wxycdb edit on an already-linked row nulls the free-text snapshot instead of writing it back` is renamed to `... still writes the trio from the payload` and now asserts the trio survives; added missing-bin-arm unit coverage for the snapshot trio sent together with a blank `rotationType`, previously entirely unexercised.

## Test plan

- [x] Unit: `pickAddRotationFields` / `addRotation` validation (album_id present vs. explicit-null vs. `0` vs. negative vs. non-integer vs. numeric-string; artist+title pair; blank/whitespace; the 128-char guard per field incl. the exactly-128 boundary, the album_id-present exemption, and 70-/129-code-point astral-plane cases), `getUncataloguedRotation` limit/offset parsing, `linkRotationToAlbum` controller dispatch incl. six malformed-`rotation_id` shapes, `getUncataloguedRotationFromDB` predicate + projection + paging + no-`DISTINCT ON`, `linkRotationToAlbum` transaction (link-preserves-snapshot / double-link / not-found / race-to-already-linked / projected `.returning()`), webhook SET-clause shape (`album_id` COALESCE vs. bare `excluded.*` branch, the three snapshot columns as plain `excluded.*` writes — round 4 — and the unaffected plain-`excluded.*` columns), missing-bin arm coverage for the trio sent with a blank bin (round 4)
- [x] Integration (`tests/integration/library.spec.js`): uncatalogued `POST` incl. the explicit-null and `album_id: 0` shapes and the field-naming length 400; the projection pin; the limit/offset window; the two-same-artist-same-title-both-surface pin against the shape fixture's `#862` rows; `GET /library/rotation` untouched pin; full `PATCH .../link` flow incl. double-link rejection, the malformed-id pin, the snapshot-preserved assertion (round 3), and the projected-response-shape pin (round 3)
- [x] Integration (`tests/integration/internal-rotation-webhook.spec.js`): a Backend-made link survives a webhook `update` carrying `libraryReleaseId: 0` (snapshot preserved, round 3); a full `/wxycdb`-shaped edit on an already-linked row still writes the trio from the payload rather than nulling it (round 4, supersedes the round-3 test of the same scenario — see round 4 above); a resolvable `libraryReleaseId` still writes `album_id` via the bare (non-COALESCE) branch (round 3)
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck` clean; `npm run test:unit` green (443 suites / 7,553 tests as of round 4)
- [x] Integration suite run locally in round 3 via `npm run ci:testmock` against real Postgres: both files this PR touches were fully green, including every round-3 test. 16 unrelated integration suites failed in the same local run on pre-existing local-environment gaps (missing per-job `dist/` builds, missing Slack-mock/seed-fixture credentials) unconnected to any file this PR changes — none of the 9 files this diff touches appeared among them. Not re-run in round 4 (Docker-gated in this environment); the round-4 diff is scoped to two files already covered above and verified via `npm run test:unit`.

