### PR TITLE
docs: stop claiming a /v2/flowsheet route group that was never mounted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,14 +81,17 @@ Express 5 application with these route groups:
 | `/config`       | Public app bootstrap configuration                         |
 | `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit)          |
 | `/library`      | Music library catalog                                      |
-| `/flowsheet`    | V1 flowsheet (legacy)                                      |
-| `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs)                    |
-| `/djs`          | DJ profiles and management                                 |
+| `/flowsheet`    | Flowsheet — serves both the V1 shape and the V2 projection (see below) |
+| `/djs`          | DJ bin and playlists                                       |
 | `/request`      | Song request line                                          |
 | `/schedule`     | Schedule management                                        |
 | `/events`       | SSE for real-time updates                                  |
 | `/healthcheck`  | Health check                                               |
 | `/internal`     | Internal endpoints (ETL notifications, tubafrenzy webhook) |
+
+**There is no `/v2/flowsheet` route, and this table used to claim there was.** `app.ts` mounts no `/v2` router; `projectEntriesV2` (`utils/album-metadata-projection.ts`) is called by `getEntries`, the handler mounted at plain `GET /flowsheet`, so **the V2 discriminated-union shape ships on the V1 path**. Three source comments still name `/v2/flowsheet` as though it were mounted (`utils/album-metadata-projection.ts:5`, `services/flowsheet.service.ts:392`, `services/playlist-proxy.service.ts:451`) — read those as naming the projection, not a route. `api.wxyc.org/v2/flowsheet` returns 404 with an HTML `Cannot GET` body, and always has.
+
+The prefix was planned and never mounted. Mounting it now would mean maintaining two paths to one projection for zero callers, so `@wxyc/shared` deleted the two `/v2/flowsheet*` declarations from `api.yaml` in [WXYC/wxyc-shared#372](https://github.com/WXYC/wxyc-shared/issues/372) / [PR #378](https://github.com/WXYC/wxyc-shared/pull/378) and moved the explanation into `GET /flowsheet`'s description. This table was the second place the error was written down; correcting both together is the point.
 
 Code is organized as controllers (HTTP handling) → services (business logic) → database (Drizzle queries).
 


### PR DESCRIPTION
Docs-only. Companion to **WXYC/wxyc-shared#378** (which closes [WXYC/wxyc-shared#372](https://github.com/WXYC/wxyc-shared/issues/372)); split out because the two changes live in different repos.

## The claim that was wrong

The API route table in `CLAUDE.md` listed `/v2/flowsheet` as a route group. There is no such route.

- `app.ts` mounts no `/v2` router, and never has.
- `api.wxyc.org/v2/flowsheet` returns **404** with an HTML `Cannot GET` body — verified by probe, alongside the other sixteen phantom paths in the wxyc-shared sweep.
- `projectEntriesV2` (`utils/album-metadata-projection.ts`) is called by `getEntries`, the handler mounted at plain `GET /flowsheet`. **The V2 discriminated-union shape ships on the V1 path.**

The prefix was planned and the mount never happened.

## Why it mattered enough to fix

`api.yaml` declared `GET /v2/flowsheet` and `GET /v2/flowsheet/latest` and generated client methods for both, in five languages, for a path that 404s. wxyc-shared#378 removes those declarations and moves the explanation into `GET /flowsheet`'s description, where the next reader meets it before the 404 rather than after.

This table was the second place the belief was written down, and plausibly where the declaration came from. Correcting only the spec would leave this file free to reintroduce it.

## What this PR does not touch

The three source comments naming `/v2/flowsheet` — `utils/album-metadata-projection.ts:5`, `services/flowsheet.service.ts:392`, `services/playlist-proxy.service.ts:451` — are left in place and explicitly called out in the new prose instead. They describe the projection rather than a route, and a reader who finds them after this file has gone quiet would reasonably conclude the docs are stale rather than the comments loose. Naming them is the cheaper fix than rewording three comments in three services.

## Also in the diff

`/djs` in the same table said "DJ profiles and management". `dj_route` serves `/djs/bin` and `/djs/playlists`; there is no profile surface. The `GET /djs` and `/djs/register` operations that would have been one were Cognito-era declarations (`NewDJ` keyed on `cognito_user_name`, a string that appears nowhere in this repo) which wxyc-shared#378 also deletes. Corrected while the table was open.
