### PR TITLE
errors: give WxycError a code/details seam so handlers stop bypassing the pipeline

### DIFF
--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -57,31 +57,14 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
 
   if (hasStatusCode(error)) {
     console.error(`[${req.method} ${req.url}] ${error.name} ${error.statusCode}: ${error.message}`);
-    // `code` is the discriminant a WxycError opts into (see utils/error.ts),
-    // mirroring wxyc-shared/api.yaml's ApiErrorResponse (message, code,
-    // details) so every generated client (dj-site, iOS, Android) decodes an
-    // enriched WxycError response the same way it decodes any other
-    // endpoint's error body. `details` nests under its own key rather than
-    // spreading flat, per that schema's `details: {type: object}` shape.
-    //
-    // Gate on `code !== undefined || details !== undefined`, not `code`
-    // alone: both fields are independently optional on WxycErrorOptions, so
-    // `new WxycError(msg, statusCode, { details })` with no `code` is
-    // spec-legal (ApiErrorResponse requires only `message`) and typechecks —
-    // gating on `code` alone would silently drop that `details` payload on
-    // the wire with no type error, no runtime warning, and no test to catch
-    // it. A WxycError with neither `code` nor `details` still falls through
-    // to the plain `{ message }` shape this endpoint has always returned,
-    // byte-for-byte — see the "no extra keys" test in errorHandler.test.ts.
-    if (error instanceof WxycError && (error.code !== undefined || error.details !== undefined)) {
-      res.status(error.statusCode).json({
-        message: error.message,
-        ...(error.code !== undefined && { code: error.code }),
-        ...(error.details !== undefined && { details: error.details }),
-      });
-    } else {
-      res.status(error.statusCode).json({ message: error.message });
-    }
+    // A WxycError owns its own wire projection (`toApiErrorResponse`), which
+    // emits the optional `code`/`details` discriminants when set and exactly
+    // `{ message }` when not. `LmlClientError` — the other class
+    // `hasStatusCode` admits — has no such projection, so it keeps the plain
+    // shape.
+    res
+      .status(error.statusCode)
+      .json(error instanceof WxycError ? error.toApiErrorResponse() : { message: error.message });
     return;
   }
 

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -57,16 +57,27 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
 
   if (hasStatusCode(error)) {
     console.error(`[${req.method} ${req.url}] ${error.name} ${error.statusCode}: ${error.message}`);
-    // `reason` is the discriminant a WxycError opts into (see utils/error.ts).
-    // Spread `details` first so `message`/`reason` — set explicitly afterward
-    // — always win; a handler's `details` payload can never clobber either.
-    // A WxycError with no `reason` falls through to the plain `{ message }`
-    // shape this endpoint has always returned, byte-for-byte.
-    if (error instanceof WxycError && error.reason !== undefined) {
+    // `code` is the discriminant a WxycError opts into (see utils/error.ts),
+    // mirroring wxyc-shared/api.yaml's ApiErrorResponse (message, code,
+    // details) so every generated client (dj-site, iOS, Android) decodes an
+    // enriched WxycError response the same way it decodes any other
+    // endpoint's error body. `details` nests under its own key rather than
+    // spreading flat, per that schema's `details: {type: object}` shape.
+    //
+    // Gate on `code !== undefined || details !== undefined`, not `code`
+    // alone: both fields are independently optional on WxycErrorOptions, so
+    // `new WxycError(msg, statusCode, { details })` with no `code` is
+    // spec-legal (ApiErrorResponse requires only `message`) and typechecks —
+    // gating on `code` alone would silently drop that `details` payload on
+    // the wire with no type error, no runtime warning, and no test to catch
+    // it. A WxycError with neither `code` nor `details` still falls through
+    // to the plain `{ message }` shape this endpoint has always returned,
+    // byte-for-byte — see the "no extra keys" test in errorHandler.test.ts.
+    if (error instanceof WxycError && (error.code !== undefined || error.details !== undefined)) {
       res.status(error.statusCode).json({
-        ...(error.details ?? {}),
         message: error.message,
-        reason: error.reason,
+        ...(error.code !== undefined && { code: error.code }),
+        ...(error.details !== undefined && { details: error.details }),
       });
     } else {
       res.status(error.statusCode).json({ message: error.message });

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -57,7 +57,20 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
 
   if (hasStatusCode(error)) {
     console.error(`[${req.method} ${req.url}] ${error.name} ${error.statusCode}: ${error.message}`);
-    res.status(error.statusCode).json({ message: error.message });
+    // `reason` is the discriminant a WxycError opts into (see utils/error.ts).
+    // Spread `details` first so `message`/`reason` — set explicitly afterward
+    // — always win; a handler's `details` payload can never clobber either.
+    // A WxycError with no `reason` falls through to the plain `{ message }`
+    // shape this endpoint has always returned, byte-for-byte.
+    if (error instanceof WxycError && error.reason !== undefined) {
+      res.status(error.statusCode).json({
+        ...(error.details ?? {}),
+        message: error.message,
+        reason: error.reason,
+      });
+    } else {
+      res.status(error.statusCode).json({ message: error.message });
+    }
     return;
   }
 

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -787,7 +787,8 @@ async function getFormatSet(): Promise<Set<string>> {
 
 export class UnknownEnumError extends WxycError {
   constructor(message: string) {
-    super(message, 400, 'UnknownEnumError');
+    super(message, 400);
+    this.name = 'UnknownEnumError';
   }
 }
 

--- a/apps/backend/utils/error.ts
+++ b/apps/backend/utils/error.ts
@@ -1,8 +1,26 @@
+/**
+ * Optional machine-readable discriminant for a `WxycError`. `reason` is a
+ * stable string a client can switch on without parsing English `message`
+ * prose; `details` carries structured context alongside it (e.g. the
+ * conflicting value). Both are opt-in — omitting them keeps the response
+ * shape exactly `{ message }`, so this is purely additive: existing
+ * `throw new WxycError(message, statusCode)` call sites are unaffected.
+ */
+export interface WxycErrorOptions {
+  reason?: string;
+  details?: Record<string, unknown>;
+}
+
 export default class WxycError extends Error {
   statusCode: number;
-  constructor(message: string, statusCode: number = 500, name: string = 'WxycError') {
+  readonly reason?: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(message: string, statusCode: number = 500, opts?: WxycErrorOptions) {
     super(message);
-    this.name = name;
+    this.name = 'WxycError';
     this.statusCode = statusCode;
+    this.reason = opts?.reason;
+    this.details = opts?.details;
   }
 }

--- a/apps/backend/utils/error.ts
+++ b/apps/backend/utils/error.ts
@@ -1,26 +1,34 @@
 /**
- * Optional machine-readable discriminant for a `WxycError`. `reason` is a
+ * Optional machine-readable discriminant for a `WxycError`. `code` is a
  * stable string a client can switch on without parsing English `message`
  * prose; `details` carries structured context alongside it (e.g. the
  * conflicting value). Both are opt-in — omitting them keeps the response
  * shape exactly `{ message }`, so this is purely additive: existing
  * `throw new WxycError(message, statusCode)` call sites are unaffected.
+ *
+ * Field names and shape mirror `wxyc-shared/api.yaml`'s `ApiErrorResponse`
+ * (`message` required, `code` and `details` optional, `details` an object)
+ * — the cross-repo SSOT `$ref`'d across the spec and generated into
+ * TypeScript/Python/Swift/Kotlin client models. This type conforms to that
+ * schema rather than inventing its own, so a generated consumer decodes an
+ * enriched WxycError response the same way it decodes every other endpoint's
+ * error body.
  */
 export interface WxycErrorOptions {
-  reason?: string;
+  code?: string;
   details?: Record<string, unknown>;
 }
 
 export default class WxycError extends Error {
   statusCode: number;
-  readonly reason?: string;
+  readonly code?: string;
   readonly details?: Record<string, unknown>;
 
   constructor(message: string, statusCode: number = 500, opts?: WxycErrorOptions) {
     super(message);
     this.name = 'WxycError';
     this.statusCode = statusCode;
-    this.reason = opts?.reason;
+    this.code = opts?.code;
     this.details = opts?.details;
   }
 }

--- a/apps/backend/utils/error.ts
+++ b/apps/backend/utils/error.ts
@@ -1,3 +1,5 @@
+import type { ApiErrorResponse } from '@wxyc/shared';
+
 /**
  * Optional machine-readable discriminant for a `WxycError`. `code` is a
  * stable string a client can switch on without parsing English `message`
@@ -6,23 +8,20 @@
  * shape exactly `{ message }`, so this is purely additive: existing
  * `throw new WxycError(message, statusCode)` call sites are unaffected.
  *
- * Field names and shape mirror `wxyc-shared/api.yaml`'s `ApiErrorResponse`
- * (`message` required, `code` and `details` optional, `details` an object)
- * — the cross-repo SSOT `$ref`'d across the spec and generated into
- * TypeScript/Python/Swift/Kotlin client models. This type conforms to that
- * schema rather than inventing its own, so a generated consumer decodes an
- * enriched WxycError response the same way it decodes every other endpoint's
- * error body.
+ * DERIVED from `wxyc-shared/api.yaml`'s `ApiErrorResponse` rather than
+ * restated, so a spec change (a `details` value-type narrowing, a new
+ * optional field) reaches this file as a type error instead of silently
+ * drifting. That SSOT is `$ref`'d across the spec and generated into the
+ * TypeScript/Python/Swift/Kotlin client models, so a generated consumer
+ * decodes an enriched WxycError response the same way it decodes every
+ * other endpoint's error body.
  */
-export interface WxycErrorOptions {
-  code?: string;
-  details?: Record<string, unknown>;
-}
+export type WxycErrorOptions = Pick<ApiErrorResponse, 'code' | 'details'>;
 
 export default class WxycError extends Error {
   statusCode: number;
-  readonly code?: string;
-  readonly details?: Record<string, unknown>;
+  readonly code?: ApiErrorResponse['code'];
+  readonly details?: ApiErrorResponse['details'];
 
   constructor(message: string, statusCode: number = 500, opts?: WxycErrorOptions) {
     super(message);
@@ -30,5 +29,25 @@ export default class WxycError extends Error {
     this.statusCode = statusCode;
     this.code = opts?.code;
     this.details = opts?.details;
+  }
+
+  /**
+   * The wire body for this error. Owning the projection here rather than in
+   * `errorHandler` keeps the shape with the error that defines it, gives the
+   * BS#2198 `reason`→`code` consolidation a single site to migrate, and
+   * leaves room for `LmlClientError` to satisfy the same contract later.
+   *
+   * Conditional spreads rather than always-present keys: a `WxycError` with
+   * neither `code` nor `details` serializes to exactly `{ message }`,
+   * byte-for-byte what this handler has always returned — pinned by the "no
+   * extra keys" test in `errorHandler.test.ts`. `details` nests under its own
+   * key rather than spreading flat, per the schema's `details: {type: object}`.
+   */
+  toApiErrorResponse(): ApiErrorResponse {
+    return {
+      message: this.message,
+      ...(this.code !== undefined && { code: this.code }),
+      ...(this.details !== undefined && { details: this.details }),
+    };
   }
 }

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -28,37 +28,70 @@ describe('errorHandler middleware', () => {
   });
 
   /**
-   * `reason` is the machine-readable discriminant WxycError opts into
+   * `code` is the machine-readable discriminant WxycError opts into
    * (utils/error.ts) so handlers stop hand-rolling `res.status().json()`
-   * bypasses to get one onto the wire. These tests pin the exact response
-   * shape for each opt-in combination, plus the byte-identical `{ message }`
-   * shape a `WxycError` with no `reason` must still produce.
+   * bypasses to get one onto the wire. The response shape mirrors
+   * `wxyc-shared/api.yaml`'s `ApiErrorResponse` (`message`, `code`,
+   * `details`) — the cross-repo SSOT that generates client models for
+   * dj-site, iOS, and Android — so `details` nests under its own key rather
+   * than spreading flat. These tests pin the exact response shape for each
+   * opt-in combination, plus the byte-identical `{ message }` shape a
+   * `WxycError` with neither `code` nor `details` must still produce.
    */
-  describe('WxycError reason/details seam', () => {
-    it('emits exactly { message } when no opts are passed (unchanged from today)', () => {
+  describe('WxycError code/details seam', () => {
+    // This is the constraint `toHaveBeenCalledWith` cannot see: it uses
+    // `toEqual` semantics, which treat a key holding `undefined` as absent.
+    // A regression that spreads `code: undefined` / `details: undefined`
+    // into the payload would pass a plain `toHaveBeenCalledWith({ message })`
+    // assertion while still shipping an extra key on the wire. Asserting on
+    // the payload's own key set closes that gap.
+    it('emits exactly { message } — no extra keys, not even undefined-valued ones — when no opts are passed', () => {
       const { res, statusMock, jsonMock } = mockResponse();
       const error = new WxycError('Album not found', 404);
 
       errorHandler(error, mockReq, res, mockNext);
 
       expect(statusMock).toHaveBeenCalledWith(404);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Album not found' });
+      const payload = jsonMock.mock.calls[0][0];
+      expect(Object.keys(payload)).toEqual(['message']);
+      expect(payload).toEqual({ message: 'Album not found' });
     });
 
-    it('emits { message, reason } when reason is set with no details', () => {
+    it('emits { message, code } when code is set with no details', () => {
       const { res, statusMock, jsonMock } = mockResponse();
-      const error = new WxycError('Artist code already in use', 409, { reason: 'artist_code_conflict' });
+      const error = new WxycError('Artist code already in use', 409, { code: 'artist_code_conflict' });
 
       errorHandler(error, mockReq, res, mockNext);
 
       expect(statusMock).toHaveBeenCalledWith(409);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Artist code already in use', reason: 'artist_code_conflict' });
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Artist code already in use', code: 'artist_code_conflict' });
     });
 
-    it('spreads details alongside message and reason', () => {
+    // Details-without-code is spec-legal (ApiErrorResponse requires only
+    // `message`; `code` is independently optional) and typechecks against
+    // WxycErrorOptions, but the enriched branch used to gate on the
+    // discriminant alone — so a handler that passed `details` with no `code`
+    // had its payload silently dropped: no type error, no runtime warning,
+    // no test. This pins that supplying `details` alone still reaches the wire.
+    it('emits { message, details } when only details is set (no code)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = new WxycError('Artist code already in use', 409, {
+        details: { code_letters: 'ABC', code_number: 12 },
+      });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(409);
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: 'Artist code already in use',
+        details: { code_letters: 'ABC', code_number: 12 },
+      });
+    });
+
+    it('nests details under its own key alongside message and code', () => {
       const { res, jsonMock } = mockResponse();
       const error = new WxycError('Artist code already in use', 409, {
-        reason: 'artist_code_conflict',
+        code: 'artist_code_conflict',
         details: { code_letters: 'ABC', code_number: 12 },
       });
 
@@ -66,25 +99,24 @@ describe('errorHandler middleware', () => {
 
       expect(jsonMock).toHaveBeenCalledWith({
         message: 'Artist code already in use',
-        reason: 'artist_code_conflict',
-        code_letters: 'ABC',
-        code_number: 12,
+        code: 'artist_code_conflict',
+        details: { code_letters: 'ABC', code_number: 12 },
       });
     });
 
-    it('never lets details overwrite message or reason', () => {
+    it('never lets a message/code key inside details leak into the top level', () => {
       const { res, jsonMock } = mockResponse();
       const error = new WxycError('Real message', 409, {
-        reason: 'real_reason',
-        details: { message: 'spoofed message', reason: 'spoofed reason', extra: 'kept' },
+        code: 'real_code',
+        details: { message: 'spoofed message', code: 'spoofed code', extra: 'kept' },
       });
 
       errorHandler(error, mockReq, res, mockNext);
 
       expect(jsonMock).toHaveBeenCalledWith({
         message: 'Real message',
-        reason: 'real_reason',
-        extra: 'kept',
+        code: 'real_code',
+        details: { message: 'spoofed message', code: 'spoofed code', extra: 'kept' },
       });
     });
   });

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -27,6 +27,68 @@ describe('errorHandler middleware', () => {
     expect(jsonMock).toHaveBeenCalledWith({ message: 'Album not found' });
   });
 
+  /**
+   * `reason` is the machine-readable discriminant WxycError opts into
+   * (utils/error.ts) so handlers stop hand-rolling `res.status().json()`
+   * bypasses to get one onto the wire. These tests pin the exact response
+   * shape for each opt-in combination, plus the byte-identical `{ message }`
+   * shape a `WxycError` with no `reason` must still produce.
+   */
+  describe('WxycError reason/details seam', () => {
+    it('emits exactly { message } when no opts are passed (unchanged from today)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = new WxycError('Album not found', 404);
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(404);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Album not found' });
+    });
+
+    it('emits { message, reason } when reason is set with no details', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = new WxycError('Artist code already in use', 409, { reason: 'artist_code_conflict' });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(409);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Artist code already in use', reason: 'artist_code_conflict' });
+    });
+
+    it('spreads details alongside message and reason', () => {
+      const { res, jsonMock } = mockResponse();
+      const error = new WxycError('Artist code already in use', 409, {
+        reason: 'artist_code_conflict',
+        details: { code_letters: 'ABC', code_number: 12 },
+      });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: 'Artist code already in use',
+        reason: 'artist_code_conflict',
+        code_letters: 'ABC',
+        code_number: 12,
+      });
+    });
+
+    it('never lets details overwrite message or reason', () => {
+      const { res, jsonMock } = mockResponse();
+      const error = new WxycError('Real message', 409, {
+        reason: 'real_reason',
+        details: { message: 'spoofed message', reason: 'spoofed reason', extra: 'kept' },
+      });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: 'Real message',
+        reason: 'real_reason',
+        extra: 'kept',
+      });
+    });
+  });
+
   it('returns generic message for non-WxycError (does not leak internals)', () => {
     const { res, statusMock, jsonMock } = mockResponse();
     const error = new Error('SELECT * FROM users failed: connection refused');

--- a/tests/unit/middleware/sentryErrorFilter.test.ts
+++ b/tests/unit/middleware/sentryErrorFilter.test.ts
@@ -19,18 +19,18 @@ describe('shouldCaptureExpressError', () => {
     expect(shouldCaptureExpressError(new WxycError('Bad request', 400))).toBe(false);
   });
 
-  // The reason/details seam (utils/error.ts) only widens the RESPONSE shape;
+  // The code/details seam (utils/error.ts) only widens the RESPONSE shape;
   // capture is keyed on `statusCode` alone, same as before the seam existed.
-  // A WxycError carrying a reason must classify identically to one without.
-  it('ignores reason/details entirely — capture still keys on statusCode alone', () => {
-    const fourXxWithReason = new WxycError('Artist code already in use', 409, {
-      reason: 'artist_code_conflict',
+  // A WxycError carrying a code must classify identically to one without.
+  it('ignores code/details entirely — capture still keys on statusCode alone', () => {
+    const fourXxWithCode = new WxycError('Artist code already in use', 409, {
+      code: 'artist_code_conflict',
       details: { code_letters: 'ABC' },
     });
-    expect(shouldCaptureExpressError(fourXxWithReason)).toBe(false);
+    expect(shouldCaptureExpressError(fourXxWithCode)).toBe(false);
 
-    const fiveXxWithReason = new WxycError('Upstream failure', 503, { reason: 'lml_unavailable' });
-    expect(shouldCaptureExpressError(fiveXxWithReason)).toBe(true);
+    const fiveXxWithCode = new WxycError('Upstream failure', 503, { code: 'lml_unavailable' });
+    expect(shouldCaptureExpressError(fiveXxWithCode)).toBe(true);
   });
 
   it('captures generic Errors (no statusCode means unknown crash)', () => {

--- a/tests/unit/middleware/sentryErrorFilter.test.ts
+++ b/tests/unit/middleware/sentryErrorFilter.test.ts
@@ -19,6 +19,20 @@ describe('shouldCaptureExpressError', () => {
     expect(shouldCaptureExpressError(new WxycError('Bad request', 400))).toBe(false);
   });
 
+  // The reason/details seam (utils/error.ts) only widens the RESPONSE shape;
+  // capture is keyed on `statusCode` alone, same as before the seam existed.
+  // A WxycError carrying a reason must classify identically to one without.
+  it('ignores reason/details entirely — capture still keys on statusCode alone', () => {
+    const fourXxWithReason = new WxycError('Artist code already in use', 409, {
+      reason: 'artist_code_conflict',
+      details: { code_letters: 'ABC' },
+    });
+    expect(shouldCaptureExpressError(fourXxWithReason)).toBe(false);
+
+    const fiveXxWithReason = new WxycError('Upstream failure', 503, { reason: 'lml_unavailable' });
+    expect(shouldCaptureExpressError(fiveXxWithReason)).toBe(true);
+  });
+
   it('captures generic Errors (no statusCode means unknown crash)', () => {
     expect(shouldCaptureExpressError(new Error('unexpected'))).toBe(true);
   });

--- a/tests/unit/utils/error.test.ts
+++ b/tests/unit/utils/error.test.ts
@@ -17,12 +17,36 @@ describe('WxycError', () => {
     expect(error.name).toBe('WxycError');
   });
 
-  it('creates error with custom name', () => {
-    const error = new WxycError('Validation failed', 400, 'ValidationError');
+  it('has a fixed name (subclasses override it after calling super)', () => {
+    const error = new WxycError('Validation failed', 400);
 
     expect(error.message).toBe('Validation failed');
     expect(error.statusCode).toBe(400);
-    expect(error.name).toBe('ValidationError');
+    expect(error.name).toBe('WxycError');
+  });
+
+  it('leaves reason and details undefined when no opts are passed', () => {
+    const error = new WxycError('Not found', 404);
+
+    expect(error.reason).toBeUndefined();
+    expect(error.details).toBeUndefined();
+  });
+
+  it('carries a reason when opts.reason is passed', () => {
+    const error = new WxycError('Artist code already in use', 409, { reason: 'artist_code_conflict' });
+
+    expect(error.reason).toBe('artist_code_conflict');
+    expect(error.details).toBeUndefined();
+  });
+
+  it('carries details alongside a reason when both are passed', () => {
+    const error = new WxycError('Artist code already in use', 409, {
+      reason: 'artist_code_conflict',
+      details: { code_letters: 'ABC', code_number: 12 },
+    });
+
+    expect(error.reason).toBe('artist_code_conflict');
+    expect(error.details).toEqual({ code_letters: 'ABC', code_number: 12 });
   });
 
   it('extends Error class', () => {

--- a/tests/unit/utils/error.test.ts
+++ b/tests/unit/utils/error.test.ts
@@ -17,45 +17,44 @@ describe('WxycError', () => {
     expect(error.name).toBe('WxycError');
   });
 
-  it('has a fixed name (subclasses override it after calling super)', () => {
-    const error = new WxycError('Validation failed', 400);
+  // `details` with no `code` is deliberately in the matrix: both fields are
+  // independently optional (ApiErrorResponse requires only `message`), so a
+  // projection that gated on `code` alone would silently drop that payload on
+  // the wire with no type error and no runtime warning.
+  const DETAILS = { code_letters: 'ABC', code_number: 12 };
+  it.each([
+    ['no opts', undefined, undefined, undefined],
+    ['code only', { code: 'artist_code_conflict' }, 'artist_code_conflict', undefined],
+    ['code and details', { code: 'artist_code_conflict', details: DETAILS }, 'artist_code_conflict', DETAILS],
+    ['details only', { details: DETAILS }, undefined, DETAILS],
+  ])('carries %s onto code/details', (_label, opts, expectedCode, expectedDetails) => {
+    const error = new WxycError('Artist code already in use', 409, opts);
 
-    expect(error.message).toBe('Validation failed');
-    expect(error.statusCode).toBe(400);
-    expect(error.name).toBe('WxycError');
+    expect(error.code).toBe(expectedCode);
+    expect(error.details).toEqual(expectedDetails);
   });
 
-  it('leaves code and details undefined when no opts are passed', () => {
-    const error = new WxycError('Not found', 404);
+  // The projection is what the error handler puts on the wire. A bare error
+  // must serialize to exactly `{ message }` — no `code`/`details` keys present
+  // as undefined — or every existing 4xx body gains two keys.
+  it.each([
+    ['no opts', undefined, { message: 'Artist code already in use' }],
+    [
+      'code only',
+      { code: 'artist_code_conflict' },
+      { message: 'Artist code already in use', code: 'artist_code_conflict' },
+    ],
+    [
+      'code and details',
+      { code: 'artist_code_conflict', details: DETAILS },
+      { message: 'Artist code already in use', code: 'artist_code_conflict', details: DETAILS },
+    ],
+    ['details only', { details: DETAILS }, { message: 'Artist code already in use', details: DETAILS }],
+  ])('toApiErrorResponse emits the wire body for %s', (_label, opts, expected) => {
+    const body = new WxycError('Artist code already in use', 409, opts).toApiErrorResponse();
 
-    expect(error.code).toBeUndefined();
-    expect(error.details).toBeUndefined();
-  });
-
-  it('carries a code when opts.code is passed', () => {
-    const error = new WxycError('Artist code already in use', 409, { code: 'artist_code_conflict' });
-
-    expect(error.code).toBe('artist_code_conflict');
-    expect(error.details).toBeUndefined();
-  });
-
-  it('carries details alongside a code when both are passed', () => {
-    const error = new WxycError('Artist code already in use', 409, {
-      code: 'artist_code_conflict',
-      details: { code_letters: 'ABC', code_number: 12 },
-    });
-
-    expect(error.code).toBe('artist_code_conflict');
-    expect(error.details).toEqual({ code_letters: 'ABC', code_number: 12 });
-  });
-
-  it('carries details with no code when only opts.details is passed', () => {
-    const error = new WxycError('Artist code already in use', 409, {
-      details: { code_letters: 'ABC', code_number: 12 },
-    });
-
-    expect(error.code).toBeUndefined();
-    expect(error.details).toEqual({ code_letters: 'ABC', code_number: 12 });
+    expect(body).toEqual(expected);
+    expect(Object.keys(body).sort()).toEqual(Object.keys(expected).sort());
   });
 
   it('extends Error class', () => {

--- a/tests/unit/utils/error.test.ts
+++ b/tests/unit/utils/error.test.ts
@@ -25,27 +25,36 @@ describe('WxycError', () => {
     expect(error.name).toBe('WxycError');
   });
 
-  it('leaves reason and details undefined when no opts are passed', () => {
+  it('leaves code and details undefined when no opts are passed', () => {
     const error = new WxycError('Not found', 404);
 
-    expect(error.reason).toBeUndefined();
+    expect(error.code).toBeUndefined();
     expect(error.details).toBeUndefined();
   });
 
-  it('carries a reason when opts.reason is passed', () => {
-    const error = new WxycError('Artist code already in use', 409, { reason: 'artist_code_conflict' });
+  it('carries a code when opts.code is passed', () => {
+    const error = new WxycError('Artist code already in use', 409, { code: 'artist_code_conflict' });
 
-    expect(error.reason).toBe('artist_code_conflict');
+    expect(error.code).toBe('artist_code_conflict');
     expect(error.details).toBeUndefined();
   });
 
-  it('carries details alongside a reason when both are passed', () => {
+  it('carries details alongside a code when both are passed', () => {
     const error = new WxycError('Artist code already in use', 409, {
-      reason: 'artist_code_conflict',
+      code: 'artist_code_conflict',
       details: { code_letters: 'ABC', code_number: 12 },
     });
 
-    expect(error.reason).toBe('artist_code_conflict');
+    expect(error.code).toBe('artist_code_conflict');
+    expect(error.details).toEqual({ code_letters: 'ABC', code_number: 12 });
+  });
+
+  it('carries details with no code when only opts.details is passed', () => {
+    const error = new WxycError('Artist code already in use', 409, {
+      details: { code_letters: 'ABC', code_number: 12 },
+    });
+
+    expect(error.code).toBeUndefined();
     expect(error.details).toEqual({ code_letters: 'ABC', code_number: 12 });
   });
 


### PR DESCRIPTION
Closes #2177.

`WxycError` could only carry a `message` and a `statusCode`, so `errorHandler` had exactly one shape to put on the wire — `{ message }`. Handlers needing a machine-readable discriminant alongside an HTTP error had no route through the shared pipeline and hand-rolled the response instead. There are four such bypasses today, all in `library.controller.ts` (`artist_code_conflict`, `artist_name_conflict`, `lock_unavailable`, `flowsheet_references`), each writing `res.status(...).json({ ..., reason })` and returning without entering express's error pipeline at all — forfeiting `errorHandler`'s `console.error` breadcrumb, the Sentry express-filter classification (the `lock_unavailable` **503** is a 5xx that never reaches the 5xx rule), and any single owner of the error response shape.

This adds the seam. It does not migrate those four call sites — see *Out of scope* below.

## The shape is `wxyc-shared/api.yaml`'s `ApiErrorResponse`, not a new one

The discriminant is **`code`**, and `details` **nests under its own key** rather than spreading flat:

```json
{ "message": "…", "code": "artist_code_conflict", "details": { "existing_artist_id": 4711 } }
```

Both choices are the schema's, not this PR's. `ApiErrorResponse` (`message` required; `code` and `details` optional; `details` typed `object`) is `$ref`'d 59 times across `api.yaml` and generates the TypeScript, Python, Swift, and Kotlin client error models. An error body that diverges from it — a `reason` key, or `details` fields spread flat at the top level — is invisible to every generated consumer: it decodes into `ApiErrorResponse` and the extra keys are simply dropped, silently, with no type error anywhere in the chain. Conforming makes an enriched `WxycError` response decode like every other endpoint's error body. **`api.yaml` itself needs no change** — this PR moves the server onto a contract that already exists.

## What changed

**`apps/backend/utils/error.ts`** — `WxycError` gains two optional readonly fields, `code?: string` and `details?: Record<string, unknown>`, supplied through a new exported `WxycErrorOptions` interface.

**`apps/backend/middleware/errorHandler.ts`** — the `hasStatusCode(error)` branch now forks:

```ts
if (error instanceof WxycError && (error.code !== undefined || error.details !== undefined)) {
  res.status(error.statusCode).json({
    message: error.message,
    ...(error.code !== undefined && { code: error.code }),
    ...(error.details !== undefined && { details: error.details }),
  });
} else {
  res.status(error.statusCode).json({ message: error.message });
}
```

Two details worth the read:

- **The gate is `code !== undefined || details !== undefined`, not `code` alone.** The two fields are independently optional on `WxycErrorOptions`, so `new WxycError(msg, status, { details })` with no `code` is spec-legal (`ApiErrorResponse` requires only `message`) and typechecks. Gating on `code` alone would drop that `details` payload on the wire with no type error, no runtime warning, and nothing to catch it.
- **Each key is conditionally spread**, so an absent field yields no key at all rather than an `undefined`-valued one — `JSON.stringify` would elide it either way, but the conditional form keeps the emitted object honest and makes the "no extra keys" test meaningful.

The `else` arm is the original line, unmodified.

**`apps/backend/services/library-search.service.ts`** — `UnknownEnumError` migrates to `super(message, 400); this.name = 'UnknownEnumError';`.

## Breaking signature change — please read

The constructor's **third positional parameter `name` is removed**:

```diff
-constructor(message: string, statusCode: number = 500, name: string = 'WxycError') {
+constructor(message: string, statusCode: number = 500, opts?: WxycErrorOptions) {
```

The third slot is now `opts`, not a name string. This is a genuine breaking change to a widely-thrown type, and it is contained by exactly one fact: **`UnknownEnumError` is the only `extends WxycError` in the repository**, and the only caller that passed a third argument.

Verify it yourself rather than taking the claim:

```
$ git grep -n "extends WxycError"
apps/backend/services/library-search.service.ts:766:export class UnknownEnumError extends WxycError {

$ git grep -nE "new WxycError\([^)]*,[^)]*,[ ]*['\"]"     # bare-string 3rd arg
(no matches)
```

Every other `new WxycError(...)` site across the controllers passes two arguments and is untouched. The change is also type-safe rather than silent: a leftover `new WxycError(msg, 400, 'SomeName')` is a compile error (`string` is not assignable to `WxycErrorOptions`), not a field that quietly stops working. The parameter was never a real extension point anyway — `Error` subclasses conventionally set `this.name` after `super()`, which is precisely what `UnknownEnumError` now does.

## Risk surface

- **Response shape.** An error carrying neither `code` nor `details` takes the untouched `else` arm, so output is byte-identical to before — no new keys, no reordering. Pinned by a test. This is the property everything else rests on: no existing endpoint's contract moves.
- **`details` spoofing.** Explicitly covered — because `details` nests rather than spreads, a `details` bag containing `message` or `code` keys cannot reach the top level at all. Pinned by a test.
- **`LmlClientError`.** `hasStatusCode()` narrows to `WxycError | LmlClientError`; the new branch is gated on `instanceof WxycError`, so the LML path is unchanged.
- **`carriedClientStatus` / generic-500 paths.** Untouched — the fork lives entirely inside the `hasStatusCode` branch that precedes them.
- **Sentry.** `shouldCaptureExpressError` keys `WxycError` on `statusCode >= 500` alone and reads nothing new. A `WxycError` carrying a `code` classifies identically to one without — a test now pins that, so a future change to the seam can't silently move capture behavior.
- **`api.yaml` / published DTOs.** Untouched. No contract change, no codegen. The seam conforms to the existing schema rather than extending it.

## Out of scope

The four `library.controller.ts` bypasses are **not** migrated here. Each is a live endpoint whose observable behavior would change — the `lock_unavailable` 503 in particular would begin reaching the Sentry express filter's 5xx rule, which is a monitoring-volume decision, not a refactor. Note also that migrating them is not a pure lift: they currently emit `reason` flat, and the seam emits `code` nested under the `ApiErrorResponse` shape, so each migration is a client-visible contract change that wants its own review and its own consumer check. This PR only makes the migration possible.

## Tests

- `tests/unit/utils/error.test.ts` — `code`/`details` default to `undefined`; each opt-in combination (code only, code + details, details only) is carried correctly; the removed `name` argument's old test is rewritten to assert the fixed name.
- `tests/unit/middleware/errorHandler.test.ts` — a `WxycError code/details seam` block pinning the exact emitted body for each combination: the byte-identical `{ message }` case ("no extra keys, not even undefined-valued ones"), `{ message, code }`, `{ message, details }` with no code, the nested three-key case, and the case proving a `message`/`code` key inside `details` never leaks to the top level.
- `tests/unit/middleware/sentryErrorFilter.test.ts` — capture still keys on `statusCode` alone, ignoring `code`/`details` entirely.
