### PR TITLE
fix(library): parse /library/info's album_id strictly and 404 a miss (BS#2212)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -2417,21 +2417,22 @@ paths:
         fallback (BS#1880).
 
 
-        The two branches agree on the shape of a hit and disagree on a miss. An
-        unmatched `legacy_release_id` is a 404 — a library.db release not yet
-        synced into Backend Postgres. An unmatched `album_id` is a 200 with an
-        empty body. Do not port a `if (!body)` branch from one to the other.
+        The two branches now agree on a miss as well: either unmatched
+        identifier is a 404. For `legacy_release_id` that means a library.db
+        release not yet synced into Backend Postgres; for `album_id`, no such
+        serial. The `album_id` miss was a 200 with an empty body until BS#2212.
       parameters:
         - name: album_id
           in: query
           required: false
           description: >-
             Backend's serial `wxyc_schema.library.id`. Optional: supply this or
-            `legacy_release_id`, not both. Parsed leniently, unlike the strict
-            sibling below: trailing garbage is truncated to a valid-looking id
-            and a repeated param takes the first, so a corrupted value resolves
-            a different real release rather than erroring (BS#2212). Send a
-            bare integer.
+            `legacy_release_id`, not both. Parsed strictly, like the sibling
+            below and like every `/library/{id}` route: a positive int4 in
+            canonical form. Trailing garbage (`65880xyz`), leading zeros, an
+            explicit sign, whitespace, and a repeated param are each a 400 —
+            never a truncated id resolving a different real release, which is
+            what a bare `parseInt` did before BS#2212.
           schema:
             type: integer
         - name: legacy_release_id
@@ -2450,17 +2451,15 @@ paths:
             type: integer
       responses:
         '200':
-          description: >-
-            Album details. Also returned with an empty body when `album_id`
-            matches no row — see the operation description.
+          description: Album details.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Album'
         '400':
-          description: Both identifiers absent, or `legacy_release_id` present but not a positive integer
+          description: Both identifiers absent, or the supplied identifier is not a canonical positive int4
         '404':
-          description: '`legacy_release_id` matched no catalog row'
+          description: The supplied identifier matched no catalog row
 
   /schedule:
     get:

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -1632,7 +1632,25 @@ export const getAlbum: RequestHandler<
     throw new WxycError('Bad Request, missing album identifier: album_id or legacy_release_id', 400);
   }
 
-  const album = await libraryService.getAlbumFromDB(parseInt(query.album_id));
+  // BS#2212: `parseAlbumId`, not `parseInt`. This branch is the front door for
+  // dj-site's own permalinks and it had none of the discipline the legacy
+  // branch above documents: `parseInt('65880xyz')` is 65880, so a truncated or
+  // corrupted link resolved to a real, DIFFERENT release and returned it with
+  // a 200, and `parseInt('abc')` is NaN, which postgres-js serialized as the
+  // literal "NaN" for Postgres to reject with 22P02 -- a client-input 400
+  // arriving as a server-fault 500, counted against 5xx alerting and captured
+  // by Sentry. `parseResourceId` is the same guard every other `/library/:id`
+  // route on this router uses; its `typeof rawId !== 'string'` check also
+  // rejects the repeated-param case Express hands over as `string[]`.
+  const album = await libraryService.getAlbumFromDB(parseAlbumId(query.album_id));
+  // 404 on a miss, matching the legacy branch. This used to be a 200 carrying
+  // an empty body, which satisfied neither the declared response schema nor
+  // any consumer: dj-site's two readers collapse `isError || !data` into one
+  // error card, and wxyc-dj-ios decodes into a non-optional `AlbumInfo`, so an
+  // empty body already threw into its catch-and-degrade path.
+  if (album === undefined) {
+    throw new WxycError('No catalog album for that album_id', 404);
+  }
   res.status(200).json(album);
 };
 

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -2843,11 +2843,26 @@ describe('Library Album Info', () => {
       expectErrorContains(res, 'missing album identifier');
     });
 
