### PR TITLE
docs(api): record why app.yaml collapses the /library/info and PATCH 200 into one Album

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -171,26 +171,28 @@ components:
     Album:
       type: object
       description: >
-        Abbreviated album-detail summary for Swagger-UI, shared by the two
-        endpoints that return `getAlbumFromDB`'s row verbatim: `GET
-        /library/info` (both the `album_id` and the BS#1880 `legacy_release_id`
-        branches) and the `PATCH /library/{id}` 200. Both handlers return the
-        same shape, so one local schema covers both.
+        Abbreviated album-detail summary, referenced here by `GET /library/info`
+        (both the `album_id` and the BS#1880 `legacy_release_id` branches) and
+        the `PATCH /library/{id}` 200. Four handlers actually return this shape
+        — `getAlbumFromDB`'s row verbatim; `/library/{id}/missing` and
+        `/library/{id}/found` return it too but declare no response body here.
 
-        Deliberately NOT the SSOT's `Album`, and the divergence is not drift to
-        delete (BS#2170). wxyc-shared's api.yaml models these two responses with
-        two different schemas — `AlbumInfoResponse` (an allOf over its own
-        `Album`) for `/library/info`, and `AlbumSearchResult` for the PATCH 200.
-        Both are satisfiable by what BS actually returns; both under-document it
-        by nine fields, and `AlbumSearchResult` additionally declares seven
-        search-only properties (`album_dist`, `rotation_id`, `matched_via`, …)
-        that neither handler emits. Porting `AlbumInfoResponse` here would
-        import a split the implementation does not have.
+        Interim divergence note (BS#2170), not drift to delete. The SSOT models
+        these responses with two schemas — `AlbumInfoResponse` for
+        `/library/info`, `AlbumSearchResult` for the three PATCHes — and
+        neither describes them well: both omit nine returned fields,
+        `AlbumSearchResult` declares seven search-only properties no
+        album-detail handler emits, and `AlbumInfoResponse` types `genre_name`
+        as a closed ten-value enum that six of the fifteen production genres
+        fall outside. Porting either one here would import a defect and a split
+        the implementation does not have. WXYC/wxyc-shared#365 re-models the
+        SSOT side; **revisit this note when it lands** rather than treating it
+        as a settled answer.
 
         This file is Swagger-UI display only — not a codegen source and not a
-        runtime validator — so its schemas are deliberately abbreviated
-        summaries rather than mirrors. `wxyc-shared/api.yaml` remains the
-        cross-repo SSOT and carries the authoritative field descriptions.
+        runtime validator — so its schemas stay abbreviated summaries rather
+        than mirrors, and `wxyc-shared/api.yaml` carries the authoritative
+        field descriptions.
       properties:
         id:
           type: integer
@@ -200,15 +202,17 @@ components:
             BS#2128. The library.db-producer surrogate key dj-site's track picker
             resolves against; NOT NULL since migration 0137. Sourced from
             getAlbumFromDB, so it is present on both consumers of this schema —
-            GET /library/info and the PATCH /library/{id} 200. It sits directly
-            on this schema for that reason; in the SSOT the same field hangs off
-            `AlbumInfoResponse` instead, and that spec's `Album` deliberately
-            does not carry it — so the identically-named schemas place this
-            field at different levels by design, not by accident.
+            GET /library/info and the PATCH /library/{id} 200, which is why it
+            sits directly on the schema here. The SSOT hangs the same field off
+            `AlbumInfoResponse` and omits it from its own `Album`, so the
+            identically-named schemas place it at different levels.
         code_letters:
           type: string
         code_artist_number:
-          type: string
+          # `genre_artist_crossreference.artist_genre_code`, an integer column.
+          # Four sibling schemas in this file already say so; only this one said
+          # `string`.
+          type: integer
         code_number:
           type: integer
         artist_name:

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -170,6 +170,27 @@ components:
 
     Album:
       type: object
+      description: >
+        Abbreviated album-detail summary for Swagger-UI, shared by the two
+        endpoints that return `getAlbumFromDB`'s row verbatim: `GET
+        /library/info` (both the `album_id` and the BS#1880 `legacy_release_id`
+        branches) and the `PATCH /library/{id}` 200. Both handlers return the
+        same shape, so one local schema covers both.
+
+        Deliberately NOT the SSOT's `Album`, and the divergence is not drift to
+        delete (BS#2170). wxyc-shared's api.yaml models these two responses with
+        two different schemas — `AlbumInfoResponse` (an allOf over its own
+        `Album`) for `/library/info`, and `AlbumSearchResult` for the PATCH 200.
+        Both are satisfiable by what BS actually returns; both under-document it
+        by nine fields, and `AlbumSearchResult` additionally declares seven
+        search-only properties (`album_dist`, `rotation_id`, `matched_via`, …)
+        that neither handler emits. Porting `AlbumInfoResponse` here would
+        import a split the implementation does not have.
+
+        This file is Swagger-UI display only — not a codegen source and not a
+        runtime validator — so its schemas are deliberately abbreviated
+        summaries rather than mirrors. `wxyc-shared/api.yaml` remains the
+        cross-repo SSOT and carries the authoritative field descriptions.
       properties:
         id:
           type: integer
@@ -179,7 +200,11 @@ components:
             BS#2128. The library.db-producer surrogate key dj-site's track picker
             resolves against; NOT NULL since migration 0137. Sourced from
             getAlbumFromDB, so it is present on both consumers of this schema —
-            GET /library/info and the PATCH /library/{id} 200.
+            GET /library/info and the PATCH /library/{id} 200. It sits directly
+            on this schema for that reason; in the SSOT the same field hangs off
+            `AlbumInfoResponse` instead, and that spec's `Album` deliberately
+            does not carry it — so the identically-named schemas place this
+            field at different levels by design, not by accident.
         code_letters:
           type: string
         code_artist_number:


### PR DESCRIPTION
Closes #2170.

Takes the ticket's **second** option — record the divergence — because verifying against the controllers showed the first one (port `AlbumInfoResponse`) would make the spec *less* accurate, not more.

## What the handlers actually return

`GET /library/info` and `PATCH /library/{id}` both return `libraryService.getAlbumFromDB(...)` verbatim:

- `getAlbum` — the `album_id` branch and the BS#1880 `legacy_release_id` branch (via `getAlbumByLegacyId`, whose own docstring says it returns "the same shape as `getAlbumFromDB`")
- `updateAlbum` — re-reads with `getAlbumFromDB(albumId)` after the write and returns that

**One shape, two endpoints.** app.yaml's single local `Album` is the honest local rendering of that, not drift.

## Measured against that shape

Both SSOT schemas are *satisfiable* — every `required` field is returned, so neither is a wire lie — but neither describes the response well:

| | declares but no handler returns | returns but undeclared |
|---|---|---|
| `AlbumInfoResponse` (SSOT `/library/info` 200) | `rotation` | 9 |
| `AlbumSearchResult` (SSOT `PATCH /library/{id}` 200) | `album_dist`, `artist_dist`, `rotation_bin`, `rotation_id`, `artwork_url`, `matched_via`, `matched_via_alias` | 9 |

The nine in both cases are the fields the wire actually carries past the schema — `alphabetical_name`, `record_label`, `last_modified`, `reconciled_identity`, and so on (the wire shape is post-`serializeReconciledIdentity` and post-`withDiscogsUnavailableCamelCase`, which is why the three `discogs_unavailable*` columns appear as `discogsUnavailable*`).

So porting `AlbumInfoResponse` into app.yaml would import a `rotation` member BS never emits, and would leave `PATCH` pointing at a plain `Album` — asserting a difference between two responses that are byte-for-byte the same shape.

## What changed

A schema-level `description` on app.yaml's `Album` recording: the one-shape-two-endpoints fact, that the SSOT splits it and how, that this file is Swagger-UI display only (not a codegen source, not a runtime validator) so its schemas are deliberately abbreviated summaries, and that `wxyc-shared/api.yaml` stays authoritative.

The `legacy_release_id` docstring gains the placement note the ticket asked for: it sits directly on this schema because both consumers return it, while in the SSOT it hangs off `AlbumInfoResponse` and that spec's `Album` deliberately omits it — the identically-named schemas place the field at different levels **by design**.

Style follows `CatalogExportRow` above it: schema-level `description: >`, deferring authoritative field docs to the SSOT. This file has no `#` comments and gains none — a `description` also reaches the rendered Swagger UI, which is the whole audience here.

## Scope

Spec-only. No wire change, no generated types, no `@wxyc/shared` publish. No test: the repo's own parity test explicitly leaves app.yaml unguarded (BS#1479), and this change adds prose to a display-only document. `npx prettier --check apps/backend/app.yaml` is clean, and the YAML parses (it is `import`ed at `apps/backend/app.ts:8`, so a malformed edit would break the build).

## Follow-up filed separately

The SSOT-side finding above is real but belongs to wxyc-shared, not here: `PATCH /library/{id}`'s 200 is modeled as `AlbumSearchResult` — the catalog *search* row shape — when the handler returns the album-detail shape. Filed as WXYC/wxyc-shared#365.

## Related

- WXYC/wxyc-shared#340 — the spec pass that added the optional `legacy_release_id` response fields
- WXYC/Backend-Service#2128 — the change the docstring cites for the collapsed placement
- WXYC/Backend-Service#1880 — the `/library/info` legacy front-door branch
- WXYC/wxyc-shared#360 — the sibling ticket declaring `/library/info`'s undocumented query param
