### PR TITLE
feat(library): add field-level rotation update endpoint

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1883,6 +1883,112 @@ paths:
         '409':
           description: Rotation entry is already linked to a library release.
 
+  /library/rotation/{id}:
+    patch:
+      summary: Field-level edit of a rotation release (BS#2113)
+      description: >
+        Partial update of the five columns that actually exist on `wxyc_schema.rotation`:
+        `artist_name`, `album_title`, `record_label`, `add_date`, `kill_date`. Only the
+        fields present in the body are validated and written, so a typo fix on one field
+        cannot wipe another. Gated to MD/SM via `catalog:['write']`.
+
+
+        **`kill_date: null` clears the column.** This is the one non-obvious part of the
+        contract and the only way to un-kill a release through the HTTP surface: sending
+        an explicit JSON `null` writes SQL NULL, returning the row to active rotation.
+        Omitting `kill_date` entirely leaves the stored value untouched — `null` and
+        "absent" are deliberately different, which is why the field is nullable rather
+        than merely optional. `PATCH /library/rotation` (the kill endpoint) can only ever
+        set a date, never clear one.
+
+
+        **The `artist_name`/`album_title`/`record_label` snapshot trio is rejected with a
+        409 on a rotation row that has an `album_id`.** On a library-linked row the
+        rotation read path (`GET /library/rotation`) projects those three from the
+        `library`/`artists` join, so a write here would be echoed by the response and then
+        be invisible everywhere else; a non-NULL snapshot on a linked row also misroutes
+        the flowsheet rotation badge, which partitions its match arms on the invariant that
+        a linked row's denormalized names are NULL. Edit the linked release via
+        `PATCH /library/{id}` instead. `add_date` and `kill_date` stay editable on a
+        catalogued row.
+
+
+        `alphabetical_name`, `format`, and `format_size` appear on the same legacy editor
+        screen but have no `rotation` column, and are rejected with a 400 naming the field
+        rather than silently dropped.
+      security:
+        - BearerAuth: ['catalog-write']
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: '`rotation.id` of the row to edit (positive integer).'
+          schema:
+            type: integer
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                artist_name:
+                  type: string
+                  maxLength: 128
+                  description: Denormalized artist snapshot. Rejected (409) when the row has an `album_id`.
+                album_title:
+                  type: string
+                  maxLength: 128
+                  description: Denormalized album snapshot. Rejected (409) when the row has an `album_id`.
+                record_label:
+                  type: string
+                  maxLength: 128
+                  description: Denormalized label snapshot. Rejected (409) when the row has an `album_id`.
+                add_date:
+                  type: string
+                  format: date
+                  description: '`YYYY-MM-DD`. Calendar-validated: `2026-09-31` is a 400, not a 500.'
+                kill_date:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: '`YYYY-MM-DD`, or an explicit `null` to clear the column and return the release to active rotation.'
+      responses:
+        '200':
+          description: >-
+            The updated rotation row, projected to the same eight columns
+            `GET /library/rotation/uncatalogued` publishes. Not the raw `wxyc_schema.rotation`
+            row — that also carries server-derived plumbing (`legacy_rotation_id`,
+            `discogs_release_id`, `lml_identity_id`, the attempt-at markers) which this
+            endpoint does not publish — and not the joined `GET /library/rotation`
+            list-view shape either.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UncataloguedRotationRow'
+        '400':
+          description: >
+            Non-positive/non-integer `id`, empty body, a field with no `rotation` column
+            (`alphabetical_name`/`format`/`format_size`), a blank or over-128-character
+            text field, or a malformed/impossible `add_date`/`kill_date`.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Authenticated role lacks `catalog:write` (below musicDirector).
+        '404':
+          description: No rotation row with that id.
+        '409':
+          description: >
+            One or more of `artist_name`/`album_title`/`record_label` was sent for a
+            rotation row linked to a library release (`album_id` is not NULL). The remedy
+            is field-specific: `album_title`/`record_label` are editable via
+            `PATCH /library/{album_id}` (`album_title`/`label`); `artist_name` is not —
+            `library.artist_name` is derived from the linked `artists` row via `artist_id`,
+            and no endpoint currently supports renaming an artist or setting free-text
+            `artist_name` on a catalogued release.
+
   /library/artists:
     post:
       summary: Add new artist

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -906,6 +906,35 @@ export const getArtistReleases: RequestHandler<
   res.status(200).json({ artist_id: artistId, releases, total, page, totalPages: Math.ceil(total / limit) });
 };
 
