### PR TITLE
feat(catalog-search): project artist_id on catalog search results

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -57,6 +57,7 @@ export type AlbumSearchResultRow = {
   add_date: string;
   album_title: string;
   artist_name: string;
+  artist_id: number;
   code_letters: string;
   code_number: number;
   code_artist_number: number;
@@ -260,6 +261,7 @@ export async function searchLibrary(
       ${library_artist_view.add_date} AS add_date,
       ${library_artist_view.album_title} AS album_title,
       ${library_artist_view.artist_name} AS artist_name,
+      ${library_artist_view.artist_id} AS artist_id,
       ${library_artist_view.code_letters} AS code_letters,
       ${library_artist_view.code_number} AS code_number,
       ${library_artist_view.code_artist_number} AS code_artist_number,
@@ -282,6 +284,7 @@ export async function searchLibrary(
       ${library_artist_view.add_date} AS add_date,
       ${library_artist_view.album_title} AS album_title,
       ${library_artist_view.artist_name} AS artist_name,
+      ${library_artist_view.artist_id} AS artist_id,
       ${library_artist_view.code_letters} AS code_letters,
       ${library_artist_view.code_number} AS code_number,
       ${library_artist_view.code_artist_number} AS code_artist_number,
@@ -358,6 +361,7 @@ export async function searchLibrary(
         ${library_artist_view.add_date} AS add_date,
         ${library_artist_view.album_title} AS album_title,
         ${library_artist_view.artist_name} AS artist_name,
+        ${library_artist_view.artist_id} AS artist_id,
         ${library_artist_view.code_letters} AS code_letters,
         ${library_artist_view.code_number} AS code_number,
         ${library_artist_view.code_artist_number} AS code_artist_number,
@@ -577,6 +581,7 @@ function taggedRowToAlbumSearchResultRow(row: TaggedLibraryViewEntry): AlbumSear
     add_date: row.add_date instanceof Date ? row.add_date.toISOString() : String(row.add_date ?? ''),
     album_title: row.album_title,
     artist_name: row.artist_name ?? '',
+    artist_id: row.artist_id,
     code_letters: row.code_letters,
     code_number: row.code_number,
     code_artist_number: row.code_artist_number,
@@ -602,6 +607,7 @@ type RawRow = {
   add_date: Date | string;
   album_title: string;
   artist_name: string | null;
+  artist_id: number;
   code_letters: string;
   code_number: number;
   code_artist_number: number;
@@ -633,6 +639,7 @@ function toAlbumSearchResultRow(row: RawRow): AlbumSearchResultRow {
     add_date: row.add_date instanceof Date ? row.add_date.toISOString() : String(row.add_date ?? ''),
     album_title: row.album_title,
     artist_name: row.artist_name ?? '',
+    artist_id: row.artist_id,
     code_letters: row.code_letters,
     code_number: row.code_number,
     code_artist_number: row.code_artist_number,

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -3928,6 +3928,7 @@ export async function searchLibraryByCTARaw(
         ${library.album_artist} AS album_artist,
         ${library.plays} AS plays,
         ${library.artwork_url} AS artwork_url,
+        ${library.artist_id} AS artist_id,
         ${artists.discogs_artist_id} AS discogs_artist_id,
         ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
         ${artists.wikidata_qid} AS wikidata_qid,

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -294,6 +294,13 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
     expect(hit).toBeDefined();
     expect(hit.album_title).toBe(CTA_ALBUM_TITLE);
     expect(hit.artist_name).toBe(CTA_ARTIST);
+    // `artist_id` is declared non-nullable on `AlbumSearchResultRow`, and the
+    // CTA arm hand-rolls its own SELECT rather than reusing the view
+    // projection — so this is the one assertion that can catch the column
+    // going missing from that SELECT. The unit tests cannot: they hand their
+    // mocked rows an `artist_id`, so a column absent from the real SQL is
+    // invisible to them. This drives the actual statement.
+    expect(typeof hit.artist_id).toBe('number');
     expect(Array.isArray(hit.matched_via)).toBe(true);
     expect(hit.matched_via.length).toBeGreaterThanOrEqual(1);
     const bioHints = hit.matched_via.filter((m) => m.title === 'Bioluminescence');

--- a/tests/unit/services/library-search.artist-id.test.ts
+++ b/tests/unit/services/library-search.artist-id.test.ts
@@ -3,12 +3,27 @@ import { db } from '../../mocks/database.mock';
 
 /**
  * BS#2227: `artist_id` must reach `AlbumSearchResultRow` on every path that
- * produces one — the alias-OFF direct-match SELECT, the alias-ON branch B
- * (alias-only) SELECT, and the track-title cascade (which maps a
- * `TaggedLibraryViewEntry`, already carrying `artist_id` off
- * `library_artist_view`). A V/A compilation row must carry the shared
- * compilation artist id, not null — proven here via the same direct-match
- * path a real compilation row takes.
+ * produces one.
+ *
+ * What this file covers, and what it deliberately does not:
+ *
+ * These tests pin the two MAPPERS (`toAlbumSearchResultRow`,
+ * `taggedRowToAlbumSearchResultRow`) — that each carries `artist_id` from its
+ * input row to its output. They cannot verify that the SQL selects the column
+ * at all: `db.execute` is a bare mock that ignores its argument, and every
+ * fixture below supplies `artist_id` by hand, so deleting the
+ * `AS artist_id` projections from the SELECTs leaves this whole file green.
+ *
+ * Coverage of the projections themselves is therefore the integration suite's
+ * job, against real SQL: `tests/integration/library-query.spec.js` asserts
+ * `typeof hit.artist_id === 'number'` on a CTA cascade hit. Add an assertion
+ * there, not here, when a new search path starts producing these rows.
+ *
+ * Note the cascade's CTA arm does NOT read `library_artist_view` — it
+ * hand-rolls a join over `compilation_track_artist` / `library` / `artists`
+ * and returns `as TaggedLibraryViewEntry`, an unchecked cast. `artist_id`
+ * reaches it only because `searchLibraryByCTARaw` projects the column
+ * explicitly; nothing in the type system enforces that.
  */
 
 const mockRunCatalogTrackSearchCascade = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);

--- a/tests/unit/services/library-search.artist-id.test.ts
+++ b/tests/unit/services/library-search.artist-id.test.ts
@@ -1,0 +1,159 @@
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+/**
+ * BS#2227: `artist_id` must reach `AlbumSearchResultRow` on every path that
+ * produces one — the alias-OFF direct-match SELECT, the alias-ON branch B
+ * (alias-only) SELECT, and the track-title cascade (which maps a
+ * `TaggedLibraryViewEntry`, already carrying `artist_id` off
+ * `library_artist_view`). A V/A compilation row must carry the shared
+ * compilation artist id, not null — proven here via the same direct-match
+ * path a real compilation row takes.
+ */
+
+const mockRunCatalogTrackSearchCascade = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  runCatalogTrackSearchCascade: mockRunCatalogTrackSearchCascade,
+}));
+
+type SpanLike = { setAttribute: jest.Mock; setAttributes: jest.Mock };
+type SpanOpts = { name: string; op: string; attributes?: Record<string, unknown> };
+const spanInstance: SpanLike = { setAttribute: jest.fn(), setAttributes: jest.fn() };
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(_opts: SpanOpts, callback: (span: SpanLike) => T | Promise<T>): Promise<T> =>
+    Promise.resolve(callback(spanInstance)),
+  getActiveSpan: () => spanInstance,
+}));
+
+import { searchLibrary } from '../../../apps/backend/services/library-search.service';
+import { resetConfig as resetCatalogSearchAliasConfig } from '../../../apps/backend/config/catalogSearchAlias';
+
+const PARAMS = {
+  q: 'autechre',
+  page: 0,
+  limit: 20,
+  sort: 'artist' as const,
+  order: 'asc' as const,
+};
+
+function primaryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7100,
+    add_date: '2024-01-15',
+    album_title: 'Confield',
+    artist_name: 'Autechre',
+    code_letters: 'AU',
+    code_number: 3,
+    code_artist_number: 1,
+    format_name: 'CD',
+    genre_name: 'Electronic',
+    label: 'Warp',
+    label_id: 10,
+    rotation_bin: null,
+    plays: 5,
+    on_streaming: true,
+    album_artist: null,
+    discogs_unavailable: false,
+    discogs_unavailable_note: null,
+    last_discogs_recheck_at: null,
+    artist_id: 501,
+    ...overrides,
+  };
+}
+
+describe('searchLibrary: artist_id on AlbumSearchResultRow (BS#2227)', () => {
+  const originalFlag = process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+
+  beforeEach(() => {
+    db.execute.mockReset();
+    mockRunCatalogTrackSearchCascade.mockReset();
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([]);
+    delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    resetCatalogSearchAliasConfig();
+  });
+
+  afterAll(() => {
+    if (originalFlag === undefined) delete process.env.CATALOG_SEARCH_ALIAS_ENABLED;
+    else process.env.CATALOG_SEARCH_ALIAS_ENABLED = originalFlag;
+    resetCatalogSearchAliasConfig();
+  });
+
+  it('alias off: direct-hit row carries artist_id', async () => {
+    db.execute.mockResolvedValueOnce([primaryRow()]).mockResolvedValueOnce([{ total: 1 }]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].artist_id).toBe(501);
+  });
+
+  it('alias on: alias-only hit (branch B) carries artist_id', async () => {
+    process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+    resetCatalogSearchAliasConfig();
+    db.execute
+      .mockResolvedValueOnce([
+        primaryRow({
+          artist_id: 502,
+          alias_max_sim: 0.85,
+          alias_matched_variant: 'Autecher',
+          alias_matched_source: 'discogs_name_variation',
+        }),
+      ])
+      .mockResolvedValueOnce([{ total: 1, total_non_alias: 0 }]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].artist_id).toBe(502);
+    expect(results[0].matched_via_alias).toEqual([{ matched_variant: 'Autecher', source: 'discogs_name_variation' }]);
+  });
+
+  it('V/A compilation hit returns the shared compilation artist id, not null', async () => {
+    db.execute
+      .mockResolvedValueOnce([
+        primaryRow({
+          id: 9200,
+          artist_name: 'Various Artists',
+          code_letters: 'V/A',
+          album_title: 'Sample Various',
+          artist_id: 1087,
+        }),
+      ])
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].artist_id).toBe(1087);
+  });
+
+  it('track-title cascade hit (TaggedLibraryViewEntry mapper) carries artist_id', async () => {
+    db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([
+      {
+        id: 314,
+        add_date: '2024-03-01',
+        album_title: 'DOGA',
+        artist_name: 'Juana Molina',
+        code_letters: 'JU',
+        code_number: 1,
+        code_artist_number: 4,
+        format_name: 'CD',
+        genre_name: 'Rock',
+        label: 'Sonamos',
+        label_id: null,
+        rotation_bin: null,
+        plays: 12,
+        on_streaming: true,
+        album_artist: null,
+        artist_id: 4200,
+      },
+    ]);
+
+    const { results } = await searchLibrary(PARAMS);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].artist_id).toBe(4200);
+  });
+});


