### PR TITLE
chore: reformat the CLAUDE.md route table so the whole-repo prettier check passes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,18 +76,18 @@ npm workspaces:
 
 Express 5 application with these route groups:
 
-| Route           | Purpose                                                    |
-| --------------- | ---------------------------------------------------------- |
-| `/config`       | Public app bootstrap configuration                         |
-| `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit)          |
-| `/library`      | Music library catalog                                      |
-| `/flowsheet`    | Flowsheet — serves both the V1 shape and the V2 projection (see below) |
-| `/djs`          | DJ bin and playlists                                       |
-| `/request`      | Song request line                                          |
-| `/schedule`     | Schedule management                                        |
-| `/events`       | SSE for real-time updates                                  |
-| `/healthcheck`  | Health check                                               |
-| `/internal`     | Internal endpoints (ETL notifications, tubafrenzy webhook) |
+| Route          | Purpose                                                                |
+| -------------- | ---------------------------------------------------------------------- |
+| `/config`      | Public app bootstrap configuration                                     |
+| `/proxy`       | iOS proxy endpoints (anonymous auth + rate limit)                      |
+| `/library`     | Music library catalog                                                  |
+| `/flowsheet`   | Flowsheet — serves both the V1 shape and the V2 projection (see below) |
+| `/djs`         | DJ bin and playlists                                                   |
+| `/request`     | Song request line                                                      |
+| `/schedule`    | Schedule management                                                    |
+| `/events`      | SSE for real-time updates                                              |
+| `/healthcheck` | Health check                                                           |
+| `/internal`    | Internal endpoints (ETL notifications, tubafrenzy webhook)             |
 
 **There is no `/v2/flowsheet` route, and this table used to claim there was.** `app.ts` mounts no `/v2` router; `projectEntriesV2` (`utils/album-metadata-projection.ts`) is called by `getEntries`, the handler mounted at plain `GET /flowsheet`, so **the V2 discriminated-union shape ships on the V1 path**. Three source comments still name `/v2/flowsheet` as though it were mounted (`utils/album-metadata-projection.ts:5`, `services/flowsheet.service.ts:392`, `services/playlist-proxy.service.ts:451`) — read those as naming the projection, not a route. `api.wxyc.org/v2/flowsheet` returns 404 with an HTML `Cannot GET` body, and always has.
 


### PR DESCRIPTION
`CLAUDE.md` has been failing `prettier --check` on `main`, and it is currently reddening an unrelated PR.

## What broke

[`15ecc98a`](https://github.com/WXYC/Backend-Service/commit/15ecc98a) rewrote the route table — dropped the `/v2/flowsheet` row, and gave `/flowsheet` a much longer description. The new cell is wider than the padding on every other row, so prettier wants the table realigned. `CLAUDE.md` was prettier-clean at `15ecc98a~1`; it has not been since.

## Why CI stayed green on main

A paths filter meeting a whole-repo linter.

`lint-and-typecheck` runs only `if: needs.detect-changes.outputs.src == 'true'`, and the `src` filter is:

```yaml
src:
  - 'apps/**'
  - 'jobs/**'
  - 'shared/**'
  - 'tests/**'
```

`CLAUDE.md` is in none of them, so a docs-only change **skips the job that would have caught it**. But when that job does run — on any PR touching code — its formatting step is `prettier --cache --check .`, which scans the **entire repository**, doc files included.

The result is asymmetric in the worst way: a docs-only commit plants a failure it cannot itself trip, and the next code PR inherits a red check it had nothing to do with. WXYC/Backend-Service#2228 is the PR that tripped it here — its own diff is two files under `apps/` and `tests/`, neither of them this one.

## The change

Pure whitespace: 12 lines of markdown table padding. No prose, no links, no rows added or removed.

Verified with `npm run format:check` over the whole repo: *All matched files use Prettier code style!*

## Not fixed here

The filter asymmetry itself — that `format:check` covers paths the job's own trigger ignores — is the underlying defect, and it will re-fire the next time a doc changes alone. Worth either narrowing the formatting step to the filtered paths or widening the filter to cover what prettier actually checks. Left out of this PR deliberately so the unblock stays a one-line-per-row whitespace diff.