+/**
+ * Validate one optional free-text body field: must be a string, must not be
+ * blank after trimming, must fit the column. Returns the trimmed value.
+ *
+ * The three `rotation` snapshot columns and `updateAlbum`'s `album_title`
+ * all sit on `varchar(128)` and all want the identical trim / non-empty /
+ * max-length shape; over-length input is rejected as a 400 here rather than
+ * reaching the UPDATE and tripping PG 22001 ("value too long") → 500.
+ * Callers pass their own limit so a future wider column doesn't have to
+ * fork the helper.
+ */
+const validateTextField = (value: unknown, field: string, maxLength: number): string => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new WxycError(`${field} must be a non-empty string`, 400);
+  }
+  const trimmed = value.trim();
+  // Code points, not UTF-16 units — `codePointLength`, not `.length`. Postgres
+  // measures `varchar(n)` in characters, so a bare `.length` counts every
+  // astral character (emoji, CJK Ext-B) twice and rejects values PG would
+  // store happily. `addRotation` already measures these same three columns
+  // that way; using `.length` here made a 128-code-point `album_title`
+  // creatable via POST and un-editable via PATCH — a row you cannot fix a
+  // typo in without first shortening a legal title.
+  if (codePointLength(trimmed) > maxLength) {
+    throw new WxycError(`${field} must be ${maxLength} characters or fewer`, 400);
+  }
+  return trimmed;
+};
+
 export const getRotation: RequestHandler = async (req, res) => {
   const rotation = await libraryService.getRotationFromDB();
   res.status(200).json(rotation);
@@ -999,6 +1028,21 @@ export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
  * display sourced from the `library` join, and a client-supplied snapshot on
  * a catalogued row would leave stale free text nothing ever clears.
  *
+ * EDITING that trio after the fact is a different write path: `updateRotation`
+ * (BS#2113) on `PATCH /library/rotation/:id` owns post-creation edits, and
+ * `add_date` is post-creation-only in that same sense — it stays off this
+ * allowlist because `POST` mints a fresh row, not because the column is
+ * unwritable. (An earlier revision of this comment said the whole snapshot
+ * group "must never be client-supplied through this endpoint"; BS#2109 shipped
+ * exactly that for the uncatalogued case, so the rule is now conditional on
+ * `album_id`, not absolute.)
+ *
+ * `rotation` has been Backend-canonical since WXYC/wiki#88 Phase 3:
+ * `jobs/rotation-etl` is unscheduled (`"job-type": "one-shot"`, no
+ * `cron-schedule`) and refuses to run without
+ * `LEGACY_ETL_ALLOW_BACKWARDS_WRITE=1`, so tubafrenzy is no longer "the
+ * legitimate source" for anything here.
+ *
  * **`null` and `undefined` mean the same thing in every test here.**
  * `{ album_id: selected?.id ?? null, ... }` is the idiomatic client shape,
  * and an `=== undefined` test would take the has-an-album_id branch on it —
@@ -1048,7 +1092,14 @@ export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRot
  * very reason this endpoint chose reject-over-truncate.
  */
 const ROTATION_SNAPSHOT_MAX_LENGTH = 128;
-const ROTATION_SNAPSHOT_FIELDS = ['artist_name', 'album_title', 'record_label'] as const;
+
+/**
+ * The denormalized display snapshot. A rotation row carries these three ONLY
+ * when it has no `album_id`; on a library-linked row they must stay NULL. See
+ * `updateRotation` (BS#2113) for why writing them on a catalogued row is
+ * rejected rather than accepted-and-ignored, and `addRotation` (BS#2109) for
+ * the creation-time half of the same rule.
+ */
 
 /** Unicode-code-point length — see `ROTATION_SNAPSHOT_MAX_LENGTH` above. */
 function codePointLength(value: string): number {
@@ -1122,7 +1173,7 @@ export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = 
     // Only guarded on the uncatalogued path: with an `album_id` present the
     // trio is deliberately dropped by `pickAddRotationFields`, so a long
     // value there is never written and must not fail an otherwise-valid add.
-    for (const field of ROTATION_SNAPSHOT_FIELDS) {
+    for (const field of libraryService.ROTATION_SNAPSHOT_COLUMNS) {
       const value = body[field];
       if (value == null) continue;
       if (typeof value !== 'string') {
@@ -1216,12 +1267,223 @@ export const killRotation: RequestHandler<object, unknown, KillRotationRelease> 
     throw new WxycError('Bad Request, Incorrect Date Format: kill_date should be of form YYYY-MM-DD', 400);
   }
 
-  const updatedRotation: RotationRelease = await libraryService.killRotationInDB(body.rotation_id, body.kill_date);
+  const updatedRotation = await libraryService.killRotationInDB(body.rotation_id, body.kill_date);
   if (updatedRotation !== undefined) {
     res.status(200).json(updatedRotation);
   } else {
     throw new WxycError('Rotation entry not found', 400);
   }
+};
+
+export type RotationUpdateRequest = {
+  artist_name?: string;
+  album_title?: string;
+  record_label?: string;
+  add_date?: string; //Accepts ISO8601 formatted dates YYYY-MM-DD
+  kill_date?: string | null; //Accepts ISO8601 formatted dates YYYY-MM-DD, or null to clear
+  // The JSP editor (tubafrenzy's `rotationReleaseModify.jsp`) also carries
+  // these three fields, but none has a column on `rotation` —
+  // alphabetical_name lives on `artists.alphabetical_name`
+  // (WXYC/Backend-Service#2156), format and format_size on the `library` ->
+  // `format` join (WXYC/dj-site#1169). Declared here (not just left unread)
+  // so `ROTATION_NO_COLUMN_FIELDS` below can reject a client that sends
+  // them with a precise 400 instead of silently writing less than it asked
+  // for.
+  alphabetical_name?: unknown;
+  format?: unknown;
+  format_size?: unknown;
+};
+
+const ROTATION_UPDATABLE_FIELDS = ['artist_name', 'album_title', 'record_label', 'add_date', 'kill_date'] as const;
+
+const ROTATION_NO_COLUMN_FIELDS = ['alphabetical_name', 'format', 'format_size'] as const;
+
+// Why each field has no `rotation` column, phrased so the remedy is correct
+// for BOTH a catalogued row (`album_id` present) and an uncatalogued one.
+//
+// `alphabetical_name` is the subtle case. `getRotationFromDB` projects
+// `COALESCE(artists.alphabetical_name, rotation.artist_name)`, so on a
+// catalogued row the value is the `artists` row's and #2156 is the fix,
+// but on an uncatalogued row there IS no `artists` row and the value falls
+// through to `rotation.artist_name` — a column this very endpoint writes.
+// Pointing such a caller at #2156 would send them to edit a row that does
+// not exist.
+const ROTATION_NO_COLUMN_FIELD_OWNERS: Record<(typeof ROTATION_NO_COLUMN_FIELDS)[number], string> = {
+  alphabetical_name:
+    "derived, not stored: a catalogued row takes it from artists.alphabetical_name (edit via PATCH /library/artists/:id, WXYC/Backend-Service#2156); an uncatalogued row falls back to this row's own artist_name, so send artist_name instead",
+  format: 'owned by the release PATCH surface (WXYC/dj-site#1169)',
+  format_size: 'owned by the release PATCH surface (WXYC/dj-site#1169)',
+};
+
+/**
+ * Field-specific remedy text for the linked-snapshot 409 (BS#2113 review
+ * finding 2). `album_title`/`record_label` have a working remedy on
+ * `PATCH /library/:id` (`album_title`/`label` respectively); `artist_name`
+ * does not — `library.artist_name` only ever changes by re-pointing
+ * `artist_id` at a different, already-existing `artists` row (which
+ * reattributes the release, not renames anyone), and no endpoint exposes a
+ * direct rename. Telling a caller to "edit the library release" for an
+ * `artist_name` rejection would send them looking for a field that isn't
+ * there.
+ */
+const ROTATION_SNAPSHOT_LIBRARY_FIELD: Partial<
+  Record<(typeof libraryService.ROTATION_SNAPSHOT_COLUMNS)[number], string>
+> = {
+  album_title: 'album_title',
+  record_label: 'label',
+};
+
+function buildLinkedSnapshotConflictMessage(
+  snapshotFields: ReadonlyArray<(typeof libraryService.ROTATION_SNAPSHOT_COLUMNS)[number]>,
+  albumId: number
+): string {
+  const editableViaLibrary = snapshotFields
+    .map((field) => ROTATION_SNAPSHOT_LIBRARY_FIELD[field])
+    .filter((field): field is string => field !== undefined);
+  const rejectsArtistName = snapshotFields.includes('artist_name');
+
+  const remedies: string[] = [];
+  if (editableViaLibrary.length > 0) {
+    remedies.push(`edit ${editableViaLibrary.join(', ')} via PATCH /library/${albumId} instead`);
+  }
+  if (rejectsArtistName) {
+    remedies.push(
+      'artist_name has no remedy here: library.artist_name is derived from the linked artists row via ' +
+        'artist_id, and no endpoint currently supports renaming an artist or setting free-text artist_name ' +
+        'on a catalogued release'
+    );
+  }
+
+  return (
+    `Conflict: ${snapshotFields.join(', ')} cannot be set on a rotation row linked to a library release ` +
+    `(album_id ${albumId}) — the rotation read path takes those values from the library join, so the write ` +
+    `would be invisible, and a non-NULL snapshot on a linked row misroutes the flowsheet rotation badge. ` +
+    `${remedies.join('; ')}.`
+  );
+}
+
+/**
+ * PATCH /library/rotation/:id (BS#2113): field-level edit for the five
+ * `rotation` columns the tubafrenzy JSP editor (`rotationReleaseModify.jsp`)
+ * exposes that actually have a column here — the alphabetical name, format,
+ * and format-size fields on that same screen are rejected (no column;
+ * `ROTATION_NO_COLUMN_FIELDS`), not silently dropped.
+ *
+ * True partial semantics — only fields present in the body are validated
+ * and written — mirroring `updateAlbum`. Delegates to the same
+ * `libraryService.updateRotation()` writer `killRotation` (`PATCH
+ * /library/rotation`) uses, so the two routes can't drift on how they set
+ * `kill_date`.
+ *
+ * The `artist_name`/`album_title`/`record_label` snapshot trio is rejected
+ * with a 409 on a row that HAS an `album_id`, for two independent reasons:
+ *
+ *   1. It would be a write nobody can read. `getRotationFromDB` projects
+ *      `COALESCE(artists.artist_name, rotation.artist_name)`,
+ *      `COALESCE(library.album_title, rotation.album_title)` and
+ *      `COALESCE(library.label, rotation.record_label)` — on a linked row
+ *      the library join always wins. The UPDATE would land in the column
+ *      and be echoed back by `.returning()`, then be invisible on the only
+ *      rotation read path: exactly the "silently writing less than it asked
+ *      for" failure `ROTATION_NO_COLUMN_FIELDS` above exists to prevent.
+ *   2. It would break a load-bearing invariant. "A library-LINKED rotation
+ *      row carries NULL denormalized names" is documented verbatim in
+ *      `flowsheet.service.ts` (the rotation-badge read path) and restated in
+ *      `shared/legacy-mirror/src/rotation-match.ts`; BS#2080's arm-(b) /
+ *      arm-(c) partition rests on it and neither arm filters
+ *      `album_id IS NULL`. A snapshot on a linked row makes arm (b) match
+ *      any hand-typed flowsheet entry with the same (artist, album), so one
+ *      rotation row badges two different releases — on the BS read path and
+ *      via `isActiveRotationMatch` on the tubafrenzy mirror write path.
+ *
+ * The 409's remedy is field-specific, not a blanket "edit the library
+ * release" — `PATCH /library/:id` genuinely covers `album_title` (its own
+ * `album_title` field) and `record_label` (its `label` field), but has no
+ * `artist_name` field at all: `library.artist_name` is derived from the
+ * linked `artists` row via `artist_id`, and no endpoint today lets a caller
+ * rename an artist or set free-text `artist_name` on a catalogued release.
+ * An earlier revision pointed every rejection at `PATCH /library/:id`
+ * uniformly, which was a real remedy for two of the three fields and a dead
+ * end for the third; `buildLinkedSnapshotConflictMessage` below says so
+ * rather than repeating the blanket claim.
+ *
+ * Sibling PR WXYC/Backend-Service#2164 (issue BS#2109) forbids the same trio
+ * on `POST /library/rotation` at creation time, on the same grounds — it
+ * picks the snapshot columns onto the insert allowlist only when the client
+ * supplied no `album_id`. `add_date` and `kill_date` stay
+ * editable on a catalogued row: `getRotationFromDB` reads both straight off
+ * `rotation`, with no library-join shadow.
+ *
+ * The linked/unlinked precondition on the trio is enforced as a
+ * compare-and-set inside `libraryService.updateRotation`, not from a read
+ * taken here first: `rotation` is a live ingest target (the tubafrenzy
+ * rotation webhook writes it continuously), so a row this handler read as
+ * unlinked can be linked by the time the write lands. The service carries
+ * `album_id IS NULL` into the UPDATE's own WHERE and reports a zero-row
+ * result as a conflict — this handler never makes the linked/unlinked call
+ * itself.
+ */
+export const updateRotation: RequestHandler<{ id: string }, unknown, RotationUpdateRequest> = async (req, res) => {
+  const rotationId = parseResourceId(req.params.id, 'rotation');
+
+  const { body } = req;
+
+  const rejectedFields = ROTATION_NO_COLUMN_FIELDS.filter((field) => field in body);
+  if (rejectedFields.length > 0) {
+    // `field — reason`, not `field (see reason)`. The reasons are phrases and
+    // sentences, not place names, so the "(see …)" frame produced unreadable
+    // output ("alphabetical_name (see derived, not stored: …)") and nested
+    // parens for the two entries that already carry their own.
+    const detail = rejectedFields.map((field) => `${field} — ${ROTATION_NO_COLUMN_FIELD_OWNERS[field]}`).join('; ');
+    throw new WxycError(`Bad Request: no rotation column exists for ${detail}`, 400);
+  }
+
+  if (!ROTATION_UPDATABLE_FIELDS.some((field) => field in body)) {
+    throw new WxycError(`Bad Request: provide at least one of ${ROTATION_UPDATABLE_FIELDS.join(', ')}`, 400);
+  }
+
+  const updates: libraryService.UpdateRotationRow = {};
+
+  for (const field of libraryService.ROTATION_SNAPSHOT_COLUMNS) {
+    if (body[field] !== undefined) {
+      updates[field] = validateTextField(body[field], field, ROTATION_SNAPSHOT_MAX_LENGTH);
+    }
+  }
+
+  if (body.add_date !== undefined) {
+    if (typeof body.add_date !== 'string' || !libraryService.isISODate(body.add_date)) {
+      throw new WxycError('Bad Request, Incorrect Date Format: add_date should be of form YYYY-MM-DD', 400);
+    }
+    updates.add_date = body.add_date;
+  }
+
+  if (body.kill_date !== undefined) {
+    if (body.kill_date !== null && (typeof body.kill_date !== 'string' || !libraryService.isISODate(body.kill_date))) {
+      throw new WxycError('Bad Request, Incorrect Date Format: kill_date should be of form YYYY-MM-DD', 400);
+    }
+    updates.kill_date = body.kill_date;
+  }
+
+  // BS#2113 review finding 4: the linked/unlinked precondition lives in the
+  // service's own compare-and-set UPDATE, not in a read taken here — see
+  // `libraryService.updateRotation` for why.
+  const outcome = await libraryService.updateRotation(rotationId, updates);
+
+  if (outcome.outcome === 'not_found') {
+    throw new WxycError('Rotation entry not found', 404);
+  }
+
+  if (outcome.outcome === 'linked_conflict') {
+    const snapshotFields = libraryService.ROTATION_SNAPSHOT_COLUMNS.filter((field) => body[field] !== undefined);
+    throw new WxycError(buildLinkedSnapshotConflictMessage(snapshotFields, outcome.albumId), 409);
+  }
+
+  // Projected, not the bare `.returning()` row: `rotation` also carries
+  // `legacy_rotation_id`, `legacy_library_release_id`, `discogs_release_id`,
+  // `discogs_release_id_source`, `lml_identity_id` and the two attempt-at
+  // markers, none of which any rotation read publishes -- and wxyc-shared#354
+  // transcribes whatever this returns into a published contract.
+  res.status(200).json(libraryService.toRotationRowSummary(outcome.rotation));
 };
 
 // Wire shape `RotationTrack` lives in `library.service.ts` so the service
@@ -1439,14 +1701,7 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
   const updates: libraryService.UpdateAlbumRow = {};
 
   if (body.album_title !== undefined) {
-    if (typeof body.album_title !== 'string' || body.album_title.trim() === '') {
-      throw new WxycError('album_title must be a non-empty string', 400);
-    }
-    const trimmedTitle = body.album_title.trim();
-    if (trimmedTitle.length > MAX_ALBUM_TEXT_LENGTH) {
-      throw new WxycError(`album_title must be ${MAX_ALBUM_TEXT_LENGTH} characters or fewer`, 400);
-    }
-    updates.album_title = trimmedTitle;
+    updates.album_title = validateTextField(body.album_title, 'album_title', MAX_ALBUM_TEXT_LENGTH);
   }
 
   if ('alternate_artist_name' in body) {

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -126,6 +126,11 @@ library_route.patch(
   libraryController.linkRotationToAlbum
 );
 
+// BS#2113: field-level rotation edit. Registered after every literal
+// `/rotation/*` route above (and any WXYC/Backend-Service#2109 adds to this
+// block later) so `:id` never shadows a more specific path.
+library_route.patch('/rotation/:id', requirePermissions({ catalog: ['write'] }), libraryController.updateRotation);
+
 library_route.post('/artists', requirePermissions({ catalog: ['write'] }), libraryController.addArtist);
 
 library_route.get(

--- a/apps/backend/services/bmi-performance.service.ts
+++ b/apps/backend/services/bmi-performance.service.ts
@@ -85,12 +85,12 @@ export type BmiDateRange = {
   toExclusive: Date;
 };
 
-// Shape-only ISO-day guard. A byte-identical regex backs the weaker shape-only
-// `isISODate` (library.service.ts); `parseIsoDay` below intentionally goes further,
-// also rejecting impossible calendar dates via an ISO round-trip. Not consolidated
-// here: reusing `isISODate` would drop the calendar-validity check, and promoting the
-// stronger check into a shared util would change `killRotation`'s accepted inputs —
-// out of scope for this shell.
+// Shape guard. A byte-identical regex backs `isISODate` (library.service.ts), which
+// as of BS#2113 also round-trips through `Date` to reject impossible calendar dates —
+// the two predicates now accept the same set of strings. Still not consolidated: the
+// two differ in what they do on failure (`parseIsoDay` throws a field-named 400,
+// `isISODate` returns a boolean its callers turn into their own message), so a shared
+// util would have to carry both shapes for no gain.
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, ne, notInArray, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, ne, notInArray, or, sql, SQL } from 'drizzle-orm';
 import { LRUCache } from 'lru-cache';
 import * as Sentry from '@sentry/node';
 import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
@@ -574,13 +574,177 @@ export const addToRotation = async (newRotation: RotationAddRequest) => {
   return insertedRotation[0];
 };
 
-export const killRotationInDB = async (rotationId: number, updatedKillDate?: string) => {
-  const updatedRotation = await db
-    .update(rotation)
-    .set({ kill_date: updatedKillDate || sql`CURRENT_DATE` })
-    .where(eq(rotation.id, rotationId))
-    .returning();
-  return updatedRotation[0];
+/**
+ * Partial-update payload for `PATCH /library/rotation/:id` (BS#2113). Every
+ * field is optional — `updateRotation` only SETs keys that are present, so
+ * a typo fix on `artist_name` can't wipe `record_label` or reset
+ * `kill_date`. Covers exactly the five columns the JSP editor's field set
+ * maps onto a real `rotation` column (see the controller's
+ * `ROTATION_NO_COLUMN_FIELDS` for the three that don't).
+ *
+ * `kill_date` additionally accepts a raw `SQL<unknown>` fragment — the sole
+ * caller of that widened type is `killRotationInDB` below, whose no-date
+ * default is `CURRENT_DATE` evaluated server-side. The public controller
+ * surface only ever passes a plain ISO string or `null`.
+ */
+export type UpdateRotationRow = {
+  artist_name?: string;
+  album_title?: string;
+  record_label?: string;
+  add_date?: string;
+  kill_date?: string | SQL<unknown> | null;
+};
+
+/**
+ * The three denormalized snapshot columns `updateRotation` may only set on
+ * an unlinked row — see the controller's `updateRotation` JSDoc for why.
+ *
+ * Exported, and the single declaration of this tuple in the codebase. The
+ * compare-and-set WHERE, the tracklist-cache invalidation branch below
+ * (BS#2113 review findings 4 and 1), and the controller's request validation +
+ * 409 message builder all read off it. An earlier revision declared it here and
+ * again in the controller as `ROTATION_SNAPSHOT_FIELDS` — two lists governing
+ * one invariant, which is precisely the drift this comment claimed to prevent.
+ */
+export const ROTATION_SNAPSHOT_COLUMNS = ['artist_name', 'album_title', 'record_label'] as const;
+
+/**
+ * Outcome of a `PATCH /library/rotation/:id` write attempt (BS#2113).
+ * `linked_conflict` carries the row's `album_id` as observed by the write
+ * itself — not by an earlier read — so the controller's 409 names the
+ * correct release even when the link happened concurrently with the
+ * request (review finding 4).
+ */
+export type UpdateRotationOutcome =
+  | { outcome: 'updated'; rotation: RotationRelease }
+  | { outcome: 'not_found' }
+  | { outcome: 'linked_conflict'; albumId: number };
+
+/**
+ * Sole writer of the five in-scope `rotation` columns among the
+ * `/library/rotation*` HTTP surfaces (BS#2113): both
+ * `PATCH /library/rotation/:id` (`updateRotation` controller handler) and
+ * `PATCH /library/rotation` (`killRotation`, via `killRotationInDB` below)
+ * delegate here rather than issuing their own UPDATE — the
+ * `rotation_bin` divergence (two writers, one column, drifting SET clauses)
+ * is the failure mode a shared writer forecloses.
+ *
+ * NOT the only writer of `rotation.kill_date` process-wide: the tubafrenzy
+ * webhook in `apps/backend/routes/internal.route.ts` sets it directly on its
+ * kill/unkill branches, keyed on `legacy_rotation_id` rather than `id`. That
+ * is a deliberately separate write path (a legacy-id-keyed mirror, not an
+ * HTTP edit surface) — grep before assuming exclusivity.
+ *
+ * Two review findings folded into this one function rather than left as two
+ * separate patches:
+ *
+ *   - **Finding 1 (stale tracklist-picker cache).** Editing any member of
+ *     the snapshot trio changes the text `resolveRotationDiscogsReleaseViaLml`
+ *     (the tier-3 tracklist-picker cascade) keys its cache on, so the same
+ *     write NULLs `rotation.tracklist_lookup_attempted_at` in its own SET and
+ *     evicts this `rotation_id` from both `rotationLmlPositiveCache` and
+ *     `rotationLmlNegativeCache` once the transaction has committed.
+ *
+ *     Scope, stated precisely because an earlier revision of this comment
+ *     overstated it: this clears **tier 3 only**. `resolveRotationPickerSource`
+ *     returns at its `stored !== null` short-circuit — on
+ *     `rotation.discogs_release_id`, or the `library_identity` fallback —
+ *     *before* it consults either the stamp or these caches. So on a row
+ *     already carrying a direct release id, correcting the free text does not
+ *     change which release the picker serves, even though the text that id was
+ *     derived from just changed. Clearing a machine-derived
+ *     `discogs_release_id` on a snapshot edit is the real fix; it means
+ *     reasoning about `discogs_release_id_source` (a trust-gated column —
+ *     `md_verified` and `tubafrenzy_paste` must survive), so it is deliberately
+ *     not done here. Tracked in BS#2214.
+ *   - **Finding 4 (TOCTOU).** The snapshot trio may only be set on an
+ *     unlinked row (`album_id IS NULL`). `rotation` is a live ingest
+ *     target — the tubafrenzy rotation webhook
+ *     (`POST /internal/rotation-webhook`) can link this exact row in the
+ *     window between a caller's read and a naive write — so the precondition
+ *     is asserted in the UPDATE's own WHERE, never trusted from an earlier
+ *     SELECT. A zero-row result while the trio is present means "this row
+ *     is linked as of right now", not "this row doesn't exist" or "the
+ *     write silently no-opped". Mirrors the re-guarded-WHERE discipline in
+ *     `linkRotationToAlbum` / `legacy-linkage-resolve`: a guarded write, then
+ *     one more read — inside the same transaction — to tell "no such row"
+ *     apart from "row changed under us" when the write matches nothing.
+ */
+export const updateRotation = async (
+  rotation_id: number,
+  updates: UpdateRotationRow
+): Promise<UpdateRotationOutcome> => {
+  const set: Record<string, unknown> = {};
+  for (const key of ['artist_name', 'album_title', 'record_label', 'add_date', 'kill_date'] as const) {
+    if (updates[key] !== undefined) set[key] = updates[key];
+  }
+  // Drizzle's `mapUpdateSet` throws `No values to set` on an empty payload
+  // before it generates any SQL. Refuse it here instead, so a future direct
+  // caller gets a message naming this function rather than an opaque ORM
+  // error. Unreachable through either HTTP surface: the controller 400s on
+  // an empty body and `killRotationInDB` always supplies a `kill_date`.
+  if (Object.keys(set).length === 0) {
+    throw new WxycError('updateRotation requires at least one column to set', 400);
+  }
+
+  const touchesSnapshot = ROTATION_SNAPSHOT_COLUMNS.some((key) => key in set);
+
+  // Only the snapshot path needs a transaction. Its guarded UPDATE can match
+  // zero rows for two different reasons, and telling them apart takes a second
+  // read that has to see the same snapshot. The other path — an `add_date` /
+  // `kill_date`-only edit, which is every `PATCH /library/rotation` kill via
+  // `killRotationInDB` — is a single statement, so wrapping it would turn one
+  // round trip into three (BEGIN / UPDATE / COMMIT) and hold a pooled
+  // connection across all three on a box that also serves the live flowsheet.
+  // That endpoint issued one bare UPDATE before BS#2113; keep it that way.
+  if (!touchesSnapshot) {
+    const [updated] = await db.update(rotation).set(set).where(eq(rotation.id, rotation_id)).returning();
+    // No guard beyond `id` in the WHERE — zero rows really does mean "no such
+    // row", exactly as before this function returned a bare row.
+    return updated ? { outcome: 'updated' as const, rotation: updated } : { outcome: 'not_found' as const };
+  }
+
+  set.tracklist_lookup_attempted_at = null;
+
+  const outcome = await db.transaction(async (tx): Promise<UpdateRotationOutcome> => {
+    const updatedRows = await tx
+      .update(rotation)
+      .set(set)
+      .where(and(eq(rotation.id, rotation_id), isNull(rotation.album_id)))
+      .returning();
+    const updated = updatedRows[0];
+    if (updated) {
+      return { outcome: 'updated' as const, rotation: updated };
+    }
+
+    // The guarded UPDATE matched nothing: either the row doesn't exist, or a
+    // concurrent writer linked it since the caller last looked. One more
+    // read, inside the same transaction, tells the two apart.
+    const [current] = await tx
+      .select({ album_id: rotation.album_id })
+      .from(rotation)
+      .where(eq(rotation.id, rotation_id))
+      .limit(1);
+    if (!current || current.album_id === null) {
+      // Either genuinely gone, or (a second concurrent write unlinked it
+      // again in the instant between our failed guarded UPDATE and this
+      // read) not actually linked after all. Neither is a 409 the caller
+      // can act on, so report not-found rather than fabricate an album id.
+      return { outcome: 'not_found' as const };
+    }
+    return { outcome: 'linked_conflict' as const, albumId: current.album_id };
+  });
+
+  // Evict AFTER the commit, never inside it. Between an in-transaction evict
+  // and the commit, a concurrent `/library/rotation/:id/tracks` read on its own
+  // connection still sees the pre-commit text and can re-prime the very entry
+  // this write just cleared — which would then outlive the commit for the full
+  // TTL. Post-commit, any racing reader primes from the new text instead.
+  if (outcome.outcome === 'updated') {
+    rotationLmlPositiveCache.delete(rotation_id);
+    rotationLmlNegativeCache.delete(rotation_id);
+  }
+  return outcome;
 };
 
 /**
@@ -614,6 +778,31 @@ const UNCATALOGUED_ROTATION_PROJECTION = {
  * the reverse) is a compile error instead of silent drift.
  */
 export type UncataloguedRotationRow = Pick<RotationRelease, keyof typeof UNCATALOGUED_ROTATION_PROJECTION>;
+
+/**
+ * Project a full `rotation` row down to the published surface — the same eight
+ * columns `UNCATALOGUED_ROTATION_PROJECTION` selects, so the rotation surface
+ * has ONE published shape rather than one per endpoint.
+ *
+ * Applied by the CALLER, deliberately not inside `updateRotation`'s
+ * `.returning()`. `killRotationInDB` delegates to that same writer and
+ * unwraps `outcome.rotation` straight onto `PATCH /library/rotation`'s
+ * response, so narrowing the writer would silently change a pre-existing
+ * endpoint's wire shape as a side effect of adding a new one. That endpoint's
+ * leak of the server-derived columns is real but is its own change, with its
+ * own consumer check.
+ */
+export function toRotationRowSummary(row: RotationRelease): UncataloguedRotationRow {
+  // Destructured explicitly rather than built via `Object.fromEntries(...) as
+  // UncataloguedRotationRow`. That form type-checks through `fromEntries`'s
+  // `{[k: string]: T}` return, so the `as` silences exactly the drift error
+  // `UncataloguedRotationRow`'s own docblock promises: widen
+  // `UNCATALOGUED_ROTATION_PROJECTION` without widening the type (or the
+  // reverse) and the cast keeps compiling. Written out, either direction is a
+  // compile error — which is the guarantee that was being advertised.
+  const { id, album_id, rotation_bin, add_date, kill_date, artist_name, album_title, record_label } = row;
+  return { id, album_id, rotation_bin, add_date, kill_date, artist_name, album_title, record_label };
+}
 
 /**
  * Ceiling on `?limit=` for the uncatalogued queue, and the default when the
@@ -792,6 +981,11 @@ export const linkRotationToAlbum = async (rotationId: number, albumId: number): 
 
     return { outcome: 'linked' as const, rotation: updated };
   });
+};
+
+export const killRotationInDB = async (rotationId: number, updatedKillDate?: string) => {
+  const outcome = await updateRotation(rotationId, { kill_date: updatedKillDate || sql`CURRENT_DATE` });
+  return outcome.outcome === 'updated' ? outcome.rotation : undefined;
 };
 
 export const insertAlbum = async (newAlbum: NewAlbum) => {
@@ -3160,9 +3354,37 @@ export const insertGenre = async (genre: NewGenre) => {
   return response[0];
 };
 
+/**
+ * `YYYY-MM-DD` guard for the `rotation.add_date` / `rotation.kill_date`
+ * write surfaces (`PATCH /library/rotation/:id`, `PATCH /library/rotation`).
+ *
+ * Shape AND calendar validity. The shape-only predecessor let `2026-09-31`
+ * and `2026-13-01` through the 400 gate; Postgres then raised 22008
+ * ("date/time field value out of range") and the caller got a 500 plus a
+ * Sentry event for what is plainly a client mistake. The round-trip below
+ * is the same one `parseIsoDay` in `bmi-performance.service.ts` uses: parse
+ * as UTC midnight, then require the re-serialized ISO day to equal the
+ * input, which rejects both NaN parses and silent rollovers.
+ */
+/**
+ * `0001-01-01T00:00:00.000Z` as epoch ms — the earliest instant PostgreSQL's
+ * `date` type can represent. Anything below it is a year-0 (or negative-year)
+ * value that JS is happy to parse and PG rejects with SQLSTATE 22008.
+ */
+const MIN_PG_DATE_MS = -62135596800000;
+
 export const isISODate = (date: string): boolean => {
-  const regex = /^\d{4}-\d{2}-\d{2}$/;
-  return date.match(regex) !== null;
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const ms = Date.parse(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(ms)) return false;
+  // JS has a year 0; PostgreSQL does not (1 BC is followed directly by 1 AD),
+  // so every `0000-*` date raises 22008 "date/time field value out of range" —
+  // the same 500 this round-trip exists to keep out. `Date.parse` accepts them
+  // and `toISOString()` round-trips them cleanly, so the round-trip alone
+  // cannot see it. Written as a literal rather than `Date.UTC(1, 0, 1)`, which
+  // is 1901: `Date.UTC` maps years 0-99 onto 1900-1999.
+  if (ms < MIN_PG_DATE_MS) return false;
+  return new Date(ms).toISOString().slice(0, 10) === date;
 };
 
 // =============================================================================

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -520,6 +520,21 @@ describe('Library Rotation', () => {
 
       expectErrorContains(res, 'Incorrect Date Format');
     });
+
+    // BS#2113: the shared `isISODate` guard is calendar-validating, so a
+    // well-formed-but-impossible date is a 400 here rather than a PG 22008
+    // ("date/time field value out of range") surfacing as a 500.
+    test('returns 400 for a well-formed but impossible kill_date', async () => {
+      const res = await auth
+        .patch('/library/rotation')
+        .send({
+          rotation_id: 1,
+          kill_date: '2026-09-31',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Incorrect Date Format');
+    });
   });
 
   // BS#2109: an uncatalogued rotation release — no album_id, represented by
@@ -833,6 +848,288 @@ describe('Library Rotation', () => {
 
       const res = await auth.patch(`/library/rotation/${created.id}/link`).send({}).expect(400);
       expectErrorContains(res, 'Missing Parameters');
+    });
+  });
+
+  // BS#2113: field-level rotation edit. `killRotation` above and this route
+  // both delegate to the same `libraryService.updateRotation()` writer —
+  // the "identical column writes for kill_date" pin lives at the unit level
+  // (tests/unit/services/library.service.updateRotation.test.ts); this
+  // block is the end-to-end wire-shape coverage.
+  describe('PATCH /library/rotation/:id (Field-Level Update)', () => {
+    // A CATALOGUED row (`album_id` set), created through the public POST.
+    let testRotationId;
+    // An UNCATALOGUED row (`album_id` NULL), inserted directly: on this
+    // branch `POST /library/rotation` still requires `album_id`, and the
+    // denormalized snapshot trio is only writable on a row without one.
+    let uncataloguedRotationId;
+
+    beforeEach(async () => {
+      const res = await auth.post('/library/rotation').send({
+        album_id: 3,
+        rotation_bin: 'L',
+      });
+
+      // A failed setup must read as a failed setup. The old shape left
+      // `testRotationId` undefined and every request below went to
+      // `/library/rotation/undefined`, reporting as a validation failure.
+      expect(res.status).toBe(201);
+      expect(res.body.id).toEqual(expect.any(Number));
+      testRotationId = res.body.id;
+
+      const sql = getTestDb();
+      const [row] = await sql`
+        INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, add_date, artist_name, album_title, record_label)
+        VALUES (NULL, 'L', CURRENT_DATE, 'Csillagrablok', 'Promo Tape', 'self-released')
+        RETURNING id`;
+      uncataloguedRotationId = row.id;
+    });
+
+    afterEach(async () => {
+      if (testRotationId) {
+        await auth.patch('/library/rotation').send({ rotation_id: testRotationId });
+        testRotationId = undefined;
+      }
+      if (uncataloguedRotationId) {
+        const sql = getTestDb();
+        await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE id = ${uncataloguedRotationId}`;
+        uncataloguedRotationId = undefined;
+      }
+    });
+
+    test('updates the five in-scope columns on an uncatalogued row, including kill_date, in one call', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${uncataloguedRotationId}`)
+        .send({
+          artist_name: 'Chuquimamani-Condori',
+          album_title: 'Edits',
+          record_label: 'self-released',
+          add_date: '2024-01-15',
+          kill_date: '2024-06-01',
+        })
+        .expect(200);
+
+      expect(res.body.id).toBe(uncataloguedRotationId);
+      expect(res.body.artist_name).toBe('Chuquimamani-Condori');
+      expect(res.body.album_title).toBe('Edits');
+      expect(res.body.record_label).toBe('self-released');
+      expect(res.body.add_date).toBe('2024-01-15');
+      expect(res.body.kill_date).toBe('2024-06-01');
+    });
+
+    // Mirrors the `link response is projected` pin above. Without an explicit
+    // key-set assertion, every other test here reads named fields only, so a
+    // controller that returned `outcome.rotation` bare — leaking
+    // `legacy_rotation_id`, `discogs_release_id`, `lml_identity_id` and the two
+    // attempt-at markers — would keep all of them green. `toRotationRowSummary`
+    // is applied by this caller precisely so that cannot happen; this is what
+    // proves it stayed applied.
+    test('update response is projected — no server-derived or external-ID columns', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${uncataloguedRotationId}`)
+        .send({ artist_name: 'Chuquimamani-Condori' })
+        .expect(200);
+
+      expect(Object.keys(res.body).sort()).toEqual([
+        'add_date',
+        'album_id',
+        'album_title',
+        'artist_name',
+        'id',
+        'kill_date',
+        'record_label',
+        'rotation_bin',
+      ]);
+    });
+
+    test('true partial semantics — an artist_name-only edit leaves other fields untouched', async () => {
+      await auth
+        .patch(`/library/rotation/${uncataloguedRotationId}`)
+        .send({ album_title: 'DOGA', record_label: 'Sonamos' })
+        .expect(200);
+
+      const res = await auth
+        .patch(`/library/rotation/${uncataloguedRotationId}`)
+        .send({ artist_name: 'Juana Molina' })
+        .expect(200);
+
+      expect(res.body.artist_name).toBe('Juana Molina');
+      expect(res.body.album_title).toBe('DOGA');
+      expect(res.body.record_label).toBe('Sonamos');
+    });
+
+    test('an explicit null kill_date clears the column', async () => {
+      await auth.patch(`/library/rotation/${testRotationId}`).send({ kill_date: '2024-06-01' }).expect(200);
+
+      const res = await auth.patch(`/library/rotation/${testRotationId}`).send({ kill_date: null }).expect(200);
+
+      expect(res.body.kill_date).toBeNull();
+    });
+
+    // Every other assertion in this block reads the PATCH's own `.returning()`
+    // row, which reports what landed in the COLUMN. `GET /library/rotation` is
+    // the only rotation read path, and it projects the library join over the
+    // rotation columns — so a write that is invisible there is invisible to
+    // every client. Re-reading is what makes that shadowing observable.
+    //
+    // This asserts against the UNCATALOGUED row, not `testRotationId`, and the
+    // reason is load-bearing. `getRotationFromDB` is
+    // `SELECT DISTINCT ON (partitionKey, rotation_bin) … ORDER BY partitionKey,
+    // rotation_bin, add_date DESC, id ASC`, where `partitionKey` is
+    // `coalesce(album_id, -(abs(hashtext(lower(artist)||'|'||lower(album)))+1))`.
+    // So only ONE row per (album, bin) survives the read, and `add_date` is the
+    // tiebreak. `testRotationId` is created against the shared `album_id: 3`
+    // fixture, whose (3, 'L') partition already has an occupant — it loses on
+    // `id ASC` at equal `add_date`, and loses outright once its `add_date` is
+    // pushed back. Asserting on it tests the dedup, not the write. The
+    // uncatalogued row partitions on a hash of its own artist/album, which this
+    // block creates and drops per test, so it owns its partition outright.
+    //
+    // The dedup is deliberate (it is the #862 fix for the bin selector showing
+    // one release three times), so an MD editing `add_date` on one of several
+    // same-(album, bin) rotation rows can change WHICH of them the dropdown
+    // shows. That is the intended collapse, not a regression.
+    test('a written add_date is visible on the GET /library/rotation read path', async () => {
+      await auth.patch(`/library/rotation/${uncataloguedRotationId}`).send({ add_date: '2024-01-15' }).expect(200);
+
+      const list = await auth.get('/library/rotation').expect(200);
+      const row = list.body.find((r) => r.rotation_id === uncataloguedRotationId);
+
+      expect(row).toBeDefined();
+      expect(row.rotation_add_date).toBe('2024-01-15');
+    });
+
+    // BS#2080 invariant: a library-LINKED rotation row carries NULL
+    // denormalized names. `getRotationFromDB` COALESCEs the library join over
+    // these three, so the write would be echoed by `.returning()` and be
+    // invisible on the read path — and a non-NULL snapshot on a linked row
+    // makes the flowsheet rotation-badge arm (b) match unrelated free-text
+    // entries. Rejected rather than accepted-and-shadowed.
+    test('rejects the artist_name/album_title/record_label trio on a catalogued row', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${testRotationId}`)
+        .send({ artist_name: 'Chuquimamani-Condori', album_title: 'Edits' })
+        .expect(409);
+
+      expectErrorContains(res, 'linked to a library release');
+
+      const sql = getTestDb();
+      const [row] = await sql`
+        SELECT artist_name, album_title FROM ${sql(SCHEMA)}.rotation WHERE id = ${testRotationId}`;
+      expect(row.artist_name).toBeNull();
+      expect(row.album_title).toBeNull();
+    });
+
+    // BS#2113 review finding 2: the 409's remedy is field-specific.
+    // album_title/record_label really are editable via PATCH /library/:id;
+    // artist_name is not — library.artist_name is derived from the linked
+    // artists row, and no endpoint renames an artist.
+    test('the 409 offers a real remedy for album_title/record_label but admits artist_name has none', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${testRotationId}`)
+        .send({ artist_name: 'Chuquimamani-Condori', album_title: 'Edits' })
+        .expect(409);
+
+      expectErrorContains(res, 'edit album_title via PATCH /library/3 instead');
+      expectErrorContains(res, 'artist_name has no remedy here');
+    });
+
+    // BS#2113 review finding 4 (TOCTOU): the linked/unlinked precondition on
+    // the snapshot trio is a compare-and-set against the row's CURRENT
+    // `album_id`, not a value read earlier in the request. Re-link the
+    // fixture row to a DIFFERENT catalogued release after the beforeEach
+    // fixture already linked it to album 3 — the 409 must name the release
+    // this write actually collided with (2), not the one the fixture
+    // originally set up (3), proving the conflict is detected and reported
+    // from the row's live state.
+    test('a 409 on a linked row names the album it is linked to right now, not a stale value', async () => {
+      const sql = getTestDb();
+      await sql`UPDATE ${sql(SCHEMA)}.rotation SET album_id = 2 WHERE id = ${testRotationId}`;
+
+      const res = await auth.patch(`/library/rotation/${testRotationId}`).send({ album_title: 'Edits' }).expect(409);
+
+      expectErrorContains(res, 'album_id 2');
+
+      const [row] = await sql`SELECT album_title FROM ${sql(SCHEMA)}.rotation WHERE id = ${testRotationId}`;
+      expect(row.album_title).toBeNull();
+    });
+
+    // BS#2113 review finding 1: a snapshot edit invalidates the tracklist
+    // picker's persisted "don't bother asking LML" marker in the same write,
+    // so the picker re-attempts LML instead of trusting a stamp that
+    // describes the release the row used to name.
+    test('a snapshot edit resets tracklist_lookup_attempted_at to NULL', async () => {
+      const sql = getTestDb();
+      await sql`
+        UPDATE ${sql(SCHEMA)}.rotation SET tracklist_lookup_attempted_at = NOW()
+        WHERE id = ${uncataloguedRotationId}`;
+
+      await auth.patch(`/library/rotation/${uncataloguedRotationId}`).send({ artist_name: 'Juana Molina' }).expect(200);
+
+      const [row] = await sql`
+        SELECT tracklist_lookup_attempted_at FROM ${sql(SCHEMA)}.rotation WHERE id = ${uncataloguedRotationId}`;
+      expect(row.tracklist_lookup_attempted_at).toBeNull();
+    });
+
+    // Negative case for the same finding: an edit that never touches the
+    // snapshot trio has nothing stale to invalidate, so the marker — and
+    // whatever positive/negative picker verdict it protects — must survive.
+    test('an add_date/kill_date-only edit leaves tracklist_lookup_attempted_at untouched', async () => {
+      const sql = getTestDb();
+      const [{ tracklist_lookup_attempted_at: stampedAt }] = await sql`
+        UPDATE ${sql(SCHEMA)}.rotation SET tracklist_lookup_attempted_at = NOW()
+        WHERE id = ${uncataloguedRotationId}
+        RETURNING tracklist_lookup_attempted_at`;
+
+      await auth.patch(`/library/rotation/${uncataloguedRotationId}`).send({ add_date: '2024-01-15' }).expect(200);
+
+      const [row] = await sql`
+        SELECT tracklist_lookup_attempted_at FROM ${sql(SCHEMA)}.rotation WHERE id = ${uncataloguedRotationId}`;
+      expect(row.tracklist_lookup_attempted_at).not.toBeNull();
+      expect(new Date(row.tracklist_lookup_attempted_at)).toEqual(new Date(stampedAt));
+    });
+
+    test('add_date and kill_date stay editable on a catalogued row', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${testRotationId}`)
+        .send({ add_date: '2024-02-01', kill_date: '2024-07-01' })
+        .expect(200);
+
+      expect(res.body.add_date).toBe('2024-02-01');
+      expect(res.body.kill_date).toBe('2024-07-01');
+    });
+
+    test('rejects alphabetical_name, format, and format_size — no column exists', async () => {
+      const res = await auth
+        .patch(`/library/rotation/${testRotationId}`)
+        .send({ alphabetical_name: 'Molina, Juana', format: 'LP', format_size: '12"' })
+        .expect(400);
+
+      expectErrorContains(res, 'no rotation column exists');
+    });
+
+    test('returns 400 when no updatable field is provided', async () => {
+      const res = await auth.patch(`/library/rotation/${testRotationId}`).send({}).expect(400);
+
+      expectErrorContains(res, 'provide at least one of');
+    });
+
+    test('returns 400 with invalid date format', async () => {
+      const res = await auth.patch(`/library/rotation/${testRotationId}`).send({ add_date: '01/15/2024' }).expect(400);
+
+      expectErrorContains(res, 'Incorrect Date Format');
+    });
+
+    // Well-formed shape, impossible calendar date. Used to sail through the
+    // 400 gate and surface as a PG 22008 -> 500 + Sentry event.
+    test('returns 400 for a well-formed but impossible calendar date', async () => {
+      const res = await auth.patch(`/library/rotation/${testRotationId}`).send({ add_date: '2026-09-31' }).expect(400);
+
+      expectErrorContains(res, 'Incorrect Date Format');
+    });
+
+    test('returns 404 for a rotation id that does not exist', async () => {
+      await auth.patch('/library/rotation/999999999').send({ add_date: '2024-01-15' }).expect(404);
     });
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -91,6 +91,16 @@ type ArtistReleaseRowMock = {
 const mockGetReleasesForArtist =
   jest.fn<(artistId: number, page: number, limit: number) => Promise<ArtistReleaseRowMock[]>>();
 const mockCountReleasesForArtist = jest.fn<(artistId: number) => Promise<number>>();
+// PATCH /library/rotation/:id (updateRotation, BS#2113). The service now
+// resolves a compare-and-set outcome (review finding 4) rather than a bare
+// row, so the controller can't tell "not found" apart from "linked
+// concurrently" by re-reading the row itself.
+type UpdateRotationOutcome =
+  | { outcome: 'updated'; rotation: Record<string, unknown> }
+  | { outcome: 'not_found' }
+  | { outcome: 'linked_conflict'; albumId: number };
+const mockUpdateRotation = jest.fn<(id: number, updates: Record<string, unknown>) => Promise<UpdateRotationOutcome>>();
+const mockIsISODate = jest.fn<(date: string) => boolean>();
 
 // POST /library/:id/discogs-recheck (BS#1283).
 const mockRecheckDiscogsAvailability =
@@ -141,6 +151,18 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   getRotationFromDB: mockGetRotationFromDB,
   addToRotation: mockAddToRotation,
   killRotationInDB: mockKillRotationInDB,
+  // Real projection, not a stub: the controller now routes its 200 through
+  // this, so a pass-through mock would assert a shape the endpoint no longer
+  // returns. Mirrors `UNCATALOGUED_ROTATION_PROJECTION`'s key set. (Value and
+  // helper exports going missing from these hand-maintained mocks is the
+  // recurring hazard tracked in WXYC/Backend-Service#2209.)
+  ROTATION_SNAPSHOT_COLUMNS: ['artist_name', 'album_title', 'record_label'] as const,
+  toRotationRowSummary: (row) =>
+    Object.fromEntries(
+      ['id', 'album_id', 'rotation_bin', 'add_date', 'kill_date', 'artist_name', 'album_title', 'record_label'].map(
+        (key) => [key, row?.[key]]
+      )
+    ),
   getUncataloguedRotationFromDB: mockGetUncataloguedRotationFromDB,
   // Not a function — a real value export the controller destructures at module
   // load for its 400 message and bound check. Omitting it makes the ceiling
@@ -167,7 +189,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertGenre: jest.fn(),
   insertFormat: jest.fn(),
   getFormatById: mockGetFormatById,
-  isISODate: jest.fn(),
+  isISODate: mockIsISODate,
   resolveRotationPickerSource: mockResolveRotationPickerSource,
   getRotationTracksFromRelease: mockGetRotationTracksFromRelease,
   getLibraryRowById: mockGetLibraryRowById,
@@ -180,6 +202,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   updateArtistInDB: mockUpdateArtistInDB,
   getReleasesForArtist: mockGetReleasesForArtist,
   countReleasesForArtist: mockCountReleasesForArtist,
+  updateRotation: mockUpdateRotation,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -260,6 +283,7 @@ import {
   getArtistCard,
   updateArtistCard,
   getArtistReleases,
+  updateRotation,
 } from '../../../apps/backend/controllers/library.controller';
 import WxycError from '../../../apps/backend/utils/error';
 
@@ -3265,6 +3289,327 @@ describe('library.controller', () => {
 
       await expect(getArtistReleases(req, res, next)).rejects.toThrow(message);
       expect(mockGetReleasesForArtist).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateRotation (BS#2113)', () => {
+    const reqFor = (body: Record<string, unknown>, id = '42') => ({ params: { id }, body }) as unknown as Request;
+
+    beforeEach(() => {
+      mockIsISODate.mockImplementation((date: string) => /^\d{4}-\d{2}-\d{2}$/.test(date));
+      // Default: the service reports a successful write. The linked/unlinked
+      // precondition on the snapshot trio (review finding 4) now lives
+      // entirely inside `libraryService.updateRotation`'s compare-and-set —
+      // this controller never reads the row itself, so there is no "target an
+      // uncatalogued row" fixture to arrange here the way there used to be.
+      mockUpdateRotation.mockResolvedValue({ outcome: 'updated', rotation: { id: 42, artist_name: 'Juana Molina' } });
+    });
+
+    // The message is `Invalid rotation ID` (capital ID) because this handler
+    // shares `parseResourceId` with the artist and album routes rather than
+    // carrying its own parser. That one is stricter than the parser this
+    // endpoint originally shipped -- it also rejects '42.0', '1e3', '+42' and
+    // '007' -- and one implementation per router is the point. Safe to change
+    // the wording: the endpoint is new and has no clients.
+    it.each(['42.0', '1e3', '+42', '007', ' 42 ', '0x2a'])(
+      'returns 400 for the non-canonical id spelling %s',
+      async (rawId) => {
+        const res = mockResponse();
+
+        await expect(updateRotation(reqFor({ artist_name: 'x' }, rawId), res, next)).rejects.toThrow(
+          'Invalid rotation ID'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      }
+    );
+
+    it('returns 400 for a non-numeric id', async () => {
+      const res = mockResponse();
+
+      await expect(updateRotation(reqFor({ artist_name: 'x' }, 'abc'), res, next)).rejects.toThrow(
+        'Invalid rotation ID'
+      );
+      expect(mockUpdateRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a non-positive id', async () => {
+      const res = mockResponse();
+
+      await expect(updateRotation(reqFor({ artist_name: 'x' }, '0'), res, next)).rejects.toThrow('Invalid rotation ID');
+      expect(mockUpdateRotation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when no updatable field is provided', async () => {
+      const res = mockResponse();
+
+      await expect(updateRotation(reqFor({}), res, next)).rejects.toThrow('provide at least one of');
+      expect(mockUpdateRotation).not.toHaveBeenCalled();
+    });
+
+    // The issue's explicit scope correction: alphabetical_name, format, and
+    // format_size have no column on `rotation` and must be rejected outright,
+    // not silently dropped like an unrecognized field would be.
+    describe('no-column fields are rejected, not silently dropped (BS#2156 / dj-site#1169)', () => {
+      it.each([['alphabetical_name'], ['format'], ['format_size']])('rejects %s', async (field) => {
+        const res = mockResponse();
+
+        await expect(updateRotation(reqFor({ artist_name: 'ok', [field]: 'nope' }), res, next)).rejects.toThrow(
+          'no rotation column exists'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      });
+
+      it('reports every rejected field at once', async () => {
+        const res = mockResponse();
+
+        await expect(
+          updateRotation(reqFor({ alphabetical_name: 'a', format: 'LP', format_size: '12"' }), res, next)
+        ).rejects.toThrow(/alphabetical_name.*format.*format_size/s);
+      });
+    });
+
+    describe('per-field validation', () => {
+      it('rejects an empty artist_name', async () => {
+        const res = mockResponse();
+        await expect(updateRotation(reqFor({ artist_name: '   ' }), res, next)).rejects.toThrow(
+          'artist_name must be a non-empty string'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      });
+
+      it('rejects an over-length album_title (>128 chars)', async () => {
+        const res = mockResponse();
+        await expect(updateRotation(reqFor({ album_title: 'a'.repeat(129) }), res, next)).rejects.toThrow(
+          'album_title must be 128 characters or fewer'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      });
+
+      // Postgres measures `varchar(128)` in characters; a bare `.length`
+      // measures UTF-16 units and counts every astral character twice. This
+      // string is 128 code points (PG stores it) but `.length === 129`, so
+      // measuring the wrong unit made it creatable via `POST /library/rotation`
+      // — which uses `codePointLength` — and un-editable here. A librarian
+      // could not fix a typo elsewhere in the row without first shortening a
+      // title the system had already accepted.
+      it('accepts a 128-code-point album_title containing astral characters', async () => {
+        const astral = 'a'.repeat(127) + '\u{1F600}';
+        expect([...astral].length).toBe(128);
+        expect(astral.length).toBe(129);
+
+        const res = mockResponse();
+        mockUpdateRotation.mockResolvedValueOnce({
+          outcome: 'updated',
+          rotation: { id: 42, album_title: astral },
+        });
+
+        await updateRotation(reqFor({ album_title: astral }), res, next);
+
+        expect(mockUpdateRotation).toHaveBeenCalledWith(42, { album_title: astral });
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('rejects a malformed add_date', async () => {
+        const res = mockResponse();
+        await expect(updateRotation(reqFor({ add_date: '01/15/2024' }), res, next)).rejects.toThrow(
+          'Incorrect Date Format: add_date'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      });
+
+      it('rejects a malformed kill_date', async () => {
+        const res = mockResponse();
+        await expect(updateRotation(reqFor({ kill_date: '12/31/2025' }), res, next)).rejects.toThrow(
+          'Incorrect Date Format: kill_date'
+        );
+        expect(mockUpdateRotation).not.toHaveBeenCalled();
+      });
+
+      it('accepts an explicit null kill_date (clears the column)', async () => {
+        const res = mockResponse();
+
+        await updateRotation(reqFor({ kill_date: null }), res, next);
+
+        expect(mockUpdateRotation).toHaveBeenCalledWith(42, { kill_date: null });
+      });
+    });
+
+    // The snapshot trio is only meaningful on a rotation row with no library
+    // link. `getRotationFromDB` projects COALESCE(artists.artist_name,
+    // rotation.artist_name) and friends, so on a linked row the library join
+    // wins and the write would be invisible on the only rotation read path —
+    // while still breaking the "a library-LINKED rotation row carries NULL
+    // denormalized names" invariant the flowsheet rotation-badge arms rest on.
+    //
+    // Review finding 4 moved the linked/unlinked decision into the service's
+    // own compare-and-set, so from here the "row is linked" case is just
+    // another shape the mocked service resolves to (`linked_conflict`) — the
+    // controller no longer reads the row to decide this itself.
+    describe('the denormalized snapshot trio is rejected on a catalogued row (BS#2080 invariant)', () => {
+      beforeEach(() => {
+        mockUpdateRotation.mockResolvedValue({ outcome: 'linked_conflict', albumId: 3 });
+      });
+
+      it.each([['artist_name'], ['album_title'], ['record_label']])(
+        'rejects %s with a 409 naming the reason',
+        async (field) => {
+          const res = mockResponse();
+
+          await expect(updateRotation(reqFor({ [field]: 'Stereolab' }), res, next)).rejects.toMatchObject({
+            statusCode: 409,
+            message: expect.stringContaining(field),
+          });
+          // Unlike the old read-then-write shape, the service IS called here —
+          // it is the one deciding the row is linked, from inside its own
+          // UPDATE, not from a controller-side pre-check.
+          expect(mockUpdateRotation).toHaveBeenCalledWith(42, { [field]: 'Stereolab' });
+        }
+      );
+
+      it('names every rejected snapshot field at once', async () => {
+        const res = mockResponse();
+
+        await expect(
+          updateRotation(
+            reqFor({ artist_name: 'Stereolab', album_title: 'Dots and Loops', record_label: 'Duophonic' }),
+            res,
+            next
+          )
+        ).rejects.toThrow(/artist_name.*album_title.*record_label/s);
+      });
+
+      // BS#2113 review finding 2: the remedy is field-specific, not a blanket
+      // "edit the library release" — album_title/record_label really are
+      // editable there, artist_name is not.
+      it('honestly refuses to offer PATCH /library/:id as a remedy for artist_name', async () => {
+        const res = mockResponse();
+
+        await expect(updateRotation(reqFor({ artist_name: 'Stereolab' }), res, next)).rejects.toMatchObject({
+          statusCode: 409,
+          message: expect.stringContaining(
+            'artist_name has no remedy here: library.artist_name is derived from the linked artists row via ' +
+              'artist_id, and no endpoint currently supports renaming an artist'
+          ),
+        });
+      });
+
+      it('names the real remedy for album_title and record_label', async () => {
+        const res = mockResponse();
+
+        await expect(
+          updateRotation(reqFor({ album_title: 'Dots and Loops', record_label: 'Duophonic' }), res, next)
+        ).rejects.toMatchObject({
+          statusCode: 409,
+          message: expect.stringContaining('edit album_title, label via PATCH /library/3 instead'),
+        });
+      });
+
+      it('still accepts add_date and kill_date — those have no library-join shadow', async () => {
+        mockUpdateRotation.mockResolvedValue({
+          outcome: 'updated',
+          rotation: { id: 42, add_date: '2024-01-15', kill_date: null },
+        });
+        const res = mockResponse();
+
+        await updateRotation(reqFor({ add_date: '2024-01-15', kill_date: null }), res, next);
+
+        expect(mockUpdateRotation).toHaveBeenCalledWith(42, { add_date: '2024-01-15', kill_date: null });
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+
+    // Not writable today — the handler builds `updates` field-by-field and the
+    // service loops a hardcoded five-key array — but nothing pinned it, so a
+    // refactor to `Object.assign(set, updates)` would pass the whole suite
+    // while opening BS#1029's trust-gated provenance columns to client writes.
+    it('drops every server-derived and non-in-scope column the client sends', async () => {
+      const res = mockResponse();
+
+      await updateRotation(
+        reqFor({
+          add_date: '2024-01-15',
+          legacy_rotation_id: 555_000_001,
+          legacy_library_release_id: 555_000_002,
+          discogs_release_id: 999777,
+          discogs_release_id_source: 'discogs_direct_backfill',
+          lml_identity_id: 8_888_888,
+          tracklist_lookup_attempted_at: '2024-01-15T00:00:00.000Z',
+          album_id: 7,
+          rotation_bin: 'H',
+        }),
+        res,
+        next
+      );
+
+      expect(mockUpdateRotation).toHaveBeenCalledWith(42, { add_date: '2024-01-15' });
+    });
+
+    it('trims and forwards only the fields present in the body (true partial semantics)', async () => {
+      const res = mockResponse();
+
+      await updateRotation(
+        reqFor({
+          artist_name: '  Juana Molina  ',
+          album_title: 'DOGA',
+        }),
+        res,
+        next
+      );
+
+      expect(mockUpdateRotation).toHaveBeenCalledWith(42, {
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+      });
+    });
+
+    it('forwards all five in-scope fields, including kill_date, in one call', async () => {
+      const res = mockResponse();
+
+      await updateRotation(
+        reqFor({
+          artist_name: 'Jessica Pratt',
+          album_title: 'On Your Own Love Again',
+          record_label: 'Drag City',
+          add_date: '2024-01-15',
+          kill_date: '2024-06-01',
+        }),
+        res,
+        next
+      );
+
+      expect(mockUpdateRotation).toHaveBeenCalledWith(42, {
+        artist_name: 'Jessica Pratt',
+        album_title: 'On Your Own Love Again',
+        record_label: 'Drag City',
+        add_date: '2024-01-15',
+        kill_date: '2024-06-01',
+      });
+    });
+
+    it('returns 200 with the updated row on success', async () => {
+      const res = mockResponse();
+      mockUpdateRotation.mockResolvedValue({
+        outcome: 'updated',
+        rotation: { id: 42, artist_name: 'Juana Molina', kill_date: null },
+      });
+
+      await updateRotation(reqFor({ artist_name: 'Juana Molina' }), res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ id: 42, artist_name: 'Juana Molina', kill_date: null });
+    });
+
+    // Covers both "never existed" and "deleted between validation and the
+    // write" — the compare-and-set service can't (and doesn't try to) tell
+    // those apart from a zero-row UPDATE, so both resolve to the same
+    // `not_found` outcome the controller maps to 404.
+    it('returns 404 when the service reports the row not found', async () => {
+      const res = mockResponse();
+      mockUpdateRotation.mockResolvedValue({ outcome: 'not_found' });
+
+      await expect(updateRotation(reqFor({ artist_name: 'Juana Molina' }, '999'), res, next)).rejects.toThrow(
+        'Rotation entry not found'
+      );
     });
   });
 });

--- a/tests/unit/routes/library-rotation-route-order.route.test.ts
+++ b/tests/unit/routes/library-rotation-route-order.route.test.ts
@@ -1,0 +1,277 @@
+/**
+ * BS#2113: `PATCH /library/rotation/:id` must be registered AFTER every
+ * literal one-segment `/rotation/<name>` route on this router — a
+ * parameterized route registered earlier would shadow a more specific
+ * literal path (e.g. a future `PATCH /rotation/uncatalogued` from
+ * WXYC/Backend-Service#2109, which lands in this same route block).
+ *
+ * SCOPE OF THE HAZARD. Express does NOT match on path alone: in the router's
+ * dispatch loop a Layer whose Route does not handle the request method sets
+ * `match = false` and dispatch falls through to the next layer. So the
+ * `GET /rotation/uncatalogued` vs. `PATCH /rotation/:id` pair cited in the
+ * original #2164 note could never actually collide — only a future literal
+ * registered for the SAME method as the parameterized route can be shadowed.
+ * The order assertion is kept because that future is cheap to arrive at
+ * (#2109 adding a `PATCH /rotation/uncatalogued`, say) and expensive to
+ * debug, but the classifier below is deliberately narrow so it flags only
+ * genuinely shadowable paths.
+ *
+ * Two levels of coverage:
+ *   1. Structural — inspect the Express router's own `.stack` to assert the
+ *      registration order directly.
+ *   2. Behavioral — a request to the literal `/rotation/:rotation_id/tracks`
+ *      path still reaches its own handler rather than being captured by
+ *      `/rotation/:id`.
+ *
+ * Mirrors the mock scaffolding of
+ * tests/unit/routes/library-discogs-recheck-permissions.route.test.ts —
+ * only enough is stubbed to let library.route's import chain resolve
+ * without touching a real DB, LML, or lru-cache.
+ */
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
+import express from 'express';
+import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
+
+const mockGetRotationTracksFromRelease = jestGlobals.fn<() => Promise<unknown[] | null>>();
+const mockResolveRotationPickerSource = jestGlobals.fn<() => Promise<unknown>>();
+// The linked/unlinked precondition (BS#2113 review finding 4) is now a
+// compare-and-set inside the service, so it resolves an outcome rather than
+// a bare row — see `library.controller.test.ts` for the full shape.
+type UpdateRotationOutcome =
+  | { outcome: 'updated'; rotation: Record<string, unknown> }
+  | { outcome: 'not_found' }
+  | { outcome: 'linked_conflict'; albumId: number };
+const mockUpdateRotation = jestGlobals.fn<() => Promise<UpdateRotationOutcome>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  // Real projection, not a stub: the controller now routes its 200 through
+  // this, so a pass-through mock would assert a shape the endpoint no longer
+  // returns. Mirrors `UNCATALOGUED_ROTATION_PROJECTION`'s key set. (Value and
+  // helper exports going missing from these hand-maintained mocks is the
+  // recurring hazard tracked in WXYC/Backend-Service#2209.)
+  ROTATION_SNAPSHOT_COLUMNS: ['artist_name', 'album_title', 'record_label'] as const,
+  toRotationRowSummary: (row) =>
+    Object.fromEntries(
+      ['id', 'album_id', 'rotation_bin', 'add_date', 'kill_date', 'artist_name', 'album_title', 'record_label'].map(
+        (key) => [key, row?.[key]]
+      )
+    ),
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getAlbumFromDB: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: mockResolveRotationPickerSource,
+  getRotationTracksFromRelease: mockGetRotationTracksFromRelease,
+  getLibraryRowById: jest.fn(),
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+  recheckDiscogsAvailability: jest.fn(),
+  updateRotation: mockUpdateRotation,
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => true,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+type RouteLayer = { route?: { path: string; methods: Record<string, boolean> } };
+
+const PARAM_PATH = '/rotation/:id';
+
+/**
+ * Is `path` a route that `/rotation/:id` could shadow?
+ *
+ * Only if it is exactly ONE literal segment below `/rotation`. `:id` matches
+ * a single path segment, so:
+ *   - `/rotation` itself is above it, not under it — unreachable.
+ *   - `/rotation/:rotation_id/tracks` (and a hypothetical
+ *     `/rotation/:id/notes`) is two segments deep — also unreachable, and
+ *     flagging it would fail this suite for a change with no defect in it.
+ *     That over-broad classification is what this predicate replaced.
+ *   - a parameterized sibling (`/rotation/:other`) is not a literal, so
+ *     ordering it is meaningless — the first one registered wins either way.
+ */
+function isShadowableByRotationIdParam(path: string): boolean {
+  return /^\/rotation\/[^/:][^/]*$/.test(path);
+}
+
+function rotationLayers() {
+  return (library_route.stack as RouteLayer[])
+    .map((layer) => layer.route)
+    .filter(
+      (route): route is NonNullable<RouteLayer['route']> => route !== undefined && route.path.startsWith('/rotation')
+    )
+    .map((route) => ({ path: route.path, methods: Object.keys(route.methods) }));
+}
+
+describe('rotation route shadowing classifier (BS#2113)', () => {
+  test.each([
+    ['/rotation/uncatalogued', true],
+    ['/rotation/catalog', true],
+    ['/rotation', false],
+    ['/rotation/:id', false],
+    ['/rotation/:other', false],
+    ['/rotation/:rotation_id/tracks', false],
+    ['/rotation/:id/notes', false],
+    ['/rotation/uncatalogued/notes', false],
+  ])('classifies %s as shadowable=%s', (path, expected) => {
+    expect(isShadowableByRotationIdParam(path)).toBe(expected);
+  });
+});
+
+describe('library.route rotation ordering (BS#2113)', () => {
+  test('every literal one-segment /rotation/<name> route is registered before /rotation/:id', () => {
+    const layers = rotationLayers();
+    const paramLayerIndex = layers.findIndex((l) => l.path === PARAM_PATH);
+
+    expect(paramLayerIndex).toBeGreaterThan(-1);
+
+    // No shadowable literal exists on this router today — `/rotation` and
+    // `/rotation/:rotation_id/tracks` are both out of `:id`'s reach — so this
+    // assertion is vacuously true until #2109 (or a successor) adds one.
+    // The classifier itself is pinned by the table above so it can't rot in
+    // the meantime.
+    const shadowableIndices = layers
+      .map((l, i) => ({ i, path: l.path }))
+      .filter((l) => isShadowableByRotationIdParam(l.path))
+      .map((l) => l.i);
+
+    for (const index of shadowableIndices) {
+      expect(index).toBeLessThan(paramLayerIndex);
+    }
+  });
+
+  test('registers exactly one PATCH handler on /rotation/:id', () => {
+    const layers = rotationLayers();
+    const paramLayers = layers.filter((l) => l.path === '/rotation/:id');
+
+    expect(paramLayers).toHaveLength(1);
+    expect(paramLayers[0].methods).toEqual(['patch']);
+  });
+
+  test('a request to the literal /rotation/:rotation_id/tracks path still reaches its own handler', async () => {
+    mockRole('dj');
+    mockGetRotationTracksFromRelease.mockResolvedValue([]);
+    mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 5, inlineTracklist: null });
+
+    const res = await request(app).get('/library/rotation/5/tracks').set('Authorization', 'Bearer test-token');
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateRotation).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /library/rotation/:id — permission tier (BS#2113, catalog:write)', () => {
+  beforeEach(() => {
+    mockUpdateRotation
+      .mockReset()
+      .mockResolvedValue({ outcome: 'updated', rotation: { id: 5, artist_name: 'Juana Molina' } });
+  });
+
+  test('a musicDirector-role token is authorized', async () => {
+    mockRole('musicDirector');
+    const res = await request(app)
+      .patch('/library/rotation/5')
+      .set('Authorization', 'Bearer test-token')
+      .send({ artist_name: 'Juana Molina' });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateRotation).toHaveBeenCalledWith(5, { artist_name: 'Juana Molina' });
+  });
+
+  test('a dj-role token (catalog:read only) is rejected', async () => {
+    mockRole('dj');
+    const res = await request(app)
+      .patch('/library/rotation/5')
+      .set('Authorization', 'Bearer test-token')
+      .send({ artist_name: 'Juana Molina' });
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateRotation).not.toHaveBeenCalled();
+  });
+
+  test('a request with no Authorization header is rejected', async () => {
+    const res = await request(app).patch('/library/rotation/5').send({ artist_name: 'Juana Molina' });
+
+    expect(res.status).toBe(401);
+    expect(mockUpdateRotation).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -95,6 +95,8 @@ import {
   updateArtworkUrl,
   resolveRotationPickerSource,
   __resetRotationLmlLookupCacheForTests,
+  __rotationLmlCacheSizesForWarm,
+  updateRotation,
   isVariousArtistsName,
   getRotationTracksFromRelease,
   __resetReleaseTracklistCacheForTests,
@@ -1722,11 +1724,42 @@ describe('library.service', () => {
       expect(isISODate('2024-01')).toBe(false);
     });
 
-    it('returns true for edge case dates (format only, not validity)', () => {
-      // Note: isISODate only checks format, not calendar validity
+    // JS has a year 0; PostgreSQL does not (1 BC is followed directly by
+    // 1 AD). `Date.parse('0000-01-01T00:00:00.000Z')` succeeds AND
+    // round-trips cleanly through `toISOString()`, so the round-trip check
+    // alone cannot see these — they sailed through the 400 gate and raised
+    // the same 22008 the guard exists to prevent.
+    it('rejects year-0000 dates that JS parses but PostgreSQL cannot store', () => {
+      expect(isISODate('0000-01-01')).toBe(false);
+      expect(isISODate('0000-12-31')).toBe(false);
+      expect(isISODate('0000-06-15')).toBe(false);
+    });
+
+    it('still accepts the earliest date PostgreSQL can represent', () => {
+      expect(isISODate('0001-01-01')).toBe(true);
+      expect(isISODate('9999-12-31')).toBe(true);
+    });
+
+    // BS#2113: the guard used to be shape-only, so a well-formed but
+    // impossible date sailed through the 400 gate and PG raised 22008
+    // ("date/time field value out of range") — a 500 plus a Sentry event for
+    // a plain client mistake. Both `PATCH /library/rotation` (kill_date) and
+    // `PATCH /library/rotation/:id` (add_date + kill_date) read this.
+    it('rejects well-formed but impossible calendar dates', () => {
+      expect(isISODate('2024-02-30')).toBe(false); // February never has 30 days
+      expect(isISODate('2026-09-31')).toBe(false); // September has 30
+      expect(isISODate('2024-13-01')).toBe(false); // month 13
+      expect(isISODate('2024-00-10')).toBe(false); // month 0
+      expect(isISODate('2024-01-00')).toBe(false); // day 0
+      expect(isISODate('2024-01-32')).toBe(false); // day 32
+      expect(isISODate('2023-02-29')).toBe(false); // 2023 is not a leap year
+    });
+
+    it('still accepts real leap days and month boundaries', () => {
       expect(isISODate('2024-02-29')).toBe(true); // leap year
-      expect(isISODate('2024-02-30')).toBe(true); // invalid day but correct format
-      expect(isISODate('2024-13-01')).toBe(true); // invalid month but correct format
+      expect(isISODate('2000-02-29')).toBe(true); // century leap year
+      expect(isISODate('2024-01-31')).toBe(true);
+      expect(isISODate('2024-04-30')).toBe(true);
     });
   });
 
@@ -2549,6 +2582,85 @@ describe('library.service', () => {
       const second = await resolveRotationPickerSource(42);
       expect(second).toBeNull();
 
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    // BS#2113 review finding 1: a snapshot-trio edit through `updateRotation`
+    // must evict this rotation_id from both LRUs, not just null the DB
+    // marker — otherwise the picker keeps serving a cached resolution for
+    // the release the row used to name until the TTL lapses.
+    it('evicts the positive cache when updateRotation writes a snapshot-trio edit', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValueOnce({
+        results: [{ artwork: { release_id: 4080 } }],
+        search_type: 'direct',
+      });
+
+      const primed = await resolveRotationPickerSource(42);
+      expect(primed).toEqual({ releaseId: 4080, inlineTracklist: null });
+      expect(__rotationLmlCacheSizesForWarm().positive).toBe(1);
+
+      const updateChain = createMockQueryChain([{ id: 42, artist_name: 'Juana Molina', album_id: null }]);
+      db.update.mockReturnValueOnce(updateChain);
+      const outcome = await updateRotation(42, { artist_name: 'Juana Molina' });
+      expect(outcome.outcome).toBe('updated');
+      expect(__rotationLmlCacheSizesForWarm().positive).toBe(0);
+
+      // Eviction that doesn't cause a re-query on the next open would be a
+      // no-op with extra steps — prove the freed slot is actually re-asked.
+      mockRow({ direct: null, fallback: null, artist_name: 'Juana Molina', album_title: 'DOGA' });
+      mockLookupMetadata.mockResolvedValueOnce({
+        results: [{ artwork: { release_id: 9999 } }],
+        search_type: 'direct',
+      });
+      const afterEdit = await resolveRotationPickerSource(42);
+      expect(afterEdit).toEqual({ releaseId: 9999, inlineTracklist: null });
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+    });
+
+    it('evicts the negative cache too, so a row that becomes resolvable is re-asked immediately', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
+      mockLookupMetadata.mockResolvedValueOnce({ results: [], search_type: 'none' });
+
+      const primed = await resolveRotationPickerSource(42);
+      expect(primed).toBeNull();
+      expect(__rotationLmlCacheSizesForWarm().negative).toBe(1);
+
+      const updateChain = createMockQueryChain([{ id: 42, album_title: 'Corrected Title', album_id: null }]);
+      db.update.mockReturnValueOnce(updateChain);
+      await updateRotation(42, { album_title: 'Corrected Title' });
+      expect(__rotationLmlCacheSizesForWarm().negative).toBe(0);
+
+      mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Corrected Title' });
+      mockLookupMetadata.mockResolvedValueOnce({
+        results: [{ artwork: { release_id: 5555 } }],
+        search_type: 'direct',
+      });
+      const afterEdit = await resolveRotationPickerSource(42);
+      expect(afterEdit).toEqual({ releaseId: 5555, inlineTracklist: null });
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+    });
+
+    // A non-snapshot edit (add_date/kill_date only) has nothing stale to
+    // invalidate — the cache pair must survive it.
+    it('does NOT evict either cache when the edit never touches the snapshot trio', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValueOnce({
+        results: [{ artwork: { release_id: 4080 } }],
+        search_type: 'direct',
+      });
+
+      await resolveRotationPickerSource(42);
+      expect(__rotationLmlCacheSizesForWarm().positive).toBe(1);
+
+      const updateChain = createMockQueryChain([{ id: 42, kill_date: '2024-06-01' }]);
+      db.update.mockReturnValueOnce(updateChain);
+      await updateRotation(42, { kill_date: '2024-06-01' });
+
+      expect(__rotationLmlCacheSizesForWarm().positive).toBe(1);
+
+      const second = await resolveRotationPickerSource(42);
+      expect(second).toEqual({ releaseId: 4080, inlineTracklist: null });
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/unit/services/library.service.updateRotation.test.ts
+++ b/tests/unit/services/library.service.updateRotation.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for `updateRotation` + its `killRotationInDB` delegate
+ * (BS#2113).
+ *
+ * `updateRotation` is the sole writer of the five in-scope `rotation`
+ * columns (`artist_name`, `album_title`, `record_label`, `add_date`,
+ * `kill_date`) — both `PATCH /library/rotation/:id` (the new field-level
+ * editor) and `PATCH /library/rotation` (`killRotation`, via
+ * `killRotationInDB`) delegate to it rather than issuing their own UPDATE.
+ * `killRotationInDB`'s wire behavior (default-to-`CURRENT_DATE` when no
+ * date is supplied) must stay unchanged.
+ *
+ * Review findings 1 and 4 changed the function's contract: it now resolves
+ * an `UpdateRotationOutcome` (`updated` / `not_found` / `linked_conflict`)
+ * rather than a bare row, and a write that touches the snapshot trio
+ * (`artist_name`/`album_title`/`record_label`) is a compare-and-set —
+ * `album_id IS NULL` rides in the UPDATE's own WHERE, and the SET bundles a
+ * `tracklist_lookup_attempted_at: null` reset in the same statement. See
+ * `library.service.test.ts`'s "rotation LML cache invalidation" block for
+ * the companion proof that a snapshot write actually evicts the tier-3
+ * picker's in-memory LRUs, which needs the LML-lookup mocking already wired
+ * up there.
+ *
+ * Drizzle is mocked via the established `database.mock` so the assertions
+ * below inspect the exact `.set()` payload each call produces.
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain, rotation } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: mockIsLmlConfigured,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+import { updateRotation, killRotationInDB } from '../../../apps/backend/services/library.service';
+
+/**
+ * The disambiguating read `updateRotation` issues after a guarded zero-row
+ * UPDATE terminates on `.limit(1)`, not `.returning()`/`.execute()` —
+ * `createMockQueryChain`'s default `.limit()` just returns the chain itself
+ * for further chaining, so it isn't awaitable on its own. Every other SELECT
+ * fixture in this codebase that terminates on `.limit()` (e.g.
+ * `library.service.test.ts`'s `mockRow` helper) overrides it the same way.
+ */
+function mockSelectViaLimit(rows: unknown[]): void {
+  const chain = createMockQueryChain(rows);
+  chain.limit = jest.fn().mockResolvedValue(rows);
+  db.select.mockReturnValueOnce(chain);
+}
+
+describe('updateRotation (BS#2113)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('non-snapshot fields (add_date / kill_date) — no compare-and-set, no cache touch', () => {
+    test('only SETs the keys present in the update payload', async () => {
+      const chain = createMockQueryChain([{ id: 42, kill_date: '2024-06-01' }]);
+      db.update.mockReturnValueOnce(chain);
+
+      const outcome = await updateRotation(42, { kill_date: '2024-06-01' });
+
+      expect(db.update).toHaveBeenCalledWith(rotation);
+      expect(chain.set).toHaveBeenCalledWith({ kill_date: '2024-06-01' });
+      expect(chain.where).toHaveBeenCalled();
+      expect(outcome).toEqual({ outcome: 'updated', rotation: { id: 42, kill_date: '2024-06-01' } });
+    });
+
+    test('writes add_date and kill_date together with no tracklist_lookup_attempted_at in SET', async () => {
+      const chain = createMockQueryChain([{ id: 42 }]);
+      db.update.mockReturnValueOnce(chain);
+
+      await updateRotation(42, { add_date: '2024-01-15', kill_date: '2024-06-01' });
+
+      expect(chain.set).toHaveBeenCalledWith({ add_date: '2024-01-15', kill_date: '2024-06-01' });
+    });
+
+    test('an explicit null kill_date clears the column', async () => {
+      const chain = createMockQueryChain([{ id: 42, kill_date: null }]);
+      db.update.mockReturnValueOnce(chain);
+
+      const outcome = await updateRotation(42, { kill_date: null });
+
+      expect(chain.set).toHaveBeenCalledWith({ kill_date: null });
+      expect(outcome).toEqual({ outcome: 'updated', rotation: { id: 42, kill_date: null } });
+    });
+
+    // BS#2113 review finding 4: without the snapshot trio in play there is no
+    // linked/unlinked precondition to disambiguate — a zero-row UPDATE can
+    // only mean "no such row", so this resolves not_found off the UPDATE
+    // alone, with no follow-up SELECT.
+    test('a zero-row UPDATE resolves not_found without a follow-up SELECT', async () => {
+      const chain = createMockQueryChain([]);
+      db.update.mockReturnValueOnce(chain);
+
+      const outcome = await updateRotation(999, { kill_date: '2024-06-01' });
+
+      expect(outcome).toEqual({ outcome: 'not_found' });
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('snapshot-trio fields (artist_name / album_title / record_label) — BS#2113 review findings 1 and 4', () => {
+    test('bundles tracklist_lookup_attempted_at: null into the same SET (finding 1)', async () => {
+      const chain = createMockQueryChain([{ id: 42, artist_name: 'Juana Molina' }]);
+      db.update.mockReturnValueOnce(chain);
+
+      await updateRotation(42, { artist_name: 'Juana Molina' });
+
+      expect(chain.set).toHaveBeenCalledWith({
+        artist_name: 'Juana Molina',
+        tracklist_lookup_attempted_at: null,
+      });
+    });
+
+    test('writes all five in-scope columns when all are supplied, still nulling the picker marker', async () => {
+      const chain = createMockQueryChain([{ id: 42 }]);
+      db.update.mockReturnValueOnce(chain);
+
+      await updateRotation(42, {
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        record_label: 'self-released',
+        add_date: '2024-01-15',
+        kill_date: '2024-06-01',
+      });
+
+      expect(chain.set).toHaveBeenCalledWith({
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        record_label: 'self-released',
+        add_date: '2024-01-15',
+        kill_date: '2024-06-01',
+        tracklist_lookup_attempted_at: null,
+      });
+    });
+
+    test('carries a WHERE guard beyond plain id equality (the album_id IS NULL precondition)', async () => {
+      const plainChain = createMockQueryChain([{ id: 42, kill_date: '2024-06-01' }]);
+      db.update.mockReturnValueOnce(plainChain);
+      await updateRotation(42, { kill_date: '2024-06-01' });
+      const plainWhere = plainChain.where.mock.calls[0][0];
+
+      db.update.mockClear();
+      const guardedChain = createMockQueryChain([{ id: 42, artist_name: 'Juana Molina' }]);
+      db.update.mockReturnValueOnce(guardedChain);
+      await updateRotation(42, { artist_name: 'Juana Molina' });
+      const guardedWhere = guardedChain.where.mock.calls[0][0];
+
+      // Not asserting the exact drizzle expression tree (that would couple the
+      // test to ORM internals), but comparing the two WHEREs against each
+      // other: an earlier revision asserted only `toBeDefined()`, which the
+      // unguarded `eq(rotation.id, 42)` satisfies just as well — deleting
+      // `isNull(rotation.album_id)` left it green. A structural difference
+      // between the snapshot and non-snapshot WHERE is the ORM-agnostic
+      // property that actually fails when the guard is removed.
+      expect(guardedChain.where).toHaveBeenCalledTimes(1);
+      expect(guardedWhere).toBeDefined();
+      expect(JSON.stringify(guardedWhere)).not.toEqual(JSON.stringify(plainWhere));
+    });
+
+    test('opens a transaction ONLY for the snapshot path — a kill-only write stays a single statement', async () => {
+      // `killRotationInDB` (PATCH /library/rotation) routes through this
+      // writer. Wrapping its one UPDATE in a transaction turned one round
+      // trip into three (BEGIN / UPDATE / COMMIT) and held a pooled
+      // connection across all three, on a box that also serves the live
+      // flowsheet. Only the compare-and-set path needs a transaction, because
+      // only it follows a zero-row UPDATE with a disambiguating read.
+      db.transaction.mockClear();
+      db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, kill_date: '2024-06-01' }]));
+      await updateRotation(42, { kill_date: '2024-06-01' });
+      expect(db.transaction).not.toHaveBeenCalled();
+
+      db.transaction.mockClear();
+      db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, artist_name: 'Juana Molina' }]));
+      await updateRotation(42, { artist_name: 'Juana Molina' });
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    test('a guarded zero-row UPDATE followed by a still-linked row resolves linked_conflict with the current album_id', async () => {
+      const updateChain = createMockQueryChain([]); // guarded UPDATE matches nothing: row is linked
+      db.update.mockReturnValueOnce(updateChain);
+      mockSelectViaLimit([{ album_id: 7 }]); // disambiguating read: row exists, linked
+
+      const outcome = await updateRotation(42, { artist_name: 'Juana Molina' });
+
+      expect(outcome).toEqual({ outcome: 'linked_conflict', albumId: 7 });
+    });
+
+    test('a guarded zero-row UPDATE followed by no row at all resolves not_found', async () => {
+      const updateChain = createMockQueryChain([]);
+      db.update.mockReturnValueOnce(updateChain);
+      mockSelectViaLimit([]); // row genuinely doesn't exist
+
+      const outcome = await updateRotation(999, { artist_name: 'Juana Molina' });
+
+      expect(outcome).toEqual({ outcome: 'not_found' });
+    });
+
+    // Pathological but handled: the disambiguating read finds the row again
+    // NULL (a second concurrent write raced the first). Reporting a 409 with
+    // a fabricated album id would be worse than a 404 the caller can retry.
+    test('a disambiguating read that finds the row unlinked after all resolves not_found, not a fabricated conflict', async () => {
+      const updateChain = createMockQueryChain([]);
+      db.update.mockReturnValueOnce(updateChain);
+      mockSelectViaLimit([{ album_id: null }]);
+
+      const outcome = await updateRotation(42, { artist_name: 'Juana Molina' });
+
+      expect(outcome).toEqual({ outcome: 'not_found' });
+    });
+
+    test('a successful snapshot write still returns the outcome shape success callers expect', async () => {
+      const chain = createMockQueryChain([{ id: 42, artist_name: 'Juana Molina', album_id: null }]);
+      db.update.mockReturnValueOnce(chain);
+
+      const outcome = await updateRotation(42, { artist_name: 'Juana Molina' });
+
+      expect(outcome).toEqual({
+        outcome: 'updated',
+        rotation: { id: 42, artist_name: 'Juana Molina', album_id: null },
+      });
+    });
+  });
+
+  // Real drizzle never issues this UPDATE: `mapUpdateSet` throws
+  // `Error: No values to set` before it generates any SQL, so an earlier
+  // version of this test — which asserted `chain.set` was called with `{}` —
+  // documented a contract the ORM does not honor. `updateRotation` now
+  // refuses the empty payload itself, with a message that names the function
+  // instead of the ORM internal. Unreachable through either HTTP surface
+  // (the controller 400s on an empty body; `killRotationInDB` always supplies
+  // a `kill_date`), but a future direct caller gets a usable error.
+  test('an empty payload is refused before any UPDATE is issued', async () => {
+    await expect(updateRotation(42, {})).rejects.toThrow('at least one column to set');
+
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('killRotationInDB delegates to updateRotation (BS#2113)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('an explicit kill_date produces the identical SET payload updateRotation would for the same field', async () => {
+    const killDate = '2027-01-01';
+
+    const viaKillRotation = createMockQueryChain([{ id: 42, kill_date: killDate }]);
+    db.update.mockReturnValueOnce(viaKillRotation);
+    await killRotationInDB(42, killDate);
+
+    const viaUpdateRotation = createMockQueryChain([{ id: 42, kill_date: killDate }]);
+    db.update.mockReturnValueOnce(viaUpdateRotation);
+    await updateRotation(42, { kill_date: killDate });
+
+    expect(viaKillRotation.set).toHaveBeenCalledWith({ kill_date: killDate });
+    expect(viaUpdateRotation.set).toHaveBeenCalledWith({ kill_date: killDate });
+    expect(viaKillRotation.set.mock.calls[0]).toEqual(viaUpdateRotation.set.mock.calls[0]);
+  });
+
+  test('omitting kill_date falls back to a CURRENT_DATE SQL fragment, not a JS-computed date', async () => {
+    const chain = createMockQueryChain([{ id: 42 }]);
+    db.update.mockReturnValueOnce(chain);
+
+    await killRotationInDB(42);
+
+    const setArg = chain.set.mock.calls[0][0] as Record<string, unknown>;
+    // A drizzle `sql` template tag returns an SQL object, not a string.
+    expect(typeof setArg.kill_date).not.toBe('string');
+    expect(JSON.stringify(setArg.kill_date)).toMatch(/CURRENT_DATE/);
+  });
+
+  test('the id and row-shape contract are unchanged: still targets rotation.id and unwraps to row[0]', async () => {
+    const chain = createMockQueryChain([{ id: 7, kill_date: '2025-01-01' }]);
+    db.update.mockReturnValueOnce(chain);
+
+    const result = await killRotationInDB(7, '2025-01-01');
+
+    expect(db.update).toHaveBeenCalledWith(rotation);
+    expect(result).toEqual({ id: 7, kill_date: '2025-01-01' });
+  });
+
+  // killRotationInDB never touches the snapshot trio, so it can never hit
+  // the compare-and-set guard — but if the row simply doesn't exist, the
+  // unwrap must still degrade to `undefined` (the pre-BS#2113 contract),
+  // not leak the new outcome object.
+  test('unwraps a not_found outcome to undefined, matching the pre-existing contract', async () => {
+    const chain = createMockQueryChain([]);
+    db.update.mockReturnValueOnce(chain);
+
+    const result = await killRotationInDB(999, '2025-01-01');
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `PATCH /library/rotation/:id` at `catalog:['write']`, writing only the five columns that exist on `wxyc_schema.rotation`: `artist_name`, `album_title`, `record_label`, `add_date`, `kill_date`. True partial semantics — only fields present in the body are validated and written.
- Fields with no column on `rotation` (`alphabetical_name`, `format`, `format_size`) are rejected with a 400, not silently dropped — they're owned by #2156 and dj-site#1169 respectively.
- Both this route and the existing `PATCH /library/rotation` (`killRotation`) now delegate to a single `libraryService.updateRotation()` writer, so the two routes can't drift on how they set `kill_date`. `killRotation`'s wire shape (path, request body, response) is unchanged, pinned by pre-existing and new tests.
- Corrects the `pickAddRotationFields` comment, which still said tubafrenzy was "the only legitimate source" for the snapshot columns — `rotation` has been Backend-canonical since wiki#88 Phase 3, and `jobs/rotation-etl` is unscheduled (`job-type: one-shot`, no `cron-schedule`) and refuses to run without `LEGACY_ETL_ALLOW_BACKWARDS_WRITE=1`.
- `PATCH /library/rotation/:id` is registered after the literal `/rotation/*` routes so a future literal path (e.g. #2109's `/rotation/uncatalogued`) can't be shadowed by the `:id` param — pinned by a route-ordering test.

Closes #2113

## Test plan

- [x] `tests/unit/services/library.service.updateRotation.test.ts` — `updateRotation` partial-write semantics, null-clears-kill_date, undefined-on-no-match; `killRotationInDB` produces an identical `.set()` payload to `updateRotation` for an explicit `kill_date`, and its no-date default still uses a `CURRENT_DATE` SQL fragment.
- [x] `tests/unit/controllers/library.controller.test.ts` — id validation, no-column-field rejection (`alphabetical_name`/`format`/`format_size`, individually and combined), per-field validation (empty/over-length strings, malformed dates), partial-field forwarding, 200/404 responses.
- [x] `tests/unit/routes/library-rotation-route-order.route.test.ts` — structural assertion that every literal `/rotation/*` route precedes `/rotation/:id` in the router stack, plus a behavioral check that `/rotation/:rotation_id/tracks` isn't captured by `:id`; permission-tier coverage (musicDirector allowed, dj rejected, no-auth rejected).
- [x] `tests/integration/library.spec.js` — new `PATCH /library/rotation/:id` block: full five-column update, partial-update isolation, null-clears-kill_date, no-column-field rejection, empty-body/malformed-date 400s, 404 for a nonexistent id. Ran against a local stack (`npm run dev` + docker `db:start`); all new and existing rotation tests pass.
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:unit` (7378 tests) all green.