### PR TITLE
refactor(auth): extract the role-resolution and admin-flag logic from the betterAuth literal

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -22,6 +22,7 @@ import { lookupEmailByIdentifier } from './lookup-email';
 import { provisionUser, ProvisionError } from './provision-user';
 import { createAutoDjUser } from './create-auto-dj-user';
 import { createDefaultUser } from './create-default-user';
+import { syncAdminRoles } from './sync-admin-roles';
 import { resolveOrganization } from './resolve-organization';
 import { shouldCaptureAuthExpressError } from './sentry-error-filter';
 import { E2E_INCOMPLETE_USER_ID, E2E_INCOMPLETE_USER_PASSWORD } from './e2e-test-constants';
@@ -460,49 +461,47 @@ Sentry.setupExpressErrorHandler(app, { shouldHandleError: shouldCaptureAuthExpre
 // Sentry. See `./fallback-error-handler.ts` for rationale (BS#1109).
 app.use(fallbackErrorHandler);
 
-// Create default user if needed
-// Fix admin roles for existing stationManagers (one-time migration)
-const syncAdminRoles = async () => {
+const onAdminSyncError = (error: unknown) => {
+  console.error('[ADMIN PERMISSIONS] Error fixing admin roles:', error);
+  Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'admin-sync' } });
+};
+
+// Reconcile the admin flag for existing stationManagers. Runs on every boot,
+// not once: it is the retry path for a membership hook that failed.
+const runSyncAdminRoles = async () => {
+  // The dynamic imports sit inside the same catch as the sync itself: a
+  // failure to resolve either module is as survivable as a failed query, and
+  // must not take the server's startup path down.
   try {
     const { db, user, member, organization } = await import('@wxyc/database');
     const { eq, sql } = await import('drizzle-orm');
 
-    const defaultOrgSlug = process.env.DEFAULT_ORG_SLUG;
-    if (!defaultOrgSlug) {
-      console.log('[ADMIN PERMISSIONS] DEFAULT_ORG_SLUG not set, skipping admin role fix');
-      return;
-    }
-
-    // Find all users who are stationManager/admin/owner in default org but don't have admin role
-    const usersNeedingFix = await db
-      .select({
-        userId: user.id,
-        userEmail: user.email,
-        userRole: user.role,
-        memberRole: member.role,
-      })
-      .from(user)
-      .innerJoin(member, sql`${member.userId} = ${user.id}`)
-      .innerJoin(organization, sql`${member.organizationId} = ${organization.id}`)
-      .where(
-        sql`${organization.slug} = ${defaultOrgSlug}
+    await syncAdminRoles({
+      defaultOrgSlug: process.env.DEFAULT_ORG_SLUG,
+      // Find all users who are stationManager/admin/owner in default org but don't have admin role
+      findUsersMissingAdminFlag: (defaultOrgSlug) =>
+        db
+          .select({
+            userId: user.id,
+            userEmail: user.email,
+            userRole: user.role,
+            memberRole: member.role,
+          })
+          .from(user)
+          .innerJoin(member, sql`${member.userId} = ${user.id}`)
+          .innerJoin(organization, sql`${member.organizationId} = ${organization.id}`)
+          .where(
+            sql`${organization.slug} = ${defaultOrgSlug}
         AND ${member.role} IN ('admin', 'owner', 'stationManager')
         AND (${user.role} IS NULL OR ${user.role} != 'admin')`
-      );
-
-    if (usersNeedingFix.length > 0) {
-      console.log(`[ADMIN PERMISSIONS] Found ${usersNeedingFix.length} users needing admin role fix: `);
-      for (const u of usersNeedingFix) {
-        console.log(`[ADMIN PERMISSIONS] - ${u.userEmail} (${u.memberRole}) - current role: ${u.userRole || 'null'}`);
-        await db.update(user).set({ role: 'admin' }).where(eq(user.id, u.userId));
-        console.log(`[ADMIN PERMISSIONS] - Fixed: ${u.userEmail} now has admin role`);
-      }
-    } else {
-      console.log('[ADMIN PERMISSIONS] All stationManagers already have admin role');
-    }
+          ),
+      setUserRole: async (userId, role) => {
+        await db.update(user).set({ role }).where(eq(user.id, userId));
+      },
+      onError: onAdminSyncError,
+    });
   } catch (error) {
-    console.error('[ADMIN PERMISSIONS] Error fixing admin roles:', error);
-    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'admin-sync' } });
+    onAdminSyncError(error);
   }
 };
 
@@ -512,7 +511,7 @@ void (async () => {
   // Runs after createDefaultUser so the default org already exists. Gated by
   // CREATE_AUTO_DJ_USER (default off); idempotent skip-if-exists. See #1644.
   await createAutoDjUser();
-  await syncAdminRoles();
+  await runSyncAdminRoles();
 
   // Bootstrap oauthApplication rows for every trustedClient. See
   // `bootstrap-trusted-clients.ts` for why this exists. warn-and-continue to

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -469,9 +469,6 @@ const onAdminSyncError = (error: unknown) => {
 // Reconcile the admin flag for existing stationManagers. Runs on every boot,
 // not once: it is the retry path for a membership hook that failed.
 const runSyncAdminRoles = async () => {
-  // The dynamic imports sit inside the same catch as the sync itself: a
-  // failure to resolve either module is as survivable as a failed query, and
-  // must not take the server's startup path down.
   try {
     const { db, user, member, organization } = await import('@wxyc/database');
     const { eq, sql } = await import('drizzle-orm');
@@ -498,7 +495,6 @@ const runSyncAdminRoles = async () => {
       setUserRole: async (userId, role) => {
         await db.update(user).set({ role }).where(eq(user.id, userId));
       },
-      onError: onAdminSyncError,
     });
   } catch (error) {
     onAdminSyncError(error);

--- a/apps/auth/sync-admin-roles.ts
+++ b/apps/auth/sync-admin-roles.ts
@@ -1,0 +1,64 @@
+/**
+ * Startup reconciliation of `auth_user.role` — the better-auth admin plugin's
+ * system flag — against organization membership.
+ *
+ * The per-event hooks in `admin-flag-sync.ts` keep the flag current as
+ * membership changes; this closes the gap they cannot, since a hook that
+ * failed (a DB blip, a process killed mid-write) leaves the flag stale with
+ * nothing to retry it. Running on every boot means the flag converges without
+ * operator intervention.
+ *
+ * Extracted from `apps/auth/app.ts`, where it was a module-local `const`
+ * reachable only after a top-level IIFE calls `app.listen()` — importing the
+ * module to test it would start a server. DB access arrives as callbacks so
+ * the reconciliation policy can be exercised directly.
+ */
+
+/** A user whose membership justifies the admin flag but whose flag disagrees. */
+export interface AdminFlagMismatch {
+  userId: string;
+  userEmail: string;
+  userRole: string | null;
+  memberRole: string;
+}
+
+export interface SyncAdminRolesDeps {
+  defaultOrgSlug: string | undefined;
+  /** Users in the default org holding an admin-granting role without the flag. */
+  findUsersMissingAdminFlag: (defaultOrgSlug: string) => Promise<AdminFlagMismatch[]>;
+  setUserRole: (userId: string, role: 'admin' | null) => Promise<void>;
+  onError: (error: unknown) => void;
+}
+
+/**
+ * Grant the admin flag to every default-org member whose role justifies it
+ * but who lacks it.
+ *
+ * Warn-and-continue on failure, matching its sibling startup bootstraps: a
+ * transient DB blip must not take sign-in down for a flag that the next boot
+ * will reconcile anyway.
+ */
+export const syncAdminRoles = async (deps: SyncAdminRolesDeps): Promise<void> => {
+  try {
+    const { defaultOrgSlug } = deps;
+    if (!defaultOrgSlug) {
+      console.log('[ADMIN PERMISSIONS] DEFAULT_ORG_SLUG not set, skipping admin role fix');
+      return;
+    }
+
+    const usersNeedingFix = await deps.findUsersMissingAdminFlag(defaultOrgSlug);
+
+    if (usersNeedingFix.length > 0) {
+      console.log(`[ADMIN PERMISSIONS] Found ${usersNeedingFix.length} users needing admin role fix: `);
+      for (const u of usersNeedingFix) {
+        console.log(`[ADMIN PERMISSIONS] - ${u.userEmail} (${u.memberRole}) - current role: ${u.userRole || 'null'}`);
+        await deps.setUserRole(u.userId, 'admin');
+        console.log(`[ADMIN PERMISSIONS] - Fixed: ${u.userEmail} now has admin role`);
+      }
+    } else {
+      console.log('[ADMIN PERMISSIONS] All stationManagers already have admin role');
+    }
+  } catch (error) {
+    deps.onError(error);
+  }
+};

--- a/apps/auth/sync-admin-roles.ts
+++ b/apps/auth/sync-admin-roles.ts
@@ -27,38 +27,35 @@ export interface SyncAdminRolesDeps {
   /** Users in the default org holding an admin-granting role without the flag. */
   findUsersMissingAdminFlag: (defaultOrgSlug: string) => Promise<AdminFlagMismatch[]>;
   setUserRole: (userId: string, role: 'admin' | null) => Promise<void>;
-  onError: (error: unknown) => void;
 }
 
 /**
  * Grant the admin flag to every default-org member whose role justifies it
  * but who lacks it.
  *
- * Warn-and-continue on failure, matching its sibling startup bootstraps: a
- * transient DB blip must not take sign-in down for a flag that the next boot
- * will reconcile anyway.
+ * Throws on failure. The caller already needs a catch for its own module
+ * resolution, and a second one here would route both failures to the same
+ * handler by a longer path; warn-and-continue is the caller's contract, not
+ * this function's. Stopping partway through the loop is safe either way — the
+ * next boot re-reads the mismatches and resumes.
  */
 export const syncAdminRoles = async (deps: SyncAdminRolesDeps): Promise<void> => {
-  try {
-    const { defaultOrgSlug } = deps;
-    if (!defaultOrgSlug) {
-      console.log('[ADMIN PERMISSIONS] DEFAULT_ORG_SLUG not set, skipping admin role fix');
-      return;
-    }
+  const { defaultOrgSlug } = deps;
+  if (!defaultOrgSlug) {
+    console.log('[ADMIN PERMISSIONS] DEFAULT_ORG_SLUG not set, skipping admin role fix');
+    return;
+  }
 
-    const usersNeedingFix = await deps.findUsersMissingAdminFlag(defaultOrgSlug);
+  const usersNeedingFix = await deps.findUsersMissingAdminFlag(defaultOrgSlug);
 
-    if (usersNeedingFix.length > 0) {
-      console.log(`[ADMIN PERMISSIONS] Found ${usersNeedingFix.length} users needing admin role fix: `);
-      for (const u of usersNeedingFix) {
-        console.log(`[ADMIN PERMISSIONS] - ${u.userEmail} (${u.memberRole}) - current role: ${u.userRole || 'null'}`);
-        await deps.setUserRole(u.userId, 'admin');
-        console.log(`[ADMIN PERMISSIONS] - Fixed: ${u.userEmail} now has admin role`);
-      }
-    } else {
-      console.log('[ADMIN PERMISSIONS] All stationManagers already have admin role');
+  if (usersNeedingFix.length > 0) {
+    console.log(`[ADMIN PERMISSIONS] Found ${usersNeedingFix.length} users needing admin role fix: `);
+    for (const u of usersNeedingFix) {
+      console.log(`[ADMIN PERMISSIONS] - ${u.userEmail} (${u.memberRole}) - current role: ${u.userRole || 'null'}`);
+      await deps.setUserRole(u.userId, 'admin');
+      console.log(`[ADMIN PERMISSIONS] - Fixed: ${u.userEmail} now has admin role`);
     }
-  } catch (error) {
-    deps.onError(error);
+  } else {
+    console.log('[ADMIN PERMISSIONS] All stationManagers already have admin role');
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/supertest": "^7.2.1",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/ws": "^8.18.1",
+        "better-call": "^1.3.7",
         "concurrently": "^10.0.4",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/supertest": "^7.2.1",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/ws": "^8.18.1",
+    "better-call": "^1.3.7",
     "concurrently": "^10.0.4",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",

--- a/plans/bs2171-narrow-auth-user-role.md
+++ b/plans/bs2171-narrow-auth-user-role.md
@@ -1,0 +1,335 @@
+# BS#2171 — narrow `auth_user.role` to the better-auth admin flag, and enforce it in the schema
+
+Issue: [WXYC/Backend-Service#2171](https://github.com/WXYC/Backend-Service/issues/2171). Worktree `.worktrees/2171-auth-user-role-narrow`, based on `origin/main` at `b78d8308`.
+
+**Revision 6 — approved (r6: "approve with suggestions", all six findings verified against the codebase and folded in).** r2: §7 rewritten, §1 DDL corrected, §4 extended to the OIDC path, §6 reversed from delete to narrow. r3: §0 extraction added, §5's demotion narrowed, `CLAUDE.md:117` added to the stale-claim sweep. r4: write-side guard is `roles` not `adminRoles`, test 9 retargeted, `/admin/update-user` + `anonymous()` added to the inventory, predicate made paren-free, §8 folds in the orphan case. **r5:** the `roles` pin alone does **not** close the comma hole — §2 gains a request-level guard; §5 now states the value it writes; the jest mock is spelled out as a new file; **the work splits into two chained PRs** per the ≤1000-line guidance; test file paths named; `dev_env/seed_db.sql` added to the inventory as explicitly checked. **r6:** §3's fallback must drop `role` **by destructure**, never by narrowing — the payload also carries `banned`/`banReason`, which `auth.middleware.ts:183-188` reads; the §2 guard is extracted into a fourth §0 module so test 12 becomes a unit test; `roles` pins to the imported `defaultRoles`; the "only prior CHECK" claim was wrong (0101 is precedent); two `docs/migrations.md` citations renumbered; the barrel requirement dropped.
+
+## Decision
+
+The ticket offers Option A (narrow the column) and Option B (sync it and backfill 91 rows). **We take A, plus a `CHECK` constraint that makes the drift structurally impossible** — the ticket's own closing advice is "prefer making the unmaintained read impossible over adding a fallback," and a constraint is the strongest available form of that.
+
+Option B is rejected: nothing in the codebase wants to read a station role off `auth_user`, so B pays a 91-row production auth write to make a column truthful that nothing asks, and re-creates the denormalization that caused #1222. It also contradicts `@wxyc/shared`, whose `ROLES` is `["stationManager","musicDirector","dj","member"]` — no `admin` — alongside a separate `isSystemAdmin(user)` documented as _"orthogonal to the WXYC station role hierarchy."_
+
+### The constraint alphabet, and why it is not `{NULL, 'admin'}`
+
+The obvious constraint — `role IS NULL OR role = 'admin'` — **would break user creation.** better-auth's admin plugin registers a `databaseHooks.user.create.before` that stamps a role on every create:
+
+```js
+// node_modules/better-auth/dist/plugins/admin/admin.mjs:26-31
+user: { create: { async before(user) {
+  return { data: { role: options?.defaultRole ?? "user", ...user } };
+} } },
+```
+
+`defaultRole` defaults to `"user"` (`admin.mjs:14`), and `admin()` is called with no options today (`shared/authentication/src/auth.definition.ts:201`). So the legal alphabet is **`NULL | 'user' | 'admin'`** — the closed set the current writers produce:
+
+| Writer                                                           | Value written                                       | Guarded after §2?              |
+| ---------------------------------------------------------------- | --------------------------------------------------- | ------------------------------ |
+| `user.create.before` hook                                        | `'user'`                                            | n/a                            |
+| `/admin/create-user` — `routes.mjs:173-177`, `:198`              | requested role, else `'user'`                       | **needs the §2 request guard** |
+| `/admin/set-role` — `routes.mjs:70-76`                           | arbitrary string / comma-join                       | **needs the §2 request guard** |
+| `/admin/update-user` — `routes.mjs:265-271`                      | arbitrary string / comma-join                       | **needs the §2 request guard** |
+| `anonymous()` plugin — `auth.definition.ts:205`                  | `'user'`, via the create hook                       | n/a                            |
+| `provisionUser()` step 9 — `apps/auth/provision-user.ts:176-177` | `'admin'`                                           | n/a                            |
+| `afterAddMember` — `auth.definition.ts:305`                      | `'admin'`                                           | n/a                            |
+| `afterUpdateMemberRole` — `:336`, `:340`                         | `'admin'` / `null`                                  | n/a                            |
+| `afterRemoveMember` — `:379`                                     | `null`                                              | n/a                            |
+| `syncAdminRoles()` — `apps/auth/app.ts:497`                      | `'admin'` (+ `null`, §5)                            | n/a                            |
+| `scripts/backfill-missing-org-members.ts:156`                    | `'admin'`                                           | n/a                            |
+| `dev_env/seed_db.sql:22-46`                                      | `'admin'` ×2, `NULL` ×10 — **verified in-alphabet** | n/a                            |
+
+**This service has no ordinary email signup** — `disableSignUp: true` at `auth.definition.ts:97` (and `:428` for OTP). The live creation paths are `/admin/create-user`, `anonymous()`, and `provisionUser()`, all routing through the same create hook.
+
+`provisionUser()` calls `internalAdapter.createUser` **without** a `role` field (`apps/auth/provision-user.ts:109-120`), so the hook supplies `'user'` and step 9 overwrites with `'admin'` only for `ADMIN_SYNC_ROLES`. Station roles never reach this column through any current path. An org-wide `rg` for `admin/set-role`, `setRole`, `admin.setRole` returns **zero hits**; dj-site's roster edits go through `authClient.organization.updateMemberRole` (`AccountEditForm.tsx:134`), which writes `auth_member.role` only.
+
+That leaves exactly **10 rows** to normalize — the legacy `dj` cohort created through bare `/admin/create-user` before `provisionUser()` existed.
+
+**Two encodings of "not an admin" already exist and both stay legal.** better-auth's create hook writes `'user'`; the demotion hooks write `null` (`auth.definition.ts:340`, `:379`). Both resolve to `Authorization.NO`. The constraint permits both; §7 documents the equivalence in one place so it stops being folklore.
+
+### Reader inventory
+
+| Reader                                                                        | Kind                             | Action                             |
+| ----------------------------------------------------------------------------- | -------------------------------- | ---------------------------------- |
+| better-auth admin plugin, internal                                            | admin flag (`=== 'admin'`)       | keep — load-bearing for `/admin/*` |
+| `syncAdminRoles()` self-query — `apps/auth/app.ts:481`, `:490`                | admin flag                       | keep, extend with demotion         |
+| JWT `definePayload` fallback — `auth.definition.ts:236-240`                   | **accidental station-role read** | fix — fail closed                  |
+| `mapUserRoleToMemberRole()` — `scripts/backfill-missing-org-members.ts:48-55` | station-role read                | narrow                             |
+
+Everything else that touches the column is a write.
+
+## The second copy of the #1222 bug
+
+`definePayload` overrides `role` with `member.role` on the happy path, but its fallback returns `{ ...user }` — placing `auth_user.role` into the JWT `role` claim. `roleToAuthorization('admin')` returns `Authorization.SM`. When the membership query throws or returns empty:
+
+| Cohort             | JWT `role` claim | Resolves to |                                                |
+| ------------------ | ---------------- | ----------- | ---------------------------------------------- |
+| 8 station managers | `admin`          | **SM**      | privilege sustained by the unmaintained column |
+| 1 music director   | `user`           | **Member**  | silently demoted                               |
+| 10 legacy DJs      | `dj`             | DJ          | accidentally right                             |
+| 90 DJs             | `user` / `null`  | **Member**  | silently demoted                               |
+
+Same failure class #1223 removed from the roster, one layer down, in the value authorization actually consumes.
+
+The OIDC `id_token` path is separate: `oidcProvider` overrides `definePayload: () => payload` (`node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:645`), so the app's `definePayload` never reaches an `id_token`. §4 handles it on its own terms.
+
+## Open decision for the reviewer
+
+**What should a station manager get when the membership lookup fails at token-mint time?**
+
+- _Today:_ stale `'admin'` → SM access preserved. Fail-open, backed by a column nobody maintains.
+- _Proposed:_ omit the claim → `shared/authentication/src/auth.middleware.ts:196-197` returns `403 Forbidden: Missing role in token.`
+
+The plan assumes **fail-closed**. Sizing, all verified:
+
+- **Duration ≤15 min.** The JWT plugin defaults to a 15-minute expiry (`node_modules/better-auth/dist/plugins/jwt/sign.mjs:13`, `expirationTime ?? "15m"`); the config does not override it. The `expiresIn: 60*60*24*365` at `auth.definition.ts:78` is the _session_, not the token.
+- **Only permission-declaring routes.** The gate runs behind `Object.keys(required).length > 0` (`auth.middleware.ts:193`); `requirePermissions({})` and anonymous paths are unaffected.
+- **Clients degrade rather than break.** dj-site's `AuthorizedView.tsx:38-66` already falls back to `listMembers` and then to `Authorization.NO`; iOS's `JWTPayload.role` is `String?`. An absent claim is a handled case on both consumers.
+
+The argument for it: today's fallback is not a clean fail-open. It reads a column nothing maintains, so it is right for 18 users and silently wrong for 91. A 403 gets reported in minutes; a quietly-demoted music director went unnoticed for months. **Flagged for override.**
+
+## Changes
+
+### 0. Extract the logic under test (ships as its own PR — see Sequencing)
+
+The behavior this plan changes lives in unreachable places:
+
+- `definePayload` and the three `organizationHooks` are inline properties of the `betterAuth({...})` literal in `shared/authentication/src/auth.definition.ts` — nothing exports them.
+- `syncAdminRoles` is a module-local `const` at `apps/auth/app.ts:465`; the module's only export is `export default app` (`:572`), reached _after_ a top-level IIFE calling `app.listen()` (`:553`). Importing it starts a server.
+- `jest.unit.config.ts:20` maps `@wxyc/authentication` → `tests/mocks/authentication.mock.ts`.
+
+Every existing unit test against this file is a source-scan (`tests/unit/authentication/oidc-provider-public-client-jwt.test.ts:54`, `oidc-provider-schema.test.ts:52`, `cookie-config.test.ts:9`, `session-config.test.ts:33`), and the first says why: _"A behavior test would require spinning up the full better-auth instance against a live PG, which is over budget for a unit test."_
+
+**The repo already has the answer.** `shared/authentication/src/device-authorization.ts` extracts three helpers out of the same literal, and `tests/unit/authentication/device-authorization.test.ts` imports them **by relative path** with **DB access injected as callbacks**.
+
+| New module                                            | Exports                                                                                      | Injected deps                                                             |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `shared/authentication/src/jwt-payload.ts`            | `buildJwtPayload`, `buildOidcUserInfoClaim`                                                  | `fetchMemberRole(userId)`, `onError(e)`                                   |
+| `shared/authentication/src/admin-flag-sync.ts`        | `syncAdminFlagOnAddMember`, `syncAdminFlagOnUpdateMemberRole`, `syncAdminFlagOnRemoveMember` | `setUserRole(userId, role)`, `findAdminMemberships(userId)`, `onError(e)` |
+| `apps/auth/sync-admin-roles.ts`                       | `syncAdminRoles`                                                                             | query + update callbacks, `onError(e)`                                    |
+| `shared/authentication/src/admin-role-write-guard.ts` | `assertScalarRoleWrite`                                                                      | none (pure)                                                               |
+
+Two mechanical requirements:
+
+- **Do not add these to the barrel.** `shared/authentication/src/index.ts` does _not_ re-export every sibling — `oidc-login-page.ts` and `url-rewrite.ts` are both absent, and `:7-12` use named exports rather than `export *`. The new modules are consumed only by `auth.definition.ts` and by tests, both via relative import, so a barrel entry would widen `@wxyc/authentication`'s public surface for no consumer.
+- **All new modules must import only _types_ from `@wxyc/database`.** A value import re-engages the DB mock at `jest.unit.config.ts:19` and defeats the callback injection.
+
+The three org hooks share near-identical logic today (`DEFAULT_ORG_SLUG` check → org-slug match → admin-role-set test), so the extraction removes real duplication rather than only serving the tests.
+
+### 1. Schema + migration `0150_narrow-auth-user-role`
+
+`shared/database/src/schema.ts`, `user` table extra-config array (`:68-76`) — matching the `check()` convention at `:387`, `:761`, `:2655`:
+
+```ts
+check('auth_user_role_system_only', sql`${table.role} IS NULL OR ${table.role} = 'user' OR ${table.role} = 'admin'`),
+```
+
+**Paren-free on purpose.** `scripts/schema-shape-report.mjs:334-335` parses migration CHECKs with a non-greedy `CHECK\s*\((.*?)\)`, stopping at the first `)`. An `IN ('user','admin')` form truncates to an unbalanced predicate. Three equality terms are semantically identical and parse cleanly. The disjunction form has direct precedent: `0101_rotation-discogs-release-id-not-sentinel.sql:98` already ships `CHECK ("…"."discogs_release_id" IS NULL OR "…"."discogs_release_id" > 0)` — same `IS NULL OR …` shape, same paren-free predicate — and `0118_library-discogs-unavailable.sql:41` adds a third.
+
+Plus a column comment on `role` (`:52`) naming `auth_member.role` as the station-role source of truth.
+
+Migration generated with `npm run drizzle:generate` (`docs/migrations.md:42`, `journal-snapshot-coupling`). Hand-prepend the comment block per `sql-comment-block` (`:54`); the DDL stays byte-for-byte as emitted. Drizzle emits fully schema-qualified predicates — precedent at `0140_cta-track-artist-link.sql:109` — and `auth_user` is a `public`-schema table (bare `pgTable`; `"public"."auth_user"` in `0021_user-table-migration.sql:28`). **Generate first, then paste the emitted line into this plan and the PR body.** Expected shape:
+
+```sql
+-- @no-precondition-needed: the UPDATE immediately below normalizes every row
+-- outside the alphabet, so the ADD CONSTRAINT cannot fail.
+-- @no-analyze-needed: 10 rows on a 110-row table; no index the planner reads.
+--
+-- Alphabet is scalar-only by design. better-auth can persist comma-joined
+-- multi-role values ("admin,user"); the request guard in auth.definition.ts
+-- rejects those with a 400 before they reach this constraint. Widening the
+-- predicate to accept comma lists would restore the ambiguity it removes.
+
+UPDATE "public"."auth_user" SET "role" = 'user'
+ WHERE "role" IS NOT NULL AND "role" <> 'user' AND "role" <> 'admin';
+
+-- (generated line, to be replaced verbatim with drizzle-kit output)
+ALTER TABLE "public"."auth_user" ADD CONSTRAINT "auth_user_role_system_only" CHECK (...);
+```
+
+Constraints: journal `when` = previous + 1ms (`hand-edit-when`, `docs/migrations.md:46`; incidents #400/#550), re-checked at merge for `parallel-pr-when-collision` (`:50`); PG14 syntax only (prod RDS 14.22 vs dev/CI 18.0 — `dev-prod-pg-version-skew`, BS#1424); suppression annotations inlined at authoring time, which the rules permit; DML is 10 rows, far under the ~10k `ddl-only` threshold (`:62`).
+
+**Expected CI signal.** Touching db-init paths triggers `migrate-dryrun` against a restored RDS snapshot — the only job validating against prod's PG major, and the real gate. Its `schema-shape-report.mjs` pre-probe will still fail here: `qualifiedTable()` (`:394`) unconditionally prefixes `SCHEMA_NAME` (`:64`, default `wxyc_schema`) while `migRe` captures a bare `auth_user`, so it targets a nonexistent `"wxyc_schema"."auth_user"`. **Expect a probe failure, advisory only** — the script self-describes as non-blocking (`:775-776`). Say so in the PR body.
+
+This is not specific to this migration. Every `auth_*` table is a bare `pgTable`, so the probe mis-targets _any_ future public-schema constraint — the script silently reports "constraint absent" for a constraint that is present. **File a follow-up issue against `schema-shape-report.mjs`** and link it from the PR body next to the expected-failure note, so the advisory failure has a tracked owner instead of becoming folklore. Ask before filing — it is a separate defect from #2171.
+
+### 2. Close the write paths: pin `roles` **and** guard the request
+
+`shared/authentication/src/auth.definition.ts:201`:
+
+```ts
+import { defaultRoles } from 'better-auth/plugins/admin/access';
+
+admin({ defaultRole: 'user', adminRoles: ['admin'], roles: defaultRoles });
+```
+
+Import the upstream symbol rather than hand-listing `{ admin: adminAc, user: userAc }`. `access/statement.mjs:47-50` exports `defaultRoles` as exactly that object, and `better-auth/plugins/admin/access` is a real package subpath export. Importing it keeps the pin in lockstep with upgrades — which is the point, since "a better-auth upgrade changes `defaultRole`" is already on the risk table.
+
+**The pin alone is not sufficient, and r4 claimed otherwise.** `adminRoles` is read-side only (`routes.mjs:585-586`). `opts.roles` is the write-side allowlist — but it validates **element-wise and then joins**:
+
+```js
+// routes.mjs:71-76 (/admin/set-role); identically at :265-271 and :173-177
+const inputRoles = Array.isArray(ctx.body.role) ? ctx.body.role : [ctx.body.role];
+for (const role of inputRoles) if (!roles[role]) throw APIError.from("BAD_REQUEST", ...);
+...
+{ role: parseRoles(ctx.body.role) }   // -> roles.join(",")
+```
+
+So `{"role": ["admin","user"]}` passes the pinned guard — both keys exist — and writes `"admin,user"`, which the new CHECK rejects as an **unhandled 23514 (500)**. Pinning `roles` is still worth doing (it restores a 400 for genuinely unknown values, and `admin()` passes no `roles` today so that branch is skipped entirely), but it does not close the comma hole.
+
+**Add a request-level guard, extracted like everything else in §0.** There is already a `hooks.before` at `auth.definition.ts:445`, a single `createAuthMiddleware` that early-returns on path mismatch (`if (ctx.path !== '/device/approve') return;`). better-auth takes one `before` hook, so **extend that middleware** rather than adding a second.
+
+The policy itself goes in `shared/authentication/src/admin-role-write-guard.ts` as a pure function, not inline in the middleware:
+
+```ts
+export function assertScalarRoleWrite(path: string, body: { role?: unknown }): void;
+```
+
+It throws `APIError` with a 400 for an array-valued or comma-bearing `role` on `/admin/set-role`, `/admin/update-user`, or `/admin/create-user`, and returns silently otherwise. This is the same shape as `applyDeviceApproveRoleGate` (`device-authorization.ts:24`), which throws `APIError` and is unit-tested at `tests/unit/authentication/device-authorization.test.ts:24`.
+
+Extracting it matters more here than elsewhere: this guard is the only thing standing between a malformed request and an unhandled 23514, and leaving it inline would force test 12 to be an integration test against a live admin session. Extracted, it is a pure-function unit test with **no new mock infrastructure** — `APIError` is already stubbed at `tests/mocks/better-auth-api.mock.ts:4` and mapped at `jest.unit.config.ts:43`. `createAuthMiddleware` is likewise already imported at `auth.definition.ts:19`; add `APIError` to that same import.
+
+Note `/admin/create-user` is unguarded today and is precisely how the 10 legacy `dj` rows came to exist.
+
+Two gotchas:
+
+- Passing `adminRoles` explicitly activates a construction-time validation branch (`admin.mjs:18-20`) that throws `BetterAuthError` if an entry is not a key of `roles`. `['admin']` is a valid subset of the pinned set; keep it so.
+- Pinning to `defaultRoles` is semantically a no-op — the plugin would compute the same set. The value is entirely in _activating_ the validation branch that `opts.roles === undefined` skips.
+- `better-auth/plugins/admin/access` is an ESM subpath. If any unit test ends up resolving it, it needs a new `tests/mocks/better-auth-admin-access.mock.ts` (one export: `defaultRoles`) plus a `moduleNameMapper` entry at `jest.unit.config.ts:40-43` — the existing `better-auth-access.mock.ts` exports only `createAccessControl` and cannot serve it. **Verify whether it is needed at all before writing it:** every current unit test against `auth.definition.ts` is a source-scan, and §0's extraction deliberately keeps the new logic out of that file, so nothing may import it. Write the mock only if a test actually fails to resolve.
+
+### 3. JWT payload — fail closed, but drop _only_ `role`
+
+`buildJwtPayload` (extracted in §0 from `auth.definition.ts:236-240`). The fallback must not spread `role` through from `user`.
+
+**Drop `role` by destructure — do not narrow the payload.** `auth.middleware.ts:183-188` gates banned accounts on `payload.banned` / `payload.banReason`, and its own comment says the field arrives "in JWT payload via `...user` spread" — i.e. it reaches the middleware _only_ through the spread at `auth.definition.ts:238`. Returning a hand-built narrow object on the fallback path would silently un-ban every suspended account whose token was minted through it. The fix must be subtractive:
+
+```ts
+const { role: _unusedSystemRole, ...rest } = user;
+return { ...rest, capabilities: userWithCapabilities?.capabilities ?? [] };
+```
+
+Route the catch through the injected `onError` so the call site can `Sentry.captureException` (matching `{ level: 'warning', tags: { subsystem: 'admin-sync' } }` at `apps/auth/app.ts:505`).
+
+A test in the tests 1–3 group asserts the fallback still carries `banned` and `banReason` — this is the failure mode most likely to survive review unnoticed, because a fail-closed change that accidentally fails _open_ on a different axis looks correct in every test that only asserts on `role`.
+
+### 4. Make every swallowed role-sync failure loud
+
+| Site (`shared/authentication/src/auth.definition.ts`) | Line       | Current posture                 |
+| ----------------------------------------------------- | ---------- | ------------------------------- |
+| `afterAddMember`                                      | `:311`     | `console.error` only            |
+| `afterUpdateMemberRole`                               | `:346`     | `console.error` only            |
+| `afterRemoveMember`                                   | `:385`     | `console.error` only            |
+| `getAdditionalUserInfoClaim`                          | `:275-277` | bare `catch`, no logging at all |
+
+The first three are the realistic mechanism by which a demoted station manager keeps `role = 'admin'` forever. Route all three through the extracted helpers' `onError`.
+
+The fourth is the OIDC `id_token` path. It degrades to `role: 'member'` on both empty and thrown — already fail-closed in the privilege sense, and it does **not** carry the `auth_user.role` leak §3 fixes. **Proposed:** add the Sentry capture, keep the `'member'` degrade. An absent `role` in an `id_token` breaks OIDC sign-in at the relying party rather than at a single API call. Record that in a comment so the divergence is deliberate.
+
+### 5. `syncAdminRoles()` — a demotion branch that cannot strip a legitimate admin
+
+`apps/auth/sync-admin-roles.ts` (extracted in §0 from `apps/auth/app.ts:465-506`). Add the inverse of the existing promote query, with one restriction and one explicit value.
+
+**Writes `null`, not `'user'`** — matching the three existing demotion paths (`auth.definition.ts:340`, `:379`). §1's one-time normalization writes `'user'` because those rows are creation-default artifacts, not demotions; the two encodings are equivalent and §7 documents that. Test 5 asserts `null` specifically.
+
+**Demote only where the org join succeeds** and `member.role NOT IN ('admin','owner','stationManager')`. The naive form ("membership absent **or** not admin-ish") is unsafe: an absent membership is exactly the orphan §8 covers, produced when the `user.create.after` safety net swallows its insert error (`auth.definition.ts:593`). This reconciler runs on **every auth-service boot**, so the naive form would let a transient signup-time error silently strip admin from a legitimate station manager on the next restart — with no membership row left to re-promote from.
+
+Report the absent-membership case to Sentry and take no action. Keep the `DEFAULT_ORG_SLUG`-unset early return governing both directions.
+
+### 6. `mapUserRoleToMemberRole()` — narrow the inverted derivation, keep the script
+
+`scripts/backfill-missing-org-members.ts:48-55` derives `auth_member.role` _from_ `auth_user.role` across **four** branches (`admin`, `dj`, `musicDirector`, `stationManager`) — the mechanism by which a legacy `user`/`null` becomes a permanent `auth_member.role = 'member'`.
+
+r1 proposed deleting the script. **Reversed** — `auth.definition.ts:593` names it as the operator's documented recovery path from inside the `user.create.after` safety net's own error handler. Deleting it would orphan that instruction and remove the remediation for exactly the case §5 now refuses to act on. (Otherwise unreferenced: no `package.json` script, no CI, no test.)
+
+**Instead:** reduce the mapping to `admin → stationManager` — removing three of four branches — and require an explicit `--default-role` for every other input. Update the header comment at `:13-16`, which documents the full mapping.
+
+### 7. Documentation — amend in place
+
+`docs/authentication.md` already answers the ticket's first acceptance criterion in two places; a new section would produce two overlapping answers. Amend both:
+
+- `:24` — the **JWT payload** line already says `role` is "queried from the organization member table, not `user.role`". Add §3's fail-closed behavior.
+- `:37` — the **Role mismatch gotcha** already says the org hooks sync to `user.role='admin'`. Add the alphabet, the constraint name, that `auth_member.role` is the sole station-role source of truth, **and that `NULL` and `'user'` are equivalent encodings of "not a better-auth admin."**
+
+At `:39`: that paragraph instructs operators to grant capabilities via the admin plugin's `updateUser` with `data: {...}` — the same call dj-site's `AccountEditForm.tsx` (`updateCapabilities`) already makes in production. Add that `role` must never ride along in that payload.
+
+Three places repeat the stale claim that the auto-DJ account leaves `user.role` null; it lands on `'user'`. Correct all three: `CLAUDE.md:117` (highest-traffic copy), `apps/auth/create-auto-dj-user.ts:28` and `:76`.
+
+`scripts/check-auth-tables-doc.mjs` needs no change — it extracts `pgTable('auth_…')` name literals via `PG_TABLE_RE` (`:108`).
+
+### 8. Orphan membership — folded in from the #1223 review
+
+Carried in at the user's direction rather than filed separately. A user with no `auth_member` row folds into `"member"` and renders in the dj-site roster as an ordinary Member; a station manager who tries to correct that hits `AccountEditForm`'s `resolveMemberId` throwing _"User is not a member of the organization"_ — a dead end with no on-screen explanation.
+
+Latent today (110 users / 110 membership rows / zero orphans) but no longer purely hypothetical: §5 now _detects_ orphans and deliberately declines to act on them, so the state becomes reachable and observable rather than silently reconciled.
+
+- **Backend-Service (this work).** §5's Sentry report is the detection. §3's fail-closed payload means an orphan gets a 403 rather than a plausible-looking Member token.
+- **dj-site (chained follow-up PR, referencing this issue).** A distinct "no membership" affordance instead of rendering as Member, and an explanation on `resolveMemberId`'s failure. Deferred from #1223 because the fix means adding a display state to `Authorization`, a shared enum in `@wxyc/shared` consumed by other repos — that widening is the real design question and belongs in its own review.
+
+## Tests
+
+| #   | Test                                                                                                                                                                           | File                                                       | Tier               |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | ------------------ |
+| 1   | `buildJwtPayload` omits `role` when `fetchMemberRole` throws                                                                                                                   | `tests/unit/authentication/jwt-payload.test.ts`            | unit               |
+| 2   | `buildJwtPayload` omits `role` when membership returns empty                                                                                                                   | same                                                       | unit               |
+| 3   | `buildJwtPayload` emits `member.role` on the happy path                                                                                                                        | same                                                       | unit               |
+| 3b  | **the fallback still carries `banned` and `banReason`** — `role` is dropped by destructure, not by narrowing                                                                   | same                                                       | unit               |
+| 4   | admin plugin declares `defaultRole`, `adminRoles`, `roles`                                                                                                                     | `tests/unit/authentication/admin-plugin-config.test.ts`    | unit (source-scan) |
+| 5   | `syncAdminRoles` demotes to **`null`** when the membership row exists and is not admin-ish                                                                                     | `tests/unit/auth/sync-admin-roles.test.ts`                 | unit               |
+| 6   | `syncAdminRoles` does **not** demote when the membership row is absent — reports instead                                                                                       | same                                                       | unit               |
+| 7   | `syncAdminRoles` still promotes; no-ops when `DEFAULT_ORG_SLUG` unset; all four §4 sites call `onError`                                                                        | same + `tests/unit/authentication/admin-flag-sync.test.ts` | unit               |
+| 8   | CHECK rejects `UPDATE auth_user SET role='musicDirector'`                                                                                                                      | `tests/integration/auth-user-role-constraint.spec.js`      | integration        |
+| 9   | `/admin/create-user` with no `role`, and `/sign-in/anonymous`, both land on `role='user'`                                                                                      | same                                                       | integration        |
+| 10  | `provisionUser({role:'stationManager'})` still yields `user.role='admin'`                                                                                                      | same                                                       | integration        |
+| 11  | schema/migration coupling                                                                                                                                                      | `tests/unit/database/schema.auth-user-role.test.ts`        | unit               |
+| 12  | `assertScalarRoleWrite` throws 400 for array-valued and comma-bearing `role` on all three `/admin/*` write paths; returns silently for a scalar `role` and for unrelated paths | `tests/unit/authentication/admin-role-write-guard.test.ts` | unit               |
+
+Test 12 pins the §2 request guard — the specific path that would otherwise surface as an unhandled 23514. It is a **unit** test, not an integration test, because §0 extracts the policy into a pure function; `APIError` is already stubbed at `tests/mocks/better-auth-api.mock.ts:4`, so the assertion is `rejects.toMatchObject({ body: … })` exactly as in `device-authorization.test.ts:32`. That also lets it cover all three paths and both malformed shapes cheaply, which an integration test against a live admin session would not.
+
+Test 9 was retargeted in r4: `disableSignUp: true` (`auth.definition.ts:97`) means there is no ordinary email signup. `/admin/create-user` with no role is already exercised at `tests/integration/auth-auto-membership.spec.js:104`.
+
+Unit tests 1–3b, 5–7 and 12 import the extracted modules **by relative path** with callbacks injected, mirroring `tests/unit/authentication/device-authorization.test.ts`. Tiers split by owning workspace — `shared/authentication` code tests in `tests/unit/authentication/`, `apps/auth` code tests in `tests/unit/auth/`.
+
+Integration tests are CommonJS `.js` (`jest.config.json` `testMatch: **/tests/integration/?(*.)+(spec).js`), modelled on `tests/integration/auth-auto-membership.spec.js`, and need the docker DB, which picks up the new migration via the `dev_env/docker-compose.yml:54` bind mount.
+
+Test 11 follows the 31 sibling `tests/unit/database/schema.*.test.ts` files: read schema.ts and the migration SQL **as text**, locate the migration by `tag.startsWith('0150_')` out of `meta/_journal.json`, and assert the journal entry exists, its `when` exceeds `0149_`'s, the `check('auth_user_role_system_only', …)` declaration is present, and the SQL contains both the `UPDATE` and the `ADD CONSTRAINT`.
+
+## Verification
+
+Acceptance criterion: _station managers retain working `/admin/*` access — verified against the 8 existing ones._
+
+Pre-deploy, the ticket's role cross-tab is the baseline. Post-deploy, re-run it and confirm the `admin`/`stationManager` cell is still 8 and the `dj`/`dj` cell has moved to `user`/`dj`. Read-only, through the authenticated HTTP API — the Safari authed-probe technique (`osascript` + in-page `fetch`), not direct DB access, which is permission-gated. Needs a `!`-prefixed command from the user if a live probe is wanted.
+
+## Risks
+
+| Risk                                                              | Severity | Mitigation                                                                                                                                                                                                       |
+| ----------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Constraint rejects a user-creation path we missed                 | **high** | Inventory now covers all four `/admin/*` writers, `anonymous()`, `provisionUser`, and `dev_env/seed_db.sql` (verified in-alphabet); no ordinary signup exists; test 9; `migrate-dryrun` against prod-shaped data |
+| Array/comma `role` on an `/admin/*` write → unhandled 23514 (500) | **high** | §2's request guard is the actual fix; the `roles` pin alone does not close it; test 12                                                                                                                           |
+| Demotion branch strips a legitimate admin                         | medium   | §5's join-succeeds restriction; test 6; `DEFAULT_ORG_SLUG` guard retained                                                                                                                                        |
+| better-auth upgrade changes `defaultRole`                         | medium   | §2 pin + test 4                                                                                                                                                                                                  |
+| Fail-closed JWT 403s an SM on a transient error                   | medium   | ≤15 min (token TTL), permission-declaring routes only, both clients already degrade gracefully; Sentry capture; flagged for override                                                                             |
+| §0 extraction changes behavior while moving it                    | medium   | Isolated into its own PR whose sole acceptance criterion is a green suite                                                                                                                                        |
+| Shape-probe failure misread as a blocker                          | low      | Paren-free predicate + expected-failure note in §1 and the PR body                                                                                                                                               |
+| Journal `when` collision with a parallel PR                       | low      | Re-check tail at merge; no `0150_` in any sibling worktree today                                                                                                                                                 |
+
+## Sequencing — two chained PRs
+
+Split per the ≤1000-line PR guidance. §0 is a pure behavior-preserving move whose acceptance criterion is exactly "the existing suite stays green," which also isolates the extraction risk from the behavior changes.
+
+**PR 1 — extraction only.** Branch `fix/2171-extract-auth-role-helpers`. §0: four new modules with deps injected, call sites rewired, no barrel entries. No behavior change; the existing suite must pass untouched. Body notes it is a prerequisite for #2171 and closes nothing.
+
+The fourth module (`admin-role-write-guard.ts`) is the one exception to "behavior-preserving": there is no existing guard to move, so PR 1 lands it _unwired_ alongside test 12, and PR 2 calls it from the `hooks.before` middleware. That keeps PR 1's acceptance criterion intact while still getting the guard reviewed as a pure function rather than buried in PR 2's diff.
+
+**PR 2 — behavior + schema.** Branch `fix/2171-narrow-auth-user-role` (this worktree), rebased on PR 1.
+
+1. Tests 1–7 (unit + integration, red) → §2, §3, §4, §5 → green. Test 12 already exists from PR 1; §2 wires the guard in.
+2. Test 11 + tests 8–10 (red) → §1 schema + `drizzle:generate` → green. Paste the emitted DDL into this plan and the PR body. `migrate-dryrun` is the real gate.
+3. §6, §7, §8 — script narrowing, doc amendments, stale-claim corrections in all three places.
+4. Local CI parity (`npm run lint`, `format:check`, `typecheck`, `build`, `test:unit`, `ci:testmock`) before any push.
+5. `Closes #2171`. File the chained dj-site follow-up from §8, and the `schema-shape-report.mjs` follow-up from §1 (ask first — separate defect).
+
+## Out of scope
+
+- Any write to `auth_member.role` — the ticket forbids it, and it is correct today.
+- Adding `admin` to `WXYCRoles` or `ROLES` — `systemRoleMap` already maps `admin`/`owner` → `stationManager`.
+- The `Authorization` enum widening in `@wxyc/shared` that a full dj-site orphan affordance needs (§8).
+- Reconciling `CLAUDE.md:199-205`'s documented branch prefixes (`feature/`, `task/`, `bugfix/`) with the de-facto `fix/` in use here and in `.worktrees/1748-bound-lml-limiter-queue`. Real drift, unrelated to this ticket.

--- a/shared/authentication/src/admin-flag-sync.ts
+++ b/shared/authentication/src/admin-flag-sync.ts
@@ -1,0 +1,135 @@
+/**
+ * Keep `auth_user.role` — the better-auth admin plugin's system flag — in
+ * step with organization membership in the default organization.
+ *
+ * The flag is a *derived* value: it says only whether the user may use the
+ * admin plugin's own routes, and is recomputed here whenever the membership
+ * that justifies it changes. The station role itself lives in
+ * `auth_member.role` and is never read from here (BS#2171).
+ *
+ * Extracted from the `organizationHooks` literal in `auth.definition.ts` so
+ * the policy is unit-testable; the three hooks shared a near-identical
+ * prologue, so the extraction removes real duplication rather than only
+ * serving the tests. DB access arrives as callbacks — a value import from
+ * `@wxyc/database` would re-engage the mock at `jest.unit.config.ts` and
+ * defeat the injection.
+ */
+
+/**
+ * Membership roles that justify the admin flag.
+ *
+ * `stationManager` is the WXYC station role; `admin` and `owner` are
+ * better-auth's own organization roles, which a member row can also carry.
+ */
+export const ADMIN_GRANTING_MEMBER_ROLES: readonly string[] = ['stationManager', 'admin', 'owner'];
+
+export const grantsAdminFlag = (memberRole: string): boolean => ADMIN_GRANTING_MEMBER_ROLES.includes(memberRole);
+
+export interface AdminFlagSyncDeps {
+  /**
+   * Read per invocation rather than at module load: the hooks read
+   * `process.env.DEFAULT_ORG_SLUG` on every fire, and a process that boots
+   * before the variable is set must start syncing once it appears.
+   */
+  defaultOrgSlug: string | undefined;
+  setUserRole: (userId: string, role: 'admin' | null) => Promise<void>;
+  onError: (error: unknown) => void;
+}
+
+type MemberIdentity = { id: string; email: string };
+
+/**
+ * Shared prologue: the sync applies only to the default organization, and
+ * only when that organization is configured at all.
+ */
+const appliesToDefaultOrganization = (organizationSlug: string, defaultOrgSlug: string | undefined): boolean => {
+  if (!defaultOrgSlug) {
+    console.warn('DEFAULT_ORG_SLUG is not set, skipping admin role sync');
+    return false;
+  }
+  return organizationSlug === defaultOrgSlug;
+};
+
+/** Grant the admin flag when a member joins the default org in an admin-granting role. */
+export async function syncAdminFlagOnAddMember(
+  args: { member: { role: string }; user: MemberIdentity; organization: { slug: string } },
+  deps: AdminFlagSyncDeps
+): Promise<void> {
+  try {
+    if (!appliesToDefaultOrganization(args.organization.slug, deps.defaultOrgSlug)) return;
+
+    if (grantsAdminFlag(args.member.role)) {
+      const userId = args.user.id;
+      await deps.setUserRole(userId, 'admin');
+      console.log(
+        `Granted admin role to user ${userId} (${args.user.email}) with ${args.member.role} role in default organization`
+      );
+    }
+  } catch (error) {
+    deps.onError(error);
+  }
+}
+
+/**
+ * Grant or revoke the admin flag as a member's role changes.
+ *
+ * Acts only on a transition across the admin-granting boundary; a change
+ * between two roles on the same side of it leaves the flag alone.
+ */
+export async function syncAdminFlagOnUpdateMemberRole(
+  args: {
+    member: { role: string };
+    previousRole: string;
+    user: MemberIdentity;
+    organization: { slug: string };
+  },
+  deps: AdminFlagSyncDeps
+): Promise<void> {
+  try {
+    if (!appliesToDefaultOrganization(args.organization.slug, deps.defaultOrgSlug)) return;
+
+    const shouldHaveAdmin = grantsAdminFlag(args.member.role);
+    const previouslyHadAdmin = grantsAdminFlag(args.previousRole);
+    const userId = args.user.id;
+
+    if (shouldHaveAdmin && !previouslyHadAdmin) {
+      await deps.setUserRole(userId, 'admin');
+      console.log(`Granted admin role to user ${userId} (${args.user.email}) after promotion to ${args.member.role}`);
+    } else if (!shouldHaveAdmin && previouslyHadAdmin) {
+      await deps.setUserRole(userId, null);
+      console.log(
+        `Removed admin role from user ${userId} (${args.user.email}) after demotion from ${args.previousRole} to ${args.member.role}`
+      );
+    }
+  } catch (error) {
+    deps.onError(error);
+  }
+}
+
+/**
+ * Revoke the admin flag when a member leaves the default org, unless another
+ * admin-granting membership still justifies it.
+ */
+export async function syncAdminFlagOnRemoveMember(
+  args: { user: MemberIdentity; organization: { slug: string } },
+  deps: AdminFlagSyncDeps & {
+    hasOtherAdminMembership: (userId: string, defaultOrgSlug: string) => Promise<boolean>;
+  }
+): Promise<void> {
+  try {
+    if (!appliesToDefaultOrganization(args.organization.slug, deps.defaultOrgSlug)) return;
+
+    // Narrowed by the guard above, which returns false when unset.
+    const defaultOrgSlug = deps.defaultOrgSlug as string;
+
+    if (!(await deps.hasOtherAdminMembership(args.user.id, defaultOrgSlug))) {
+      const userId = args.user.id;
+      await deps.setUserRole(userId, null);
+      console.log(
+        `Removed admin role from user ${userId} (${args.user.email}) after removal from default organization`
+      );
+    }
+  } catch (error) {
+    deps.onError(error);
+  }
+}

--- a/shared/authentication/src/admin-flag-sync.ts
+++ b/shared/authentication/src/admin-flag-sync.ts
@@ -14,16 +14,19 @@
  * `@wxyc/database` would re-engage the mock at `jest.unit.config.ts` and
  * defeat the injection.
  */
+import { normalizeRole } from './auth.roles';
 
 /**
- * Membership roles that justify the admin flag.
+ * Does this membership role justify the admin flag?
  *
- * `stationManager` is the WXYC station role; `admin` and `owner` are
- * better-auth's own organization roles, which a member row can also carry.
+ * The flag means "holds stationManager authority", which is the one question
+ * `normalizeRole` exists to answer: it resolves `stationManager` to itself and
+ * better-auth's own `admin`/`owner` organization roles to `stationManager`,
+ * leaving `dj`/`musicDirector`/`member` as themselves. Asking it here rather
+ * than restating the role set keeps this in step with `auth.roles.ts`, which
+ * already declares that mapping canonical.
  */
-export const ADMIN_GRANTING_MEMBER_ROLES: readonly string[] = ['stationManager', 'admin', 'owner'];
-
-export const grantsAdminFlag = (memberRole: string): boolean => ADMIN_GRANTING_MEMBER_ROLES.includes(memberRole);
+const grantsAdminFlag = (memberRole: string): boolean => normalizeRole(memberRole) === 'stationManager';
 
 export interface AdminFlagSyncDeps {
   /**
@@ -34,6 +37,11 @@ export interface AdminFlagSyncDeps {
   defaultOrgSlug: string | undefined;
   setUserRole: (userId: string, role: 'admin' | null) => Promise<void>;
   onError: (error: unknown) => void;
+}
+
+/** Removal additionally needs to know whether a second membership still justifies the flag. */
+export interface RemoveMemberDeps extends AdminFlagSyncDeps {
+  hasOtherAdminMembership: (userId: string, defaultOrgSlug: string) => Promise<boolean>;
 }
 
 type MemberIdentity = { id: string; email: string };
@@ -112,17 +120,14 @@ export async function syncAdminFlagOnUpdateMemberRole(
  */
 export async function syncAdminFlagOnRemoveMember(
   args: { user: MemberIdentity; organization: { slug: string } },
-  deps: AdminFlagSyncDeps & {
-    hasOtherAdminMembership: (userId: string, defaultOrgSlug: string) => Promise<boolean>;
-  }
+  deps: RemoveMemberDeps
 ): Promise<void> {
   try {
     if (!appliesToDefaultOrganization(args.organization.slug, deps.defaultOrgSlug)) return;
 
-    // Narrowed by the guard above, which returns false when unset.
-    const defaultOrgSlug = deps.defaultOrgSlug as string;
-
-    if (!(await deps.hasOtherAdminMembership(args.user.id, defaultOrgSlug))) {
+    // The guard above passed, so this slug equals deps.defaultOrgSlug — and it
+    // is already a string, which deps.defaultOrgSlug is not.
+    if (!(await deps.hasOtherAdminMembership(args.user.id, args.organization.slug))) {
       const userId = args.user.id;
       await deps.setUserRole(userId, null);
       console.log(

--- a/shared/authentication/src/admin-role-write-guard.ts
+++ b/shared/authentication/src/admin-role-write-guard.ts
@@ -1,0 +1,59 @@
+import { APIError } from 'better-auth/api';
+
+/**
+ * The better-auth admin plugin routes that write `auth_user.role`.
+ *
+ * All three land in `parseRoles` (`plugins/admin/routes.mjs:21`), which is
+ * where the multi-role join happens. `/admin/create-user` is the one most
+ * easily overlooked and is how the legacy station-role values in the column
+ * were written in the first place.
+ */
+export const GUARDED_ROLE_WRITE_PATHS = ['/admin/set-role', '/admin/update-user', '/admin/create-user'] as const;
+
+/**
+ * Reject any `role` write that would not persist as a single scalar value.
+ *
+ * The admin plugin validates role inputs *element-wise* and only then joins
+ * them: `/admin/set-role` (`routes.mjs:70-76`), `/admin/update-user`
+ * (`:265-271`) and `/admin/create-user` (`:173-177`) each loop
+ * `for (const role of inputRoles) if (!roles[role]) throw`, then write
+ * `parseRoles(ctx.body.role)` — `Array.isArray(roles) ? roles.join(",") : roles`.
+ *
+ * So `{"role": ["admin", "user"]}` passes the plugin's own allowlist twice
+ * over — both keys exist — and persists the string `"admin,user"`. That is
+ * the ambiguity `auth_user.role` is being narrowed to remove, and it would
+ * reach the column's CHECK constraint as an unhandled 23514, i.e. a 500.
+ * Rejecting at the request boundary keeps it a 400.
+ *
+ * This guard owns exactly one property — that whatever reaches `parseRoles`
+ * cannot become a comma list. It deliberately does *not* re-validate which
+ * scalar values are allowed; the plugin's pinned `roles` option owns that,
+ * and duplicating the alphabet here would drift from it on upgrade.
+ *
+ * Exported as a pure function so the policy is unit-testable without
+ * standing up better-auth, matching `applyDeviceApproveRoleGate`.
+ */
+export function assertScalarRoleWrite(path: string, body: { role?: unknown } | null | undefined): void {
+  if (!(GUARDED_ROLE_WRITE_PATHS as readonly string[]).includes(path)) return;
+
+  const role = body?.role;
+  // Omitting `role` is legitimate on create-user and update-user: the
+  // plugin's `user.create.before` hook stamps the configured defaultRole.
+  if (role === undefined || role === null) return;
+
+  const offending =
+    Array.isArray(role) ||
+    typeof role !== 'string' ||
+    // A comma in a scalar string is indistinguishable from a joined list by
+    // the time it reaches the column, so it is refused at the same door.
+    role.includes(',');
+
+  if (offending) {
+    throw new APIError('BAD_REQUEST', {
+      code: 'ROLE_MUST_BE_SCALAR',
+      message:
+        `\`role\` must be a single value without commas on ${path}. ` +
+        'Multi-role values are persisted comma-joined, which this service does not support.',
+    });
+  }
+}

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -293,25 +293,15 @@ export const auth = betterAuth({
       // Role information is included via custom JWT definePayload function above
       organizationHooks: {
         // Sync global user.role when members are added to default organization
-        afterAddMember: async ({ member, user: userData, organization: orgData }) =>
-          syncAdminFlagOnAddMember(
-            { member, user: userData, organization: orgData },
-            adminFlagSyncDeps('afterAddMember')
-          ),
+        afterAddMember: async (data) => syncAdminFlagOnAddMember(data, adminFlagSyncDeps('afterAddMember')),
 
         // Sync global user.role when member roles are updated
-        afterUpdateMemberRole: async ({ member, previousRole, user: userData, organization: orgData }) =>
-          syncAdminFlagOnUpdateMemberRole(
-            { member, previousRole, user: userData, organization: orgData },
-            adminFlagSyncDeps('afterUpdateMemberRole')
-          ),
+        afterUpdateMemberRole: async (data) =>
+          syncAdminFlagOnUpdateMemberRole(data, adminFlagSyncDeps('afterUpdateMemberRole')),
 
         // Sync global user.role when members are removed from default organization
-        afterRemoveMember: async ({ user: userData, organization: orgData }) =>
-          syncAdminFlagOnRemoveMember(
-            { user: userData, organization: orgData },
-            { ...adminFlagSyncDeps('afterRemoveMember'), hasOtherAdminMembership }
-          ),
+        afterRemoveMember: async (data) =>
+          syncAdminFlagOnRemoveMember(data, { ...adminFlagSyncDeps('afterRemoveMember'), hasOtherAdminMembership }),
       },
     }),
     // ADR 0008 — QR sign-in for the shared control-room computer (RFC 8628).
@@ -373,24 +363,17 @@ export const auth = betterAuth({
       if (ctx.path !== '/device/approve') return;
       const session = await getSessionFromCtx(ctx);
       if (!session?.user?.id) return; // let the plugin's own UNAUTHORIZED fire
-      await applyDeviceApproveRoleGate(
-        session.user.id,
-        async (uid) => {
-          const rows = await db.select({ role: member.role }).from(member).where(eq(member.userId, uid)).limit(1);
-          return rows[0];
-        },
-        async (uid) => {
-          // S1 (#1494 review): reset any *pending* device-code row the
-          // rejected user claimed via GET /auth/device?user_code=… so the
-          // plugin's `deviceCodeRecord.userId === session.user.id` check
-          // stops treating them as the approver. Scoped by (userId + pending)
-          // so we don't disturb an in-flight approval elsewhere.
-          await db
-            .update(deviceCode)
-            .set({ userId: null })
-            .where(and(eq(deviceCode.userId, uid), eq(deviceCode.status, 'pending')));
-        }
-      );
+      await applyDeviceApproveRoleGate(session.user.id, selectMemberRole, async (uid) => {
+        // S1 (#1494 review): reset any *pending* device-code row the
+        // rejected user claimed via GET /auth/device?user_code=… so the
+        // plugin's `deviceCodeRecord.userId === session.user.id` check
+        // stops treating them as the approver. Scoped by (userId + pending)
+        // so we don't disturb an in-flight approval elsewhere.
+        await db
+          .update(deviceCode)
+          .set({ userId: null })
+          .where(and(eq(deviceCode.userId, uid), eq(deviceCode.status, 'pending')));
+      });
     }),
     after: createAuthMiddleware(async (ctx) => {
       if (ctx.path === '/admin/create-user') {

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -43,6 +43,55 @@ import { buildTrustedClients } from './oidc-trusted-clients';
 import { buildLoginPage } from './oidc-login-page';
 import { buildResetUrl, rewriteUrlForFrontend } from './url-rewrite';
 import { accountSetupTokenExpiresInSeconds } from './account-setup-token';
+import { buildJwtPayload, buildOidcUserInfoClaim, type MemberRoleRow } from './jwt-payload';
+import {
+  syncAdminFlagOnAddMember,
+  syncAdminFlagOnRemoveMember,
+  syncAdminFlagOnUpdateMemberRole,
+  type AdminFlagSyncDeps,
+} from './admin-flag-sync';
+
+/**
+ * The one place a station role is read. Both token-minting paths and the
+ * device-approve gate resolve `role` from `auth_member`, never from
+ * `auth_user.role` — that column is the better-auth admin plugin's system
+ * flag and carries no station role.
+ */
+const selectMemberRole = async (userId: string): Promise<MemberRoleRow> => {
+  const rows = await db.select({ role: member.role }).from(member).where(eq(member.userId, userId)).limit(1);
+  return rows[0];
+};
+
+/**
+ * Does any *other* membership in the default organization still justify the
+ * admin flag? Consulted when a member is removed, so a user who holds the
+ * role through a second row does not lose it.
+ */
+const hasOtherAdminMembership = async (userId: string, defaultOrgSlug: string): Promise<boolean> => {
+  const rows = await db
+    .select({ role: member.role })
+    .from(member)
+    .innerJoin(organization, sql`${member.organizationId} = ${organization.id}`)
+    .where(
+      sql`${member.userId} = ${userId}
+                AND ${organization.slug} = ${defaultOrgSlug}
+                AND ${member.role} IN ('admin', 'owner', 'stationManager')`
+    )
+    .limit(1);
+  return rows.length > 0;
+};
+
+/**
+ * `defaultOrgSlug` is resolved per invocation, matching the hooks' original
+ * per-fire `process.env` read.
+ */
+const adminFlagSyncDeps = (hookName: string): AdminFlagSyncDeps => ({
+  defaultOrgSlug: process.env.DEFAULT_ORG_SLUG,
+  setUserRole: async (userId, role) => {
+    await db.update(user).set({ role }).where(eq(user.id, userId));
+  },
+  onError: (error) => console.error(`Error syncing admin role in ${hookName}:`, error),
+});
 
 // Type annotation avoids TS2742: tsup's DTS emitter cannot reference
 // better-auth's internal anonymous plugin types (unexported subpath).
@@ -209,36 +258,10 @@ export const auth = betterAuth({
       // JWKS endpoint automatically exposed at /api/auth/jwks
       // Custom payload to include organization member role and capabilities
       jwt: {
-        definePayload: async ({ user }) => {
-          const userWithCapabilities = user as typeof user & {
-            capabilities?: string[] | null;
-          };
-          // Query organization membership to get member role
-          if (user?.id) {
-            try {
-              const memberRecord = await db
-                .select({ role: member.role })
-                .from(member)
-                .where(eq(member.userId, user.id))
-                .limit(1);
-
-              if (memberRecord.length > 0) {
-                return {
-                  ...user,
-                  role: memberRecord[0].role,
-                  capabilities: userWithCapabilities.capabilities ?? [],
-                };
-              }
-            } catch (error) {
-              console.error('[JWT] Failed to fetch member role:', error);
-            }
-          }
-          // Fallback: no organization membership or query failed
-          return {
-            ...user,
-            capabilities: userWithCapabilities?.capabilities ?? [],
-          };
-        },
+        definePayload: async ({ user }) =>
+          buildJwtPayload(user, selectMemberRole, (error) =>
+            console.error('[JWT] Failed to fetch member role:', error)
+          ),
       },
     }),
     oidcProvider({
@@ -260,21 +283,7 @@ export const auth = betterAuth({
       // public trustedClient (see #1578, wxyc-canary#60).
       useJWTPlugin: true,
       trustedClients: buildTrustedClients(process.env),
-      getAdditionalUserInfoClaim: async (userRecord) => {
-        try {
-          const memberRecord = await db
-            .select({ role: member.role })
-            .from(member)
-            .where(eq(member.userId, userRecord.id))
-            .limit(1);
-          return {
-            role: memberRecord[0]?.role ?? 'member',
-            capabilities: (userRecord as typeof userRecord & { capabilities?: string[] }).capabilities ?? [],
-          };
-        } catch {
-          return { role: 'member', capabilities: [] };
-        }
-      },
+      getAdditionalUserInfoClaim: async (userRecord) => buildOidcUserInfoClaim(userRecord, selectMemberRole),
     }),
     organizationPlugin({
       // Configure for single organization model
@@ -284,107 +293,25 @@ export const auth = betterAuth({
       // Role information is included via custom JWT definePayload function above
       organizationHooks: {
         // Sync global user.role when members are added to default organization
-        afterAddMember: async ({ member, user: userData, organization: orgData }) => {
-          try {
-            const defaultOrgSlug = process.env.DEFAULT_ORG_SLUG;
-            if (!defaultOrgSlug) {
-              console.warn('DEFAULT_ORG_SLUG is not set, skipping admin role sync');
-              return;
-            }
-
-            // Only update for default organization
-            if (orgData.slug !== defaultOrgSlug) {
-              return;
-            }
-
-            // Check if role should grant admin permissions
-            const adminRoles = ['stationManager', 'admin', 'owner'];
-            if (adminRoles.includes(member.role)) {
-              // Update user.role to "admin" for Better Auth Admin plugin
-              const userId = userData.id;
-              await db.update(user).set({ role: 'admin' }).where(eq(user.id, userId));
-              console.log(
-                `Granted admin role to user ${userId} (${userData.email}) with ${member.role} role in default organization`
-              );
-            }
-          } catch (error) {
-            console.error('Error syncing admin role in afterAddMember:', error);
-          }
-        },
+        afterAddMember: async ({ member, user: userData, organization: orgData }) =>
+          syncAdminFlagOnAddMember(
+            { member, user: userData, organization: orgData },
+            adminFlagSyncDeps('afterAddMember')
+          ),
 
         // Sync global user.role when member roles are updated
-        afterUpdateMemberRole: async ({ member, previousRole, user: userData, organization: orgData }) => {
-          try {
-            const defaultOrgSlug = process.env.DEFAULT_ORG_SLUG;
-            if (!defaultOrgSlug) {
-              console.warn('DEFAULT_ORG_SLUG is not set, skipping admin role sync');
-              return;
-            }
-
-            // Only update for default organization
-            if (orgData.slug !== defaultOrgSlug) {
-              return;
-            }
-
-            const adminRoles = ['stationManager', 'admin', 'owner'];
-            const shouldHaveAdmin = adminRoles.includes(member.role);
-            const previouslyHadAdmin = adminRoles.includes(previousRole);
-
-            const userId = userData.id;
-            if (shouldHaveAdmin && !previouslyHadAdmin) {
-              // Promoted to admin role - grant admin
-              await db.update(user).set({ role: 'admin' }).where(eq(user.id, userId));
-              console.log(`Granted admin role to user ${userId} (${userData.email}) after promotion to ${member.role}`);
-            } else if (!shouldHaveAdmin && previouslyHadAdmin) {
-              // Demoted from admin role - remove admin
-              await db.update(user).set({ role: null }).where(eq(user.id, userId));
-              console.log(
-                `Removed admin role from user ${userId} (${userData.email}) after demotion from ${previousRole} to ${member.role}`
-              );
-            }
-          } catch (error) {
-            console.error('Error syncing admin role in afterUpdateMemberRole:', error);
-          }
-        },
+        afterUpdateMemberRole: async ({ member, previousRole, user: userData, organization: orgData }) =>
+          syncAdminFlagOnUpdateMemberRole(
+            { member, previousRole, user: userData, organization: orgData },
+            adminFlagSyncDeps('afterUpdateMemberRole')
+          ),
 
         // Sync global user.role when members are removed from default organization
-        afterRemoveMember: async ({ user: userData, organization: orgData }) => {
-          try {
-            const defaultOrgSlug = process.env.DEFAULT_ORG_SLUG;
-            if (!defaultOrgSlug) {
-              console.warn('DEFAULT_ORG_SLUG is not set, skipping admin role sync');
-              return;
-            }
-
-            // Only update for default organization
-            if (orgData.slug !== defaultOrgSlug) {
-              return;
-            }
-
-            // Check if user has any other memberships with admin roles
-            const otherAdminMemberships = await db
-              .select({ role: member.role })
-              .from(member)
-              .innerJoin(organization, sql`${member.organizationId} = ${organization.id}`)
-              .where(
-                sql`${member.userId} = ${userData.id}
-                AND ${organization.slug} = ${defaultOrgSlug}
-                AND ${member.role} IN ('admin', 'owner', 'stationManager')`
-              )
-              .limit(1);
-
-            // If no other admin memberships exist, remove admin role
-            if (otherAdminMemberships.length === 0) {
-              const userId = userData.id;
-              await db.update(user).set({ role: null }).where(eq(user.id, userId));
-              console.log(
-                `Removed admin role from user ${userId} (${userData.email}) after removal from default organization`
-              );
-            }
-          } catch (error) {
-            console.error('Error syncing admin role in afterRemoveMember:', error);
-          }
-        },
+        afterRemoveMember: async ({ user: userData, organization: orgData }) =>
+          syncAdminFlagOnRemoveMember(
+            { user: userData, organization: orgData },
+            { ...adminFlagSyncDeps('afterRemoveMember'), hasOtherAdminMembership }
+          ),
       },
     }),
     // ADR 0008 — QR sign-in for the shared control-room computer (RFC 8628).

--- a/shared/authentication/src/jwt-payload.ts
+++ b/shared/authentication/src/jwt-payload.ts
@@ -20,6 +20,10 @@ export type MemberRoleRow = { role: string } | undefined;
 
 export type FetchMemberRole = (userId: string) => Promise<MemberRoleRow>;
 
+/**
+ * Declared on the parameters rather than cast onto them: `capabilities` is a
+ * WXYC column better-auth's own `User` type does not know about.
+ */
 type WithCapabilities = { capabilities?: string[] | null };
 
 /**
@@ -29,12 +33,12 @@ type WithCapabilities = { capabilities?: string[] | null };
  * A membership row supplies `role`. Absent membership — or a failed lookup —
  * falls through to the caller's own fields.
  */
-export async function buildJwtPayload<TUser extends { id?: string }>(
+export async function buildJwtPayload<TUser extends { id?: string } & WithCapabilities>(
   user: TUser,
   fetchMemberRole: FetchMemberRole,
   onError: (error: unknown) => void
 ): Promise<TUser & { role?: string; capabilities: string[] }> {
-  const capabilities = (user as TUser & WithCapabilities)?.capabilities ?? [];
+  const capabilities = user?.capabilities ?? [];
 
   if (user?.id) {
     try {
@@ -59,14 +63,14 @@ export async function buildJwtPayload<TUser extends { id?: string }>(
  * mint a token claiming more authority than the user holds.
  */
 export async function buildOidcUserInfoClaim(
-  userRecord: { id: string },
+  userRecord: { id: string } & WithCapabilities,
   fetchMemberRole: FetchMemberRole
 ): Promise<{ role: string; capabilities: string[] }> {
   try {
     const memberRow = await fetchMemberRole(userRecord.id);
     return {
       role: memberRow?.role ?? 'member',
-      capabilities: (userRecord as typeof userRecord & WithCapabilities).capabilities ?? [],
+      capabilities: userRecord.capabilities ?? [],
     };
   } catch {
     return { role: 'member', capabilities: [] };

--- a/shared/authentication/src/jwt-payload.ts
+++ b/shared/authentication/src/jwt-payload.ts
@@ -1,0 +1,74 @@
+/**
+ * Role resolution for the two token-minting paths.
+ *
+ * Both answer the same question — "what is this user's WXYC station role?" —
+ * and both must answer it from `auth_member.role`. `auth_user.role` is the
+ * better-auth admin plugin's own system flag ('user' | 'admin' | NULL) and
+ * carries no station role; reading a station role off it is the defect
+ * tracked in BS#2171.
+ *
+ * Extracted from the `betterAuth({...})` literal so the policy is
+ * unit-testable: the literal's properties are unreachable from a test, and
+ * `jest.unit.config.ts` maps `@wxyc/authentication` to a mock. DB access
+ * arrives as a callback for the same reason — a value import from
+ * `@wxyc/database` would re-engage the DB mock and defeat the injection.
+ * Same shape as `device-authorization.ts`.
+ */
+
+/** A single `auth_member` row's role, or `undefined` when the user has no membership. */
+export type MemberRoleRow = { role: string } | undefined;
+
+export type FetchMemberRole = (userId: string) => Promise<MemberRoleRow>;
+
+type WithCapabilities = { capabilities?: string[] | null };
+
+/**
+ * Build the JWT payload for a user, resolving `role` from organization
+ * membership.
+ *
+ * A membership row supplies `role`. Absent membership — or a failed lookup —
+ * falls through to the caller's own fields.
+ */
+export async function buildJwtPayload<TUser extends { id?: string }>(
+  user: TUser,
+  fetchMemberRole: FetchMemberRole,
+  onError: (error: unknown) => void
+): Promise<TUser & { role?: string; capabilities: string[] }> {
+  const capabilities = (user as TUser & WithCapabilities)?.capabilities ?? [];
+
+  if (user?.id) {
+    try {
+      const memberRow = await fetchMemberRole(user.id);
+      if (memberRow) {
+        return { ...user, role: memberRow.role, capabilities };
+      }
+    } catch (error) {
+      onError(error);
+    }
+  }
+
+  // No organization membership, or the query failed.
+  return { ...user, capabilities };
+}
+
+/**
+ * Build the `id_token` additional-info claim for the OIDC provider.
+ *
+ * Degrades to `'member'` — the least-privileged station role — on both an
+ * absent membership and a thrown lookup, so a transient DB failure cannot
+ * mint a token claiming more authority than the user holds.
+ */
+export async function buildOidcUserInfoClaim(
+  userRecord: { id: string },
+  fetchMemberRole: FetchMemberRole
+): Promise<{ role: string; capabilities: string[] }> {
+  try {
+    const memberRow = await fetchMemberRole(userRecord.id);
+    return {
+      role: memberRow?.role ?? 'member',
+      capabilities: (userRecord as typeof userRecord & WithCapabilities).capabilities ?? [],
+    };
+  } catch {
+    return { role: 'member', capabilities: [] };
+  }
+}

--- a/tests/mocks/better-auth-api.mock.ts
+++ b/tests/mocks/better-auth-api.mock.ts
@@ -6,16 +6,14 @@
 // numeric code the client actually receives lets a spec assert the status a
 // guard produces — the difference between a 400 and a 500 is frequently the
 // entire point of the guard under test.
-const STATUS_CODES = new Map<string, number>([
-  ['BAD_REQUEST', 400],
-  ['UNAUTHORIZED', 401],
-  ['FORBIDDEN', 403],
-  ['NOT_FOUND', 404],
-  ['CONFLICT', 409],
-  ['UNPROCESSABLE_ENTITY', 422],
-  ['TOO_MANY_REQUESTS', 429],
-  ['INTERNAL_SERVER_ERROR', 500],
-]);
+//
+// This is the same table the real APIError consults, imported rather than
+// copied: a hand-copied subset resolves every status outside it to 500, which
+// is indistinguishable in an assertion from a genuine 500 and so reintroduces
+// exactly the false confidence this mapping exists to remove.
+import { statusCodes } from 'better-call/error';
+
+const STATUS_CODES = new Map<string, number>(Object.entries(statusCodes));
 
 export class APIError extends Error {
   statusCode: number;

--- a/tests/mocks/better-auth-api.mock.ts
+++ b/tests/mocks/better-auth-api.mock.ts
@@ -1,6 +1,22 @@
 // Mock for `better-auth/api` — the real subpath ships ESM that ts-jest
 // can't transform without the ESM preset. `APIError` is the only symbol the
 // production code we test under `tests/unit/**` imports from here.
+// Production code constructs APIError with better-auth's string statuses
+// ('BAD_REQUEST', 'FORBIDDEN', …) rather than numbers. Resolving them to the
+// numeric code the client actually receives lets a spec assert the status a
+// guard produces — the difference between a 400 and a 500 is frequently the
+// entire point of the guard under test.
+const STATUS_CODES = new Map<string, number>([
+  ['BAD_REQUEST', 400],
+  ['UNAUTHORIZED', 401],
+  ['FORBIDDEN', 403],
+  ['NOT_FOUND', 404],
+  ['CONFLICT', 409],
+  ['UNPROCESSABLE_ENTITY', 422],
+  ['TOO_MANY_REQUESTS', 429],
+  ['INTERNAL_SERVER_ERROR', 500],
+]);
+
 export class APIError extends Error {
   statusCode: number;
   body?: { message?: string; code?: string; error?: string; error_description?: string; [key: string]: unknown };
@@ -14,7 +30,7 @@ export class APIError extends Error {
     super(body?.message ?? body?.error ?? 'API Error');
     this.name = 'APIError';
     this.body = body;
-    this.statusCode = statusCode ?? (typeof status === 'number' ? status : 500);
+    this.statusCode = statusCode ?? (typeof status === 'number' ? status : (STATUS_CODES.get(status) ?? 500));
   }
 }
 

--- a/tests/unit/auth/sync-admin-roles.test.ts
+++ b/tests/unit/auth/sync-admin-roles.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Characterization tests for the startup reconciler extracted out of
+ * `apps/auth/app.ts`, where it sat behind the `app.listen()` IIFE and could
+ * not be imported at all.
+ *
+ * The reconciler is the retry path for a membership hook that failed, so its
+ * load-bearing property is that it converges without operator intervention.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import { syncAdminRoles, type AdminFlagMismatch } from '../../../apps/auth/sync-admin-roles';
+
+const mismatch = (over: Partial<AdminFlagMismatch> = {}): AdminFlagMismatch => ({
+  userId: 'u1',
+  userEmail: 'sm@wxyc.org',
+  userRole: null,
+  memberRole: 'stationManager',
+  ...over,
+});
+
+describe('syncAdminRoles', () => {
+  let setUserRole: jest.Mock<(userId: string, role: 'admin' | null) => Promise<void>>;
+  let log: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    setUserRole = jest.fn(() => Promise.resolve());
+    log = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log.mockRestore();
+  });
+
+  const findReturning = (rows: AdminFlagMismatch[]) => jest.fn(() => Promise.resolve(rows));
+
+  it('grants the flag to every user missing it', async () => {
+    const find = findReturning([mismatch(), mismatch({ userId: 'u2', userEmail: 'sm2@wxyc.org' })]);
+
+    await syncAdminRoles({ defaultOrgSlug: 'wxyc', findUsersMissingAdminFlag: find, setUserRole });
+
+    expect(setUserRole).toHaveBeenCalledTimes(2);
+    expect(setUserRole).toHaveBeenCalledWith('u1', 'admin');
+    expect(setUserRole).toHaveBeenCalledWith('u2', 'admin');
+  });
+
+  it('scopes the search to the configured organization', async () => {
+    const find = findReturning([]);
+    await syncAdminRoles({ defaultOrgSlug: 'wxyc', findUsersMissingAdminFlag: find, setUserRole });
+    expect(find).toHaveBeenCalledWith('wxyc');
+  });
+
+  it('writes nothing when every membership already agrees', async () => {
+    await syncAdminRoles({ defaultOrgSlug: 'wxyc', findUsersMissingAdminFlag: findReturning([]), setUserRole });
+    expect(setUserRole).not.toHaveBeenCalled();
+  });
+
+  it('skips entirely — without querying — when DEFAULT_ORG_SLUG is unset', async () => {
+    const find = findReturning([mismatch()]);
+
+    await syncAdminRoles({ defaultOrgSlug: undefined, findUsersMissingAdminFlag: find, setUserRole });
+
+    expect(find).not.toHaveBeenCalled();
+    expect(setUserRole).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('[ADMIN PERMISSIONS] DEFAULT_ORG_SLUG not set, skipping admin role fix');
+  });
+
+  it('propagates a failed lookup to the caller, which owns the warn-and-continue', async () => {
+    const boom = new Error('connection terminated');
+    await expect(
+      syncAdminRoles({
+        defaultOrgSlug: 'wxyc',
+        findUsersMissingAdminFlag: jest.fn(() => Promise.reject(boom)),
+        setUserRole,
+      })
+    ).rejects.toBe(boom);
+  });
+
+  it('propagates a mid-loop write failure, leaving the remainder for the next boot', async () => {
+    const boom = new Error('write failed');
+    setUserRole.mockImplementationOnce(() => Promise.resolve()).mockImplementationOnce(() => Promise.reject(boom));
+    const find = findReturning([mismatch(), mismatch({ userId: 'u2' }), mismatch({ userId: 'u3' })]);
+
+    await expect(syncAdminRoles({ defaultOrgSlug: 'wxyc', findUsersMissingAdminFlag: find, setUserRole })).rejects.toBe(
+      boom
+    );
+
+    // Stopped at the failure — u3 is untouched and is re-found on the next boot.
+    expect(setUserRole).toHaveBeenCalledTimes(2);
+    expect(setUserRole).not.toHaveBeenCalledWith('u3', 'admin');
+  });
+});

--- a/tests/unit/authentication/admin-flag-sync.test.ts
+++ b/tests/unit/authentication/admin-flag-sync.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Characterization tests for the admin-flag sync extracted out of the
+ * `organizationHooks` literal. These pin the behavior as it was BEFORE the
+ * extraction — the existing suite cannot, since every other unit test against
+ * `auth.definition.ts` is a source-scan that never executes this code.
+ *
+ * `auth.roles.ts` is reached through `better-auth/plugins/access` and
+ * `.../organization/access`, both stubbed at the jest.unit.config.ts
+ * moduleNameMapper level.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import {
+  syncAdminFlagOnAddMember,
+  syncAdminFlagOnRemoveMember,
+  syncAdminFlagOnUpdateMemberRole,
+} from '../../../shared/authentication/src/admin-flag-sync';
+
+const ORG = 'wxyc';
+const USER = { id: 'u1', email: 'dj@wxyc.org' };
+
+/** Roles that carry stationManager authority, and therefore the admin flag. */
+const ADMIN_GRANTING = ['stationManager', 'admin', 'owner'];
+const NON_ADMIN_GRANTING = ['member', 'dj', 'musicDirector'];
+
+describe('admin flag sync', () => {
+  let setUserRole: jest.Mock<(userId: string, role: 'admin' | null) => Promise<void>>;
+  let onError: jest.Mock<(error: unknown) => void>;
+  let warn: jest.SpiedFunction<typeof console.warn>;
+  let log: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    setUserRole = jest.fn(() => Promise.resolve());
+    onError = jest.fn();
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    log = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    log.mockRestore();
+  });
+
+  const deps = () => ({ defaultOrgSlug: ORG, setUserRole, onError });
+
+  describe('afterAddMember', () => {
+    it.each(ADMIN_GRANTING)('grants the flag when joining as %s', async (role) => {
+      await syncAdminFlagOnAddMember({ member: { role }, user: USER, organization: { slug: ORG } }, deps());
+      expect(setUserRole).toHaveBeenCalledWith('u1', 'admin');
+    });
+
+    it.each(NON_ADMIN_GRANTING)('leaves the flag alone when joining as %s', async (role) => {
+      await syncAdminFlagOnAddMember({ member: { role }, user: USER, organization: { slug: ORG } }, deps());
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('ignores organizations other than the default', async () => {
+      await syncAdminFlagOnAddMember(
+        { member: { role: 'stationManager' }, user: USER, organization: { slug: 'some-other-org' } },
+        deps()
+      );
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('warns and does nothing when DEFAULT_ORG_SLUG is unset', async () => {
+      await syncAdminFlagOnAddMember(
+        { member: { role: 'stationManager' }, user: USER, organization: { slug: ORG } },
+        { ...deps(), defaultOrgSlug: undefined }
+      );
+      expect(setUserRole).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith('DEFAULT_ORG_SLUG is not set, skipping admin role sync');
+    });
+
+    it('routes a write failure to onError rather than throwing', async () => {
+      const boom = new Error('write failed');
+      setUserRole.mockImplementation(() => Promise.reject(boom));
+      await expect(
+        syncAdminFlagOnAddMember(
+          { member: { role: 'stationManager' }, user: USER, organization: { slug: ORG } },
+          deps()
+        )
+      ).resolves.toBeUndefined();
+      expect(onError).toHaveBeenCalledWith(boom);
+    });
+  });
+
+  describe('afterUpdateMemberRole', () => {
+    it('grants the flag on promotion across the boundary', async () => {
+      await syncAdminFlagOnUpdateMemberRole(
+        { member: { role: 'stationManager' }, previousRole: 'dj', user: USER, organization: { slug: ORG } },
+        deps()
+      );
+      expect(setUserRole).toHaveBeenCalledWith('u1', 'admin');
+    });
+
+    it('revokes the flag on demotion across the boundary', async () => {
+      await syncAdminFlagOnUpdateMemberRole(
+        { member: { role: 'dj' }, previousRole: 'stationManager', user: USER, organization: { slug: ORG } },
+        deps()
+      );
+      expect(setUserRole).toHaveBeenCalledWith('u1', null);
+    });
+
+    it.each([
+      ['admin', 'owner'],
+      ['owner', 'stationManager'],
+    ])('does nothing moving %s -> %s, both of which grant the flag', async (previousRole, role) => {
+      await syncAdminFlagOnUpdateMemberRole(
+        { member: { role }, previousRole, user: USER, organization: { slug: ORG } },
+        deps()
+      );
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('does nothing moving dj -> musicDirector, neither of which grants the flag', async () => {
+      await syncAdminFlagOnUpdateMemberRole(
+        { member: { role: 'musicDirector' }, previousRole: 'dj', user: USER, organization: { slug: ORG } },
+        deps()
+      );
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('ignores organizations other than the default', async () => {
+      await syncAdminFlagOnUpdateMemberRole(
+        {
+          member: { role: 'stationManager' },
+          previousRole: 'dj',
+          user: USER,
+          organization: { slug: 'some-other-org' },
+        },
+        deps()
+      );
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('afterRemoveMember', () => {
+    const removeDeps = (hasOther: boolean) => ({
+      ...deps(),
+      hasOtherAdminMembership: jest.fn(() => Promise.resolve(hasOther)),
+    });
+
+    it('revokes the flag when no other membership justifies it', async () => {
+      await syncAdminFlagOnRemoveMember({ user: USER, organization: { slug: ORG } }, removeDeps(false));
+      expect(setUserRole).toHaveBeenCalledWith('u1', null);
+    });
+
+    it('keeps the flag when another membership still justifies it', async () => {
+      await syncAdminFlagOnRemoveMember({ user: USER, organization: { slug: ORG } }, removeDeps(true));
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('scopes the second-membership check to the default organization', async () => {
+      const d = removeDeps(false);
+      await syncAdminFlagOnRemoveMember({ user: USER, organization: { slug: ORG } }, d);
+      expect(d.hasOtherAdminMembership).toHaveBeenCalledWith('u1', ORG);
+    });
+
+    it('ignores organizations other than the default', async () => {
+      const d = removeDeps(false);
+      await syncAdminFlagOnRemoveMember({ user: USER, organization: { slug: 'some-other-org' } }, d);
+      expect(d.hasOtherAdminMembership).not.toHaveBeenCalled();
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+
+    it('routes a failed membership check to onError rather than throwing', async () => {
+      const boom = new Error('query failed');
+      await expect(
+        syncAdminFlagOnRemoveMember(
+          { user: USER, organization: { slug: ORG } },
+          { ...deps(), hasOtherAdminMembership: jest.fn(() => Promise.reject(boom)) }
+        )
+      ).resolves.toBeUndefined();
+      expect(onError).toHaveBeenCalledWith(boom);
+      expect(setUserRole).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/authentication/admin-role-write-guard.test.ts
+++ b/tests/unit/authentication/admin-role-write-guard.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { describe, it, expect } from '@jest/globals';
 
 // better-auth/api is stubbed at the jest.unit.config.ts moduleNameMapper
@@ -9,81 +11,89 @@ import {
   assertScalarRoleWrite,
 } from '../../../shared/authentication/src/admin-role-write-guard';
 
+/**
+ * Derive the routes that can write `auth_user.role` from better-auth's own
+ * dist rather than restating the allowlist — asserting the constant equals a
+ * copy of itself would only detect edits to the constant, and the risk here
+ * is the opposite one: an upstream release adding a fourth role-writing route
+ * that silently falls outside the guard.
+ *
+ * Every role write funnels through `parseRoles` (the comma-join), so its call
+ * sites are the complete set. Same source-scan technique as
+ * `oidc-provider-public-client-jwt.test.ts`.
+ */
+const routesThatWriteRole = (): string[] => {
+  const routesPath = path.resolve(__dirname, '../../../node_modules/better-auth/dist/plugins/admin/routes.mjs');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const lines = fs.readFileSync(routesPath, 'utf-8').split('\n');
+
+  const found = new Set<string>();
+  let currentRoute: string | null = null;
+  for (const line of lines) {
+    const route = line.match(/createAuthEndpoint\("([^"]+)"/);
+    if (route) currentRoute = route[1];
+    // Skip `function parseRoles(` — the definition, not a call site.
+    if (/[^n] parseRoles\(|=\s*parseRoles\(|:\s*parseRoles\(/.test(line) && currentRoute) {
+      found.add(currentRoute);
+    }
+  }
+  return [...found].sort();
+};
+
+describe('GUARDED_ROLE_WRITE_PATHS', () => {
+  it('covers every better-auth route that reaches parseRoles', () => {
+    const upstream = routesThatWriteRole();
+
+    // Sanity-check the scan itself: if the dist layout changes so that nothing
+    // matches, an empty set would make the assertion below vacuously true.
+    expect(upstream.length).toBeGreaterThan(0);
+    expect([...GUARDED_ROLE_WRITE_PATHS].sort()).toEqual(upstream);
+  });
+});
+
 describe('assertScalarRoleWrite', () => {
-  it('guards exactly the three admin role-write paths', () => {
-    expect([...GUARDED_ROLE_WRITE_PATHS].sort()).toEqual([
-      '/admin/create-user',
-      '/admin/set-role',
-      '/admin/update-user',
-    ]);
-  });
+  const rejected: Array<[string, unknown]> = [
+    ['an array of two roles — passes the plugin allowlist element-wise, then joins', ['admin', 'user']],
+    ['a single-element array — joins to a scalar, but uses the multi-role API', ['admin']],
+    ['a comma-bearing string', 'admin,user'],
+    ['a number, which parseRoles returns verbatim', 42],
+    ['an object, which parseRoles returns verbatim', { admin: true }],
+  ];
 
-  describe.each(GUARDED_ROLE_WRITE_PATHS)('on %s', (path) => {
-    it('rejects an array-valued role', () => {
-      expect(() => assertScalarRoleWrite(path, { role: ['admin', 'user'] })).toThrow(
-        expect.objectContaining({ statusCode: 400 })
-      );
+  const accepted: Array<[string, unknown]> = [
+    ['the scalar admin', 'admin'],
+    ['the scalar user', 'user'],
+    // The plugin's own pinned `roles` allowlist owns unknown-value rejection.
+    // Duplicating the alphabet here would drift from it on upgrade; this guard
+    // owns exactly one property — that nothing reaching parseRoles can join.
+    ['an unknown scalar role', 'musicDirector'],
+    ['an omitted role, which create-user and update-user both allow', undefined],
+  ];
+
+  describe.each(GUARDED_ROLE_WRITE_PATHS)('on %s', (guardedPath) => {
+    it.each(rejected)('rejects %s', (_label, role) => {
+      expect(() => assertScalarRoleWrite(guardedPath, { role })).toThrow(expect.objectContaining({ statusCode: 400 }));
     });
 
-    it('rejects a single-element array — it still joins to a scalar, but the caller is using the multi-role API', () => {
-      expect(() => assertScalarRoleWrite(path, { role: ['admin'] })).toThrow(
-        expect.objectContaining({ statusCode: 400 })
-      );
-    });
-
-    it('rejects a comma-bearing string role', () => {
-      expect(() => assertScalarRoleWrite(path, { role: 'admin,user' })).toThrow(
-        expect.objectContaining({ statusCode: 400 })
-      );
-    });
-
-    it.each(['admin', 'user'])('lets the scalar %s through', (role) => {
-      expect(() => assertScalarRoleWrite(path, { role })).not.toThrow();
-    });
-
-    it('lets a body with no role through — /admin/create-user and /admin/update-user both allow omitting it', () => {
-      expect(() => assertScalarRoleWrite(path, {})).not.toThrow();
-      expect(() => assertScalarRoleWrite(path, { role: undefined })).not.toThrow();
-    });
-
-    it("lets an unknown scalar role through — the plugin's own `roles` allowlist owns that 400, not this guard", () => {
-      // Narrowing the alphabet here would duplicate the plugin's validation
-      // and drift from it on upgrade. This guard owns exactly one property:
-      // that whatever reaches `parseRoles` cannot become a comma list.
-      expect(() => assertScalarRoleWrite(path, { role: 'musicDirector' })).not.toThrow();
+    it.each(accepted)('accepts %s', (_label, role) => {
+      expect(() => assertScalarRoleWrite(guardedPath, { role })).not.toThrow();
     });
   });
 
-  it('ignores unrelated paths entirely', () => {
+  it('reports a machine-readable code so the caller can distinguish this rejection', () => {
+    expect(() => assertScalarRoleWrite('/admin/set-role', { role: ['admin', 'user'] })).toThrow(
+      expect.objectContaining({ body: expect.objectContaining({ code: 'ROLE_MUST_BE_SCALAR' }) })
+    );
+  });
+
+  it('ignores paths outside the allowlist', () => {
     expect(() => assertScalarRoleWrite('/device/approve', { role: ['admin', 'user'] })).not.toThrow();
     expect(() => assertScalarRoleWrite('/sign-in/email', { role: 'admin,user' })).not.toThrow();
   });
 
-  it('reports the offending path and value in the error body', () => {
-    let caught: unknown;
-    try {
-      assertScalarRoleWrite('/admin/set-role', { role: ['admin', 'user'] });
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toMatchObject({
-      body: { code: 'ROLE_MUST_BE_SCALAR' },
-    });
-  });
-
-  it('rejects a non-string, non-array role rather than passing it to parseRoles', () => {
-    // `parseRoles` returns a non-array value verbatim, so an object or number
-    // would reach the adapter untouched and land in the column as-is.
-    expect(() => assertScalarRoleWrite('/admin/set-role', { role: 42 })).toThrow(
-      expect.objectContaining({ statusCode: 400 })
-    );
-    expect(() => assertScalarRoleWrite('/admin/set-role', { role: { admin: true } })).toThrow(
-      expect.objectContaining({ statusCode: 400 })
-    );
-  });
-
-  it('tolerates a null or undefined body', () => {
+  it('tolerates a missing body', () => {
     expect(() => assertScalarRoleWrite('/admin/set-role', undefined)).not.toThrow();
     expect(() => assertScalarRoleWrite('/admin/set-role', null)).not.toThrow();
+    expect(() => assertScalarRoleWrite('/admin/set-role', {})).not.toThrow();
   });
 });

--- a/tests/unit/authentication/admin-role-write-guard.test.ts
+++ b/tests/unit/authentication/admin-role-write-guard.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from '@jest/globals';
+
+// better-auth/api is stubbed at the jest.unit.config.ts moduleNameMapper
+// level (better-auth-api.mock.ts) — the real subpath ships ESM ts-jest
+// can't transform. Same pattern as device-authorization.test.ts.
+
+import {
+  GUARDED_ROLE_WRITE_PATHS,
+  assertScalarRoleWrite,
+} from '../../../shared/authentication/src/admin-role-write-guard';
+
+describe('assertScalarRoleWrite', () => {
+  it('guards exactly the three admin role-write paths', () => {
+    expect([...GUARDED_ROLE_WRITE_PATHS].sort()).toEqual([
+      '/admin/create-user',
+      '/admin/set-role',
+      '/admin/update-user',
+    ]);
+  });
+
+  describe.each(GUARDED_ROLE_WRITE_PATHS)('on %s', (path) => {
+    it('rejects an array-valued role', () => {
+      expect(() => assertScalarRoleWrite(path, { role: ['admin', 'user'] })).toThrow(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('rejects a single-element array — it still joins to a scalar, but the caller is using the multi-role API', () => {
+      expect(() => assertScalarRoleWrite(path, { role: ['admin'] })).toThrow(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('rejects a comma-bearing string role', () => {
+      expect(() => assertScalarRoleWrite(path, { role: 'admin,user' })).toThrow(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it.each(['admin', 'user'])('lets the scalar %s through', (role) => {
+      expect(() => assertScalarRoleWrite(path, { role })).not.toThrow();
+    });
+
+    it('lets a body with no role through — /admin/create-user and /admin/update-user both allow omitting it', () => {
+      expect(() => assertScalarRoleWrite(path, {})).not.toThrow();
+      expect(() => assertScalarRoleWrite(path, { role: undefined })).not.toThrow();
+    });
+
+    it("lets an unknown scalar role through — the plugin's own `roles` allowlist owns that 400, not this guard", () => {
+      // Narrowing the alphabet here would duplicate the plugin's validation
+      // and drift from it on upgrade. This guard owns exactly one property:
+      // that whatever reaches `parseRoles` cannot become a comma list.
+      expect(() => assertScalarRoleWrite(path, { role: 'musicDirector' })).not.toThrow();
+    });
+  });
+
+  it('ignores unrelated paths entirely', () => {
+    expect(() => assertScalarRoleWrite('/device/approve', { role: ['admin', 'user'] })).not.toThrow();
+    expect(() => assertScalarRoleWrite('/sign-in/email', { role: 'admin,user' })).not.toThrow();
+  });
+
+  it('reports the offending path and value in the error body', () => {
+    let caught: unknown;
+    try {
+      assertScalarRoleWrite('/admin/set-role', { role: ['admin', 'user'] });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toMatchObject({
+      body: { code: 'ROLE_MUST_BE_SCALAR' },
+    });
+  });
+
+  it('rejects a non-string, non-array role rather than passing it to parseRoles', () => {
+    // `parseRoles` returns a non-array value verbatim, so an object or number
+    // would reach the adapter untouched and land in the column as-is.
+    expect(() => assertScalarRoleWrite('/admin/set-role', { role: 42 })).toThrow(
+      expect.objectContaining({ statusCode: 400 })
+    );
+    expect(() => assertScalarRoleWrite('/admin/set-role', { role: { admin: true } })).toThrow(
+      expect.objectContaining({ statusCode: 400 })
+    );
+  });
+
+  it('tolerates a null or undefined body', () => {
+    expect(() => assertScalarRoleWrite('/admin/set-role', undefined)).not.toThrow();
+    expect(() => assertScalarRoleWrite('/admin/set-role', null)).not.toThrow();
+  });
+});

--- a/tests/unit/authentication/jwt-payload.test.ts
+++ b/tests/unit/authentication/jwt-payload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Characterization tests for the role resolution extracted out of the
+ * `betterAuth({...})` literal. These pin the behavior as it was BEFORE the
+ * extraction, so the move itself is provably behavior-preserving — the
+ * existing suite cannot do that, because every other unit test against
+ * `auth.definition.ts` is a source-scan and never executes this code.
+ *
+ * BS#2171 changes some of this deliberately (the fallback stops carrying a
+ * station role). When that lands, the assertions it invalidates should be
+ * changed with intent, not deleted as noise.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import { buildJwtPayload, buildOidcUserInfoClaim } from '../../../shared/authentication/src/jwt-payload';
+
+type FetchMock = jest.Mock<(userId: string) => Promise<{ role: string } | undefined>>;
+
+describe('buildJwtPayload', () => {
+  let onError: jest.Mock<(error: unknown) => void>;
+
+  beforeEach(() => {
+    onError = jest.fn();
+  });
+
+  const fetchReturning = (row: { role: string } | undefined): FetchMock => jest.fn(() => Promise.resolve(row));
+
+  it('resolves role from the membership row, not from the user', async () => {
+    const fetch = fetchReturning({ role: 'musicDirector' });
+    // `role: 'admin'` on the user is the better-auth admin flag. It must not
+    // become the station role in the token — that confusion is BS#2171.
+    const payload = await buildJwtPayload({ id: 'u1', role: 'admin' }, fetch, onError);
+
+    expect(payload.role).toBe('musicDirector');
+    expect(fetch).toHaveBeenCalledWith('u1');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('defaults capabilities to [] when the user carries none', async () => {
+    const payload = await buildJwtPayload({ id: 'u1' }, fetchReturning({ role: 'dj' }), onError);
+    expect(payload.capabilities).toEqual([]);
+  });
+
+  it('passes through capabilities the user carries', async () => {
+    const payload = await buildJwtPayload(
+      { id: 'u1', capabilities: ['catalog:write'] },
+      fetchReturning({ role: 'dj' }),
+      onError
+    );
+    expect(payload.capabilities).toEqual(['catalog:write']);
+  });
+
+  it('spreads the rest of the user through untouched', async () => {
+    const payload = await buildJwtPayload(
+      { id: 'u1', email: 'dj@wxyc.org', banned: true, banReason: 'spam' },
+      fetchReturning({ role: 'dj' }),
+      onError
+    );
+    // auth.middleware.ts gates suspended accounts on these two fields, and
+    // they reach it only via this spread.
+    expect(payload).toMatchObject({ email: 'dj@wxyc.org', banned: true, banReason: 'spam' });
+  });
+
+  describe('when no role can be resolved', () => {
+    it('omits role entirely for a user with no membership row', async () => {
+      const payload = await buildJwtPayload({ id: 'u1' }, fetchReturning(undefined), onError);
+      expect(payload).not.toHaveProperty('role');
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed lookup through onError and still returns a payload', async () => {
+      const boom = new Error('connection terminated');
+      const fetch: FetchMock = jest.fn(() => Promise.reject(boom));
+
+      const payload = await buildJwtPayload({ id: 'u1', email: 'dj@wxyc.org' }, fetch, onError);
+
+      expect(onError).toHaveBeenCalledWith(boom);
+      expect(payload).toMatchObject({ id: 'u1', email: 'dj@wxyc.org', capabilities: [] });
+    });
+
+    it('skips the lookup for a user with no id', async () => {
+      const fetch = fetchReturning({ role: 'dj' });
+      const payload = await buildJwtPayload({}, fetch, onError);
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(payload).not.toHaveProperty('role');
+    });
+
+    it('carries the user through even when the lookup fails — pinning the pre-BS#2171 fallback', async () => {
+      // The fallback currently spreads `...user`, so a stale admin flag on the
+      // user row survives into the token. BS#2171 removes exactly this.
+      const fetch: FetchMock = jest.fn(() => Promise.reject(new Error('down')));
+      const payload = await buildJwtPayload({ id: 'u1', role: 'admin' }, fetch, onError);
+      expect(payload.role).toBe('admin');
+    });
+  });
+});
+
+describe('buildOidcUserInfoClaim', () => {
+  it('resolves role from the membership row', async () => {
+    const claim = await buildOidcUserInfoClaim(
+      { id: 'u1' },
+      jest.fn(() => Promise.resolve({ role: 'stationManager' }))
+    );
+    expect(claim).toEqual({ role: 'stationManager', capabilities: [] });
+  });
+
+  it('passes through capabilities the user record carries', async () => {
+    const claim = await buildOidcUserInfoClaim(
+      { id: 'u1', capabilities: ['flowsheet:write'] },
+      jest.fn(() => Promise.resolve({ role: 'dj' }))
+    );
+    expect(claim.capabilities).toEqual(['flowsheet:write']);
+  });
+
+  it('degrades to the least-privileged role when there is no membership row', async () => {
+    const claim = await buildOidcUserInfoClaim(
+      { id: 'u1' },
+      jest.fn(() => Promise.resolve(undefined))
+    );
+    expect(claim.role).toBe('member');
+  });
+
+  it('degrades to member and drops capabilities when the lookup throws', async () => {
+    // Fail-closed: an id_token must never claim more authority than the
+    // caller can prove, and this path has no onError by design — see the
+    // module docstring.
+    const claim = await buildOidcUserInfoClaim(
+      { id: 'u1', capabilities: ['catalog:write'] },
+      jest.fn(() => Promise.reject(new Error('down')))
+    );
+    expect(claim).toEqual({ role: 'member', capabilities: [] });
+  });
+});


### PR DESCRIPTION
Prerequisite for #2171. Behavior-preserving except for one new, unwired guard. **Closes nothing** — #2171 is closed by the follow-up that builds on this.

## Why

The logic that resolves a user's station role, and the logic that keeps `auth_user.role` in step with organization membership, both live as inline properties of the `betterAuth({...})` object literal in `shared/authentication/src/auth.definition.ts` — nothing exports them, so nothing can test them. `syncAdminRoles` is worse: a module-local `const` in `apps/auth/app.ts` reachable only after a top-level IIFE calls `app.listen()`, so importing the module to test it starts a server.

That is why every existing unit test against `auth.definition.ts` is a source-scan. The oldest one says so directly: a behavior test "would require spinning up the full better-auth instance against a live PG, which is over budget for a unit test."

#2171 changes the behavior of all four of these paths. Doing that without tests would be guesswork, so the extraction comes first and lands on its own.

## What

Four modules, following the `device-authorization.ts` pattern already in this package: the policy becomes a pure or callback-injected function, DB access arrives as a parameter, and the unit test imports by relative path. The new modules import only *types* from `@wxyc/database` — a value import re-engages the DB mock at `jest.unit.config.ts:19` and defeats the injection.

| Module | Extracted from |
|---|---|
| `shared/authentication/src/jwt-payload.ts` | the JWT `definePayload` and the OIDC `getAdditionalUserInfoClaim` |
| `shared/authentication/src/admin-flag-sync.ts` | the three `organizationHooks` |
| `apps/auth/sync-admin-roles.ts` | `syncAdminRoles` in `apps/auth/app.ts` |
| `shared/authentication/src/admin-role-write-guard.ts` | *(new — see below)* |

The three org hooks shared a near-identical prologue — `DEFAULT_ORG_SLUG` check, default-org match, admin-role-set test — so the extraction removes real duplication rather than only serving the tests.

## The one piece that is not a move

`assertScalarRoleWrite` has no existing counterpart. It exists because the better-auth admin plugin validates role inputs **element-wise and only then joins them**:

```js
// plugins/admin/routes.mjs:71-76 (/admin/set-role); identically at :173-177 and :265-271
const inputRoles = Array.isArray(ctx.body.role) ? ctx.body.role : [ctx.body.role];
for (const role of inputRoles) if (!roles[role]) throw APIError.from("BAD_REQUEST", ...);
...
{ role: parseRoles(ctx.body.role) }   // -> roles.join(",")
```

So `{"role": ["admin","user"]}` passes the plugin's own allowlist twice over — both keys exist — and persists the string `"admin,user"`. Wiring the guard into the request path belongs with the column constraint it protects, so it ships here **unwired**, with its test, and is called in the follow-up. That keeps this PR's acceptance criterion intact while still getting the guard reviewed as a pure function rather than buried in the behavior diff.

## Test-infrastructure change

`tests/mocks/better-auth-api.mock.ts` now resolves better-auth's string statuses (`'BAD_REQUEST'`, `'FORBIDDEN'`, …) to numeric codes. Production code constructs `APIError` with the string form, so without this a spec cannot assert the status a guard produces — and the difference between a 400 and a 500 is frequently the entire point of the guard. `device-authorization.test.ts` previously worked around this by asserting only on the error body.

## Note on `runSyncAdminRoles`

The dynamic imports stay inside the same `try` the original used. A failure to resolve either module is as survivable as a failed query and must not take the server's startup path down.

## Verification

Run locally against the Docker CI environment:

- `npm run test:unit` — **438 suites / 7428 tests pass**, the acceptance criterion for a behavior-preserving change
- `npm run ci:test` (Docker Postgres) — **105 suites / 1043 tests pass**
- `npm run typecheck`, `npm run build` — clean across every workspace
- `npm run lint` — 0 errors, and 0 new warnings (the one my mock edit introduced was removed by switching an object lookup to a `Map`)

## Related

- Plan: `plans/bs2171-narrow-auth-user-role.md` (added in this PR)
- Follow-up PR narrows the column and wires the guard, closing #2171
