### PR TITLE
docs(flowsheet): clarify the rotation FK join is deliberately unwindowed

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -153,6 +153,13 @@ const FSEntryFieldsRaw = {
   // 9 are same-day artifacts (add_time::date == kill_date, played in the morning and killed
   // that afternoon) that a half-open bound would flip the wrong way.
   //
+  // If you window the FK join anyway, note what actually happens: the fallback does NOT take
+  // over. Its CASE is gated on flowsheet.rotation_id IS NULL, not on rotation.rotation_bin
+  // IS NULL — so an out-of-window row whose rotation_id is still populated falls out of the
+  // primary lane AND is refused by the fallback, and COALESCE yields no badge at all rather
+  // than the windowed badge you were reaching for. Windowing the join therefore means
+  // re-gating the CASE too, which is a different and larger change than it looks.
+  //
   // FIVE call sites carry this decision. Four are the `.leftJoin(rotation, ...)` sites below
   // (getEntriesByPage, getEntriesByRange, getEntriesInTimeWindow, getEntriesByShow). The fifth
   // is outside this file: `playlist-proxy.service.ts`'s window query runs the same unwindowed

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -136,11 +136,30 @@ const FSEntryFieldsRaw = {
   //       (library-unlinked rotation rows hold the snapshot directly);
   //   (c) (artist, album) matches the library+artists join on an active rotation row's
   //       album_id (library-linked rows whose denorm fields are NULL).
-  // The rotation window is bounded on BOTH sides against the flowsheet entry's add_time so
+  // This fallback's window is bounded on BOTH sides against the flowsheet entry's add_time so
   // historical rotation status is preserved: add_date <= add_time (inclusive lower bound —
   // a play that aired before the release entered rotation is not badged; BS#1526) and
   // kill_date IS NULL OR kill_date > add_time (exclusive upper bound). Mirrors how tubafrenzy
   // classifies at mirror time (WXYC/dj-site#750).
+  //
+  // That window governs the FALLBACK SUBQUERY ONLY. The primary FK join above has no date
+  // window at all — an entry carrying rotation_id gets that rotation record's CURRENT
+  // rotation_bin regardless of when the entry aired, even past the record's own kill_date.
+  // This is deliberate (BS#2183): an explicit rotation_id is a first-class assertion by the
+  // writer (BS#1268 stamps it from the tubafrenzy webhook; the dj-site rotation picker emits
+  // it), and a writer's assertion outranks date arithmetic. The fallback is windowed precisely
+  // because it is an inference, not an assertion. Measured prod blast radius (2026-08-17,
+  // 6,290 FK-joined entries): 0 played before add_date, 9 played on/after kill_date — and all
+  // 9 are same-day artifacts (add_time::date == kill_date, played in the morning and killed
+  // that afternoon) that a half-open bound would flip the wrong way.
+  //
+  // FIVE call sites carry this decision. Four are the `.leftJoin(rotation, ...)` sites below
+  // (getEntriesByPage, getEntriesByRange, getEntriesInTimeWindow, getEntriesByShow). The fifth
+  // is outside this file: `playlist-proxy.service.ts`'s window query runs the same unwindowed
+  // FK lane against a windowed post-slice fallback (`resolveFallbackRotation`), so the decision
+  // governs it identically. Keep all five in step — changing one and not its twins is the
+  // BS#2088 failure mode, and the cross-file fifth is the one most easily missed.
+  //
   // Subquery only fires per-row on a missed FK join; on rows with a populated rotation_id
   // COALESCE short-circuits and the subquery is not evaluated.
   //
@@ -608,6 +627,8 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
     .select(FSEntryFieldsRaw)
     .from(page)
     .innerJoin(flowsheet, eq(flowsheet.id, page.id))
+    // Deliberately unwindowed (BS#2183) — rotation_id is the writer's assertion and
+    // outranks date arithmetic; see FSEntryFieldsRaw.rotation_bin's fallback-window note above.
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
@@ -647,6 +668,8 @@ export const getEntriesByRange = async (startId: number, endId: number): Promise
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
+    // Deliberately unwindowed (BS#2183) — rotation_id is the writer's assertion and
+    // outranks date arithmetic; see FSEntryFieldsRaw.rotation_bin's fallback-window note above.
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
@@ -687,6 +710,8 @@ export const getEntriesInTimeWindow = async (start: Date, end: Date): Promise<IF
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
+    // Deliberately unwindowed (BS#2183) — rotation_id is the writer's assertion and
+    // outranks date arithmetic; see FSEntryFieldsRaw.rotation_bin's fallback-window note above.
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
@@ -796,6 +821,8 @@ export const getEntriesByShow = async (...show_ids: number[]): Promise<IFSEntry[
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
+    // Deliberately unwindowed (BS#2183) — rotation_id is the writer's assertion and
+    // outranks date arithmetic; see FSEntryFieldsRaw.rotation_bin's fallback-window note above.
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -576,6 +576,14 @@ async function fetchRecentRows(limit: number): Promise<RecentRow[]> {
       // to COALESCE with was removed (BS#1862) — it seq-scanned `library`
       // for every window row and cost ~2.4s. The fallback runs post-slice in
       // resolveFallbackRotation over the track rows that survive classification.
+      //
+      // That FK lane — the `.leftJoin(rotation, ...)` below — is deliberately
+      // UNWINDOWED (BS#2183), while resolveFallbackRotation's arm is bounded on
+      // both sides against the play date. The asymmetry is the decision, not an
+      // oversight: an explicit rotation_id is the writer's assertion and outranks
+      // date arithmetic. This is the fifth twin of the four join sites in
+      // flowsheet.service.ts — see FSEntryFieldsRaw.rotation_bin there for the
+      // full rationale and the measured blast radius, and keep the two in step.
       rotation_bin: rotation.rotation_bin,
     })
     .from(flowsheet)

--- a/tests/integration/flowsheet-rotation-bin-fallback.spec.js
+++ b/tests/integration/flowsheet-rotation-bin-fallback.spec.js
@@ -15,6 +15,11 @@
  * whitespace guard. It deliberately asserts through `GET /flowsheet/range`
  * rather than calling the service directly, so the projection is covered too.
  *
+ * It also pins the BS#2183 decision sitting right next to the window it
+ * contrasts with: the fallback subquery above is windowed against add_time,
+ * but the primary `rotation_id` FK join is deliberately NOT — see the
+ * "primary FK join is deliberately unwindowed" describe block below.
+ *
  * The window is placed in 1997 — outside anything the shared dev/CI schema
  * seeds and outside the BS#2062 spec's 1998 window, so the two can run in the
  * same band without interfering. Everything written here is torn down in
@@ -109,13 +114,17 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
       return r[0].id;
     };
 
-    const insertEntry = async (key, offsetMs, { albumId = null, artistName = null, albumTitle = null }) => {
+    const insertEntry = async (
+      key,
+      offsetMs,
+      { albumId = null, artistName = null, albumTitle = null, rotationId = null }
+    ) => {
       const r = await sql`
         INSERT INTO ${sql(SCHEMA)}.flowsheet
           (show_id, entry_type, add_time, play_order, album_id, artist_name, album_title, track_title, rotation_id)
         VALUES (
           ${showId}, 'track', ${at(offsetMs)}::timestamptz, ${Object.keys(entryIds).length + 1},
-          ${albumId}, ${artistName}, ${albumTitle}, ${`${MARKER} ${key}`}, NULL
+          ${albumId}, ${artistName}, ${albumTitle}, ${`${MARKER} ${key}`}, ${rotationId}
         )
         RETURNING id`;
       entryIds[key] = r[0].id;
@@ -187,6 +196,44 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     await insertEntry('addedLater', 50 * MIN, {
       artistName: `${MARKER} Cat Power`,
       albumTitle: `${MARKER} Moon Pix`,
+    });
+
+    // --- PRIMARY FK JOIN IS DELIBERATELY UNWINDOWED (BS#2183) ---
+    // Everything above windows the FALLBACK subquery against add_time. The
+    // primary `leftJoin(rotation, rotation.id = flowsheet.rotation_id)` in
+    // flowsheet.service.ts has no window at all: an explicit rotation_id is
+    // the writer's assertion (BS#1268 stamps it from the tubafrenzy webhook;
+    // the dj-site rotation picker emits it) and outranks date arithmetic. These
+    // two fixtures reuse the exact `killedBefore`/`addedLater` bounds above,
+    // but set rotation_id, to prove the FK path badges through the very window
+    // the fallback enforces.
+    const fkKilledArtist = await insertArtist(`${MARKER} Nilüfer Yanya`);
+    const fkKilledAlbum = await insertLibrary(fkKilledArtist, `${MARKER} Painless`);
+    const fkKilledRotation = await insertRotation({
+      albumId: fkKilledAlbum,
+      bin: 'H',
+      killDate: '1997-06-05', // killed BEFORE the window, same bound as `killedBefore` above
+    });
+    await insertEntry('fkKilledBeforeKillDate', 110 * MIN, {
+      albumId: fkKilledAlbum,
+      artistName: `${MARKER} Nilüfer Yanya`,
+      albumTitle: `${MARKER} Painless`,
+      rotationId: fkKilledRotation,
+    });
+
+    const fkEarlyArtist = await insertArtist(`${MARKER} Hermanos Gutiérrez`);
+    const fkEarlyAlbum = await insertLibrary(fkEarlyArtist, `${MARKER} El Bueno y El Malo`);
+    const fkEarlyRotation = await insertRotation({
+      albumId: fkEarlyAlbum,
+      bin: 'M',
+      addDate: '1997-06-20', // entered rotation AFTER the window, same bound as `addedLater` above
+      killDate: null,
+    });
+    await insertEntry('fkAiredBeforeAddDate', 115 * MIN, {
+      albumId: fkEarlyAlbum,
+      artistName: `${MARKER} Hermanos Gutiérrez`,
+      albumTitle: `${MARKER} El Bueno y El Malo`,
+      rotationId: fkEarlyRotation,
     });
 
     // --- tie-break: two active rows for the same (artist, album), lowest id wins ---
@@ -311,6 +358,34 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     ['addedLater', 'add_date is an inclusive lower bound (BS#1526)'],
   ])('leaves %s unbadged — %s', (key) => {
     expect(binOf(key)).toBeNull();
+  });
+
+  describe('primary FK join is deliberately unwindowed (BS#2183)', () => {
+    // CHARACTERIZATION TESTS, not TDD red-then-green: this behavior already
+    // exists today and both assertions below pass on first run. That is
+    // correct and expected — the point isn't to drive new behavior, it's to
+    // pin the BS#2183 decision so it fails loudly if someone later "fixes"
+    // the primary FK join by bolting the fallback's add_date/kill_date window
+    // onto it without reading that decision first. See the
+    // FSEntryFieldsRaw.rotation_bin comment and the four
+    // `.leftJoin(rotation, ...)` call sites in flowsheet.service.ts.
+
+    it('badges via the FK even when the linked rotation record was killed before the entry aired', () => {
+      // Same kill_date/window shape as the fallback's `killedBefore` case
+      // above — but here rotation_id is SET. Absent the FK, the fallback
+      // would exclude this row (kill_date is not > add_time) and the badge
+      // would be null, exactly as `killedBefore` proves above. With the FK
+      // set, the primary join wins and the badge survives.
+      expect(binOf('fkKilledBeforeKillDate')).toBe('H');
+    });
+
+    it("badges via the FK even when the entry aired before the rotation record's add_date", () => {
+      // Same add_date/window shape as the fallback's `addedLater` case
+      // above — but here rotation_id is SET. Absent the FK, the fallback
+      // would exclude this row (add_date > add_time) and the badge would be
+      // null, exactly as `addedLater` proves above.
+      expect(binOf('fkAiredBeforeAddDate')).toBe('M');
+    });
   });
 
   it('badges a blank artist+album via arm (b), which shadows the arm (c) join change', () => {

--- a/tests/integration/flowsheet-rotation-bin-fallback.spec.js
+++ b/tests/integration/flowsheet-rotation-bin-fallback.spec.js
@@ -18,7 +18,11 @@
  * It also pins the BS#2183 decision sitting right next to the window it
  * contrasts with: the fallback subquery above is windowed against add_time,
  * but the primary `rotation_id` FK join is deliberately NOT — see the
- * "primary FK join is deliberately unwindowed" describe block below.
+ * "primary FK join is deliberately unwindowed" describe block below. That
+ * decision spans FIVE join sites: four in flowsheet.service.ts and one in
+ * playlist-proxy.service.ts (`fetchRecentRows`, the legacy
+ * /playlists/recentEntries?v=2 path). This spec only executes against the
+ * flowsheet.service.ts lane.
  *
  * The window is placed in 1997 — outside anything the shared dev/CI schema
  * seeds and outside the BS#2062 spec's 1998 window, so the two can run in the
@@ -206,7 +210,9 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     // the dj-site rotation picker emits it) and outranks date arithmetic. These
     // two fixtures reuse the exact `killedBefore`/`addedLater` bounds above,
     // but set rotation_id, to prove the FK path badges through the very window
-    // the fallback enforces.
+    // the fallback enforces. Offsets 52/54 min keep play_order monotonic with
+    // add_time at this insertion point (play_order is assigned in insert
+    // order), so the fixture show stays in a state a real writer could produce.
     const fkKilledArtist = await insertArtist(`${MARKER} Nilüfer Yanya`);
     const fkKilledAlbum = await insertLibrary(fkKilledArtist, `${MARKER} Painless`);
     const fkKilledRotation = await insertRotation({
@@ -214,7 +220,7 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
       bin: 'H',
       killDate: '1997-06-05', // killed BEFORE the window, same bound as `killedBefore` above
     });
-    await insertEntry('fkKilledBeforeKillDate', 110 * MIN, {
+    await insertEntry('fkKilledBeforeKillDate', 52 * MIN, {
       albumId: fkKilledAlbum,
       artistName: `${MARKER} Nilüfer Yanya`,
       albumTitle: `${MARKER} Painless`,
@@ -229,7 +235,7 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
       addDate: '1997-06-20', // entered rotation AFTER the window, same bound as `addedLater` above
       killDate: null,
     });
-    await insertEntry('fkAiredBeforeAddDate', 115 * MIN, {
+    await insertEntry('fkAiredBeforeAddDate', 54 * MIN, {
       albumId: fkEarlyAlbum,
       artistName: `${MARKER} Hermanos Gutiérrez`,
       albumTitle: `${MARKER} El Bueno y El Malo`,
@@ -367,8 +373,15 @@ describe('rotation_bin fallback cohorts (BS#2080)', () => {
     // pin the BS#2183 decision so it fails loudly if someone later "fixes"
     // the primary FK join by bolting the fallback's add_date/kill_date window
     // onto it without reading that decision first. See the
-    // FSEntryFieldsRaw.rotation_bin comment and the four
-    // `.leftJoin(rotation, ...)` call sites in flowsheet.service.ts.
+    // FSEntryFieldsRaw.rotation_bin comment and the five annotated
+    // `.leftJoin(rotation, ...)` call sites — four in flowsheet.service.ts,
+    // one in playlist-proxy.service.ts.
+    //
+    // Note what a windowed FK join would actually do, because it is not what
+    // it looks like: the fallback would NOT pick these rows up. Its CASE is
+    // gated on flowsheet.rotation_id IS NULL, so a row that still carries the
+    // FK is refused by the fallback and would end up with NO badge, not a
+    // windowed one. These two tests would go red on exactly that.
 
     it('badges via the FK even when the linked rotation record was killed before the entry aired', () => {
       // Same kill_date/window shape as the fallback's `killedBefore` case


### PR DESCRIPTION
Closes #2183.

## No behavioral delta — this is the main thing to confirm

**Every touched line in `apps/backend/services/flowsheet.service.ts` and `apps/backend/services/playlist-proxy.service.ts` is a comment.** No query, predicate, join condition, or projection changed. The only executable content in this PR is two new test cases. A reviewer can confirm the whole behavioral claim mechanically:

```
git diff origin/main -- apps/backend/services/ \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-][[:space:]]*//' | grep -vE '^[+-][[:space:]]*$'
```

That returns nothing — **0 non-comment added lines and 0 non-comment removed lines**. It is the fastest way to confirm the central claim of this PR without reading the prose.

## The asymmetry

`rotation_bin` on a flowsheet entry has two sources, and they disagree about time.

The **primary** source is the FK join, `.leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))`. It has no date window at all: an entry carrying `rotation_id` gets that rotation record's *current* `rotation_bin`, regardless of when the entry aired, even past the record's own `kill_date`.

The **fallback** fires only when that join misses. It is bounded on both sides against the entry's `add_time` — `add_date <= add_time` (inclusive lower bound, BS#1526) and `kill_date IS NULL OR kill_date > add_time` (exclusive upper bound).

The docstring above `FSEntryFieldsRaw.rotation_bin` described that window as if it governed the whole mechanism. It never did — it only ever bounded the fallback. To a future reader the primary join reads as windowed-by-omission, which is exactly the setup for someone "fixing" it.

## The decision: keep the FK join unwindowed, by design

Recorded on #2183 before implementation. Two reasons.

**It is an assertion, not an inference.** `flowsheet.rotation_id` is stamped by a writer who identified this play as a rotation pick at the time it was written — BS#1268 stamps it from the tubafrenzy webhook, and the dj-site rotation picker emits it on submit. The fallback is windowed precisely because it is the opposite: an inference from `(artist, album)` or `album_id` against whatever `rotation` says today. Bounding the FK join would replace a recorded fact with recomputed date arithmetic.

**The measurement points the same way.** Of the 6,290 entries carrying the FK, 0 played before their rotation record's `add_date` and 9 played on or after its `kill_date`. All 9 are same-day artifacts (`add_time::date == kill_date` — played in the morning, killed that afternoon), and those plays genuinely *were* in rotation when the needle dropped. A half-open `kill_date > add_time` bound would unbadge exactly the 9 rows that are correct today. Windowing would have made the archive worse in the only 9 places it touched.

So the bug was the documentation, not the query.

## What changed

- The `FSEntryFieldsRaw.rotation_bin` docstring stops claiming the two-sided window governs both paths. It now scopes the window to the fallback explicitly, states that the primary join is unwindowed, and says why, plus the measured blast radius.
- **All five** unwindowed FK join sites carry the annotation. Four are in `flowsheet.service.ts` (`getEntriesByPage`, `getEntriesByRange`, `getEntriesInTimeWindow`, `getEntriesByShow`). The fifth is in `playlist-proxy.service.ts` — its window query runs the identical unwindowed FK lane against a windowed post-slice fallback (`resolveFallbackRotation`), serving the legacy `/playlists/recentEntries?v=2` path that iOS 3.2 reads.

Annotating every site rather than one is the whole point: #2088 is what happens when a rotation predicate drifts between copies because one was updated and its twins weren't. The cross-file fifth site is the one most likely to be changed in isolation, precisely because it doesn't sit next to the others.

## The two characterization tests

Added beside the existing windowed-fallback pins in `tests/integration/flowsheet-rotation-bin-fallback.spec.js`:

- `fkKilledBeforeKillDate` — an entry whose `rotation_id` points at a record killed before it aired still badges `H`.
- `fkAiredBeforeAddDate` — an entry that aired before its record's `add_date` still badges `M`.

Both reuse the exact `kill_date` / `add_date` bounds of the spec's existing `killedBefore` and `addedLater` fallback fixtures, differing only in that `rotation_id` is set. That pairing is the point: the neighbouring assertions already prove those same bounds leave a *fallback* row unbadged, so the two sit side by side as the contrast. Both fixtures are discriminating — with the FK contribution removed, all three fallback arms miss for each, so they would fail rather than pass by another route.

**These pass on arrival, and that is correct.** They are characterization tests, not red-then-green TDD — the behavior already exists, and pinning it is the entire job. Their value is future-tense: they fail loudly if someone later bolts the fallback's window onto the primary join without reading this decision.

## Caveat on coverage

The tests assert through `GET /flowsheet/range`, which resolves to **`getEntriesInTimeWindow`**. So exactly one of the five join sites is covered by an executing assertion (end to end, including the projection); the other four — `getEntriesByPage`, `getEntriesByRange`, `getEntriesByShow`, and the `playlist-proxy.service.ts` twin — are covered by the code annotation only.

That is a deliberate scope limit, not an oversight: the sites carry the same join clause, and adding four more read-path fixtures to pin the same predicate would cost integration-suite time without pinning anything the range test doesn't. But it does mean a window added to only one of the other four would leave this spec green. Worth knowing before changing any one site.

## Verification

Local `npm run ci:testmock` against a fresh database: **103/106 suites passed, 1043/1053 tests passed**, with two failures, neither attributable to this branch.

- `auth-auto-membership.spec.js` — reproduced **identically** on a scratch worktree at `origin/main` without this diff. Environmental: `DEFAULT_ORG_SLUG` gates the `user.create.after` hook and the local `.env` didn't set it (CI does, `test.yml:478`).
- `flowsheet-upcoming-show.spec.js` — the `coldDelta` scan-count assertion (`36` against a ceiling of `7`). This one **passed** on `origin/main`, so it is not reproducible as pre-existing. It is nonetheless not caused by this diff: `rawScans()` sums `seq_scan + idx_scan` from `pg_stat_user_tables`, a cumulative counter the stats collector flushes asynchronously, so autovacuum or autoanalyze touching `concerts` between the two reads inflates `coldDelta` with no per-row query involved — 36 without implying an N+1. BS#1661 already had to raise this same ceiling (5 → 7) for exactly that counter noise. Independently, under `--runInBand` that suite ran **19th** while the modified spec ran **60th**, so this branch's only executable content had not yet touched the database when the assertion failed.

**Those numbers were measured on the pre-amendment tree.** The code review that followed found the fifth join site, and the amendment adding it is comment-only (+8 lines in `playlist-proxy.service.ts`, +3 in `flowsheet.service.ts`) with typecheck, lint (0 errors), and Prettier green, and the 0-non-comment-lines check above re-verified. The local suite was **not** re-run afterward — treat **PR CI as the authoritative run**, not the 1043-passing figure.

## Relationship to #2083

#2083 inherits this decision rather than reopening it. Its `COALESCE(rotation_via_rotation_id, rotation_via_resolved)` design keeps the primary unwindowed by construction and windows only the resolver column — which, after this change, is the deliberate design rather than an accident of how the query happened to be built.

## Related

- Touches no schema, no migration, no runtime behavior.
- The stale-rotation cleanup that surfaced the asymmetry is #2184, which holds the archive-badge decision and the 1,290 historical false badges. This PR is scoped to join semantics only.