-    test('returns undefined/empty for non-existent album_id', async () => {
-      const res = await auth.get('/library/info').query({ album_id: 999999 }).expect(200);
+    // BS#2212 flipped this from a 200 carrying an empty body. That shape
+    // satisfied no declared response schema and disagreed with the sibling
+    // legacy_release_id branch, which has always 404'd the same miss.
+    test('returns 404 for non-existent album_id', async () => {
+      const res = await auth.get('/library/info').query({ album_id: 999999 }).expect(404);
 
-      expect(res.body).toBeFalsy();
+      expectErrorContains(res, 'No catalog album for that album_id');
     });
+
+    // BS#2212: the branch used to parse with a bare parseInt, so '65880xyz'
+    // resolved to release 65880 -- a real, different album -- with a 200, and
+    // a non-numeric value reached Postgres as the literal "NaN" and 500'd.
+    test.each([['abc'], ['65880xyz'], [''], ['0'], ['-5'], ['007']])(
+      'returns 400 for a malformed album_id (%s)',
+      async (bad) => {
+        const res = await auth.get('/library/info').query({ album_id: bad }).expect(400);
+
+        expectErrorContains(res, 'Invalid album ID');
+      }
+    );
 
     test('returns nested reconciled_identity (no flat external-ID columns)', async () => {
       const res = await auth.get('/library/info').query({ album_id: 1 }).expect(200);

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -2305,6 +2305,60 @@ describe('library.controller', () => {
       await expect(getAlbum(req, res, next)).rejects.toThrow('Invalid legacy_release_id');
       expect(mockGetAlbumByLegacyId).not.toHaveBeenCalled();
     });
+
+    // BS#2212: the album_id branch parsed with a bare `parseInt`, so it had
+    // none of the discipline the legacy branch above documents. The same
+    // `parseResourceId` every other `/library/:id` route uses now guards it.
+    const rejectedAlbumIds: Array<[string, string]> = [
+      ['non-numeric', 'abc'],
+      ['trailing garbage', '65880xyz'],
+      ['empty', ''],
+      ['zero', '0'],
+      ['negative', '-5'],
+      ['leading-zero padded', '007'],
+      ['explicitly signed', '+42'],
+      ['above INT4_MAX', '2147483648'],
+      ['exponent notation', '1e21'],
+      ['surrounded by whitespace', ' 42 '],
+    ];
+
+    it.each(rejectedAlbumIds)('returns 400 for an album_id that is %s', async (_label, rawId) => {
+      const req = { query: { album_id: rawId } } as unknown as Request;
+
+      await expect(getAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    // Pinned by value, not just by status. `parseInt('65880xyz')` is 65880, so
+    // the failure this replaces did not error -- it fetched release 65880, a
+    // real and different album, and served it with a 200. Asserting the status
+    // alone would still pass if a future parse silently truncated again.
+    it('never fetches the truncated id when album_id carries trailing garbage', async () => {
+      const req = { query: { album_id: '65880xyz' } } as unknown as Request;
+
+      await expect(getAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalledWith(65880);
+    });
+
+    it('returns 400 for a repeated album_id (Express yields string[])', async () => {
+      // parseInt(['1','2']) is parseInt("1,2") = 1, so a request naming two
+      // releases used to be served the first one.
+      const req = { query: { album_id: ['1', '2'] } } as unknown as Request;
+
+      await expect(getAlbum(req, mockResponse(), next)).rejects.toThrow('Invalid album ID');
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+    });
+
+    // Matches the legacy branch's miss contract. Previously a 200 whose body
+    // was `undefined` -- which satisfied no declared response schema, and
+    // which all three consumers already routed to their error path anyway.
+    it('returns 404 when album_id resolves to no catalog row', async () => {
+      mockGetAlbumFromDB.mockResolvedValue(undefined);
+      const req = { query: { album_id: '999999' } } as unknown as Request;
+
+      await expect(getAlbum(req, mockResponse(), next)).rejects.toThrow('No catalog album for that album_id');
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(999999);
+    });
   });
 
   describe('manualDiscogsRecheck (BS#1283)', () => {


### PR DESCRIPTION
Closes #2212.

`GET /library/info?album_id=` parsed its identifier with a bare `parseInt`, while the `legacy_release_id` branch four lines above uses strict `Number()` and carries a comment about why. This routes the `album_id` branch through `parseAlbumId` — the same `parseResourceId` guard every other `/library/{id}` route on this router already uses — and flips the valid-but-absent case to a 404.

## What changes on the wire

| Request | Before | After |
|---|---|---|
| `?album_id=65880xyz` | **200 with release 65880** | 400 |
| `?album_id=abc` | **500** | 400 |
| `?album_id=` | **500** | 400 |
| `?album_id=1&album_id=2` | **200 with release 1** | 400 |
| `?album_id=999999` (no such row) | 200, empty body | 404 |
| `?album_id=42` (exists) | 200 with the album | unchanged |

The first row is the one that mattered: `parseInt('65880xyz')` is `65880`, so a truncated or corrupted permalink resolved to a **real, different release** and returned it looking like a success. Nothing errored, nothing logged, and the DJ saw someone else's record.

The 500s were real 5xx, not mislabelled 4xx. `parseInt('abc')` is `NaN`, postgres-js serializes the literal `"NaN"`, Postgres raises `22P02 invalid input syntax for type integer`, and the resulting `PostgresError` carries no `status`/`expose` — so `carriedClientStatus` returns null and `errorHandler` takes the generic 500 branch. Client input was reaching the database as a malformed literal and surfacing as a server fault, counted against 5xx alerting and captured by Sentry as our bug.

## The 404 flip, and why it's safe

The ticket flagged this as a deliberate contract change needing a decision rather than a bug fix. I checked every consumer before making it:

| Consumer | Today (200 + empty body) | After 404 |
|---|---|---|
| dj-site `AlbumDetailPanel.tsx:38` | `!data` → `AlbumErrorCard` | `isError` → same card |
| dj-site `@information/(.)album/[id]/page.tsx:73` | `!data` → same | `isError` → same |
| wxyc-dj-ios `AlbumDetailView.loadInfo()` | decode throws → clone fallback | `APIError` → same fallback |

All three already treat the empty 200 as a failure. `wxyc-dj-ios`'s `APIClient.swift:81` declares `albumInfo(albumId:) async throws -> AlbumInfo` — non-optional, via `getJSON` — so an empty body cannot decode and already lands in the catch that degrades to the on-device catalog clone. iOS and Android don't call this endpoint at all. The behavior is identical for every reader; what changes is that the status now tells the truth.

## Why `parseAlbumId` rather than a local guard

`parseResourceId` requires `/^[1-9][0-9]*$/` plus an `INT4_MAX` bound, so leading zeros, an explicit `+`, exponent and hex notation, surrounding whitespace, and overflow are all rejected in the same place. Its `typeof rawId !== 'string'` check is what catches the repeated-param case, where Express hands over a `string[]`. Its doc comment already says it exists as ONE implementation because "a hardening fix applied to one copy is a hole left open in the other" — this branch was that hole.

## Tests

Written first, confirmed red (13 failures), then green.

- **Unit** (`library.controller.test.ts`): a 10-case `it.each` over the rejected forms, a repeated-param case, a 404-on-miss case, and a separate test pinning the trailing-garbage case **by value** — `expect(mockGetAlbumFromDB).not.toHaveBeenCalledWith(65880)`. Status alone would still pass if a future parse silently truncated again.
- **Integration** (`library.spec.js`): the `999999` test flips from `.expect(200)` + falsy body to `.expect(404)`, plus a 6-case `test.each` for the malformed forms.

Local runs: 7,910 unit tests pass; the Docker CI mirror (`npm run ci:testmock`) reports 1,156 integration passing with all eleven `GET /library/info` cases green.

One integration test fails locally and is unrelated: `auth-auto-membership.spec.js`'s bare-`create-user` case needs `DEFAULT_ORG_SLUG`, which `apps/auth/app.ts:552` reads and the local `.env` doesn't set. Its `provision-user` sibling passes. Nothing in this diff touches auth.

## Spec

`apps/backend/app.yaml`'s operation and parameter text is corrected in the same commit — it documented the lenient parse and the empty-body miss as intended behavior, so leaving it would have left the Swagger page describing the bug. The `wxyc-shared/api.yaml` half rides in a separate PR alongside WXYC/wxyc-shared#365 and #367, since all three edit the same region of that file.

## Related

- WXYC/Backend-Service#1880 — added the strict `legacy_release_id` branch whose discipline this one lacked
- WXYC/wxyc-shared#365 / WXYC/wxyc-shared#367 — the SSOT-side pass this coordinates with
- WXYC/Backend-Service#2170 / WXYC/Backend-Service#2202 — the app.yaml divergence note that surfaced this