### PR DESCRIPTION
Projects the catalog `artist_id` onto catalog-search rows, so a client can link a search result to its artist.

The column was already there. `library_artist_view.artist_id` landed in migration 0089 for alias-aware search, and the alias branch already joins on it — it was simply never selected into the response. dj-site has meanwhile been reading the field through an untyped `Record<string, unknown>` cast, which laundered the absence into a silent `undefined` on every row with no type error anywhere.

## What changed

`apps/backend/services/library-search.service.ts`, seven touch points:

- `AlbumSearchResultRow` and `RawRow` both declare `artist_id: number`
- All three SELECT branches project `${library_artist_view.artist_id} AS artist_id` — direct-match, alias-match, and the combined arm
- Both row mappers carry it: `taggedRowToAlbumSearchResultRow` and `toAlbumSearchResultRow`

`GET /library/query` needs no separate touch: it builds rows through `taggedRowToAlbumSearchResultRow` over the same view, and `TaggedLibraryViewEntry` extends the view entry type.

Non-nullable is deliberate — catalog search inner-joins `library`, so every row it can return has an artist behind it.

## Tests

`tests/unit/services/library-search.artist-id.test.ts` covers a direct hit, an alias-only hit (a different SQL path, and the one most likely to be missed), and a Various Artists compilation row, which must return the shared compilation artist id rather than null.

## Scope

`api.yaml` is deliberately untouched. The SSOT declaration of this field is WXYC/wxyc-shared#383 — the two are independent, since Backend-Service defines `AlbumSearchResultRow` locally and `apps/backend/app.yaml` is Swagger-UI display only. Both must land, and the package must publish, before dj-site can consume the field.

Downstream consumers gate on this being **deployed** to api.wxyc.org, not on this merging.

Closes #2227
