### PR TITLE
feat(flowsheet): operator close for an abandoned show (#2235)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1032,6 +1032,124 @@ paths:
                   - $ref: '#/components/schemas/ShowDJ'
                     description: 'Show joined'
 
+  /flowsheet/open-shows:
+    get:
+      summary: List open shows an operator may need to close (BS#2235)
+      description: >
+        Shows with `end_time IS NULL` that started inside the lookback window,
+        oldest first, with flowsheet entry counts. Requires the
+        `flowsheet: manage` permission (musicDirector / stationManager).
+        Replaces tubafrenzy's "Resume a Show" list, which retires 2026-08-31.
+        The window matters: `end_time IS NULL` is not a reliable "on the air"
+        signal, and production's open shows reach back to 2006 — see
+        `getOpenShows` in apps/backend/services/flowsheet.service.ts.
+      parameters:
+        - name: window_hours
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 262800
+            default: 168
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+      responses:
+        '200':
+          description: Open shows inside the window, oldest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  shows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        primary_dj_id:
+                          type: string
+                          nullable: true
+                        dj_name:
+                          type: string
+                          nullable: true
+                        show_name:
+                          type: string
+                          nullable: true
+                        start_time:
+                          type: string
+                          format: date-time
+                        legacy_show_id:
+                          type: integer
+                          nullable: true
+                        entry_count:
+                          type: integer
+                        is_current:
+                          type: boolean
+                          description: The show every on-air read resolves to. Never offer to close it.
+                        likely_abandoned:
+                          type: boolean
+                          description: Advisory only — not current, and fewer than four entries.
+                  total_in_window:
+                    type: integer
+                    description: Total before `limit` truncates; the only signal a page is partial.
+                  older_open_show_count:
+                    type: integer
+                    description: Open shows older than the window. Counted, never listed.
+        '400':
+          description: 'window_hours or limit was not an integer in range'
+        '403':
+          description: 'Caller lacks the `flowsheet: manage` permission'
+
+  /flowsheet/shows/{id}/force-end:
+    post:
+      summary: End a show the caller does not own (BS#2235)
+      description: >
+        Closes an abandoned show, reusing the same `endShow` implementation as
+        `POST /flowsheet/end` — same `show_end` marker, same `show_djs`
+        deactivation, same tubafrenzy sign-off. `end_time` and the marker's
+        `add_time` come from the show's last logged entry, NOT from now(): a
+        show from the legacy backlog stamped now() would overlap every
+        `GET /flowsheet/range` window since it started and sort to the top of
+        the public flowsheet. Requires the `flowsheet: manage` permission.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Backend-Service `shows.id`, not the tubafrenzy `legacy_show_id`.
+          schema:
+            type: integer
+        - name: force
+          in: query
+          required: false
+          description: >
+            Set to `true` to close the show that is currently on air. Without
+            it, targeting `max(shows.id)` is a 409. The override exists because
+            an abandoned show IS the current show until something closes it —
+            the 2026-08-20 incident is exactly that case.
+          schema:
+            type: string
+            enum: ['true']
+      responses:
+        '200':
+          description: The finalized show, with `end_time` set
+        '400':
+          description: The id was not a positive integer, or the show is already ended
+        '403':
+          description: 'Caller lacks the `flowsheet: manage` permission'
+        '404':
+          description: No show with that id
+        '409':
+          description: The target is the current on-air show and `force=true` was not sent
+
   /flowsheet/djs-on-air:
     get:
       summary: Get list of DJs currently on air

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -934,20 +934,6 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
 };
 
 /**
- * `GET /flowsheet/open-shows` — every open show an operator might need to
- * close, oldest first (BS#2235).
- *
- * Gated to `flowsheet: ['manage']` (musicDirector / stationManager) on the
- * route. That is deliberately NARROWER than the capability it replaces:
- * tubafrenzy's `EndShowServlet` takes the show as a request parameter and
- * checks nothing about who is asking, so any signed-on DJ can end anyone's
- * recent show through the signon page's "Resume a Show" list. tubafrenzy
- * retires 2026-08-31 and takes that path with it.
- *
- * `window_hours` bounds the lookback; see `getOpenShows` for why an unwindowed
- * list is unusable in production.
- */
-/**
  * Parse a bounded positive-integer query parameter.
  *
  * Rejects anything that isn't a bare integer rather than letting `parseInt`'s
@@ -967,6 +953,20 @@ const parseBoundedInt = (raw: string | undefined, name: string, fallback: number
   return value;
 };
 
+/**
+ * `GET /flowsheet/open-shows` — every open show an operator might need to
+ * close, oldest first (BS#2235).
+ *
+ * Gated to `flowsheet: ['manage']` (musicDirector / stationManager) on the
+ * route. That is deliberately NARROWER than the capability it replaces:
+ * tubafrenzy's `EndShowServlet` takes the show as a request parameter and
+ * checks nothing about who is asking, so any signed-on DJ can end anyone's
+ * recent show through the signon page's "Resume a Show" list. tubafrenzy
+ * retires 2026-08-31 and takes that path with it.
+ *
+ * `window_hours` bounds the lookback; see `getOpenShows` for why an unwindowed
+ * list is unusable in production.
+ */
 export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hours?: string; limit?: string }> = async (
   req,
   res
@@ -1029,20 +1029,21 @@ export const forceEndShow: RequestHandler<{ id: string }, unknown, unknown, { fo
   // listing exists so a UI can warn; this is the server-side half of the same
   // signal, so a client that never implements the warning still can't do it by
   // accident.
-  if (req.query.force !== 'true') {
-    const latestShow = await flowsheet_service.getLatestShow();
-    if (latestShow?.id === showId) {
+  //
+  // The terminal-marker carve-out matches `getOpenShows`'s `is_current`
+  // exactly: a show whose `show_end` marker landed but whose `end_time` was
+  // never stamped (the lost-webhook cohort BS#2065 detects) holds
+  // `max(shows.id)` while being demonstrably over, and must not be gated.
+  if (req.query.force !== 'true' && showId === (await flowsheet_service.getLatestShow())?.id) {
+    if (!(await flowsheet_service.isLatestEntryShowEnd(showId))) {
       throw new WxycError('Conflict: this is the current on-air show. Re-send with ?force=true to end it anyway.', 409);
     }
   }
 
-  // The instant the show actually stopped, not `now()`. See
-  // `EndShowOptions` in flowsheet.service — a show from the legacy backlog
-  // stamped `end_time = now()` overlaps every archive day since it started,
-  // and its `show_end` marker sorts to the top of the live flowsheet.
+  // The instant the show actually stopped, not `now()` — see `endShow`.
   const endedAt = await flowsheet_service.resolveShowEndInstant(show);
 
-  const finalizedShow: Show = await flowsheet_service.endShow(show, { endedAt });
+  const finalizedShow: Show = await flowsheet_service.endShow(show, endedAt);
   res.status(200).json(finalizedShow);
 };
 

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -947,28 +947,44 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
  * `window_hours` bounds the lookback; see `getOpenShows` for why an unwindowed
  * list is unusable in production.
  */
-export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hours?: string }> = async (req, res) => {
-  const raw = req.query.window_hours;
-  let windowHours = flowsheet_service.OPEN_SHOWS_DEFAULT_WINDOW_HOURS;
-
-  if (raw !== undefined) {
-    // Reject anything that isn't a bare positive integer rather than letting
-    // parseInt's prefix parsing turn "24h" into 24 — an operator who mistypes
-    // the unit should learn that, not silently get a different window than
-    // they asked for.
-    if (!/^\d+$/.test(raw)) {
-      throw new WxycError('Bad Request: window_hours must be a positive integer number of hours', 400);
-    }
-    windowHours = Number.parseInt(raw, 10);
-    if (windowHours < 1 || windowHours > flowsheet_service.OPEN_SHOWS_MAX_WINDOW_HOURS) {
-      throw new WxycError(
-        `Bad Request: window_hours must be between 1 and ${flowsheet_service.OPEN_SHOWS_MAX_WINDOW_HOURS}`,
-        400
-      );
-    }
+/**
+ * Parse a bounded positive-integer query parameter.
+ *
+ * Rejects anything that isn't a bare integer rather than letting `parseInt`'s
+ * prefix parsing turn `"24h"` into `24` — an operator who mistypes the unit
+ * should learn that, not silently get a different window than they asked for.
+ * Out-of-range is a 400 too, never a silent clamp, for the same reason.
+ */
+const parseBoundedInt = (raw: string | undefined, name: string, fallback: number, max: number): number => {
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new WxycError(`Bad Request: ${name} must be a positive integer`, 400);
   }
+  const value = Number.parseInt(raw, 10);
+  if (value < 1 || value > max) {
+    throw new WxycError(`Bad Request: ${name} must be between 1 and ${max}`, 400);
+  }
+  return value;
+};
 
-  res.status(200).json(await flowsheet_service.getOpenShows(windowHours));
+export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hours?: string; limit?: string }> = async (
+  req,
+  res
+) => {
+  const windowHours = parseBoundedInt(
+    req.query.window_hours,
+    'window_hours',
+    flowsheet_service.OPEN_SHOWS_DEFAULT_WINDOW_HOURS,
+    flowsheet_service.OPEN_SHOWS_MAX_WINDOW_HOURS
+  );
+  const limit = parseBoundedInt(
+    req.query.limit,
+    'limit',
+    flowsheet_service.OPEN_SHOWS_DEFAULT_LIMIT,
+    flowsheet_service.OPEN_SHOWS_MAX_LIMIT
+  );
+
+  res.status(200).json(await flowsheet_service.getOpenShows(windowHours, limit));
 };
 
 /**
@@ -987,7 +1003,7 @@ export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hou
  * force-end therefore cannot write a duplicate marker even if two operators
  * click at the same instant.
  */
-export const forceEndShow: RequestHandler<{ id: string }> = async (req, res) => {
+export const forceEndShow: RequestHandler<{ id: string }, unknown, unknown, { force?: string }> = async (req, res) => {
   if (!/^\d+$/.test(req.params.id)) {
     throw new WxycError('Bad Request: show id must be a positive integer', 400);
   }
@@ -1001,7 +1017,32 @@ export const forceEndShow: RequestHandler<{ id: string }> = async (req, res) => 
     throw new WxycError('Bad Request: show is already ended', 400);
   }
 
-  const finalizedShow: Show = await flowsheet_service.endShow(show);
+  // Closing the show every on-air read resolves to needs `?force=true`.
+  //
+  // NOT a blanket refusal, and the 2026-08-20 incident is why: the show that
+  // hung for nine hours WAS `max(shows.id)` the whole time — an abandoned show
+  // is current until something closes it, so an unconditional guard would veto
+  // the exact case this endpoint was built for. The confirmation is aimed at
+  // the other failure: a mistyped id, or an operator acting on a list fetched
+  // before a new show started, silently ending a live broadcast (after which
+  // `POST /flowsheet` starts failing for the DJ on air). `is_current` on the
+  // listing exists so a UI can warn; this is the server-side half of the same
+  // signal, so a client that never implements the warning still can't do it by
+  // accident.
+  if (req.query.force !== 'true') {
+    const latestShow = await flowsheet_service.getLatestShow();
+    if (latestShow?.id === showId) {
+      throw new WxycError('Conflict: this is the current on-air show. Re-send with ?force=true to end it anyway.', 409);
+    }
+  }
+
+  // The instant the show actually stopped, not `now()`. See
+  // `EndShowOptions` in flowsheet.service — a show from the legacy backlog
+  // stamped `end_time = now()` overlaps every archive day since it started,
+  // and its `show_end` marker sorts to the top of the live flowsheet.
+  const endedAt = await flowsheet_service.resolveShowEndInstant(show);
+
+  const finalizedShow: Show = await flowsheet_service.endShow(show, { endedAt });
   res.status(200).json(finalizedShow);
 };
 

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -933,6 +933,78 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
   }
 };
 
+/**
+ * `GET /flowsheet/open-shows` — every open show an operator might need to
+ * close, oldest first (BS#2235).
+ *
+ * Gated to `flowsheet: ['manage']` (musicDirector / stationManager) on the
+ * route. That is deliberately NARROWER than the capability it replaces:
+ * tubafrenzy's `EndShowServlet` takes the show as a request parameter and
+ * checks nothing about who is asking, so any signed-on DJ can end anyone's
+ * recent show through the signon page's "Resume a Show" list. tubafrenzy
+ * retires 2026-08-31 and takes that path with it.
+ *
+ * `window_hours` bounds the lookback; see `getOpenShows` for why an unwindowed
+ * list is unusable in production.
+ */
+export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hours?: string }> = async (req, res) => {
+  const raw = req.query.window_hours;
+  let windowHours = flowsheet_service.OPEN_SHOWS_DEFAULT_WINDOW_HOURS;
+
+  if (raw !== undefined) {
+    // Reject anything that isn't a bare positive integer rather than letting
+    // parseInt's prefix parsing turn "24h" into 24 — an operator who mistypes
+    // the unit should learn that, not silently get a different window than
+    // they asked for.
+    if (!/^\d+$/.test(raw)) {
+      throw new WxycError('Bad Request: window_hours must be a positive integer number of hours', 400);
+    }
+    windowHours = Number.parseInt(raw, 10);
+    if (windowHours < 1 || windowHours > flowsheet_service.OPEN_SHOWS_MAX_WINDOW_HOURS) {
+      throw new WxycError(
+        `Bad Request: window_hours must be between 1 and ${flowsheet_service.OPEN_SHOWS_MAX_WINDOW_HOURS}`,
+        400
+      );
+    }
+  }
+
+  res.status(200).json(await flowsheet_service.getOpenShows(windowHours));
+};
+
+/**
+ * `POST /flowsheet/shows/:id/force-end` — close a show the caller does not
+ * own (BS#2235).
+ *
+ * Reuses `endShow` rather than reimplementing the close, so the `show_end`
+ * marker, the `show_djs` deactivation, the co-host leave markers and the
+ * tubafrenzy sign-off follow one implementation and cannot drift from
+ * `POST /flowsheet/end`. It is the same call the 2026-08-20 manual
+ * remediation script made (BS#2232).
+ *
+ * The already-closed case is left to `endShow`'s compare-and-set on
+ * `end_time IS NULL`, which raises the same 400 — the explicit check below is
+ * only a fast path that avoids a wasted UPDATE, not the guard. A second
+ * force-end therefore cannot write a duplicate marker even if two operators
+ * click at the same instant.
+ */
+export const forceEndShow: RequestHandler<{ id: string }> = async (req, res) => {
+  if (!/^\d+$/.test(req.params.id)) {
+    throw new WxycError('Bad Request: show id must be a positive integer', 400);
+  }
+  const showId = Number.parseInt(req.params.id, 10);
+
+  const show = await flowsheet_service.getShowById(showId);
+  if (!show) {
+    throw new WxycError('Not Found: no show with that id', 404);
+  }
+  if (show.end_time !== null) {
+    throw new WxycError('Bad Request: show is already ended', 400);
+  }
+
+  const finalizedShow: Show = await flowsheet_service.endShow(show);
+  res.status(200).json(finalizedShow);
+};
+
 export const getDJList: RequestHandler = async (req, res) => {
   // getOnAirDJs preserves the account-DJ shape ({ id, dj_name }) and additionally
   // surfaces legacy/tubafrenzy-mirrored shows (null id, legacy_dj_name) that the

--- a/apps/backend/routes/flowsheet.route.ts
+++ b/apps/backend/routes/flowsheet.route.ts
@@ -92,6 +92,33 @@ flowsheet_route.post(
   flowsheetController.leaveShow
 );
 
+// Operator close for an abandoned show (BS#2235) — the Backend-Service
+// replacement for tubafrenzy's `EndShowServlet` + "Resume a Show", which
+// retires with tubafrenzy on 2026-08-31.
+//
+// `flowsheet: ['manage']` is the only gate in this router above `write`: it
+// selects musicDirector and stationManager, excluding the plain `dj` role that
+// every other write route here admits. See `shared/authentication/src/auth.roles.ts`.
+//
+// Placed above `get('/:something')`-shaped routes purely by convention — this
+// router declares no parameterized GET that could shadow `/open-shows`.
+flowsheet_route.get('/open-shows', requirePermissions({ flowsheet: ['manage'] }), flowsheetController.getOpenShows);
+
+// `flowsheetMirror.endShow` is chained exactly as it is on `POST /flowsheet/end`:
+// the controller responds with the finalized `Show`, the response tap stashes it
+// as `res.locals.mirrorData`, and the tap's `isShowPayload` guard admits it — so
+// an operator close signs the show off in tubafrenzy and writes its END_OF_SHOW
+// entry through the same path a DJ's own sign-off does.
+//
+// No `showMemberMiddleware`: the entire point is to act on a show the caller is
+// not a member of.
+flowsheet_route.post(
+  '/shows/:id/force-end',
+  requirePermissions({ flowsheet: ['manage'] }),
+  flowsheetMirror.endShow,
+  flowsheetController.forceEndShow
+);
+
 flowsheet_route.get('/djs-on-air', flowsheetController.getDJList);
 
 flowsheet_route.get('/on-air', flowsheetController.getOnAir);

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1111,9 +1111,43 @@ const createJoinNotification = async (id: string, show_id: number): Promise<FSEn
   return notification[0];
 };
 
-export const endShow = async (currentShow: Show): Promise<Show> => {
+/**
+ * Options for `endShow`.
+ *
+ * `endedAt` exists because "the show ended" and "right now" are the same
+ * instant only on the live sign-off path. `POST /flowsheet/shows/:id/force-end`
+ * (BS#2235) closes shows that stopped broadcasting long ago — production's open
+ * backlog reaches back to 2006 — and stamping `now()` on one of those is not a
+ * cosmetic inaccuracy. Two public reads consume these timestamps:
+ *
+ *   1. `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
+ *      archive.wxyc.org reads) admits a closed show when
+ *      `start_time < windowEnd AND end_time > windowStart`. A show stamped
+ *      `start_time = 2006, end_time = now` satisfies that for EVERY day in
+ *      between, so closing the backlog would inject bogus multi-decade shows
+ *      into every archive page.
+ *   2. `getEntriesByPage` orders globally by `add_time DESC, id DESC` and
+ *      serves both `GET /flowsheet` page 0 and `GET /flowsheet/latest`. A
+ *      `show_end` marker written with `add_time = now()` for a 2006 show
+ *      becomes the newest entry on the public flowsheet.
+ *
+ * So the operator path passes the instant the show actually stopped, derived
+ * from its last logged entry (`resolveShowEndInstant`). The live path passes
+ * nothing and keeps `new Date()` — byte-identical to the pre-BS#2235 behavior.
+ */
+export type EndShowOptions = {
+  /** When the show actually stopped. Defaults to now (the live sign-off case). */
+  endedAt?: Date;
+};
+
+export const endShow = async (currentShow: Show, options: EndShowOptions = {}): Promise<Show> => {
   //Add leave notification for all remaining guest djs;
   //Update their active state and set show end time.
+
+  // One instant for the `end_time` column, the `show_end` marker's `add_time`,
+  // its rendered message, and every co-host `dj_leave` marker — so a closed
+  // show cannot disagree with its own markers about when it ended.
+  const endedAt = options.endedAt ?? new Date();
 
   // A NULL `primary_dj_id` no longer aborts the close (BS#2093, decided by
   // BS#2235). It used to `throw new Error('Primary DJ not found')`, which made
@@ -1153,7 +1187,7 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   //      the show first makes that add fail its own guard.
   const finalized = await db
     .update(shows)
-    .set({ end_time: new Date() })
+    .set({ end_time: endedAt })
     .where(and(eq(shows.id, currentShow.id), isNull(shows.end_time)))
     .returning();
 
@@ -1175,23 +1209,40 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
         .set({ active: false })
         .where(and(eq(show_djs.show_id, currentShow.id), eq(show_djs.dj_id, dj.dj_id)));
       if (dj.dj_id === primary_dj_id) return;
-      await createLeaveNotification(dj.dj_id, currentShow.id);
+      await createLeaveNotification(dj.dj_id, currentShow.id, endedAt);
     })
   );
 
-  const dj_information = primary_dj_id
-    ? (await db.select().from(user).where(eq(user.id, primary_dj_id)).limit(1))[0]
-    : undefined;
-  const display_dj_name = resolveDjDisplayName(dj_information?.djName ?? null);
-  const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
+  // Resolved through the SHARED chain (`dj_name_override` -> the linked
+  // account's handle -> `legacy_dj_name`), not the bare `auth_user.dj_name`
+  // read this used to do. Two things that read fixed:
+  //
+  //   - A show carrying a `dj_name_override` (BS#1321) put the override on its
+  //     `show_start` marker and on every track row, then reverted to
+  //     `auth_user.dj_name` here — the one within-show inconsistency BS#1321
+  //     set out to remove, left behind on the closing marker.
+  //   - A show with a NULL `primary_dj_id` has no user row to read at all, so
+  //     the old form resolved `null` for the ENTIRE legacy cohort (2,813 of
+  //     production's 2,814 open shows on 2026-08-21) and wrote a nameless
+  //     `End of show:` marker among sibling rows that do carry the handle.
+  //
+  // Still PII-safe by construction: `auth_user.name` is not an input to the
+  // chain (see `resolveShowDjName`).
+  const display_dj_name = await resolveDjNameForShow(currentShow);
+  const endedAtLocal = endedAt.toLocaleString('en-US', { timeZone: 'America/New_York' });
   // Symmetric to startShow: keep the row, degrade the wording to bare
   // "End of show: ${time}" when the name is unresolvable (epic #1288).
-  const message = display_dj_name ? `End of Show: ${display_dj_name} left the set at ${now}` : `End of show: ${now}`;
+  const message = display_dj_name
+    ? `End of Show: ${display_dj_name} left the set at ${endedAtLocal}`
+    : `End of show: ${endedAtLocal}`;
 
   await db.insert(flowsheet).values({
     show_id: currentShow.id,
     entry_type: 'show_end',
     dj_name: display_dj_name,
+    // Explicit, not the `defaultNow()`. See EndShowOptions: this column is the
+    // public flowsheet's global sort key.
+    add_time: endedAt,
     play_order: await nextPlayOrder(currentShow.id),
     message,
   });
@@ -1226,7 +1277,7 @@ export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowD
   return update_result;
 };
 
-const createLeaveNotification = async (dj_id: string, show_id: number): Promise<FSEntry | null> => {
+const createLeaveNotification = async (dj_id: string, show_id: number, addTime?: Date): Promise<FSEntry | null> => {
   const dj = (await db.select().from(user).where(eq(user.id, dj_id)).limit(1))[0];
 
   const display_dj_name = resolveDjDisplayName(dj?.djName ?? null);
@@ -1248,6 +1299,11 @@ const createLeaveNotification = async (dj_id: string, show_id: number): Promise<
       show_id: show_id,
       entry_type: 'dj_leave',
       dj_name: display_dj_name,
+      // Omitted on the live path so the `defaultNow()` applies, exactly as
+      // before; supplied by `endShow`'s operator path so a co-host's leave
+      // marker lands with the show it belongs to rather than at the top of
+      // today's flowsheet (see EndShowOptions).
+      ...(addTime ? { add_time: addTime } : {}),
       play_order: await nextPlayOrder(show_id),
       message: `${display_dj_name} left the set!`,
     })
@@ -1281,8 +1337,24 @@ export const LIKELY_ABANDONED_ENTRY_THRESHOLD = 4;
 /** Default lookback for `GET /flowsheet/open-shows`, in hours (7 days). */
 export const OPEN_SHOWS_DEFAULT_WINDOW_HOURS = 168;
 
-/** Hard ceiling on the caller-supplied lookback, in hours (1 year). */
-export const OPEN_SHOWS_MAX_WINDOW_HOURS = 8760;
+/**
+ * Hard ceiling on the caller-supplied lookback, in hours — 30 years.
+ *
+ * Sized to REACH the tail, not to fence it off. The first cut was 8,760 (one
+ * year), which made `older_open_show_count` a number describing rows no legal
+ * request could ever list: production's open shows start in 2006. A count an
+ * operator cannot act on is worse than no count. The ceiling is kept only so
+ * the parameter has a bound at all; what actually bounds the response is
+ * `limit`, and the partial index on `(start_time) WHERE end_time IS NULL`
+ * makes the widest scan cheap (2,814 qualifying rows of 72,736 on 2026-08-21).
+ */
+export const OPEN_SHOWS_MAX_WINDOW_HOURS = 262_800;
+
+/** Rows returned per request when the caller does not say. */
+export const OPEN_SHOWS_DEFAULT_LIMIT = 100;
+
+/** Hard ceiling on `limit`. */
+export const OPEN_SHOWS_MAX_LIMIT = 500;
 
 export type OpenShow = {
   id: number;
@@ -1299,6 +1371,13 @@ export type OpenShow = {
 
 export type OpenShowsResult = {
   shows: OpenShow[];
+  /**
+   * How many open shows the window holds in total, before `limit` truncates.
+   * `shows.length < total_in_window` is the only way a caller can tell it is
+   * looking at a partial answer — without it, a truncated page is
+   * indistinguishable from a complete one.
+   */
+  total_in_window: number;
   /**
    * Open shows that started before the window. Reported as a count, never a
    * list — see `getOpenShows`.
@@ -1327,7 +1406,7 @@ export type OpenShowsResult = {
  * does hold here, but spelling it out keeps the statement portable to a plain
  * `GROUP BY` reader and survives a future `LEFT JOIN` that widens the select.
  */
-export const buildOpenShowsQuery = (windowFloor: Date) =>
+export const buildOpenShowsQuery = (windowFloor: Date, limit: number = OPEN_SHOWS_DEFAULT_LIMIT) =>
   db
     .select({
       id: shows.id,
@@ -1360,7 +1439,8 @@ export const buildOpenShowsQuery = (windowFloor: Date) =>
     // close. `id` is a deterministic tie-break for the second-granularity
     // collisions the legacy ETL produces (see the 00:55:35/00:55:41 pairs in
     // production's open-show tail).
-    .orderBy(asc(shows.start_time), asc(shows.id));
+    .orderBy(asc(shows.start_time), asc(shows.id))
+    .limit(limit);
 
 /**
  * Every open show that started within `windowHours`, oldest first, plus a
@@ -1377,11 +1457,15 @@ export const buildOpenShowsQuery = (windowFloor: Date) =>
  * reported as `older_open_show_count` so an operator can see it exists, and
  * reached by widening `window_hours` when they actually want it.
  *
- * The count is a second statement. The "one grouped query" constraint is
- * about not re-introducing the per-show entry-count N+1; a single scalar
- * aggregate over an indexed predicate is not that.
+ * The two counts and the `getLatestShow` pivot are separate statements. The
+ * "one grouped query" constraint is about not re-introducing the per-show
+ * entry-count N+1 — a scalar aggregate over the same indexed predicate is not
+ * that, and all four run concurrently.
  */
-export const getOpenShows = async (windowHours: number = OPEN_SHOWS_DEFAULT_WINDOW_HOURS): Promise<OpenShowsResult> => {
+export const getOpenShows = async (
+  windowHours: number = OPEN_SHOWS_DEFAULT_WINDOW_HOURS,
+  limit: number = OPEN_SHOWS_DEFAULT_LIMIT
+): Promise<OpenShowsResult> => {
   const windowFloor = new Date(Date.now() - windowHours * 60 * 60 * 1000);
 
   // `is_current` is resolved against the same `max(shows.id)` pivot every
@@ -1389,8 +1473,12 @@ export const getOpenShows = async (windowHours: number = OPEN_SHOWS_DEFAULT_WIND
   // never disagree about which show is live. It matters for the abandoned
   // flag: a show that just signed on legitimately has fewer than four
   // entries, and must not be presented as a close candidate.
-  const [rows, olderCount, latestShow] = await Promise.all([
-    buildOpenShowsQuery(windowFloor),
+  const [rows, windowCount, olderCount, latestShow] = await Promise.all([
+    buildOpenShowsQuery(windowFloor, limit),
+    db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(shows)
+      .where(and(isNull(shows.end_time), gte(shows.start_time, windowFloor))),
     db
       .select({ n: sql<number>`count(*)::int` })
       .from(shows)
@@ -1420,8 +1508,45 @@ export const getOpenShows = async (windowHours: number = OPEN_SHOWS_DEFAULT_WIND
         likely_abandoned: !is_current && row.entry_count < LIKELY_ABANDONED_ENTRY_THRESHOLD,
       };
     }),
+    total_in_window: windowCount[0]?.n ?? 0,
     older_open_show_count: olderCount[0]?.n ?? 0,
   };
+};
+
+/**
+ * When a show actually stopped broadcasting: its latest flowsheet `add_time`,
+ * floored at `start_time`, falling back to `start_time` when it logged nothing.
+ *
+ * This is the instant `POST /flowsheet/shows/:id/force-end` hands `endShow`,
+ * and the reason that parameter exists at all — see `EndShowOptions` for what
+ * `now()` does to `GET /flowsheet/range` and to the public flowsheet's global
+ * sort when the show being closed is from 2006.
+ *
+ * `MAX(add_time)`, deliberately NOT `lastLoggedShowEntryOrderBy`'s "add_time of
+ * the highest-id row". The two answer different questions and this one wants
+ * AIRTIME: `flowsheet.id` is insertion order, so a backfilled or gap-imported
+ * row (BS#2118, BS#2119) holds the highest id while carrying the `add_time` of
+ * whenever it really aired. The control-flow gates that ask "is this show's
+ * last row the sign-off marker?" correctly use insertion order; "when did this
+ * stop" is the display-surface question BS#2132/#2133 moved to airtime.
+ *
+ * Floored at `start_time` because a closed show with `end_time < start_time` is
+ * an interval that cannot overlap anything, which would make it invisible to
+ * `getShowsInTimeWindow` on the very day it aired. Legacy rows carrying an
+ * `add_time` earlier than their show's `start_time` are not hypothetical — the
+ * webhook derives `add_time` from tubafrenzy's `startTime` when that parses
+ * (BS#2143), against a `shows.start_time` the ETL set separately.
+ */
+export const resolveShowEndInstant = async (show: Show): Promise<Date> => {
+  const rows = await db
+    .select({ latest: sql<Date | null>`max(${flowsheet.add_time})` })
+    .from(flowsheet)
+    .where(eq(flowsheet.show_id, show.id));
+
+  const latest = rows[0]?.latest ? new Date(rows[0].latest) : null;
+  const startedAt = new Date(show.start_time);
+
+  return latest && latest.getTime() > startedAt.getTime() ? latest : startedAt;
 };
 
 /** One show by primary key, for the operator-close path's existence check. */

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1115,8 +1115,23 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   //Add leave notification for all remaining guest djs;
   //Update their active state and set show end time.
 
+  // A NULL `primary_dj_id` no longer aborts the close (BS#2093, decided by
+  // BS#2235). It used to `throw new Error('Primary DJ not found')`, which made
+  // such a show permanently un-endable: `shows.primary_dj_id` is
+  // `onDelete: 'set null'`, so deleting a DJ's account orphans every show they
+  // ran, and the entire legacy ETL cohort (2,813 of production's 2,814 open
+  // shows as of 2026-08-21) carries NULL here by construction — those shows
+  // are exactly the ones the operator-close endpoint exists to reach.
+  //
+  // Nothing below actually needs the id: the `show_djs` deactivation already
+  // skips only the primary (a NULL one matches no row, so every membership
+  // deactivates and every co-host gets a leave marker, which is correct for an
+  // ownerless show), and the `show_end` marker already has a degraded
+  // no-name wording for an unresolvable DJ. `POST /flowsheet/end` cannot
+  // observe the change: it reaches here only when `req.body.dj_id ===
+  // currentShow.primary_dj_id`, and `dj_id` is cross-checked against
+  // `req.auth.id`, so the primary is non-null on that path by construction.
   const primary_dj_id = currentShow.primary_dj_id;
-  if (!primary_dj_id) throw new Error('Primary DJ not found');
 
   // Claim the show FIRST, before any other write.
   //
@@ -1164,7 +1179,9 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
     })
   );
 
-  const dj_information = (await db.select().from(user).where(eq(user.id, primary_dj_id)).limit(1))[0];
+  const dj_information = primary_dj_id
+    ? (await db.select().from(user).where(eq(user.id, primary_dj_id)).limit(1))[0]
+    : undefined;
   const display_dj_name = resolveDjDisplayName(dj_information?.djName ?? null);
   const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
   // Symmetric to startShow: keep the row, degrade the wording to bare
@@ -1250,6 +1267,166 @@ export const getNShows = async (numberOfShows: number = 1, page: number = 0): Pr
 
 export const getLatestShow = async (): Promise<Show | undefined> => {
   return (await getNShows(1))[0];
+};
+
+/**
+ * Operator close for abandoned shows (BS#2235). Backs
+ * `GET /flowsheet/open-shows`, the replacement for tubafrenzy's
+ * `EndShowServlet` + "Resume a Show" path, which retires 2026-08-31.
+ */
+
+/** Fewer entries than this on a non-current open show reads as abandoned. */
+export const LIKELY_ABANDONED_ENTRY_THRESHOLD = 4;
+
+/** Default lookback for `GET /flowsheet/open-shows`, in hours (7 days). */
+export const OPEN_SHOWS_DEFAULT_WINDOW_HOURS = 168;
+
+/** Hard ceiling on the caller-supplied lookback, in hours (1 year). */
+export const OPEN_SHOWS_MAX_WINDOW_HOURS = 8760;
+
+export type OpenShow = {
+  id: number;
+  primary_dj_id: string | null;
+  dj_name: string | null;
+  show_name: string | null;
+  start_time: Date;
+  legacy_show_id: number | null;
+  entry_count: number;
+  /** True for the show every on-air read resolves to — `max(shows.id)`. */
+  is_current: boolean;
+  likely_abandoned: boolean;
+};
+
+export type OpenShowsResult = {
+  shows: OpenShow[];
+  /**
+   * Open shows that started before the window. Reported as a count, never a
+   * list — see `getOpenShows`.
+   */
+  older_open_show_count: number;
+};
+
+/**
+ * The query behind `GET /flowsheet/open-shows`, exported so a unit test can
+ * render its SQL without a live Postgres.
+ *
+ * ONE grouped `LEFT JOIN … GROUP BY`, deliberately. tubafrenzy's unreachable
+ * `FixRadioShowListServlet` called `getNumberOfEntries` once per show inside
+ * its iteration — an N+1 that is fine over a handful of rows and is not fine
+ * over the population this reads. `flowsheet_show_id_play_order_idx`'s
+ * leading `show_id` column serves the join.
+ *
+ * `user` is LEFT JOINed so the shared `resolveShowDjName` chain runs in JS on
+ * columns fetched once, rather than one `resolveDjNameForShow` query per show
+ * — the same trade `getShowsInTimeWindow` (BS#2062) makes. `user.id` is
+ * selected alongside `djName` because the chain distinguishes "no user row"
+ * from "user row with an unusable djName".
+ *
+ * Grouping lists every non-aggregated column explicitly rather than leaning on
+ * Postgres's functional-dependency inference from `shows.id`: the inference
+ * does hold here, but spelling it out keeps the statement portable to a plain
+ * `GROUP BY` reader and survives a future `LEFT JOIN` that widens the select.
+ */
+export const buildOpenShowsQuery = (windowFloor: Date) =>
+  db
+    .select({
+      id: shows.id,
+      primary_dj_id: shows.primary_dj_id,
+      show_name: shows.show_name,
+      start_time: shows.start_time,
+      legacy_show_id: shows.legacy_show_id,
+      dj_name_override: shows.dj_name_override,
+      legacy_dj_name: shows.legacy_dj_name,
+      user_id: user.id,
+      user_dj_name: user.djName,
+      entry_count: sql<number>`count(${flowsheet.id})::int`,
+    })
+    .from(shows)
+    .leftJoin(user, eq(user.id, shows.primary_dj_id))
+    .leftJoin(flowsheet, eq(flowsheet.show_id, shows.id))
+    .where(and(isNull(shows.end_time), gte(shows.start_time, windowFloor)))
+    .groupBy(
+      shows.id,
+      shows.primary_dj_id,
+      shows.show_name,
+      shows.start_time,
+      shows.legacy_show_id,
+      shows.dj_name_override,
+      shows.legacy_dj_name,
+      user.id,
+      user.djName
+    )
+    // Oldest first: the most-stale show is the one an operator came here to
+    // close. `id` is a deterministic tie-break for the second-granularity
+    // collisions the legacy ETL produces (see the 00:55:35/00:55:41 pairs in
+    // production's open-show tail).
+    .orderBy(asc(shows.start_time), asc(shows.id));
+
+/**
+ * Every open show that started within `windowHours`, oldest first, plus a
+ * count of the older ones.
+ *
+ * **Why there is a window at all.** The ticket's first cut was "every show
+ * with `end_time IS NULL`". Measured against production on 2026-08-21 that is
+ * 2,814 rows, of which exactly ONE started in the last 90 days: 2,813 are
+ * legacy ETL imports whose `show_end` never arrived (`primary_dj_id IS NULL`
+ * for all but one of them), stretching back to 2006. Oldest-first over the
+ * unwindowed set therefore buries the one actionable show under two decades
+ * of orphans — the same reasoning that made `countHistoricalOpenShows` in
+ * `jobs/legacy-mirror-reconcile` count-only rather than list them. The tail is
+ * reported as `older_open_show_count` so an operator can see it exists, and
+ * reached by widening `window_hours` when they actually want it.
+ *
+ * The count is a second statement. The "one grouped query" constraint is
+ * about not re-introducing the per-show entry-count N+1; a single scalar
+ * aggregate over an indexed predicate is not that.
+ */
+export const getOpenShows = async (windowHours: number = OPEN_SHOWS_DEFAULT_WINDOW_HOURS): Promise<OpenShowsResult> => {
+  const windowFloor = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+
+  // `is_current` is resolved against the same `max(shows.id)` pivot every
+  // on-air read uses (`getLatestShow`), so this endpoint and the banner can
+  // never disagree about which show is live. It matters for the abandoned
+  // flag: a show that just signed on legitimately has fewer than four
+  // entries, and must not be presented as a close candidate.
+  const [rows, olderCount, latestShow] = await Promise.all([
+    buildOpenShowsQuery(windowFloor),
+    db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(shows)
+      .where(and(isNull(shows.end_time), lt(shows.start_time, windowFloor))),
+    getLatestShow(),
+  ]);
+
+  const latestShowId = latestShow?.id ?? null;
+
+  return {
+    shows: rows.map((row) => {
+      const is_current = latestShowId !== null && row.id === latestShowId;
+      return {
+        id: row.id,
+        primary_dj_id: row.primary_dj_id ?? null,
+        dj_name: resolveShowDjName({
+          dj_name_override: row.dj_name_override ?? null,
+          legacy_dj_name: row.legacy_dj_name ?? null,
+          primary_dj_id: row.primary_dj_id ?? null,
+          user: row.user_id == null ? null : { djName: row.user_dj_name ?? null },
+        }),
+        show_name: row.show_name ?? null,
+        start_time: row.start_time,
+        legacy_show_id: row.legacy_show_id ?? null,
+        entry_count: row.entry_count,
+        is_current,
+        likely_abandoned: !is_current && row.entry_count < LIKELY_ABANDONED_ENTRY_THRESHOLD,
+      };
+    }),
+    older_open_show_count: olderCount[0]?.n ?? 0,
+  };
+};
+
+/** One show by primary key, for the operator-close path's existence check. */
+export const getShowById = async (show_id: number): Promise<Show | undefined> => {
+  return (await db.select().from(shows).where(eq(shows.id, show_id)).limit(1))[0];
 };
 
 /**

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1111,43 +1111,38 @@ const createJoinNotification = async (id: string, show_id: number): Promise<FSEn
   return notification[0];
 };
 
-/**
- * Options for `endShow`.
- *
- * `endedAt` exists because "the show ended" and "right now" are the same
- * instant only on the live sign-off path. `POST /flowsheet/shows/:id/force-end`
- * (BS#2235) closes shows that stopped broadcasting long ago — production's open
- * backlog reaches back to 2006 — and stamping `now()` on one of those is not a
- * cosmetic inaccuracy. Two public reads consume these timestamps:
- *
- *   1. `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
- *      archive.wxyc.org reads) admits a closed show when
- *      `start_time < windowEnd AND end_time > windowStart`. A show stamped
- *      `start_time = 2006, end_time = now` satisfies that for EVERY day in
- *      between, so closing the backlog would inject bogus multi-decade shows
- *      into every archive page.
- *   2. `getEntriesByPage` orders globally by `add_time DESC, id DESC` and
- *      serves both `GET /flowsheet` page 0 and `GET /flowsheet/latest`. A
- *      `show_end` marker written with `add_time = now()` for a 2006 show
- *      becomes the newest entry on the public flowsheet.
- *
- * So the operator path passes the instant the show actually stopped, derived
- * from its last logged entry (`resolveShowEndInstant`). The live path passes
- * nothing and keeps `new Date()` — byte-identical to the pre-BS#2235 behavior.
- */
-export type EndShowOptions = {
-  /** When the show actually stopped. Defaults to now (the live sign-off case). */
-  endedAt?: Date;
-};
-
-export const endShow = async (currentShow: Show, options: EndShowOptions = {}): Promise<Show> => {
+export const endShow = async (currentShow: Show, endedAt: Date = new Date()): Promise<Show> => {
   //Add leave notification for all remaining guest djs;
   //Update their active state and set show end time.
-
-  // One instant for the `end_time` column, the `show_end` marker's `add_time`,
-  // its rendered message, and every co-host `dj_leave` marker — so a closed
-  // show cannot disagree with its own markers about when it ended.
-  const endedAt = options.endedAt ?? new Date();
+  //
+  // `endedAt` is one instant for the `end_time` column, the `show_end`
+  // marker's `add_time`, its rendered message, and every co-host `dj_leave`
+  // marker — so a closed show cannot disagree with its own markers about when
+  // it ended.
+  //
+  // It is a parameter because "the show ended" and "right now" are the same
+  // instant only on the live sign-off path. `POST /flowsheet/shows/:id/force-end`
+  // (BS#2235) closes shows that stopped broadcasting long ago — production's open
+  // backlog reaches back to 2006 — and stamping `now()` on one of those is not a
+  // cosmetic inaccuracy. Two public reads consume these timestamps:
+  //
+  //   1. `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
+  //      archive.wxyc.org reads) admits a closed show when
+  //      `start_time < windowEnd AND end_time > windowStart`. A show stamped
+  //      `start_time = 2006, end_time = now` satisfies that for EVERY day in
+  //      between, so closing the backlog would inject bogus multi-decade shows
+  //      into every archive page.
+  //   2. `getEntriesByPage` orders globally by `add_time DESC, id DESC` and
+  //      serves both `GET /flowsheet` page 0 and `GET /flowsheet/latest`. A
+  //      `show_end` marker written with `add_time = now()` for a 2006 show
+  //      becomes the newest entry on the public flowsheet.
+  //
+  // The operator path passes the instant the show actually stopped, derived
+  // from its last logged entry (`resolveShowEndInstant`). The live path passes
+  // nothing and keeps `new Date()` — byte-identical to the pre-BS#2235
+  // behavior. Deriving it unconditionally here would be wrong: a DJ signing
+  // off twenty minutes after their last logged track really did stay on the
+  // air for those twenty minutes.
 
   // A NULL `primary_dj_id` no longer aborts the close (BS#2093, decided by
   // BS#2235). It used to `throw new Error('Primary DJ not found')`, which made
@@ -1389,25 +1384,48 @@ export type OpenShowsResult = {
  * The query behind `GET /flowsheet/open-shows`, exported so a unit test can
  * render its SQL without a live Postgres.
  *
- * ONE grouped `LEFT JOIN … GROUP BY`, deliberately. tubafrenzy's unreachable
- * `FixRadioShowListServlet` called `getNumberOfEntries` once per show inside
- * its iteration — an N+1 that is fine over a handful of rows and is not fine
- * over the population this reads. `flowsheet_show_id_play_order_idx`'s
- * leading `show_id` column serves the join.
+ * ONE statement, one round trip — never the per-show count tubafrenzy's
+ * unreachable `FixRadioShowListServlet` made by calling `getNumberOfEntries`
+ * from inside its iteration. That is the invariant; the shape below is how it
+ * is bought.
+ *
+ * **The page is truncated BEFORE anything joins to it.** The first cut wrote
+ * this as a single `LEFT JOIN flowsheet … GROUP BY … LIMIT`, which reads
+ * correctly and behaves badly at exactly the request this endpoint tells
+ * operators to make. `LIMIT` after `GROUP BY` cannot push down: Postgres has
+ * to build every group before it can sort by `(start_time, id)` and truncate.
+ * At the widened window the docstring on `getOpenShows` recommends for
+ * reaching the 2006 tail, that is all 2,814 open shows fanned out across
+ * ~100k `flowsheet` rows — and since neither `flowsheet_show_id_idx` nor
+ * `flowsheet_show_id_play_order_idx` carries `flowsheet.id`, `count(id)`
+ * forces a heap fetch for every one of them, ~4% of a 1.7 GB table in random
+ * order, on a `db.t3.micro` with a 5 s statement timeout — to then discard
+ * 2,714 of the 2,814 groups. Limiting `shows` first bounds the work at
+ * `limit` rows (≤ 500) regardless of how wide the window is opened.
+ *
+ * The count is then a correlated `count(*)` per page row. That is NOT the
+ * legacy N+1: the legacy defect was N+1 *round trips*, and this is still one
+ * statement. `count(*)` needs no column value, so each subquery is an
+ * index-only scan of `flowsheet_show_id_idx` — no heap fetches at all, where
+ * the grouped form paid one per joined row.
  *
  * `user` is LEFT JOINed so the shared `resolveShowDjName` chain runs in JS on
  * columns fetched once, rather than one `resolveDjNameForShow` query per show
  * — the same trade `getShowsInTimeWindow` (BS#2062) makes. `user.id` is
  * selected alongside `djName` because the chain distinguishes "no user row"
- * from "user row with an unusable djName".
- *
- * Grouping lists every non-aggregated column explicitly rather than leaning on
- * Postgres's functional-dependency inference from `shows.id`: the inference
- * does hold here, but spelling it out keeps the statement portable to a plain
- * `GROUP BY` reader and survives a future `LEFT JOIN` that widens the select.
+ * from "user row with an unusable djName". It joins against the already-
+ * truncated page for the same reason the count does.
  */
-export const buildOpenShowsQuery = (windowFloor: Date, limit: number = OPEN_SHOWS_DEFAULT_LIMIT) =>
-  db
+export const buildOpenShowsQuery = (windowFloor: Date, limit: number = OPEN_SHOWS_DEFAULT_LIMIT) => {
+  // Served end to end by `shows_open_start_time_idx` (migration 0154): the
+  // partial predicate is the filter, and the indexed key is both the range
+  // bound and the sort, so this is an index-only scan truncated at `limit`.
+  //
+  // Oldest first: the most-stale show is the one an operator came here to
+  // close. `id` is a deterministic tie-break for the second-granularity
+  // collisions the legacy ETL produces (see the 00:55:35/00:55:41 pairs in
+  // production's open-show tail).
+  const page = db
     .select({
       id: shows.id,
       primary_dj_id: shows.primary_dj_id,
@@ -1416,31 +1434,35 @@ export const buildOpenShowsQuery = (windowFloor: Date, limit: number = OPEN_SHOW
       legacy_show_id: shows.legacy_show_id,
       dj_name_override: shows.dj_name_override,
       legacy_dj_name: shows.legacy_dj_name,
-      user_id: user.id,
-      user_dj_name: user.djName,
-      entry_count: sql<number>`count(${flowsheet.id})::int`,
     })
     .from(shows)
-    .leftJoin(user, eq(user.id, shows.primary_dj_id))
-    .leftJoin(flowsheet, eq(flowsheet.show_id, shows.id))
     .where(and(isNull(shows.end_time), gte(shows.start_time, windowFloor)))
-    .groupBy(
-      shows.id,
-      shows.primary_dj_id,
-      shows.show_name,
-      shows.start_time,
-      shows.legacy_show_id,
-      shows.dj_name_override,
-      shows.legacy_dj_name,
-      user.id,
-      user.djName
-    )
-    // Oldest first: the most-stale show is the one an operator came here to
-    // close. `id` is a deterministic tie-break for the second-granularity
-    // collisions the legacy ETL produces (see the 00:55:35/00:55:41 pairs in
-    // production's open-show tail).
     .orderBy(asc(shows.start_time), asc(shows.id))
-    .limit(limit);
+    .limit(limit)
+    .as('page');
+
+  return (
+    db
+      .select({
+        id: page.id,
+        primary_dj_id: page.primary_dj_id,
+        show_name: page.show_name,
+        start_time: page.start_time,
+        legacy_show_id: page.legacy_show_id,
+        dj_name_override: page.dj_name_override,
+        legacy_dj_name: page.legacy_dj_name,
+        user_id: user.id,
+        user_dj_name: user.djName,
+        entry_count: sql<number>`(SELECT count(*) FROM ${flowsheet} WHERE ${flowsheet.show_id} = ${page.id})::int`,
+      })
+      .from(page)
+      .leftJoin(user, eq(user.id, page.primary_dj_id))
+      // The subquery already emitted the page in order; re-stating it here is
+      // what makes the ordering a property of THIS statement rather than of an
+      // unordered-by-definition subquery the planner is free to reshuffle.
+      .orderBy(asc(page.start_time), asc(page.id))
+  );
+};
 
 /**
  * Every open show that started within `windowHours`, oldest first, plus a
@@ -1468,29 +1490,47 @@ export const getOpenShows = async (
 ): Promise<OpenShowsResult> => {
   const windowFloor = new Date(Date.now() - windowHours * 60 * 60 * 1000);
 
-  // `is_current` is resolved against the same `max(shows.id)` pivot every
-  // on-air read uses (`getLatestShow`), so this endpoint and the banner can
-  // never disagree about which show is live. It matters for the abandoned
-  // flag: a show that just signed on legitimately has fewer than four
-  // entries, and must not be presented as a close candidate.
-  const [rows, windowCount, olderCount, latestShow] = await Promise.all([
+  const [rows, counts, latestShow] = await Promise.all([
     buildOpenShowsQuery(windowFloor, limit),
+    // Both sides of the window in one pass over `shows_open_start_time_idx`.
+    // The `gte`/`lt` operators are embedded rather than the bare `windowFloor`
+    // so the column-aware timestamptz encoder still applies — interpolating the
+    // Date directly hits the postgres-js serializer trap documented on
+    // `getShowsInTimeWindow`.
     db
-      .select({ n: sql<number>`count(*)::int` })
+      .select({
+        in_window: sql<number>`count(*) FILTER (WHERE ${gte(shows.start_time, windowFloor)})::int`,
+        older: sql<number>`count(*) FILTER (WHERE ${lt(shows.start_time, windowFloor)})::int`,
+      })
       .from(shows)
-      .where(and(isNull(shows.end_time), gte(shows.start_time, windowFloor))),
-    db
-      .select({ n: sql<number>`count(*)::int` })
-      .from(shows)
-      .where(and(isNull(shows.end_time), lt(shows.start_time, windowFloor))),
+      .where(isNull(shows.end_time)),
     getLatestShow(),
   ]);
 
   const latestShowId = latestShow?.id ?? null;
 
+  // `is_current` is NOT a bare `id === max(shows.id)` test, and the difference
+  // is the whole cohort this endpoint serves. `jobs/legacy-mirror-reconcile`
+  // already paid for this correction (BS#2068): a show whose `show_end`
+  // webhook delivery was lost keeps its marker, never gets `end_time` stamped,
+  // and — until someone else goes live — holds `max(shows.id)`. Under the bare
+  // test it reports `is_current: true`, which suppresses `likely_abandoned`
+  // and makes `force-end` demand `?force=true` for precisely the show the
+  // nightly detector flagged as needing to be closed.
+  //
+  // `isLatestEntryShowEnd` is the same terminal-marker signal the reconcile
+  // job's `newestEntryType = 'show_end'` arm reads. Its docstring warns it is
+  // not self-safe without an `end_time` guard; every row here comes from a
+  // predicate that already required `end_time IS NULL`.
+  //
+  // At most ONE extra query, and only when the newest show is on this page —
+  // `is_current` can be true for exactly one row by construction.
+  const latestOnPage = latestShowId !== null && rows.some((row) => row.id === latestShowId);
+  const currentShowId = latestOnPage && !(await isLatestEntryShowEnd(latestShowId!)) ? latestShowId : null;
+
   return {
     shows: rows.map((row) => {
-      const is_current = latestShowId !== null && row.id === latestShowId;
+      const is_current = currentShowId !== null && row.id === currentShowId;
       return {
         id: row.id,
         primary_dj_id: row.primary_dj_id ?? null,
@@ -1508,8 +1548,8 @@ export const getOpenShows = async (
         likely_abandoned: !is_current && row.entry_count < LIKELY_ABANDONED_ENTRY_THRESHOLD,
       };
     }),
-    total_in_window: windowCount[0]?.n ?? 0,
-    older_open_show_count: olderCount[0]?.n ?? 0,
+    total_in_window: counts[0]?.in_window ?? 0,
+    older_open_show_count: counts[0]?.older ?? 0,
   };
 };
 
@@ -1518,9 +1558,9 @@ export const getOpenShows = async (
  * floored at `start_time`, falling back to `start_time` when it logged nothing.
  *
  * This is the instant `POST /flowsheet/shows/:id/force-end` hands `endShow`,
- * and the reason that parameter exists at all — see `EndShowOptions` for what
- * `now()` does to `GET /flowsheet/range` and to the public flowsheet's global
- * sort when the show being closed is from 2006.
+ * and the reason that parameter exists at all — see `endShow` for what `now()`
+ * does to `GET /flowsheet/range` and to the public flowsheet's global sort
+ * when the show being closed is from 2006.
  *
  * `MAX(add_time)`, deliberately NOT `lastLoggedShowEntryOrderBy`'s "add_time of
  * the highest-id row". The two answer different questions and this one wants
@@ -1543,10 +1583,13 @@ export const resolveShowEndInstant = async (show: Show): Promise<Date> => {
     .from(flowsheet)
     .where(eq(flowsheet.show_id, show.id));
 
-  const latest = rows[0]?.latest ? new Date(rows[0].latest) : null;
+  // "No entries at all" and "last entry predates start_time" have the same
+  // answer, so they share one branch rather than a nullable local plus a
+  // compound condition.
   const startedAt = new Date(show.start_time);
+  const latest = rows[0]?.latest ? new Date(rows[0].latest) : startedAt;
 
-  return latest && latest.getTime() > startedAt.getTime() ? latest : startedAt;
+  return latest.getTime() > startedAt.getTime() ? latest : startedAt;
 };
 
 /** One show by primary key, for the operator-close path's existence check. */

--- a/shared/authentication/src/auth.roles.ts
+++ b/shared/authentication/src/auth.roles.ts
@@ -5,7 +5,23 @@ const statement = {
   ...defaultStatements,
   catalog: ['read', 'write'],
   bin: ['read', 'write'],
-  flowsheet: ['read', 'write'],
+  // `manage` is the operator tier: acting on a show you are not a member of.
+  // Held by musicDirector and stationManager, NOT by dj — which is what makes
+  // it a distinct action rather than a reuse of `write` (every DJ has that).
+  // It backs `GET /flowsheet/open-shows` and `POST
+  // /flowsheet/shows/:id/force-end` (BS#2235), the Backend-Service replacement
+  // for tubafrenzy's `EndShowServlet`, which any signed-on DJ could reach for
+  // any recent show with no ownership check at all. Deliberately NOT expressed
+  // as `catalog: ['write']` — that happens to select the same two roles today,
+  // but it is the catalog's grant, and a future re-grant of catalog editing
+  // would silently move who can close a stranger's show.
+  //
+  // Not mirrored into `@wxyc/shared`'s `RESOURCES`/`ROLE_PERMISSIONS` (which
+  // already carries a `roster` resource this statement does not). Nothing
+  // cross-repo consumes it: the JWT carries a role, not a permission set, and
+  // this middleware resolves the role against the table below server-side.
+  // dj-site gates its operator UI on `roleToAuthorization(...) >= MD`.
+  flowsheet: ['read', 'write', 'manage'],
 } as const;
 
 export type AccessControlStatement = typeof statement;
@@ -27,14 +43,14 @@ export const dj = accessControl.newRole({
 export const musicDirector = accessControl.newRole({
   bin: ['read', 'write'],
   catalog: ['read', 'write'],
-  flowsheet: ['read', 'write'],
+  flowsheet: ['read', 'write', 'manage'],
 });
 
 export const stationManager = accessControl.newRole({
   ...adminAc.statements,
   bin: ['read', 'write'],
   catalog: ['read', 'write'],
-  flowsheet: ['read', 'write'],
+  flowsheet: ['read', 'write', 'manage'],
 });
 
 export const WXYCRoles = {

--- a/shared/database/src/migrations/0154_shows-open-start-time-idx.sql
+++ b/shared/database/src/migrations/0154_shows-open-start-time-idx.sql
@@ -1,0 +1,47 @@
+-- BS#2235. A partial B-tree on `shows.start_time`, restricted to open shows
+-- (`WHERE end_time IS NULL`).
+--
+-- `shows.end_time` carried no index at all before this. The only two indexes on
+-- the table are `shows_legacy_show_id_idx` (unique, on the tubafrenzy surrogate
+-- key) and the primary key, so every `end_time IS NULL` read is a full scan.
+--
+-- The consumer is `GET /flowsheet/open-shows` (BS#2235), the Backend-Service
+-- replacement for tubafrenzy's `EndShowServlet` + "Resume a Show" path, which
+-- retires with tubafrenzy on 2026-08-31. Its query is
+-- `WHERE end_time IS NULL AND start_time >= $floor ORDER BY start_time ASC`,
+-- which this index serves end to end: the partial predicate is the filter, and
+-- the indexed key is both the range bound and the sort.
+--
+-- `jobs/legacy-mirror-reconcile`'s stale-open-show sweep (BS#2065/#2067/#2068)
+-- runs the same `end_time IS NULL` + `start_time` bounds nightly and picks this
+-- up for free. It is not the reason the index exists — a nightly cron can
+-- afford a seq scan — but it is why the shape is `(start_time) WHERE end_time
+-- IS NULL` rather than a bare marker index on `end_time`.
+--
+-- Sized by the predicate, not the table. Measured on production 2026-08-21:
+-- 72,736 rows in `shows`, of which 2,814 have `end_time IS NULL` — so the index
+-- covers under 4% of the table and the closed 96% never enter it. (That 2,814
+-- is itself the backlog this endpoint exists to work through: 2,813 of them are
+-- legacy ETL imports whose `show_end` never arrived, all but one carrying a
+-- NULL `primary_dj_id`, stretching back to 2006. The number should fall.)
+--
+-- Production ops:
+--   - This is NOT the CONCURRENTLY form, because Drizzle wraps each migration
+--     file in a transaction and `CREATE INDEX CONCURRENTLY cannot run inside a
+--     transaction block` — same constraint as 0057, 0068, 0070, 0074, 0078,
+--     0080, 0139, 0144, 0148.
+--   - Unlike those, the in-migration form here is genuinely cheap: the
+--     AccessExclusiveLock is held for a sub-second build over 2,814 qualifying
+--     rows on a 72,736-row table, not the multi-minute build over `flowsheet`'s
+--     ~2.6M-row / ~1.7 GB heap that made 0148's out-of-band step mandatory. The
+--     lock still pauses `POST /flowsheet/join` and `POST /flowsheet/end` for
+--     its duration, so if the deploy lands mid-show, run it out of band first:
+--       CREATE INDEX CONCURRENTLY IF NOT EXISTS "shows_open_start_time_idx"
+--         ON "wxyc_schema"."shows" USING btree ("start_time")
+--         WHERE "wxyc_schema"."shows"."end_time" IS NULL;
+--   - `IF NOT EXISTS` makes the migration a no-op against a database where the
+--     index already exists (the out-of-band case above), while fresh dev and CI
+--     databases pick it up on first migrate. Same shape as 0068, 0070, 0074,
+--     0080, 0139, 0144, 0148.
+
+CREATE INDEX IF NOT EXISTS "shows_open_start_time_idx" ON "wxyc_schema"."shows" USING btree ("start_time") WHERE "wxyc_schema"."shows"."end_time" IS NULL;

--- a/shared/database/src/migrations/meta/0154_snapshot.json
+++ b/shared/database/src/migrations/meta/0154_snapshot.json
@@ -1,0 +1,6547 @@
+{
+  "id": "24f2e010-224b-47f0-adc0-69a04cbbda57",
+  "prevId": "9f6fced7-6fd7-426b-8f5e-8c0b57237d67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_status": {
+          "name": "spotify_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_status": {
+          "name": "apple_music_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_status": {
+          "name": "bandcamp_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_reask_attempts": {
+          "name": "streaming_reask_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_id": {
+          "name": "track_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_link_confidence": {
+          "name": "track_artist_link_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_artist_link_method": {
+          "name": "track_artist_link_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_track_artist_id_idx": {
+          "name": "cta_track_artist_id_idx",
+          "columns": [
+            {
+              "expression": "track_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_trgm_idx": {
+          "name": "cta_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "cta_track_title_trgm_idx": {
+          "name": "cta_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compilation_track_artist_track_artist_id_artists_id_fk": {
+          "name": "compilation_track_artist_track_artist_id_artists_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "track_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cta_track_artist_link_confidence_range": {
+          "name": "cta_track_artist_link_confidence_range",
+          "value": "\"wxyc_schema\".\"compilation_track_artist\".\"track_artist_link_confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concert_performers": {
+      "name": "concert_performers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "concert_id": {
+          "name": "concert_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_name": {
+          "name": "raw_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "concert_performer_role_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id_source": {
+          "name": "discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concert_performers_concert_role_raw_name_idx": {
+          "name": "concert_performers_concert_role_raw_name_idx",
+          "columns": [
+            {
+              "expression": "concert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concert_performers_concert_id_concerts_id_fk": {
+          "name": "concert_performers_concert_id_concerts_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "concerts",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "concert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "concert_performers_artist_id_artists_id_fk": {
+          "name": "concert_performers_artist_id_artists_id_fk",
+          "tableFrom": "concert_performers",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "has_resolved_support": {
+          "name": "has_resolved_support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"has_resolved_support\") AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cursor_position": {
+          "name": "cursor_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_match_recheck_attempted_at": {
+          "name": "no_match_recheck_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_add_time_idx": {
+          "name": "flowsheet_add_time_idx",
+          "columns": [
+            {
+              "expression": "add_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_linked_idx": {
+          "name": "flowsheet_album_id_linked_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metadata_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_rotation_no_match_idx": {
+          "name": "flowsheet_rotation_no_match_idx",
+          "columns": [
+            {
+              "expression": "rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriched_no_match' AND \"wxyc_schema\".\"flowsheet\".\"rotation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_rotation_id_idx": {
+          "name": "flowsheet_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"rotation_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_no_match_recheck_id_desc_idx": {
+          "name": "flowsheet_no_match_recheck_id_desc_idx",
+          "columns": [
+            {
+              "expression": "no_match_recheck_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriched_no_match' AND \"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('\"wxyc_schema\".\"library_legacy_release_id_seq\"'::regclass)"
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unresolved_attempted_at": {
+          "name": "unresolved_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_norm_album_title_idx": {
+          "name": "library_norm_album_title_idx",
+          "columns": [
+            {
+              "expression": "lower(trim(coalesce(\"album_title\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_delete_denylist": {
+      "name": "library_delete_denylist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_email": {
+          "name": "deleted_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_role": {
+          "name": "deleted_by_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "discogs_release_id_resolve_attempted_at": {
+          "name": "discogs_release_id_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_norm_artist_album_idx": {
+          "name": "rotation_norm_artist_album_idx",
+          "columns": [
+            {
+              "expression": "lower(trim(coalesce(\"artist_name\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(trim(coalesce(\"album_title\", '')))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shows_open_start_time_idx": {
+          "name": "shows_open_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"shows\".\"end_time\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.slack_ban_moderators": {
+      "name": "slack_ban_moderators",
+      "schema": "wxyc_schema",
+      "columns": {
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "added_by_slack_user_id": {
+          "name": "added_by_slack_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_ban_moderators_slack_user_id_upper_ck": {
+          "name": "slack_ban_moderators_slack_user_id_upper_ck",
+          "value": "\"wxyc_schema\".\"slack_ban_moderators\".\"slack_user_id\" ~ '^[A-Z0-9]+$'"
+        },
+        "slack_ban_moderators_added_by_upper_ck": {
+          "name": "slack_ban_moderators_added_by_upper_ck",
+          "value": "\"wxyc_schema\".\"slack_ban_moderators\".\"added_by_slack_user_id\" IS NULL OR \"wxyc_schema\".\"slack_ban_moderators\".\"added_by_slack_user_id\" ~ '^[A-Z0-9]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_performer_role_enum": {
+      "name": "concert_performer_role_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "headliner",
+        "support"
+      ]
+    },
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {
+    "wxyc_schema.library_legacy_release_id_seq": {
+      "name": "library_legacy_release_id_seq",
+      "schema": "wxyc_schema",
+      "increment": "1",
+      "startWith": "1000000",
+      "minValue": "1000000",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\", \"wxyc_schema\".\"library\".\"discogs_unavailable\", \"wxyc_schema\".\"library\".\"discogs_unavailable_note\", \"wxyc_schema\".\"library\".\"last_discogs_recheck_at\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -1058,6 +1058,13 @@
       "when": 1787111304341,
       "tag": "0153_flowsheet-no-match-recheck-id-desc-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 154,
+      "version": "7",
+      "when": 1787330210040,
+      "tag": "0154_shows-open-start-time-idx",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -149,5 +149,6 @@
   "0150_reclassify-and-drop-fictional-n-bin": "009f764551c669ae8e346b019cff785503adc58d369a02af3b97043a3e1c7b86",
   "0151_flowsheet-no-match-recheck-attempted-at": "8e574a0411d5174b7c078aa32522d8a98f6a9a5f965ff502e15937356c1e96db",
   "0152_flowsheet-no-match-recheck-cursor": "890d692b4e754635550016387070026d6f6aed5533a823c6bb75c50bcc21be65",
-  "0153_flowsheet-no-match-recheck-id-desc-idx": "869145cc65342d30c6ff8defb22184817f1e4a15aabc13369a263d74243c2844"
+  "0153_flowsheet-no-match-recheck-id-desc-idx": "869145cc65342d30c6ff8defb22184817f1e4a15aabc13369a263d74243c2844",
+  "0154_shows-open-start-time-idx": "8a2925defd3f84f0326ad4a5d36903577316b2e55a9cba433b1624a8b33e3d2d"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -2468,6 +2468,17 @@ export const shows = wxyc_schema.table(
     // dj-site-originated shows.
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     uniqueIndex('shows_legacy_show_id_idx').on(table.legacy_show_id),
+    // Operator close (BS#2235): `GET /flowsheet/open-shows` filters on
+    // `end_time IS NULL` and orders by `start_time` ASC. `end_time` carried no
+    // index at all before this, so the read was a full scan of `shows`
+    // (72,736 rows in production on 2026-08-21) plus a sort. Partial on the
+    // predicate, which is what makes it cheap to maintain: only 2,814 of those
+    // rows qualify, and the closed 96% never enter the index. `start_time` is
+    // the indexed key rather than a bare `end_time` marker so the same index
+    // serves the ORDER BY and the window floor.
+    index('shows_open_start_time_idx')
+      .on(table.start_time)
+      .where(sql`${table.end_time} IS NULL`),
     // shows_legacy_dj_name_trgm_idx was dropped in migrations 0054 + 0065 —
     // search no longer joins through shows; dj-name reads come from
     // flowsheet.dj_name + flowsheet_dj_name_trgm_idx. Declaration removed to

--- a/tests/integration/flowsheet-open-shows.spec.js
+++ b/tests/integration/flowsheet-open-shows.spec.js
@@ -82,6 +82,7 @@ describe('operator close (BS#2235)', () => {
     await insertShow('busy', { startedDaysAgo: 5, legacyDjName: 'dj meowww', entries: 6 });
     await insertShow('closed', { startedDaysAgo: 4, endedDaysAgo: 4, legacyDjName: 'DJ Flacko', entries: 3 });
     await insertShow('ancient', { startedDaysAgo: 300, legacyDjName: 'DJ Flounder', entries: 1 });
+    await insertShow('cohost', { startedDaysAgo: 3, legacyDjName: 'El Vaquero', entries: 5 });
     await insertShow('current', { startedDaysAgo: 0, legacyDjName: 'dj barely there', entries: 2 });
   });
 
@@ -155,6 +156,21 @@ describe('operator close (BS#2235)', () => {
       expect(findShow(body, 'busy').likely_abandoned).toBe(false);
     });
 
+    it('reports total_in_window alongside the (possibly truncated) page', async () => {
+      const full = await fetchOpenShows();
+      const capped = await fetchOpenShows('?limit=1');
+
+      expect(capped.shows).toHaveLength(1);
+      // The only signal that a page is partial.
+      expect(capped.total_in_window).toBe(full.total_in_window);
+      expect(capped.total_in_window).toBeGreaterThan(1);
+    });
+
+    it('rejects a limit outside the allowed range', async () => {
+      const res = await request.get('/flowsheet/open-shows?limit=0').set('Authorization', global.access_token);
+      expect(res.status).toBe(400);
+    });
+
     // The exclusion that keeps an operator from ending a live broadcast: the
     // newest show has only two entries but is on the air.
     it('marks the newest show current and never flags it abandoned', async () => {
@@ -171,6 +187,26 @@ describe('operator close (BS#2235)', () => {
   });
 
   describe('POST /flowsheet/shows/:id/force-end', () => {
+    /**
+     * The server-side half of `is_current`. Not unconditional — the 2026-08-20
+     * stuck show WAS `max(shows.id)` for all nine hours it hung, so a blanket
+     * refusal would veto the case this endpoint exists for.
+     */
+    it('409s on the current on-air show, and proceeds with ?force=true', async () => {
+      const id = showIds.current;
+
+      const refused = await request.post(`/flowsheet/shows/${id}/force-end`).set('Authorization', global.access_token);
+      expect(refused.status).toBe(409);
+
+      const [stillOpen] = await sql`SELECT end_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+      expect(stillOpen.end_time).toBeNull();
+
+      const forced = await request
+        .post(`/flowsheet/shows/${id}/force-end?force=true`)
+        .set('Authorization', global.access_token);
+      expect(forced.status).toBe(200);
+    });
+
     it('404s an id that matches no show', async () => {
       const res = await request.post('/flowsheet/shows/2147483646/force-end').set('Authorization', global.access_token);
       expect(res.status).toBe(404);
@@ -200,7 +236,67 @@ describe('operator close (BS#2235)', () => {
         SELECT entry_type, message FROM ${sql(SCHEMA)}.flowsheet
         WHERE show_id = ${id} AND entry_type = 'show_end'`;
       expect(markers).toHaveLength(1);
-      expect(markers[0].message).toMatch(/^End of show: /);
+      // `stale` has a legacy handle and no account, so the marker carries it
+      // through the shared name chain rather than degrading to nameless.
+      expect(markers[0].message).toContain('DJ Mouseness');
+    });
+
+    /**
+     * The finding this endpoint's first cut got wrong, pinned end-to-end.
+     *
+     * `endShow` stamps `end_time = now()` for a live sign-off. Reused unchanged
+     * for an OLD show, that produces an interval `[2006, today]`, and
+     * `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
+     * archive.wxyc.org reads) admits a closed show whenever
+     * `start_time < windowEnd AND end_time > windowStart` — so the closed show
+     * would surface on every archive day between. `force-end` therefore derives
+     * the instant from the show's own last entry.
+     */
+    it('stamps end_time from the show’s last entry, not now()', async () => {
+      const id = showIds.busy;
+
+      const [{ latest }] = await sql`
+        SELECT max(add_time) AS latest FROM ${sql(SCHEMA)}.flowsheet WHERE show_id = ${id}`;
+      expect(latest).not.toBeNull();
+
+      const res = await request.post(`/flowsheet/shows/${id}/force-end`).set('Authorization', global.access_token);
+      expect(res.status).toBe(200);
+
+      const [row] = await sql`SELECT start_time, end_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+      expect(new Date(row.end_time).getTime()).toBe(new Date(latest).getTime());
+
+      // The property that matters downstream: the closed interval does not
+      // stretch to the present, so the show cannot overlap today's archive
+      // window.
+      const ageMs = Date.now() - new Date(row.end_time).getTime();
+      expect(ageMs).toBeGreaterThan(4 * DAY_MS);
+      // ...and it is still a valid interval.
+      expect(new Date(row.end_time).getTime()).toBeGreaterThanOrEqual(new Date(row.start_time).getTime());
+    });
+
+    /**
+     * Sibling of the above. `getEntriesByPage` orders globally by
+     * `add_time DESC, id DESC` and serves both `GET /flowsheet` page 0 and
+     * `GET /flowsheet/latest`, so a `show_end` marker written with the default
+     * `now()` for a five-day-old show becomes the newest entry on the public
+     * flowsheet.
+     */
+    it('writes the show_end marker with the show’s own add_time', async () => {
+      const id = showIds.busy;
+
+      const [marker] = await sql`
+        SELECT add_time FROM ${sql(SCHEMA)}.flowsheet
+        WHERE show_id = ${id} AND entry_type = 'show_end'`;
+      const [row] = await sql`SELECT end_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+
+      expect(new Date(marker.add_time).getTime()).toBe(new Date(row.end_time).getTime());
+
+      // The consequence, read through the endpoint that would have shown it:
+      // the marker is not the newest row on the public flowsheet.
+      const latest = await request.get('/flowsheet/latest');
+      expect(latest.status).toBe(200);
+      const latestBody = Array.isArray(latest.body) ? latest.body[0] : latest.body;
+      expect(latestBody?.show_id).not.toBe(id);
     });
 
     it('drops the closed show out of the open-shows list', async () => {
@@ -223,7 +319,7 @@ describe('operator close (BS#2235)', () => {
     });
 
     it('deactivates every show_djs membership on the closed show', async () => {
-      const id = showIds.busy;
+      const id = showIds.cohost;
 
       // A co-host membership, the state a stranded DJ is left in when the
       // primary walks away: `POST /flowsheet/end` can only deactivate them via

--- a/tests/integration/flowsheet-open-shows.spec.js
+++ b/tests/integration/flowsheet-open-shows.spec.js
@@ -135,9 +135,10 @@ describe('operator close (BS#2235)', () => {
       expect(body.older_open_show_count).toBeGreaterThanOrEqual(1);
     });
 
-    // 300 days back: outside the 7-day default, inside the 8760-hour (1 year)
-    // ceiling. A probe past the ceiling would be unreachable by any legal
-    // request and could not distinguish a working widen from a broken one.
+    // 300 days back: outside the 7-day default, well inside the
+    // `OPEN_SHOWS_MAX_WINDOW_HOURS` ceiling. A probe past the ceiling would be
+    // unreachable by any legal request and could not distinguish a working
+    // widen from a broken one.
     it('includes the older show once the window is widened to reach it', async () => {
       const body = await fetchOpenShows('?window_hours=8760');
       expect(findShow(body, 'ancient')).toMatchObject({ entry_count: 1, dj_name: 'DJ Flounder' });
@@ -244,13 +245,11 @@ describe('operator close (BS#2235)', () => {
     /**
      * The finding this endpoint's first cut got wrong, pinned end-to-end.
      *
-     * `endShow` stamps `end_time = now()` for a live sign-off. Reused unchanged
-     * for an OLD show, that produces an interval `[2006, today]`, and
-     * `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
-     * archive.wxyc.org reads) admits a closed show whenever
-     * `start_time < windowEnd AND end_time > windowStart` — so the closed show
-     * would surface on every archive day between. `force-end` therefore derives
-     * the instant from the show's own last entry.
+     * `endShow` stamps `end_time = now()` for a live sign-off; reused unchanged
+     * for an OLD show that produces an interval `[2006, today]`, which
+     * `getShowsInTimeWindow` admits on every archive day between. See `endShow`
+     * for the full argument. `force-end` derives the instant from the show's
+     * own last entry instead.
      */
     it('stamps end_time from the show’s last entry, not now()', async () => {
       const id = showIds.busy;
@@ -275,11 +274,9 @@ describe('operator close (BS#2235)', () => {
     });
 
     /**
-     * Sibling of the above. `getEntriesByPage` orders globally by
-     * `add_time DESC, id DESC` and serves both `GET /flowsheet` page 0 and
-     * `GET /flowsheet/latest`, so a `show_end` marker written with the default
-     * `now()` for a five-day-old show becomes the newest entry on the public
-     * flowsheet.
+     * Sibling of the above, for the marker rather than the column: the public
+     * flowsheet's global sort key is `add_time`, so a `show_end` written with
+     * the default `now()` for a five-day-old show lands at the top of it.
      */
     it('writes the show_end marker with the show’s own add_time', async () => {
       const id = showIds.busy;

--- a/tests/integration/flowsheet-open-shows.spec.js
+++ b/tests/integration/flowsheet-open-shows.spec.js
@@ -1,0 +1,244 @@
+/**
+ * BS#2235 — operator close, against a real database.
+ *
+ * `GET /flowsheet/open-shows` + `POST /flowsheet/shows/:id/force-end`, the
+ * Backend-Service replacement for tubafrenzy's `EndShowServlet` +
+ * "Resume a Show" path, which retires with tubafrenzy on 2026-08-31.
+ *
+ * What only a live Postgres can prove: the grouped entry counts are right for
+ * shows with zero, few, and many entries; the `end_time IS NULL` filter and the
+ * window floor actually exclude what they claim to; `force-end` writes the same
+ * `show_end` marker and `show_djs` deactivation as `POST /flowsheet/end`,
+ * including for a show with a NULL `primary_dj_id` (BS#2093) that the old
+ * `endShow` guard refused outright; and the compare-and-set rejects a second
+ * force-end without writing a duplicate marker.
+ *
+ * The role gate is NOT exercised here and cannot be: integration runs under
+ * `AUTH_BYPASS=true`, whose branch short-circuits to `next()` before any
+ * permission check. That tier lives in
+ * `tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts`.
+ *
+ * Timestamps are relative to `now()` rather than the 1998 window this suite's
+ * siblings use, because the endpoint's whole contract is a lookback window off
+ * the current instant. Every row written here is torn down in afterAll —
+ * load-bearing, not tidiness: an open show left behind would be `max(shows.id)`
+ * for whichever spec runs next, and `joinShow` routes a go-live onto the newest
+ * open show. Leaving one would reproduce the incident this ticket came from
+ * inside the test suite.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+const daysAgo = (n) => new Date(Date.now() - n * DAY_MS).toISOString();
+
+describe('operator close (BS#2235)', () => {
+  let sql;
+  const showIds = {};
+
+  const insertShow = async (key, { startedDaysAgo, endedDaysAgo = null, legacyDjName = null, entries = 0 }) => {
+    const rows = await sql`
+      INSERT INTO ${sql(SCHEMA)}.shows (start_time, end_time, legacy_dj_name)
+      VALUES (
+        ${daysAgo(startedDaysAgo)}::timestamptz,
+        ${endedDaysAgo === null ? null : daysAgo(endedDaysAgo)}::timestamptz,
+        ${legacyDjName}
+      )
+      RETURNING id`;
+    const id = rows[0].id;
+    showIds[key] = id;
+
+    for (let i = 1; i <= entries; i += 1) {
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.flowsheet (show_id, entry_type, play_order, message, add_time)
+        VALUES (${id}, 'message', ${i}, ${`BS2235 probe ${key} ${i}`}, ${daysAgo(startedDaysAgo)}::timestamptz)`;
+    }
+    return id;
+  };
+
+  beforeAll(async () => {
+    sql = makeSql();
+
+    // Insertion order is also id order (serial), and the endpoint resolves
+    // `is_current` from `max(shows.id)` — so `current` is inserted LAST and is
+    // the newest show in the database for the duration of this spec.
+    await insertShow('stale', { startedDaysAgo: 6, legacyDjName: 'DJ Mouseness', entries: 0 });
+    await insertShow('busy', { startedDaysAgo: 5, legacyDjName: 'dj meowww', entries: 6 });
+    await insertShow('closed', { startedDaysAgo: 4, endedDaysAgo: 4, legacyDjName: 'DJ Flacko', entries: 3 });
+    await insertShow('ancient', { startedDaysAgo: 300, legacyDjName: 'DJ Flounder', entries: 1 });
+    await insertShow('current', { startedDaysAgo: 0, legacyDjName: 'dj barely there', entries: 2 });
+  });
+
+  afterAll(async () => {
+    if (!sql) return;
+    const ids = Object.values(showIds);
+    if (ids.length) {
+      // Children first, both of them. `flowsheet.show_id` is ON DELETE SET
+      // NULL, so its rows must go before the show or they outlive it as
+      // orphans in this shared schema.
+      //
+      // `show_djs` needs an explicit DELETE too, even though `schema.ts`
+      // declares `onDelete: 'cascade'` on that FK: the constraint actually
+      // present in the migrated database has no referential action, and a
+      // bare `DELETE FROM shows` raises `show_djs_show_id_shows_id_fk`.
+      // Observed, not assumed — it is what failed this teardown on first run.
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE show_id = ANY(${sql.array(ids)}::int[])`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.show_djs WHERE show_id = ANY(${sql.array(ids)}::int[])`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.shows WHERE id = ANY(${sql.array(ids)}::int[])`;
+    }
+    await sql.end({ timeout: 5 });
+  });
+
+  const fetchOpenShows = async (query = '') => {
+    const res = await request.get(`/flowsheet/open-shows${query}`).set('Authorization', global.access_token);
+    expect(res.status).toBe(200);
+    return res.body;
+  };
+
+  const findShow = (body, key) => body.shows.find((s) => s.id === showIds[key]);
+
+  describe('GET /flowsheet/open-shows', () => {
+    it('returns the in-window open shows with correct grouped entry counts', async () => {
+      const body = await fetchOpenShows();
+
+      expect(findShow(body, 'stale')).toMatchObject({ entry_count: 0, dj_name: 'DJ Mouseness' });
+      expect(findShow(body, 'busy')).toMatchObject({ entry_count: 6, dj_name: 'dj meowww' });
+      expect(findShow(body, 'current')).toMatchObject({ entry_count: 2, dj_name: 'dj barely there' });
+    });
+
+    it('omits a closed show', async () => {
+      const body = await fetchOpenShows();
+      expect(findShow(body, 'closed')).toBeUndefined();
+    });
+
+    it('omits an open show older than the window and counts it instead', async () => {
+      const body = await fetchOpenShows();
+
+      expect(findShow(body, 'ancient')).toBeUndefined();
+      expect(body.older_open_show_count).toBeGreaterThanOrEqual(1);
+    });
+
+    // 300 days back: outside the 7-day default, inside the 8760-hour (1 year)
+    // ceiling. A probe past the ceiling would be unreachable by any legal
+    // request and could not distinguish a working widen from a broken one.
+    it('includes the older show once the window is widened to reach it', async () => {
+      const body = await fetchOpenShows('?window_hours=8760');
+      expect(findShow(body, 'ancient')).toMatchObject({ entry_count: 1, dj_name: 'DJ Flounder' });
+    });
+
+    it('orders oldest first', async () => {
+      const body = await fetchOpenShows();
+      const times = body.shows.map((s) => new Date(s.start_time).getTime());
+      expect(times).toEqual([...times].sort((a, b) => a - b));
+    });
+
+    it('flags the abandoned show and spares the busy one', async () => {
+      const body = await fetchOpenShows();
+
+      expect(findShow(body, 'stale').likely_abandoned).toBe(true);
+      expect(findShow(body, 'busy').likely_abandoned).toBe(false);
+    });
+
+    // The exclusion that keeps an operator from ending a live broadcast: the
+    // newest show has only two entries but is on the air.
+    it('marks the newest show current and never flags it abandoned', async () => {
+      const body = await fetchOpenShows();
+
+      expect(findShow(body, 'current')).toMatchObject({ is_current: true, likely_abandoned: false });
+      expect(findShow(body, 'stale').is_current).toBe(false);
+    });
+
+    it('rejects a malformed window_hours', async () => {
+      const res = await request.get('/flowsheet/open-shows?window_hours=24h').set('Authorization', global.access_token);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /flowsheet/shows/:id/force-end', () => {
+    it('404s an id that matches no show', async () => {
+      const res = await request.post('/flowsheet/shows/2147483646/force-end').set('Authorization', global.access_token);
+      expect(res.status).toBe(404);
+    });
+
+    it('400s a non-numeric id', async () => {
+      const res = await request.post('/flowsheet/shows/abc/force-end').set('Authorization', global.access_token);
+      expect(res.status).toBe(400);
+    });
+
+    // BS#2093: every one of these probe shows has a NULL primary_dj_id, the
+    // shape `endShow` used to refuse with 'Primary DJ not found'. That is also
+    // the shape of the entire legacy open-show backlog.
+    it('closes an abandoned NULL-primary show, writing exactly one show_end marker', async () => {
+      const id = showIds.stale;
+
+      const res = await request.post(`/flowsheet/shows/${id}/force-end`).set('Authorization', global.access_token);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(id);
+      expect(res.body.end_time).not.toBeNull();
+
+      const [row] = await sql`SELECT end_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+      expect(row.end_time).not.toBeNull();
+
+      const markers = await sql`
+        SELECT entry_type, message FROM ${sql(SCHEMA)}.flowsheet
+        WHERE show_id = ${id} AND entry_type = 'show_end'`;
+      expect(markers).toHaveLength(1);
+      expect(markers[0].message).toMatch(/^End of show: /);
+    });
+
+    it('drops the closed show out of the open-shows list', async () => {
+      const body = await fetchOpenShows();
+      expect(findShow(body, 'stale')).toBeUndefined();
+    });
+
+    // The guarantee is endShow's compare-and-set on `end_time IS NULL`; the
+    // controller's own check is only a fast path in front of it. Either way the
+    // second call must not append a second marker.
+    it('rejects a second force-end and writes no duplicate marker', async () => {
+      const id = showIds.stale;
+
+      const res = await request.post(`/flowsheet/shows/${id}/force-end`).set('Authorization', global.access_token);
+      expect(res.status).toBe(400);
+
+      const markers = await sql`
+        SELECT id FROM ${sql(SCHEMA)}.flowsheet WHERE show_id = ${id} AND entry_type = 'show_end'`;
+      expect(markers).toHaveLength(1);
+    });
+
+    it('deactivates every show_djs membership on the closed show', async () => {
+      const id = showIds.busy;
+
+      // A co-host membership, the state a stranded DJ is left in when the
+      // primary walks away: `POST /flowsheet/end` can only deactivate them via
+      // the primary's own sign-off, which never comes.
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.show_djs (show_id, dj_id, active)
+        VALUES (${id}, ${global.primary_dj_id}, true)
+        ON CONFLICT (show_id, dj_id) DO UPDATE SET active = true`;
+
+      const res = await request.post(`/flowsheet/shows/${id}/force-end`).set('Authorization', global.access_token);
+      expect(res.status).toBe(200);
+
+      const memberships = await sql`SELECT active FROM ${sql(SCHEMA)}.show_djs WHERE show_id = ${id}`;
+      expect(memberships).toHaveLength(1);
+      expect(memberships[0].active).toBe(false);
+    });
+  });
+});

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -12,6 +12,7 @@ type MockQueryChain = {
   where: jest.Mock;
   innerJoin: jest.Mock;
   leftJoin: jest.Mock;
+  groupBy: jest.Mock;
   orderBy: jest.Mock;
   limit: jest.Mock;
   offset: jest.Mock;
@@ -36,6 +37,10 @@ export function createMockQueryChain(resolvedValue: unknown = []): MockQueryChai
     'where',
     'innerJoin',
     'leftJoin',
+    // `groupBy` is part of the query builder this stub models (BS#2235's
+    // `buildOpenShowsQuery` is the first caller here); without it an aggregate
+    // read fails as "groupBy is not a function" rather than returning the chain.
+    'groupBy',
     'orderBy',
     'limit',
     'insert',

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -13,6 +13,7 @@ type MockQueryChain = {
   innerJoin: jest.Mock;
   leftJoin: jest.Mock;
   groupBy: jest.Mock;
+  as: jest.Mock;
   orderBy: jest.Mock;
   limit: jest.Mock;
   offset: jest.Mock;
@@ -41,6 +42,10 @@ export function createMockQueryChain(resolvedValue: unknown = []): MockQueryChai
     // `buildOpenShowsQuery` is the first caller here); without it an aggregate
     // read fails as "groupBy is not a function" rather than returning the chain.
     'groupBy',
+    // `.as(alias)` closes a subquery so it can be selected FROM. BS#2235's
+    // `buildOpenShowsQuery` is the first caller here; without it a subquery
+    // build fails as "as is not a function" rather than returning the chain.
+    'as',
     'orderBy',
     'limit',
     'insert',

--- a/tests/mocks/flowsheet-service.mock.ts
+++ b/tests/mocks/flowsheet-service.mock.ts
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+
+/**
+ * The `flowsheet.service` doubles the BS#2235 operator-close suites share.
+ *
+ * Two files mock the same five functions and four constants with the same
+ * defaults; keeping one copy means the next export the service grows is added
+ * once, not once per suite that happened to import it.
+ *
+ * `jest.mock` factories are hoisted above imports, so a consumer loads this
+ * from inside the factory via `jest.requireActual` — not a bare `require`,
+ * which `@typescript-eslint/no-require-imports` rejects:
+ *
+ * ```ts
+ * jest.mock('../../../apps/backend/services/flowsheet.service', () =>
+ *   jest.requireActual<typeof import('../../mocks/flowsheet-service.mock')>(
+ *     '../../mocks/flowsheet-service.mock'
+ *   ).createFlowsheetServiceMock()
+ * );
+ * ```
+ *
+ * and then reaches the individual fns back through the module registry.
+ */
+export function createFlowsheetServiceMock() {
+  return {
+    getOpenShows: jest.fn<(hours?: number, limit?: number) => Promise<unknown>>(),
+    getShowById: jest.fn<(id: number) => Promise<unknown>>(),
+    endShow: jest.fn<(show: unknown, endedAt?: Date) => Promise<unknown>>(),
+    getLatestShow: jest.fn<() => Promise<unknown>>(),
+    isLatestEntryShowEnd: jest.fn<(showId: number) => Promise<boolean>>(),
+    resolveShowEndInstant: jest.fn<(show: unknown) => Promise<Date>>(),
+    OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
+    OPEN_SHOWS_MAX_WINDOW_HOURS: 262_800,
+    OPEN_SHOWS_DEFAULT_LIMIT: 100,
+    OPEN_SHOWS_MAX_LIMIT: 500,
+  };
+}
+
+/**
+ * The quiet baseline every operator-close suite wants between tests: nothing
+ * open, the target is not the on-air show, and a fixed end instant.
+ */
+export function resetFlowsheetServiceMock(mock: ReturnType<typeof createFlowsheetServiceMock>, endInstant: Date) {
+  mock.getOpenShows.mockReset().mockResolvedValue({ shows: [], total_in_window: 0, older_open_show_count: 0 });
+  mock.getShowById.mockReset();
+  mock.endShow.mockReset();
+  mock.getLatestShow.mockReset().mockResolvedValue({ id: -1 });
+  mock.isLatestEntryShowEnd.mockReset().mockResolvedValue(false);
+  mock.resolveShowEndInstant.mockReset().mockResolvedValue(endInstant);
+}

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -9,23 +9,11 @@
  */
 import { jest } from '@jest/globals';
 
-const mockGetOpenShows = jest.fn<(hours?: number, limit?: number) => Promise<unknown>>();
-const mockGetShowById = jest.fn<(id: number) => Promise<unknown>>();
-const mockEndShow = jest.fn<(show: unknown, options?: unknown) => Promise<unknown>>();
-const mockGetLatestShow = jest.fn<() => Promise<unknown>>();
-const mockResolveShowEndInstant = jest.fn<(show: unknown) => Promise<Date>>();
-
-jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
-  getOpenShows: mockGetOpenShows,
-  getShowById: mockGetShowById,
-  endShow: mockEndShow,
-  getLatestShow: mockGetLatestShow,
-  resolveShowEndInstant: mockResolveShowEndInstant,
-  OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
-  OPEN_SHOWS_MAX_WINDOW_HOURS: 262_800,
-  OPEN_SHOWS_DEFAULT_LIMIT: 100,
-  OPEN_SHOWS_MAX_LIMIT: 500,
-}));
+jest.mock('../../../apps/backend/services/flowsheet.service', () =>
+  jest
+    .requireActual<typeof import('../../mocks/flowsheet-service.mock')>('../../mocks/flowsheet-service.mock')
+    .createFlowsheetServiceMock()
+);
 
 jest.mock('async-mutex', () => ({
   Mutex: jest.fn().mockImplementation(() => ({
@@ -33,6 +21,8 @@ jest.mock('async-mutex', () => ({
   })),
 }));
 
+import { resetFlowsheetServiceMock } from '../../mocks/flowsheet-service.mock';
+import * as flowsheetService from '../../../apps/backend/services/flowsheet.service';
 import { getOpenShows, forceEndShow } from '../../../apps/backend/controllers/flowsheet.controller';
 import WxycError from '../../../apps/backend/utils/error';
 import type { Request, Response, NextFunction } from 'express';
@@ -50,14 +40,25 @@ function createMockRes() {
 
 const next = jest.fn() as unknown as NextFunction;
 
+const END_INSTANT = new Date('2026-08-20T18:46:20.000Z');
+const service = flowsheetService as unknown as ReturnType<
+  typeof import('../../mocks/flowsheet-service.mock').createFlowsheetServiceMock
+>;
+const {
+  getOpenShows: mockGetOpenShows,
+  getShowById: mockGetShowById,
+  endShow: mockEndShow,
+  getLatestShow: mockGetLatestShow,
+  isLatestEntryShowEnd: mockIsLatestEntryShowEnd,
+  resolveShowEndInstant: mockResolveShowEndInstant,
+} = service;
+
 const makeReq = (query: Record<string, string> = {}, params: Record<string, string> = {}) =>
   ({ query, params }) as unknown as Request;
 
-describe('GET /flowsheet/open-shows — query parameters', () => {
-  beforeEach(() => {
-    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], total_in_window: 0, older_open_show_count: 0 });
-  });
+beforeEach(() => resetFlowsheetServiceMock(service, END_INSTANT));
 
+describe('GET /flowsheet/open-shows — query parameters', () => {
   it('defaults to the 7-day window and the default limit when neither is given', async () => {
     const { res, statusMock, jsonMock } = createMockRes();
 
@@ -89,7 +90,9 @@ describe('GET /flowsheet/open-shows — query parameters', () => {
     expect(mockGetOpenShows).not.toHaveBeenCalled();
   });
 
-  it.each(['0', '501', 'all', '1.5'])('rejects limit=%p with 400', async (raw) => {
+  // Only `limit`'s own bounds — both parameters share one parser, and its
+  // malformed-input handling is covered by the window_hours battery above.
+  it.each(['0', '501'])('rejects limit=%p with 400', async (raw) => {
     const { res } = createMockRes();
 
     await expect(getOpenShows(makeReq({ limit: raw }), res, next)).rejects.toThrow(WxycError);
@@ -121,15 +124,7 @@ describe('GET /flowsheet/open-shows — query parameters', () => {
 });
 
 describe('POST /flowsheet/shows/:id/force-end', () => {
-  const endInstant = new Date('2026-08-20T18:46:20.000Z');
-
-  beforeEach(() => {
-    mockGetShowById.mockReset();
-    mockEndShow.mockReset();
-    // Default: the target is not the on-air show, so the guard stays quiet.
-    mockGetLatestShow.mockReset().mockResolvedValue({ id: -1 });
-    mockResolveShowEndInstant.mockReset().mockResolvedValue(endInstant);
-  });
+  const endInstant = END_INSTANT;
 
   it('reuses endShow with the show’s own end instant and responds with the finalized show', async () => {
     const openShow = { id: 1951164, primary_dj_id: 'dj-1', end_time: null };
@@ -149,7 +144,7 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
     // and put its show_end marker at the top of the live flowsheet — see
     // EndShowOptions in flowsheet.service.
     expect(mockResolveShowEndInstant).toHaveBeenCalledWith(openShow);
-    expect(mockEndShow).toHaveBeenCalledWith(openShow, { endedAt: endInstant });
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, endInstant);
     expect(statusMock).toHaveBeenCalledWith(200);
     expect(jsonMock).toHaveBeenCalledWith(finalized);
   });
@@ -165,7 +160,7 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
     const { res, statusMock } = createMockRes();
     await forceEndShow(makeReq({}, { id: '74840' }), res, next);
 
-    expect(mockEndShow).toHaveBeenCalledWith(orphan, { endedAt: endInstant });
+    expect(mockEndShow).toHaveBeenCalledWith(orphan, endInstant);
     expect(statusMock).toHaveBeenCalledWith(200);
   });
 
@@ -185,6 +180,28 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
 
     await expect(forceEndShow(makeReq({}, { id: '1951168' }), res, next)).rejects.toThrow('current on-air show');
     expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The carve-out that keeps the guard from blocking its own cohort. A show
+   * whose `show_end` marker landed but whose `end_time` was never stamped (the
+   * lost-webhook residue `jobs/legacy-mirror-reconcile` detects, BS#2065) holds
+   * `max(shows.id)` while being demonstrably over. `jobs/legacy-mirror-reconcile`
+   * already paid for this correction once (BS#2068); a bare `id === max(id)`
+   * test would 409 exactly the show the nightly detector flagged for closing.
+   */
+  it('does not 409 a max(id) show whose terminal entry is already a show_end marker', async () => {
+    const orphaned = { id: 1951168, primary_dj_id: null, end_time: null };
+    mockGetShowById.mockResolvedValue(orphaned);
+    mockGetLatestShow.mockResolvedValue(orphaned);
+    mockIsLatestEntryShowEnd.mockResolvedValue(true);
+    mockEndShow.mockResolvedValue({ ...orphaned, end_time: endInstant });
+
+    const { res, statusMock } = createMockRes();
+    await forceEndShow(makeReq({}, { id: '1951168' }), res, next);
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(mockEndShow).toHaveBeenCalledWith(orphaned, endInstant);
   });
 
   it('ends the current on-air show when force=true is passed explicitly', async () => {

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Controller-level behaviour for the operator-close pair (BS#2235).
+ *
+ * The permission tier lives in
+ * `tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts`; the
+ * rendered query shape in
+ * `tests/unit/services/flowsheet.getOpenShows.sql.test.ts`. This file covers
+ * what the handlers do with their inputs.
+ */
+import { jest } from '@jest/globals';
+
+const mockGetOpenShows = jest.fn<(hours?: number) => Promise<unknown>>();
+const mockGetShowById = jest.fn<(id: number) => Promise<unknown>>();
+const mockEndShow = jest.fn<(show: unknown) => Promise<unknown>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getOpenShows: mockGetOpenShows,
+  getShowById: mockGetShowById,
+  endShow: mockEndShow,
+  OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
+  OPEN_SHOWS_MAX_WINDOW_HOURS: 8760,
+}));
+
+jest.mock('async-mutex', () => ({
+  Mutex: jest.fn().mockImplementation(() => ({
+    acquire: jest.fn().mockResolvedValue(jest.fn()),
+  })),
+}));
+
+import { getOpenShows, forceEndShow } from '../../../apps/backend/controllers/flowsheet.controller';
+import WxycError from '../../../apps/backend/utils/error';
+import type { Request, Response, NextFunction } from 'express';
+
+function createMockRes() {
+  const statusMock = jest.fn();
+  const jsonMock = jest.fn();
+  const res: Partial<Response> = {};
+  statusMock.mockReturnValue(res);
+  jsonMock.mockReturnValue(res);
+  res.status = statusMock as unknown as Response['status'];
+  res.json = jsonMock as unknown as Response['json'];
+  return { res: res as Response, statusMock, jsonMock };
+}
+
+const next = jest.fn() as unknown as NextFunction;
+
+describe('GET /flowsheet/open-shows — window_hours handling', () => {
+  beforeEach(() => {
+    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], older_open_show_count: 0 });
+  });
+
+  it('defaults to the 7-day window when window_hours is absent', async () => {
+    const req = { query: {} } as unknown as Request;
+    const { res, statusMock, jsonMock } = createMockRes();
+
+    await getOpenShows(req, res, next);
+
+    expect(mockGetOpenShows).toHaveBeenCalledWith(168);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({ shows: [], older_open_show_count: 0 });
+  });
+
+  it('passes a valid window_hours through', async () => {
+    const req = { query: { window_hours: '24' } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await getOpenShows(req, res, next);
+
+    expect(mockGetOpenShows).toHaveBeenCalledWith(24);
+  });
+
+  // parseInt('24h') is 24. An operator who types a unit should be told, not
+  // silently handed a window they did not ask for.
+  it.each(['24h', '', ' ', '-1', '2.5', 'all', '0x10'])('rejects window_hours=%p with 400', async (raw) => {
+    const req = { query: { window_hours: raw } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await expect(getOpenShows(req, res, next)).rejects.toThrow(WxycError);
+    expect(mockGetOpenShows).not.toHaveBeenCalled();
+  });
+
+  it('rejects a window past the one-year ceiling', async () => {
+    const req = { query: { window_hours: '8761' } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await expect(getOpenShows(req, res, next)).rejects.toThrow('window_hours must be between 1 and 8760');
+    expect(mockGetOpenShows).not.toHaveBeenCalled();
+  });
+
+  it('accepts the ceiling itself', async () => {
+    const req = { query: { window_hours: '8760' } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await getOpenShows(req, res, next);
+
+    expect(mockGetOpenShows).toHaveBeenCalledWith(8760);
+  });
+});
+
+describe('POST /flowsheet/shows/:id/force-end', () => {
+  beforeEach(() => {
+    mockGetShowById.mockReset();
+    mockEndShow.mockReset();
+  });
+
+  it('reuses endShow and responds with the finalized show', async () => {
+    const openShow = { id: 1951164, primary_dj_id: 'dj-1', end_time: null };
+    const finalized = { ...openShow, end_time: new Date('2026-08-21T03:03:36.000Z') };
+    mockGetShowById.mockResolvedValue(openShow);
+    mockEndShow.mockResolvedValue(finalized);
+
+    const req = { params: { id: '1951164' } } as unknown as Request;
+    const { res, statusMock, jsonMock } = createMockRes();
+
+    await forceEndShow(req, res, next);
+
+    // Not a reimplementation: the same call the 2026-08-20 remediation made,
+    // so markers, show_djs deactivation and the tubafrenzy sign-off follow one
+    // implementation shared with POST /flowsheet/end.
+    expect(mockEndShow).toHaveBeenCalledWith(openShow);
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith(finalized);
+  });
+
+  // The endpoint's reason to exist: closing a show the caller has no
+  // relationship to, including one whose primary DJ is NULL (BS#2093 — the
+  // entire legacy cohort).
+  it('closes a show with a NULL primary_dj_id', async () => {
+    const orphan = { id: 74840, primary_dj_id: null, end_time: null };
+    mockGetShowById.mockResolvedValue(orphan);
+    mockEndShow.mockResolvedValue({ ...orphan, end_time: new Date() });
+
+    const req = { params: { id: '74840' } } as unknown as Request;
+    const { res, statusMock } = createMockRes();
+
+    await forceEndShow(req, res, next);
+
+    expect(mockEndShow).toHaveBeenCalledWith(orphan);
+    expect(statusMock).toHaveBeenCalledWith(200);
+  });
+
+  it('404s an id that matches no show', async () => {
+    mockGetShowById.mockResolvedValue(undefined);
+
+    const req = { params: { id: '999999999' } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await expect(forceEndShow(req, res, next)).rejects.toThrow('Not Found: no show with that id');
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  // The fast path. The real guarantee against a duplicate show_end marker is
+  // endShow's compare-and-set on `end_time IS NULL`, exercised in
+  // tests/unit/services/flowsheet.endShow.test.ts.
+  it('400s an already-ended show without calling endShow', async () => {
+    mockGetShowById.mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
+
+    const req = { params: { id: '5' } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await expect(forceEndShow(req, res, next)).rejects.toThrow('Bad Request: show is already ended');
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  it.each(['abc', '1.5', '-3', '', ' 5'])('400s a non-integer id %p without touching the database', async (id) => {
+    const req = { params: { id } } as unknown as Request;
+    const { res } = createMockRes();
+
+    await expect(forceEndShow(req, res, next)).rejects.toThrow('show id must be a positive integer');
+    expect(mockGetShowById).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -9,16 +9,22 @@
  */
 import { jest } from '@jest/globals';
 
-const mockGetOpenShows = jest.fn<(hours?: number) => Promise<unknown>>();
+const mockGetOpenShows = jest.fn<(hours?: number, limit?: number) => Promise<unknown>>();
 const mockGetShowById = jest.fn<(id: number) => Promise<unknown>>();
-const mockEndShow = jest.fn<(show: unknown) => Promise<unknown>>();
+const mockEndShow = jest.fn<(show: unknown, options?: unknown) => Promise<unknown>>();
+const mockGetLatestShow = jest.fn<() => Promise<unknown>>();
+const mockResolveShowEndInstant = jest.fn<(show: unknown) => Promise<Date>>();
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getOpenShows: mockGetOpenShows,
   getShowById: mockGetShowById,
   endShow: mockEndShow,
+  getLatestShow: mockGetLatestShow,
+  resolveShowEndInstant: mockResolveShowEndInstant,
   OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
-  OPEN_SHOWS_MAX_WINDOW_HOURS: 8760,
+  OPEN_SHOWS_MAX_WINDOW_HOURS: 262_800,
+  OPEN_SHOWS_DEFAULT_LIMIT: 100,
+  OPEN_SHOWS_MAX_LIMIT: 500,
 }));
 
 jest.mock('async-mutex', () => ({
@@ -44,80 +50,106 @@ function createMockRes() {
 
 const next = jest.fn() as unknown as NextFunction;
 
-describe('GET /flowsheet/open-shows — window_hours handling', () => {
+const makeReq = (query: Record<string, string> = {}, params: Record<string, string> = {}) =>
+  ({ query, params }) as unknown as Request;
+
+describe('GET /flowsheet/open-shows — query parameters', () => {
   beforeEach(() => {
-    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], older_open_show_count: 0 });
+    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], total_in_window: 0, older_open_show_count: 0 });
   });
 
-  it('defaults to the 7-day window when window_hours is absent', async () => {
-    const req = { query: {} } as unknown as Request;
+  it('defaults to the 7-day window and the default limit when neither is given', async () => {
     const { res, statusMock, jsonMock } = createMockRes();
 
-    await getOpenShows(req, res, next);
+    await getOpenShows(makeReq(), res, next);
 
-    expect(mockGetOpenShows).toHaveBeenCalledWith(168);
+    expect(mockGetOpenShows).toHaveBeenCalledWith(168, 100);
     expect(statusMock).toHaveBeenCalledWith(200);
-    expect(jsonMock).toHaveBeenCalledWith({ shows: [], older_open_show_count: 0 });
+    expect(jsonMock).toHaveBeenCalledWith({ shows: [], total_in_window: 0, older_open_show_count: 0 });
   });
 
   it('passes a valid window_hours through', async () => {
-    const req = { query: { window_hours: '24' } } as unknown as Request;
     const { res } = createMockRes();
+    await getOpenShows(makeReq({ window_hours: '24' }), res, next);
+    expect(mockGetOpenShows).toHaveBeenCalledWith(24, 100);
+  });
 
-    await getOpenShows(req, res, next);
-
-    expect(mockGetOpenShows).toHaveBeenCalledWith(24);
+  it('passes a valid limit through', async () => {
+    const { res } = createMockRes();
+    await getOpenShows(makeReq({ limit: '25' }), res, next);
+    expect(mockGetOpenShows).toHaveBeenCalledWith(168, 25);
   });
 
   // parseInt('24h') is 24. An operator who types a unit should be told, not
   // silently handed a window they did not ask for.
-  it.each(['24h', '', ' ', '-1', '2.5', 'all', '0x10'])('rejects window_hours=%p with 400', async (raw) => {
-    const req = { query: { window_hours: raw } } as unknown as Request;
+  it.each(['24h', '', ' ', '-1', '2.5', 'all', '0x10', '0'])('rejects window_hours=%p with 400', async (raw) => {
     const { res } = createMockRes();
 
-    await expect(getOpenShows(req, res, next)).rejects.toThrow(WxycError);
+    await expect(getOpenShows(makeReq({ window_hours: raw }), res, next)).rejects.toThrow(WxycError);
     expect(mockGetOpenShows).not.toHaveBeenCalled();
   });
 
-  it('rejects a window past the one-year ceiling', async () => {
-    const req = { query: { window_hours: '8761' } } as unknown as Request;
+  it.each(['0', '501', 'all', '1.5'])('rejects limit=%p with 400', async (raw) => {
     const { res } = createMockRes();
 
-    await expect(getOpenShows(req, res, next)).rejects.toThrow('window_hours must be between 1 and 8760');
+    await expect(getOpenShows(makeReq({ limit: raw }), res, next)).rejects.toThrow(WxycError);
     expect(mockGetOpenShows).not.toHaveBeenCalled();
   });
 
-  it('accepts the ceiling itself', async () => {
-    const req = { query: { window_hours: '8760' } } as unknown as Request;
+  it('rejects a window past the ceiling', async () => {
     const { res } = createMockRes();
 
-    await getOpenShows(req, res, next);
+    await expect(getOpenShows(makeReq({ window_hours: '262801' }), res, next)).rejects.toThrow(
+      'window_hours must be between 1 and 262800'
+    );
+    expect(mockGetOpenShows).not.toHaveBeenCalled();
+  });
 
-    expect(mockGetOpenShows).toHaveBeenCalledWith(8760);
+  /**
+   * The ceiling has to REACH the backlog. The first cut was 8,760 (one year),
+   * which made `older_open_show_count` a number describing rows no legal
+   * request could ever list — production's open shows start in 2006.
+   */
+  it('accepts a window wide enough to reach a 2006 show', async () => {
+    const hoursBackTo2006 = 20 * 365 * 24;
+    const { res } = createMockRes();
+
+    await getOpenShows(makeReq({ window_hours: String(hoursBackTo2006) }), res, next);
+
+    expect(mockGetOpenShows).toHaveBeenCalledWith(hoursBackTo2006, 100);
   });
 });
 
 describe('POST /flowsheet/shows/:id/force-end', () => {
+  const endInstant = new Date('2026-08-20T18:46:20.000Z');
+
   beforeEach(() => {
     mockGetShowById.mockReset();
     mockEndShow.mockReset();
+    // Default: the target is not the on-air show, so the guard stays quiet.
+    mockGetLatestShow.mockReset().mockResolvedValue({ id: -1 });
+    mockResolveShowEndInstant.mockReset().mockResolvedValue(endInstant);
   });
 
-  it('reuses endShow and responds with the finalized show', async () => {
+  it('reuses endShow with the show’s own end instant and responds with the finalized show', async () => {
     const openShow = { id: 1951164, primary_dj_id: 'dj-1', end_time: null };
-    const finalized = { ...openShow, end_time: new Date('2026-08-21T03:03:36.000Z') };
+    const finalized = { ...openShow, end_time: endInstant };
     mockGetShowById.mockResolvedValue(openShow);
     mockEndShow.mockResolvedValue(finalized);
 
-    const req = { params: { id: '1951164' } } as unknown as Request;
     const { res, statusMock, jsonMock } = createMockRes();
-
-    await forceEndShow(req, res, next);
+    await forceEndShow(makeReq({}, { id: '1951164' }), res, next);
 
     // Not a reimplementation: the same call the 2026-08-20 remediation made,
     // so markers, show_djs deactivation and the tubafrenzy sign-off follow one
     // implementation shared with POST /flowsheet/end.
-    expect(mockEndShow).toHaveBeenCalledWith(openShow);
+    //
+    // `endedAt` is what makes that reuse safe for an OLD show. Stamping now()
+    // would give a 2006 show an interval overlapping every archive day since,
+    // and put its show_end marker at the top of the live flowsheet — see
+    // EndShowOptions in flowsheet.service.
+    expect(mockResolveShowEndInstant).toHaveBeenCalledWith(openShow);
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, { endedAt: endInstant });
     expect(statusMock).toHaveBeenCalledWith(200);
     expect(jsonMock).toHaveBeenCalledWith(finalized);
   });
@@ -128,24 +160,69 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
   it('closes a show with a NULL primary_dj_id', async () => {
     const orphan = { id: 74840, primary_dj_id: null, end_time: null };
     mockGetShowById.mockResolvedValue(orphan);
-    mockEndShow.mockResolvedValue({ ...orphan, end_time: new Date() });
+    mockEndShow.mockResolvedValue({ ...orphan, end_time: endInstant });
 
-    const req = { params: { id: '74840' } } as unknown as Request;
     const { res, statusMock } = createMockRes();
+    await forceEndShow(makeReq({}, { id: '74840' }), res, next);
 
-    await forceEndShow(req, res, next);
-
-    expect(mockEndShow).toHaveBeenCalledWith(orphan);
+    expect(mockEndShow).toHaveBeenCalledWith(orphan, { endedAt: endInstant });
     expect(statusMock).toHaveBeenCalledWith(200);
+  });
+
+  /**
+   * The server-side half of `is_current`. Deliberately NOT unconditional: the
+   * 2026-08-20 stuck show WAS `max(shows.id)` for the whole nine hours it hung,
+   * so a blanket refusal would veto the exact case this endpoint was built for.
+   * What it stops is a mistyped id, or an operator acting on a list fetched
+   * before a new show signed on.
+   */
+  it('409s when the target is the current on-air show', async () => {
+    const live = { id: 1951168, primary_dj_id: 'dj-1', end_time: null };
+    mockGetShowById.mockResolvedValue(live);
+    mockGetLatestShow.mockResolvedValue(live);
+
+    const { res } = createMockRes();
+
+    await expect(forceEndShow(makeReq({}, { id: '1951168' }), res, next)).rejects.toThrow('current on-air show');
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  it('ends the current on-air show when force=true is passed explicitly', async () => {
+    const live = { id: 1951164, primary_dj_id: 'dj-1', end_time: null };
+    mockGetShowById.mockResolvedValue(live);
+    mockGetLatestShow.mockResolvedValue(live);
+    mockEndShow.mockResolvedValue({ ...live, end_time: endInstant });
+
+    const { res, statusMock } = createMockRes();
+    await forceEndShow(makeReq({ force: 'true' }, { id: '1951164' }), res, next);
+
+    expect(mockEndShow).toHaveBeenCalled();
+    expect(statusMock).toHaveBeenCalledWith(200);
+    // force=true waives the confirmation and nothing else — the end instant is
+    // still derived, never replaced by now().
+    expect(mockResolveShowEndInstant).toHaveBeenCalledWith(live);
+  });
+
+  it('does not treat force=1 or force=yes as confirmation', async () => {
+    const live = { id: 7, primary_dj_id: 'dj-1', end_time: null };
+    mockGetShowById.mockResolvedValue(live);
+    mockGetLatestShow.mockResolvedValue(live);
+
+    for (const force of ['1', 'yes', 'TRUE', '']) {
+      const { res } = createMockRes();
+      await expect(forceEndShow(makeReq({ force }, { id: '7' }), res, next)).rejects.toThrow('current on-air show');
+    }
+    expect(mockEndShow).not.toHaveBeenCalled();
   });
 
   it('404s an id that matches no show', async () => {
     mockGetShowById.mockResolvedValue(undefined);
 
-    const req = { params: { id: '999999999' } } as unknown as Request;
     const { res } = createMockRes();
 
-    await expect(forceEndShow(req, res, next)).rejects.toThrow('Not Found: no show with that id');
+    await expect(forceEndShow(makeReq({}, { id: '999999999' }), res, next)).rejects.toThrow(
+      'Not Found: no show with that id'
+    );
     expect(mockEndShow).not.toHaveBeenCalled();
   });
 
@@ -155,18 +232,18 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
   it('400s an already-ended show without calling endShow', async () => {
     mockGetShowById.mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
 
-    const req = { params: { id: '5' } } as unknown as Request;
     const { res } = createMockRes();
 
-    await expect(forceEndShow(req, res, next)).rejects.toThrow('Bad Request: show is already ended');
+    await expect(forceEndShow(makeReq({}, { id: '5' }), res, next)).rejects.toThrow(
+      'Bad Request: show is already ended'
+    );
     expect(mockEndShow).not.toHaveBeenCalled();
   });
 
   it.each(['abc', '1.5', '-3', '', ' 5'])('400s a non-integer id %p without touching the database', async (id) => {
-    const req = { params: { id } } as unknown as Request;
     const { res } = createMockRes();
 
-    await expect(forceEndShow(req, res, next)).rejects.toThrow('show id must be a positive integer');
+    await expect(forceEndShow(makeReq({}, { id }), res, next)).rejects.toThrow('show id must be a positive integer');
     expect(mockGetShowById).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
+++ b/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
@@ -33,23 +33,10 @@ function mockRole(role: string) {
   });
 }
 
-const mockGetOpenShows = jestGlobals.fn<() => Promise<unknown>>();
-const mockGetShowById = jestGlobals.fn<() => Promise<unknown>>();
-const mockEndShow = jestGlobals.fn<() => Promise<unknown>>();
-
-const mockGetLatestShow = jestGlobals.fn<() => Promise<unknown>>();
-const mockResolveShowEndInstant = jestGlobals.fn<() => Promise<Date>>();
-
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
-  getOpenShows: mockGetOpenShows,
-  getShowById: mockGetShowById,
-  endShow: mockEndShow,
-  getLatestShow: mockGetLatestShow,
-  resolveShowEndInstant: mockResolveShowEndInstant,
-  OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
-  OPEN_SHOWS_MAX_WINDOW_HOURS: 262_800,
-  OPEN_SHOWS_DEFAULT_LIMIT: 100,
-  OPEN_SHOWS_MAX_LIMIT: 500,
+  ...jest
+    .requireActual<typeof import('../../mocks/flowsheet-service.mock')>('../../mocks/flowsheet-service.mock')
+    .createFlowsheetServiceMock(),
   getLastModifiedAt: jest.fn(),
 }));
 
@@ -65,7 +52,14 @@ jest.mock('../../../apps/backend/middleware/legacy/flowsheet.mirror', () => ({
   ),
 }));
 
+import { resetFlowsheetServiceMock } from '../../mocks/flowsheet-service.mock';
+import * as flowsheetService from '../../../apps/backend/services/flowsheet.service';
 import { flowsheet_route } from '../../../apps/backend/routes/flowsheet.route';
+
+const service = flowsheetService as unknown as ReturnType<
+  typeof import('../../mocks/flowsheet-service.mock').createFlowsheetServiceMock
+>;
+const { getOpenShows: mockGetOpenShows, getShowById: mockGetShowById, endShow: mockEndShow } = service;
 
 const app = express();
 app.use(express.json());
@@ -87,13 +81,11 @@ app.use('/flowsheet', flowsheet_route);
  */
 describe('operator close — permission tier (BS#2235)', () => {
   beforeEach(() => {
-    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], total_in_window: 0, older_open_show_count: 0 });
-    // Not the on-air show, so force-end's confirmation guard stays quiet —
-    // this suite is about the permission tier, not that guard.
-    mockGetLatestShow.mockReset().mockResolvedValue({ id: -1 });
-    mockResolveShowEndInstant.mockReset().mockResolvedValue(new Date('2026-08-20T18:46:20.000Z'));
-    mockGetShowById.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: null });
-    mockEndShow.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
+    // The permission tier is what this suite is about; the baseline keeps the
+    // force-end confirmation guard quiet so a 403 can only come from the gate.
+    resetFlowsheetServiceMock(service, new Date('2026-08-20T18:46:20.000Z'));
+    mockGetShowById.mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: null });
+    mockEndShow.mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
   });
 
   describe.each([

--- a/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
+++ b/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
@@ -37,12 +37,19 @@ const mockGetOpenShows = jestGlobals.fn<() => Promise<unknown>>();
 const mockGetShowById = jestGlobals.fn<() => Promise<unknown>>();
 const mockEndShow = jestGlobals.fn<() => Promise<unknown>>();
 
+const mockGetLatestShow = jestGlobals.fn<() => Promise<unknown>>();
+const mockResolveShowEndInstant = jestGlobals.fn<() => Promise<Date>>();
+
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getOpenShows: mockGetOpenShows,
   getShowById: mockGetShowById,
   endShow: mockEndShow,
+  getLatestShow: mockGetLatestShow,
+  resolveShowEndInstant: mockResolveShowEndInstant,
   OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
-  OPEN_SHOWS_MAX_WINDOW_HOURS: 8760,
+  OPEN_SHOWS_MAX_WINDOW_HOURS: 262_800,
+  OPEN_SHOWS_DEFAULT_LIMIT: 100,
+  OPEN_SHOWS_MAX_LIMIT: 500,
   getLastModifiedAt: jest.fn(),
 }));
 
@@ -80,7 +87,11 @@ app.use('/flowsheet', flowsheet_route);
  */
 describe('operator close — permission tier (BS#2235)', () => {
   beforeEach(() => {
-    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], older_open_show_count: 0 });
+    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], total_in_window: 0, older_open_show_count: 0 });
+    // Not the on-air show, so force-end's confirmation guard stays quiet —
+    // this suite is about the permission tier, not that guard.
+    mockGetLatestShow.mockReset().mockResolvedValue({ id: -1 });
+    mockResolveShowEndInstant.mockReset().mockResolvedValue(new Date('2026-08-20T18:46:20.000Z'));
     mockGetShowById.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: null });
     mockEndShow.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
   });

--- a/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
+++ b/tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts
@@ -1,0 +1,135 @@
+// Set required env vars before module load (ts-jest transforms imports to
+// requires, so these execute before the auth middleware module's top-level
+// code runs). Mirrors tests/unit/routes/library-missing-found-permissions.route.test.ts.
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+// jest.unit.config.ts's moduleNameMapper sends `@wxyc/authentication` to a stub
+// whose requirePermissions only checks for an Authorization header, ignoring
+// the permission argument entirely. This suite is about the permission
+// argument, so the REAL implementation is wired back in.
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import { jest as jestGlobals } from '@jest/globals';
+import { jwtVerify } from 'jose';
+import express from 'express';
+import request from 'supertest';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function mockRole(role: string) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: { sub: 'test-user-id', email: 'test@wxyc.org', role },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  });
+}
+
+const mockGetOpenShows = jestGlobals.fn<() => Promise<unknown>>();
+const mockGetShowById = jestGlobals.fn<() => Promise<unknown>>();
+const mockEndShow = jestGlobals.fn<() => Promise<unknown>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getOpenShows: mockGetOpenShows,
+  getShowById: mockGetShowById,
+  endShow: mockEndShow,
+  OPEN_SHOWS_DEFAULT_WINDOW_HOURS: 168,
+  OPEN_SHOWS_MAX_WINDOW_HOURS: 8760,
+  getLastModifiedAt: jest.fn(),
+}));
+
+// The mirror middleware is registered on the force-end route; it taps the
+// response and defers everything else to `res.once('finish')`. Stubbed to a
+// pass-through so this suite tests the gate, not the tubafrenzy path.
+jest.mock('../../../apps/backend/middleware/legacy/flowsheet.mirror', () => ({
+  flowsheetMirror: new Proxy(
+    {},
+    {
+      get: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+    }
+  ),
+}));
+
+import { flowsheet_route } from '../../../apps/backend/routes/flowsheet.route';
+
+const app = express();
+app.use(express.json());
+app.use('/flowsheet', flowsheet_route);
+
+/**
+ * BS#2235. The operator-close pair is the only surface in this router gated
+ * above `flowsheet: ['write']` — every DJ holds that, and the whole point of
+ * these two routes is to act on a show the caller does not own.
+ *
+ * `flowsheet: ['manage']` is held by musicDirector and stationManager only
+ * (shared/authentication/src/auth.roles.ts). Note that the capability this
+ * replaces — tubafrenzy's `EndShowServlet`, reachable from the signon page's
+ * "Resume a Show" list — had NO ownership or role check at all, so this is a
+ * narrowing, not a new grant.
+ *
+ * Integration tests run under AUTH_BYPASS=true, whose branch short-circuits to
+ * next() before any permission check, so they cannot cover this tier.
+ */
+describe('operator close — permission tier (BS#2235)', () => {
+  beforeEach(() => {
+    mockGetOpenShows.mockReset().mockResolvedValue({ shows: [], older_open_show_count: 0 });
+    mockGetShowById.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: null });
+    mockEndShow.mockReset().mockResolvedValue({ id: 5, primary_dj_id: 'dj-1', end_time: new Date() });
+  });
+
+  describe.each([
+    ['GET /flowsheet/open-shows', (r: express.Express) => request(r).get('/flowsheet/open-shows')],
+    ['POST /flowsheet/shows/:id/force-end', (r: express.Express) => request(r).post('/flowsheet/shows/5/force-end')],
+  ])('%s', (_label, call) => {
+    test('a musicDirector token is authorized', async () => {
+      mockRole('musicDirector');
+      const res = await call(app).set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(200);
+    });
+
+    test('a stationManager token is authorized', async () => {
+      mockRole('stationManager');
+      const res = await call(app).set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(200);
+    });
+
+    test('an admin token is authorized (normalizeRole maps admin -> stationManager)', async () => {
+      mockRole('admin');
+      const res = await call(app).set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(200);
+    });
+
+    // The load-bearing assertion: a plain DJ holds flowsheet:write and is
+    // admitted by every other write route in this router. It must not reach
+    // these two.
+    test('a dj token is rejected with 403', async () => {
+      mockRole('dj');
+      const res = await call(app).set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(403);
+      expect(mockGetOpenShows).not.toHaveBeenCalled();
+      expect(mockEndShow).not.toHaveBeenCalled();
+    });
+
+    test('a member token is rejected with 403', async () => {
+      mockRole('member');
+      const res = await call(app).set('Authorization', 'Bearer test-token');
+      expect(res.status).toBe(403);
+      expect(mockEndShow).not.toHaveBeenCalled();
+    });
+
+    test('a request with no Authorization header is rejected with 401', async () => {
+      const res = await call(app);
+      expect(res.status).toBe(401);
+      expect(mockGetOpenShows).not.toHaveBeenCalled();
+      expect(mockEndShow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -136,20 +136,10 @@ describe('endShow', () => {
   });
 
   /**
-   * BS#2235 review finding 1/2. `endShow` was written for a DJ signing off NOW,
-   * and the operator-close path reuses it for shows that stopped broadcasting
-   * long ago. Two public reads make `now()` wrong there, not merely imprecise:
-   *
-   *   1. `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
-   *      archive.wxyc.org reads) admits a closed show when
-   *      `start_time < windowEnd AND end_time > windowStart`. A 2006 show
-   *      stamped `end_time = now` satisfies that for EVERY day since, so
-   *      working the backlog would inject bogus multi-decade shows into every
-   *      archive page.
-   *   2. `getEntriesByPage` orders globally by `add_time DESC, id DESC` and
-   *      serves `GET /flowsheet` page 0 and `GET /flowsheet/latest`. A
-   *      `show_end` marker at `add_time = now()` becomes the newest entry on
-   *      the public flowsheet.
+   * BS#2235 review finding 1/2 — `endShow` was written for a DJ signing off
+   * NOW, and the operator path reuses it for shows that stopped long ago. The
+   * two public reads that make `now()` wrong there (rather than merely
+   * imprecise) are set out once, on `endShow` itself.
    */
   it('stamps end_time and the marker add_time from the supplied instant, not now()', async () => {
     const endedAt = new Date('2006-04-02T05:15:30.276Z');
@@ -169,7 +159,7 @@ describe('endShow', () => {
     const showsUpdate = createMockQueryChain([{ id: 72464, end_time: endedAt }]);
     db.update.mockReturnValueOnce(showsUpdate);
 
-    await endShow({ id: 72464, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0], { endedAt });
+    await endShow({ id: 72464, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0], endedAt);
 
     expect(showsUpdate.set).toHaveBeenCalledWith({ end_time: endedAt });
 

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -135,6 +135,130 @@ describe('endShow', () => {
     expect(leaveInsert.values).toHaveBeenCalledWith(expect.objectContaining({ entry_type: 'dj_leave' }));
   });
 
+  /**
+   * BS#2235 review finding 1/2. `endShow` was written for a DJ signing off NOW,
+   * and the operator-close path reuses it for shows that stopped broadcasting
+   * long ago. Two public reads make `now()` wrong there, not merely imprecise:
+   *
+   *   1. `getShowsInTimeWindow` (backing `GET /flowsheet/range`, which
+   *      archive.wxyc.org reads) admits a closed show when
+   *      `start_time < windowEnd AND end_time > windowStart`. A 2006 show
+   *      stamped `end_time = now` satisfies that for EVERY day since, so
+   *      working the backlog would inject bogus multi-decade shows into every
+   *      archive page.
+   *   2. `getEntriesByPage` orders globally by `add_time DESC, id DESC` and
+   *      serves `GET /flowsheet` page 0 and `GET /flowsheet/latest`. A
+   *      `show_end` marker at `add_time = now()` becomes the newest entry on
+   *      the public flowsheet.
+   */
+  it('stamps end_time and the marker add_time from the supplied instant, not now()', async () => {
+    const endedAt = new Date('2006-04-02T05:15:30.276Z');
+
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'DJ Flacko' }]);
+    db.select.mockReturnValueOnce(userSelect);
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(1));
+
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+
+    const showsUpdate = createMockQueryChain([{ id: 72464, end_time: endedAt }]);
+    db.update.mockReturnValueOnce(showsUpdate);
+
+    await endShow({ id: 72464, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0], { endedAt });
+
+    expect(showsUpdate.set).toHaveBeenCalledWith({ end_time: endedAt });
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.add_time).toEqual(endedAt);
+    // The rendered wording follows the same instant, so a closed show cannot
+    // disagree with its own marker about when it ended.
+    expect(flowsheetValues.message).toContain('2006');
+  });
+
+  it('defaults to now() when no instant is supplied, leaving the live sign-off unchanged', async () => {
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'DJ Night Owl' }]);
+    db.select.mockReturnValueOnce(userSelect);
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(1));
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
+
+    const showsUpdate = createMockQueryChain([{ id: 42, end_time: new Date() }]);
+    db.update.mockReturnValueOnce(showsUpdate);
+
+    const before = Date.now();
+    await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
+    const after = Date.now();
+
+    const stamped = (showsUpdate.set.mock.calls[0]?.[0] as { end_time: Date }).end_time;
+    expect(stamped.getTime()).toBeGreaterThanOrEqual(before);
+    expect(stamped.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  /**
+   * BS#2235 review finding 3. The marker name used to come from a bare
+   * `auth_user.dj_name` read, which ignored `shows.dj_name_override` — so a
+   * show carrying an override put it on `show_start` and on every track row,
+   * then reverted here, leaving the one within-show inconsistency BS#1321 set
+   * out to remove on the closing marker.
+   */
+  it('honours dj_name_override on the show_end marker', async () => {
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(4));
+
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 42, end_time: new Date() }]));
+
+    await endShow({
+      id: 42,
+      primary_dj_id: 'user-1',
+      dj_name_override: 'Aubrey Hearst',
+    } as unknown as Parameters<typeof endShow>[0]);
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('Aubrey Hearst');
+  });
+
+  /**
+   * The other half of finding 3: with a NULL `primary_dj_id` there is no user
+   * row at all, so the old bare read resolved `null` for the ENTIRE legacy
+   * cohort and wrote a nameless marker among sibling rows that do carry the
+   * tubafrenzy handle.
+   */
+  it('falls back to legacy_dj_name on the show_end marker of an ownerless show', async () => {
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(2));
+
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 73249, end_time: new Date() }]));
+
+    await endShow({
+      id: 73249,
+      primary_dj_id: null,
+      legacy_dj_name: 'DJ Mouseness',
+    } as unknown as Parameters<typeof endShow>[0]);
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('DJ Mouseness');
+    expect(flowsheetValues.message).toContain('DJ Mouseness');
+  });
+
   it('rejects the loser of a concurrent double-end without writing a second show_end marker', async () => {
     // The end_time UPDATE is a compare-and-set (`WHERE id = ? AND end_time IS
     // NULL`) and runs FIRST, before any other write. The controller's own

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -69,6 +69,72 @@ describe('endShow', () => {
     expect(flowsheetValues.dj_name).toBeNull();
   });
 
+  /**
+   * BS#2093, decided by BS#2235. This used to `throw new Error('Primary DJ not
+   * found')`, which made a NULL-primary show permanently un-endable — and
+   * `shows.primary_dj_id` is `onDelete: 'set null'`, so deleting a DJ's
+   * account orphans every show they ran. The legacy ETL cohort is the bulk of
+   * it: 2,813 of production's 2,814 open shows carried NULL here on
+   * 2026-08-21, and they are exactly what `POST /flowsheet/shows/:id/force-end`
+   * exists to close.
+   */
+  it('ends a show whose primary_dj_id is NULL, with the degraded marker wording', async () => {
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    // No user lookup happens on this path — there is no id to look up — so the
+    // next select the implementation reaches for is nextPlayOrder's.
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(3));
+
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 74840, end_time: new Date() }]));
+
+    const finalized = await endShow({
+      id: 74840,
+      primary_dj_id: null,
+    } as unknown as Parameters<typeof endShow>[0]);
+
+    expect(finalized).toMatchObject({ id: 74840 });
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues).toEqual(expect.objectContaining({ entry_type: 'show_end', show_id: 74840, dj_name: null }));
+    // The name-less template, same one an unresolvable djName produces.
+    expect(flowsheetValues.message).toMatch(/^End of show: /);
+  });
+
+  it('deactivates every show_djs row when primary_dj_id is NULL', async () => {
+    // The loop skips the primary so it does not write itself a leave marker.
+    // With a NULL primary, `dj.dj_id === primary_dj_id` is false for every row
+    // (dj_id is NOT NULL), so every membership deactivates and every co-host
+    // gets a leave marker — correct for an ownerless show.
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([{ show_id: 74840, dj_id: 'guest-1', active: true }]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    // createLeaveNotification: user lookup, then nextPlayOrder, then insert.
+    const guestUserSelect = createMockQueryChain();
+    guestUserSelect.limit.mockResolvedValue([{ djName: 'DJ Guest' }]);
+    db.select.mockReturnValueOnce(guestUserSelect);
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(1));
+    const leaveInsert = createMockQueryChain([{ id: 111 }]);
+    db.insert.mockReturnValueOnce(leaveInsert);
+
+    // Then the show_end marker's own nextPlayOrder + insert.
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(2));
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
+
+    const showDjsUpdate = createMockQueryChain([{ show_id: 74840, dj_id: 'guest-1', active: false }]);
+    db.update.mockReturnValueOnce(createMockQueryChain([{ id: 74840, end_time: new Date() }]));
+    db.update.mockReturnValueOnce(showDjsUpdate);
+
+    await endShow({ id: 74840, primary_dj_id: null } as unknown as Parameters<typeof endShow>[0]);
+
+    expect(showDjsUpdate.set).toHaveBeenCalledWith({ active: false });
+    expect(leaveInsert.values).toHaveBeenCalledWith(expect.objectContaining({ entry_type: 'dj_leave' }));
+  });
+
   it('rejects the loser of a concurrent double-end without writing a second show_end marker', async () => {
     // The end_time UPDATE is a compare-and-set (`WHERE id = ? AND end_time IS
     // NULL`) and runs FIRST, before any other write. The controller's own

--- a/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
@@ -71,7 +71,16 @@ describe('buildOpenShowsQuery — rendered statement (BS#2235)', () => {
   it('filters on end_time IS NULL and binds the window floor as a parameter', () => {
     expect(text).toContain(`"${SCHEMA}"."shows"."end_time" is null`);
     expect(text).toContain(`"${SCHEMA}"."shows"."start_time" >= $1`);
-    expect(params).toHaveLength(1);
+    // Two bound values: the window floor and the row cap. Both parameters, not
+    // interpolated text.
+    // The floor arrives already serialized by drizzle's timestamptz encoder.
+    expect(params).toEqual(['2026-08-14T00:00:00.000Z', 100]);
+  });
+
+  it('caps the row count so the read is bounded by construction', () => {
+    // `window_hours` reaches 30 years, so without this the response is every
+    // open show in the database in one JSON body.
+    expect(text).toContain('limit $2');
   });
 
   it('orders oldest-first with a deterministic tie-break on id', () => {

--- a/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Genuinely-rendered-SQL pin for `GET /flowsheet/open-shows` (BS#2235).
+ *
+ * WHAT THIS PROTECTS. tubafrenzy's open-show list called `getNumberOfEntries`
+ * once per show from inside its iteration — an N+1 that is invisible over the
+ * handful of rows a dev database holds and is not invisible over production's
+ * (2,814 open shows measured 2026-08-21, against a `flowsheet` table of ~2.6M
+ * rows on a `db.t3.micro` with a 5s statement timeout). The replacement gets
+ * its counts from ONE grouped `LEFT JOIN`, and the acceptance criterion on the
+ * ticket is that a future edit cannot quietly reintroduce the per-show count.
+ *
+ * A call-shape mock cannot express that: "did anyone call `db.select` twice?"
+ * is not the same question as "does the statement aggregate". So this renders
+ * the real `buildOpenShowsQuery` through drizzle's own dialect and asserts on
+ * the statement text.
+ *
+ * The mechanism is the one `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts`
+ * established: `jest.unit.config.ts`'s moduleNameMapper unconditionally
+ * redirects the bare `@wxyc/database` specifier to a chain-returning stub whose
+ * tables are plain string maps, so real drizzle operators cannot compose an
+ * `SQL` AST from them. An explicit `jest.mock` factory overrides that redirect
+ * for this file's registry — including `flowsheet.service.ts`'s own import —
+ * supplying the REAL schema plus a real (never-connected) drizzle instance.
+ * `.toSQL()` never touches the client.
+ */
+
+jest.unmock('drizzle-orm');
+
+jest.mock('@wxyc/database', () => {
+  const realSchema = jest.requireActual('../../../shared/database/src/schema');
+  const realDjName = jest.requireActual('../../../shared/database/src/dj-name');
+  const realOrderBy = jest.requireActual('../../../shared/database/src/last-logged-show-entry');
+  const { drizzle } = jest.requireActual('drizzle-orm/postgres-js');
+  return {
+    ...realSchema,
+    ...realDjName,
+    ...realOrderBy,
+    // A drizzle instance over a client that is never called: the query builder
+    // renders SQL without executing, and nothing in this file awaits a query.
+    db: drizzle({}),
+  };
+});
+
+import { buildOpenShowsQuery } from '../../../apps/backend/services/flowsheet.service';
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const { sql: text, params } = buildOpenShowsQuery(new Date('2026-08-14T00:00:00.000Z')).toSQL();
+
+describe('buildOpenShowsQuery — rendered statement (BS#2235)', () => {
+  it('aggregates the entry count in the statement rather than per show', () => {
+    expect(text).toContain(`count("${SCHEMA}"."flowsheet"."id")::int`);
+    expect(text).toContain(`group by`);
+  });
+
+  it('reaches flowsheet through a LEFT JOIN, so a show with zero entries still appears', () => {
+    // An INNER JOIN here would silently drop exactly the cohort the endpoint
+    // exists for: production show 74840 is open with zero flowsheet entries.
+    expect(text).toContain(
+      `left join "${SCHEMA}"."flowsheet" on "${SCHEMA}"."flowsheet"."show_id" = "${SCHEMA}"."shows"."id"`
+    );
+  });
+
+  it('resolves the DJ handle via a LEFT JOIN on auth_user, not a per-show lookup', () => {
+    // `resolveDjNameForShow` would cost one query per show. The chain runs in
+    // JS over columns this join already fetched — the same trade
+    // `getShowsInTimeWindow` (BS#2062) makes.
+    expect(text).toContain(`left join "auth_user" on "auth_user"."id" = "${SCHEMA}"."shows"."primary_dj_id"`);
+    expect(text).toContain(`"auth_user"."dj_name"`);
+  });
+
+  it('filters on end_time IS NULL and binds the window floor as a parameter', () => {
+    expect(text).toContain(`"${SCHEMA}"."shows"."end_time" is null`);
+    expect(text).toContain(`"${SCHEMA}"."shows"."start_time" >= $1`);
+    expect(params).toHaveLength(1);
+  });
+
+  it('orders oldest-first with a deterministic tie-break on id', () => {
+    // Second-granularity start_time collisions are real in this data: the
+    // legacy ETL produced the 00:55:35 / 00:55:41 pairs visible in
+    // production's open-show tail. Without the `id` tie-break the list
+    // reshuffles between identical requests.
+    expect(text).toContain(`order by "${SCHEMA}"."shows"."start_time" asc, "${SCHEMA}"."shows"."id" asc`);
+  });
+
+  it('emits exactly one statement — no correlated per-show subquery', () => {
+    expect(text.toLowerCase().split('select').length - 1).toBe(1);
+  });
+
+  it('groups by every non-aggregated selected column', () => {
+    // Spelled out rather than leaning on Postgres inferring functional
+    // dependency from `shows.id`, so a future widening of the select list
+    // fails loudly here instead of at runtime.
+    for (const column of [
+      `"${SCHEMA}"."shows"."id"`,
+      `"${SCHEMA}"."shows"."primary_dj_id"`,
+      `"${SCHEMA}"."shows"."show_name"`,
+      `"${SCHEMA}"."shows"."start_time"`,
+      `"${SCHEMA}"."shows"."legacy_show_id"`,
+      `"${SCHEMA}"."shows"."dj_name_override"`,
+      `"${SCHEMA}"."shows"."legacy_dj_name"`,
+      `"auth_user"."id"`,
+      `"auth_user"."dj_name"`,
+    ]) {
+      expect(text.slice(text.indexOf('group by'))).toContain(column);
+    }
+  });
+});

--- a/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.sql.test.ts
@@ -1,18 +1,21 @@
 /**
  * Genuinely-rendered-SQL pin for `GET /flowsheet/open-shows` (BS#2235).
  *
- * WHAT THIS PROTECTS. tubafrenzy's open-show list called `getNumberOfEntries`
- * once per show from inside its iteration — an N+1 that is invisible over the
- * handful of rows a dev database holds and is not invisible over production's
- * (2,814 open shows measured 2026-08-21, against a `flowsheet` table of ~2.6M
- * rows on a `db.t3.micro` with a 5s statement timeout). The replacement gets
- * its counts from ONE grouped `LEFT JOIN`, and the acceptance criterion on the
- * ticket is that a future edit cannot quietly reintroduce the per-show count.
+ * WHAT THIS PROTECTS, precisely. tubafrenzy's open-show list called
+ * `getNumberOfEntries` once per show from inside its iteration — an N+1 of
+ * ROUND TRIPS. The invariant is one statement, and the page bounded before
+ * anything fans out from it.
  *
- * A call-shape mock cannot express that: "did anyone call `db.select` twice?"
- * is not the same question as "does the statement aggregate". So this renders
- * the real `buildOpenShowsQuery` through drizzle's own dialect and asserts on
- * the statement text.
+ * A prior version of this file asserted "the rendered text contains exactly
+ * one `select` keyword", which conflates a subquery with a round trip. That
+ * pin was not just imprecise, it was actively harmful: it forbade the very
+ * shape that fixes the performance defect. The first cut of the query was a
+ * `LEFT JOIN flowsheet … GROUP BY … LIMIT`, and `LIMIT` after `GROUP BY`
+ * cannot push down — at the widened window `getOpenShows` documents for
+ * reaching the 2006 tail that means grouping all 2,814 open shows across
+ * ~100k joined `flowsheet` rows (each needing a heap fetch, since no index on
+ * `show_id` carries `flowsheet.id`) and then discarding 2,714 of them. The
+ * assertions below pin the property that actually matters instead.
  *
  * The mechanism is the one `tests/unit/jobs/legacy-mirror-reconcile/stale-open-shows-sql.test.ts`
  * established: `jest.unit.config.ts`'s moduleNameMapper unconditionally
@@ -44,73 +47,69 @@ jest.mock('@wxyc/database', () => {
 import { buildOpenShowsQuery } from '../../../apps/backend/services/flowsheet.service';
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-const { sql: text, params } = buildOpenShowsQuery(new Date('2026-08-14T00:00:00.000Z')).toSQL();
+const { sql: text, params } = buildOpenShowsQuery(new Date('2026-08-14T00:00:00.000Z'), 100).toSQL();
+
+/** Everything up to the first join — i.e. the subquery that produces the page. */
+const beforeJoin = text.slice(0, text.indexOf('left join'));
 
 describe('buildOpenShowsQuery — rendered statement (BS#2235)', () => {
-  it('aggregates the entry count in the statement rather than per show', () => {
-    expect(text).toContain(`count("${SCHEMA}"."flowsheet"."id")::int`);
-    expect(text).toContain(`group by`);
+  it('truncates the page BEFORE anything joins to it', () => {
+    // The load-bearing assertion. `limit` must land inside the `shows`
+    // subquery, not at the end of a grouped join — that is the difference
+    // between bounded work and 2,814 groups at the widened window.
+    expect(beforeJoin).toContain('limit $2');
+    expect(beforeJoin).toContain(`from "${SCHEMA}"."shows"`);
   });
 
-  it('reaches flowsheet through a LEFT JOIN, so a show with zero entries still appears', () => {
-    // An INNER JOIN here would silently drop exactly the cohort the endpoint
-    // exists for: production show 74840 is open with zero flowsheet entries.
+  it('bounds the page on the partial index: end_time IS NULL, ordered by start_time', () => {
+    // Filter, range bound and sort all come from `shows_open_start_time_idx`
+    // (migration 0154), so the truncation above is an index-only scan.
+    expect(beforeJoin).toContain(`"${SCHEMA}"."shows"."end_time" is null`);
+    expect(beforeJoin).toContain(`"${SCHEMA}"."shows"."start_time" >= $1`);
+    expect(beforeJoin).toContain(`order by "${SCHEMA}"."shows"."start_time" asc, "${SCHEMA}"."shows"."id" asc`);
+  });
+
+  it('counts entries in the same statement — one round trip, not the legacy N+1', () => {
     expect(text).toContain(
-      `left join "${SCHEMA}"."flowsheet" on "${SCHEMA}"."flowsheet"."show_id" = "${SCHEMA}"."shows"."id"`
+      `(SELECT count(*) FROM "${SCHEMA}"."flowsheet" WHERE "${SCHEMA}"."flowsheet"."show_id" = "page"."id")`
     );
+  });
+
+  it('counts with count(*), so the subquery is index-only', () => {
+    // `count(flowsheet.id)` — the grouped form's aggregate — would force a heap
+    // fetch per row, because neither `flowsheet_show_id_idx` nor
+    // `flowsheet_show_id_play_order_idx` carries `id`. `count(*)` needs no
+    // column value and is served entirely from the index.
+    expect(text).toContain('count(*)');
+    expect(text).not.toContain(`count("${SCHEMA}"."flowsheet"."id")`);
+  });
+
+  it('reaches flowsheet only through the correlated count, never an outer join', () => {
+    // An outer join to `flowsheet` would re-introduce the fan-out this shape
+    // exists to avoid, and an INNER one would silently drop exactly the cohort
+    // the endpoint is for — production show 74840 is open with zero entries.
+    expect(text).not.toContain(`join "${SCHEMA}"."flowsheet"`);
   });
 
   it('resolves the DJ handle via a LEFT JOIN on auth_user, not a per-show lookup', () => {
     // `resolveDjNameForShow` would cost one query per show. The chain runs in
     // JS over columns this join already fetched — the same trade
-    // `getShowsInTimeWindow` (BS#2062) makes.
-    expect(text).toContain(`left join "auth_user" on "auth_user"."id" = "${SCHEMA}"."shows"."primary_dj_id"`);
+    // `getShowsInTimeWindow` (BS#2062) makes. Joined to the already-truncated
+    // page, so it too is bounded by `limit`.
+    expect(text).toContain(`left join "auth_user" on "auth_user"."id" = "page"."primary_dj_id"`);
     expect(text).toContain(`"auth_user"."dj_name"`);
   });
 
-  it('filters on end_time IS NULL and binds the window floor as a parameter', () => {
-    expect(text).toContain(`"${SCHEMA}"."shows"."end_time" is null`);
-    expect(text).toContain(`"${SCHEMA}"."shows"."start_time" >= $1`);
-    // Two bound values: the window floor and the row cap. Both parameters, not
-    // interpolated text.
+  it('re-states the ordering on the outer statement', () => {
+    // A subquery is unordered by definition; without this the planner is free
+    // to reshuffle the page after the join. Second-granularity `start_time`
+    // collisions are real in this data (the legacy ETL's 00:55:35 / 00:55:41
+    // pairs), which is what the `id` tie-break is for.
+    expect(text.slice(text.indexOf('left join'))).toContain('order by "page"."start_time" asc, "page"."id" asc');
+  });
+
+  it('binds the window floor and the row cap as parameters', () => {
     // The floor arrives already serialized by drizzle's timestamptz encoder.
     expect(params).toEqual(['2026-08-14T00:00:00.000Z', 100]);
-  });
-
-  it('caps the row count so the read is bounded by construction', () => {
-    // `window_hours` reaches 30 years, so without this the response is every
-    // open show in the database in one JSON body.
-    expect(text).toContain('limit $2');
-  });
-
-  it('orders oldest-first with a deterministic tie-break on id', () => {
-    // Second-granularity start_time collisions are real in this data: the
-    // legacy ETL produced the 00:55:35 / 00:55:41 pairs visible in
-    // production's open-show tail. Without the `id` tie-break the list
-    // reshuffles between identical requests.
-    expect(text).toContain(`order by "${SCHEMA}"."shows"."start_time" asc, "${SCHEMA}"."shows"."id" asc`);
-  });
-
-  it('emits exactly one statement — no correlated per-show subquery', () => {
-    expect(text.toLowerCase().split('select').length - 1).toBe(1);
-  });
-
-  it('groups by every non-aggregated selected column', () => {
-    // Spelled out rather than leaning on Postgres inferring functional
-    // dependency from `shows.id`, so a future widening of the select list
-    // fails loudly here instead of at runtime.
-    for (const column of [
-      `"${SCHEMA}"."shows"."id"`,
-      `"${SCHEMA}"."shows"."primary_dj_id"`,
-      `"${SCHEMA}"."shows"."show_name"`,
-      `"${SCHEMA}"."shows"."start_time"`,
-      `"${SCHEMA}"."shows"."legacy_show_id"`,
-      `"${SCHEMA}"."shows"."dj_name_override"`,
-      `"${SCHEMA}"."shows"."legacy_dj_name"`,
-      `"auth_user"."id"`,
-      `"auth_user"."dj_name"`,
-    ]) {
-      expect(text.slice(text.indexOf('group by'))).toContain(column);
-    }
   });
 });

--- a/tests/unit/services/flowsheet.getOpenShows.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Row-mapping behaviour for `getOpenShows` (BS#2235) — the `is_current` /
+ * `likely_abandoned` decision and the DJ-name chain. The rendered SQL is pinned
+ * separately in `flowsheet.getOpenShows.sql.test.ts`.
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+import {
+  getOpenShows,
+  LIKELY_ABANDONED_ENTRY_THRESHOLD,
+  OPEN_SHOWS_DEFAULT_WINDOW_HOURS,
+} from '../../../apps/backend/services/flowsheet.service';
+
+type Row = Record<string, unknown>;
+
+/**
+ * `getOpenShows` fires three reads concurrently through `Promise.all`, so the
+ * `db.select` mock is primed positionally in call order: the grouped open-shows
+ * query, the older-than-window count, then `getLatestShow`'s `getNShows`.
+ */
+const primeReads = (rows: Row[], olderCount: number, latestShowId: number | null) => {
+  const openShows = createMockQueryChain();
+  openShows.orderBy.mockResolvedValue(rows);
+  db.select.mockReturnValueOnce(openShows);
+
+  const older = createMockQueryChain();
+  older.where.mockResolvedValue([{ n: olderCount }]);
+  db.select.mockReturnValueOnce(older);
+
+  const latest = createMockQueryChain();
+  latest.limit.mockResolvedValue(latestShowId === null ? [] : [{ id: latestShowId }]);
+  db.select.mockReturnValueOnce(latest);
+
+  return { openShows };
+};
+
+const row = (over: Row = {}): Row => ({
+  id: 1,
+  primary_dj_id: null,
+  show_name: null,
+  start_time: new Date('2026-08-14T12:00:00.000Z'),
+  legacy_show_id: null,
+  dj_name_override: null,
+  legacy_dj_name: null,
+  user_id: null,
+  user_dj_name: null,
+  entry_count: 0,
+  ...over,
+});
+
+describe('getOpenShows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('flags a low-entry non-current show as likely abandoned', async () => {
+    primeReads([row({ id: 74840, entry_count: 0 })], 0, 1951168);
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0]).toMatchObject({ id: 74840, entry_count: 0, is_current: false, likely_abandoned: true });
+  });
+
+  /**
+   * The load-bearing exclusion. A DJ who signed on two minutes ago has one or
+   * two entries and is emphatically not abandoned — flagging the live show as a
+   * close candidate is how an operator ends a broadcast in progress. `is_current`
+   * resolves against `getLatestShow`'s `max(shows.id)`, the same pivot every
+   * on-air read uses, so this endpoint and the banner cannot disagree.
+   */
+  it('never flags the current show, however few entries it has', async () => {
+    primeReads([row({ id: 1951168, entry_count: 1 })], 0, 1951168);
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0]).toMatchObject({ id: 1951168, is_current: true, likely_abandoned: false });
+  });
+
+  it('does not flag a non-current show at or above the entry threshold', async () => {
+    primeReads(
+      [
+        row({ id: 10, entry_count: LIKELY_ABANDONED_ENTRY_THRESHOLD - 1 }),
+        row({ id: 11, entry_count: LIKELY_ABANDONED_ENTRY_THRESHOLD }),
+      ],
+      0,
+      99
+    );
+
+    const { shows } = await getOpenShows();
+
+    expect(shows.map((s) => s.likely_abandoned)).toEqual([true, false]);
+  });
+
+  it('treats every show as non-current when nothing is open at all', async () => {
+    primeReads([row({ id: 7, entry_count: 1 })], 0, null);
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0]).toMatchObject({ is_current: false, likely_abandoned: true });
+  });
+
+  it('resolves the DJ handle through the shared chain: override beats the user row', async () => {
+    primeReads(
+      [
+        row({
+          primary_dj_id: 'dj-1',
+          user_id: 'dj-1',
+          user_dj_name: 'DJ Night Owl',
+          dj_name_override: 'Aubrey Hearst',
+        }),
+      ],
+      0,
+      99
+    );
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0].dj_name).toBe('Aubrey Hearst');
+  });
+
+  it('falls back to legacy_dj_name for a show with no linked account', async () => {
+    // The shape of the entire historical cohort: primary_dj_id NULL, identity
+    // carried by the tubafrenzy handle.
+    primeReads([row({ primary_dj_id: null, legacy_dj_name: 'DJ Mouseness' })], 0, 99);
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0].dj_name).toBe('DJ Mouseness');
+  });
+
+  it('reports the count of open shows older than the window without listing them', async () => {
+    primeReads([row({ id: 1951168, entry_count: 11 })], 2813, 1951168);
+
+    const result = await getOpenShows();
+
+    // Production on 2026-08-21: 2,814 open shows, one of them inside a 7-day
+    // window. Listing the other 2,813 would bury the actionable one.
+    expect(result.shows).toHaveLength(1);
+    expect(result.older_open_show_count).toBe(2813);
+  });
+
+  it('defaults the window to a week', () => {
+    expect(OPEN_SHOWS_DEFAULT_WINDOW_HOURS).toBe(24 * 7);
+  });
+});

--- a/tests/unit/services/flowsheet.getOpenShows.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.test.ts
@@ -9,6 +9,7 @@ import {
   getOpenShows,
   LIKELY_ABANDONED_ENTRY_THRESHOLD,
   OPEN_SHOWS_DEFAULT_WINDOW_HOURS,
+  OPEN_SHOWS_MAX_WINDOW_HOURS,
 } from '../../../apps/backend/services/flowsheet.service';
 
 type Row = Record<string, unknown>;
@@ -18,10 +19,14 @@ type Row = Record<string, unknown>;
  * `db.select` mock is primed positionally in call order: the grouped open-shows
  * query, the older-than-window count, then `getLatestShow`'s `getNShows`.
  */
-const primeReads = (rows: Row[], olderCount: number, latestShowId: number | null) => {
+const primeReads = (rows: Row[], olderCount: number, latestShowId: number | null, windowCount?: number) => {
   const openShows = createMockQueryChain();
-  openShows.orderBy.mockResolvedValue(rows);
+  openShows.limit.mockResolvedValue(rows);
   db.select.mockReturnValueOnce(openShows);
+
+  const inWindow = createMockQueryChain();
+  inWindow.where.mockResolvedValue([{ n: windowCount ?? rows.length }]);
+  db.select.mockReturnValueOnce(inWindow);
 
   const older = createMockQueryChain();
   older.where.mockResolvedValue([{ n: olderCount }]);
@@ -139,7 +144,37 @@ describe('getOpenShows', () => {
     expect(result.older_open_show_count).toBe(2813);
   });
 
+  /**
+   * `total_in_window` is the only way a caller can tell a truncated page from a
+   * complete one — without it, `limit` silently lies about how much is open.
+   */
+  it('reports total_in_window separately from the truncated page', async () => {
+    primeReads([row({ id: 1 }), row({ id: 2 })], 0, 99, 57);
+
+    const result = await getOpenShows(168, 2);
+
+    expect(result.shows).toHaveLength(2);
+    expect(result.total_in_window).toBe(57);
+  });
+
+  it('passes the caller’s limit to the query', async () => {
+    const { openShows } = primeReads([], 0, 99);
+
+    await getOpenShows(168, 25);
+
+    expect(openShows.limit).toHaveBeenCalledWith(25);
+  });
+
   it('defaults the window to a week', () => {
     expect(OPEN_SHOWS_DEFAULT_WINDOW_HOURS).toBe(24 * 7);
+  });
+
+  /**
+   * The ceiling must be able to reach the cohort `older_open_show_count`
+   * counts, or that number describes rows no request can list. Production's
+   * open shows start in 2006; the first cut was 8,760 hours (one year).
+   */
+  it('caps the window wide enough to reach a 2006 show', () => {
+    expect(OPEN_SHOWS_MAX_WINDOW_HOURS).toBeGreaterThan(20 * 365 * 24);
   });
 });

--- a/tests/unit/services/flowsheet.getOpenShows.test.ts
+++ b/tests/unit/services/flowsheet.getOpenShows.test.ts
@@ -5,12 +5,7 @@
  */
 import { jest } from '@jest/globals';
 import { db, createMockQueryChain } from '../../mocks/database.mock';
-import {
-  getOpenShows,
-  LIKELY_ABANDONED_ENTRY_THRESHOLD,
-  OPEN_SHOWS_DEFAULT_WINDOW_HOURS,
-  OPEN_SHOWS_MAX_WINDOW_HOURS,
-} from '../../../apps/backend/services/flowsheet.service';
+import { getOpenShows, LIKELY_ABANDONED_ENTRY_THRESHOLD } from '../../../apps/backend/services/flowsheet.service';
 
 type Row = Record<string, unknown>;
 
@@ -19,24 +14,63 @@ type Row = Record<string, unknown>;
  * `db.select` mock is primed positionally in call order: the grouped open-shows
  * query, the older-than-window count, then `getLatestShow`'s `getNShows`.
  */
-const primeReads = (rows: Row[], olderCount: number, latestShowId: number | null, windowCount?: number) => {
+/**
+ * `getOpenShows` fires three reads concurrently through `Promise.all`, so the
+ * `db.select` mock is primed positionally in call order: the open-shows page,
+ * the one FILTERed count row, then `getLatestShow`'s `getNShows`. A fourth
+ * (`isLatestEntryShowEnd`) follows only when the newest show is on the page.
+ *
+ * An options object rather than four positionals: `latestShowId` defaults to a
+ * value no fixture row uses, so the common "nothing is current" case says
+ * nothing at all instead of passing a bare sentinel.
+ */
+const NO_SHOW_IS_CURRENT = -1;
+
+const primeReads = ({
+  rows = [],
+  olderCount = 0,
+  latestShowId = NO_SHOW_IS_CURRENT,
+  windowCount,
+  latestEntryIsShowEnd = false,
+}: {
+  rows?: Row[];
+  olderCount?: number;
+  latestShowId?: number | null;
+  windowCount?: number;
+  latestEntryIsShowEnd?: boolean;
+} = {}) => {
+  // `buildOpenShowsQuery` builds two selects: the inner `shows` page (closed
+  // with `.as('page')`) and the outer statement that joins and counts against
+  // it. Both are constructed before anything awaits, so they take the first
+  // two `db.select` slots in that order.
+  const page = createMockQueryChain();
+  db.select.mockReturnValueOnce(page);
+
   const openShows = createMockQueryChain();
-  openShows.limit.mockResolvedValue(rows);
+  openShows.orderBy.mockResolvedValue(rows);
   db.select.mockReturnValueOnce(openShows);
 
-  const inWindow = createMockQueryChain();
-  inWindow.where.mockResolvedValue([{ n: windowCount ?? rows.length }]);
-  db.select.mockReturnValueOnce(inWindow);
-
-  const older = createMockQueryChain();
-  older.where.mockResolvedValue([{ n: olderCount }]);
-  db.select.mockReturnValueOnce(older);
+  const counts = createMockQueryChain();
+  counts.where.mockResolvedValue([{ in_window: windowCount ?? rows.length, older: olderCount }]);
+  db.select.mockReturnValueOnce(counts);
 
   const latest = createMockQueryChain();
   latest.limit.mockResolvedValue(latestShowId === null ? [] : [{ id: latestShowId }]);
   db.select.mockReturnValueOnce(latest);
 
-  return { openShows };
+  // Queued ONLY when it will actually be consumed. `getOpenShows` reads the
+  // terminal marker just for the newest show, and only when that show is on
+  // the page — `mockReturnValueOnce` is a queue, so an unconsumed entry does
+  // not vanish at `jest.clearAllMocks()` (that clears calls, not the queue).
+  // It leaks into the next test and hands the inner page query a chain whose
+  // `orderBy` resolves to rows, which fails on the following `.limit`.
+  if (latestShowId !== null && rows.some((r) => r.id === latestShowId)) {
+    const terminalMarker = createMockQueryChain();
+    terminalMarker.limit.mockResolvedValue([{ entry_type: latestEntryIsShowEnd ? 'show_end' : 'track' }]);
+    db.select.mockReturnValueOnce(terminalMarker);
+  }
+
+  return { page, openShows };
 };
 
 const row = (over: Row = {}): Row => ({
@@ -59,7 +93,7 @@ describe('getOpenShows', () => {
   });
 
   it('flags a low-entry non-current show as likely abandoned', async () => {
-    primeReads([row({ id: 74840, entry_count: 0 })], 0, 1951168);
+    primeReads({ rows: [row({ id: 74840, entry_count: 0 })], latestShowId: 1951168 });
 
     const { shows } = await getOpenShows();
 
@@ -74,7 +108,7 @@ describe('getOpenShows', () => {
    * on-air read uses, so this endpoint and the banner cannot disagree.
    */
   it('never flags the current show, however few entries it has', async () => {
-    primeReads([row({ id: 1951168, entry_count: 1 })], 0, 1951168);
+    primeReads({ rows: [row({ id: 1951168, entry_count: 1 })], latestShowId: 1951168 });
 
     const { shows } = await getOpenShows();
 
@@ -82,14 +116,12 @@ describe('getOpenShows', () => {
   });
 
   it('does not flag a non-current show at or above the entry threshold', async () => {
-    primeReads(
-      [
+    primeReads({
+      rows: [
         row({ id: 10, entry_count: LIKELY_ABANDONED_ENTRY_THRESHOLD - 1 }),
         row({ id: 11, entry_count: LIKELY_ABANDONED_ENTRY_THRESHOLD }),
       ],
-      0,
-      99
-    );
+    });
 
     const { shows } = await getOpenShows();
 
@@ -97,7 +129,25 @@ describe('getOpenShows', () => {
   });
 
   it('treats every show as non-current when nothing is open at all', async () => {
-    primeReads([row({ id: 7, entry_count: 1 })], 0, null);
+    primeReads({ rows: [row({ id: 7, entry_count: 1 })], latestShowId: null });
+
+    const { shows } = await getOpenShows();
+
+    expect(shows[0]).toMatchObject({ is_current: false, likely_abandoned: true });
+  });
+
+  /**
+   * BS#2068's correction, re-applied here. A show whose `show_end` marker
+   * landed but whose `end_time` was never stamped keeps `max(shows.id)` while
+   * being demonstrably over — a bare `id === max(id)` test reports it as live,
+   * suppressing `likely_abandoned` on exactly the cohort this endpoint serves.
+   */
+  it('does not treat a max(id) show as current when its terminal entry is a show_end marker', async () => {
+    primeReads({
+      rows: [row({ id: 1951168, entry_count: 2 })],
+      latestShowId: 1951168,
+      latestEntryIsShowEnd: true,
+    });
 
     const { shows } = await getOpenShows();
 
@@ -105,8 +155,8 @@ describe('getOpenShows', () => {
   });
 
   it('resolves the DJ handle through the shared chain: override beats the user row', async () => {
-    primeReads(
-      [
+    primeReads({
+      rows: [
         row({
           primary_dj_id: 'dj-1',
           user_id: 'dj-1',
@@ -114,9 +164,7 @@ describe('getOpenShows', () => {
           dj_name_override: 'Aubrey Hearst',
         }),
       ],
-      0,
-      99
-    );
+    });
 
     const { shows } = await getOpenShows();
 
@@ -126,7 +174,7 @@ describe('getOpenShows', () => {
   it('falls back to legacy_dj_name for a show with no linked account', async () => {
     // The shape of the entire historical cohort: primary_dj_id NULL, identity
     // carried by the tubafrenzy handle.
-    primeReads([row({ primary_dj_id: null, legacy_dj_name: 'DJ Mouseness' })], 0, 99);
+    primeReads({ rows: [row({ primary_dj_id: null, legacy_dj_name: 'DJ Mouseness' })] });
 
     const { shows } = await getOpenShows();
 
@@ -134,7 +182,7 @@ describe('getOpenShows', () => {
   });
 
   it('reports the count of open shows older than the window without listing them', async () => {
-    primeReads([row({ id: 1951168, entry_count: 11 })], 2813, 1951168);
+    primeReads({ rows: [row({ id: 1951168, entry_count: 11 })], olderCount: 2813, latestShowId: 1951168 });
 
     const result = await getOpenShows();
 
@@ -149,32 +197,11 @@ describe('getOpenShows', () => {
    * complete one — without it, `limit` silently lies about how much is open.
    */
   it('reports total_in_window separately from the truncated page', async () => {
-    primeReads([row({ id: 1 }), row({ id: 2 })], 0, 99, 57);
+    primeReads({ rows: [row({ id: 1 }), row({ id: 2 })], windowCount: 57 });
 
     const result = await getOpenShows(168, 2);
 
     expect(result.shows).toHaveLength(2);
     expect(result.total_in_window).toBe(57);
-  });
-
-  it('passes the caller’s limit to the query', async () => {
-    const { openShows } = primeReads([], 0, 99);
-
-    await getOpenShows(168, 25);
-
-    expect(openShows.limit).toHaveBeenCalledWith(25);
-  });
-
-  it('defaults the window to a week', () => {
-    expect(OPEN_SHOWS_DEFAULT_WINDOW_HOURS).toBe(24 * 7);
-  });
-
-  /**
-   * The ceiling must be able to reach the cohort `older_open_show_count`
-   * counts, or that number describes rows no request can list. Production's
-   * open shows start in 2006; the first cut was 8,760 hours (one year).
-   */
-  it('caps the window wide enough to reach a 2006 show', () => {
-    expect(OPEN_SHOWS_MAX_WINDOW_HOURS).toBeGreaterThan(20 * 365 * 24);
   });
 });


### PR DESCRIPTION
Closes #2235. Part of the #2232 epic, independent of the takeover chain.

## Why now

Tubafrenzy retires **2026-08-31**. Of everything in #2232, this is the piece where slipping the date has a permanent cost: today `EndShowServlet` is mapped at `/endShow`, takes the show as a request parameter, and checks nothing about who is asking — so any signed-on DJ can reach the signon page's "Resume a Show" list and end anyone's recent show. Backend-Service has no equivalent: `POST /flowsheet/end` hard-requires `req.body.dj_id === req.auth.id`. When the 2026-08-20 show stuck open, closing it took a hand-written script and direct database access.

## What this adds

**`GET /flowsheet/open-shows`** — open shows, oldest first, with entry counts and a `likely_abandoned` flag.
**`POST /flowsheet/shows/:id/force-end`** — closes one.

Both gated on a new `flowsheet: ['manage']` action, held by `musicDirector` and `stationManager` only. Deliberately **not** expressed as `catalog: ['write']`: that selects the same two roles today, but it is the catalog's grant, and a future re-grant of catalog editing would silently move who can close a stranger's show. Note the direction of travel — the capability being replaced has no role check at all, so this is a narrowing.

`force-end` reuses `endShow` rather than reimplementing the close, so the `show_end` marker, the `show_djs` deactivation, the co-host leave markers and the tubafrenzy sign-off follow one implementation shared with `POST /flowsheet/end`. `flowsheetMirror.endShow` is chained on the route exactly as it is there. No `showMemberMiddleware` — acting on a show the caller is not a member of is the entire point.

## Two departures from the issue as filed

Both came out of measuring production on 2026-08-21 rather than reasoning from the ticket.

### 1. The read is windowed

The issue asked for every show with `end_time IS NULL`. That is **2,814 rows, of which exactly one started in the last 90 days.**

| year | open shows | of those, NULL `primary_dj_id` |
|---|---|---|
| 2026 | 13 | 12 |
| 2025 | 261 | 261 |
| 2024 | 449 | 449 |
| … | … | … |
| 2006 | 111 | 111 |

The 2,813 are legacy ETL imports whose `show_end` never arrived, stretching back to 2006. Oldest-first over the unwindowed set buries the one actionable show under two decades of orphans — the same reasoning that made `countHistoricalOpenShows` count-only rather than list them in `jobs/legacy-mirror-reconcile`.

So: `window_hours`, default `168` (7 days), ceiling `8760` (1 year), with the tail reported as `older_open_show_count` so an operator can see it exists and widen deliberately.

### 2. `likely_abandoned` excludes the current show

A bare `< 4 entries` heuristic flags a DJ who signed on two minutes ago, and presenting the live show as a close candidate is how an operator ends a broadcast in progress. `is_current` resolves against `getLatestShow`'s `max(shows.id)` — the same pivot every on-air read uses — so this endpoint and the on-air banner cannot disagree about which show is live.

## #2093 falls out of this

`endShow` used to `throw new Error('Primary DJ not found')` on a NULL `primary_dj_id`, making such a show permanently un-endable. Since `shows.primary_dj_id` is `onDelete: 'set null'`, deleting a DJ's account orphans every show they ran — and per the table above, the NULL-primary cohort *is* the backlog this endpoint exists to work through.

`POST /flowsheet/end` cannot observe the relaxation: it reaches `endShow` only when `req.body.dj_id === currentShow.primary_dj_id`, and `dj_id` is cross-checked against `req.auth.id`, so the primary is non-null on that path by construction.

#2093 can be closed once this merges.

## Migration 0154

`shows.end_time` carried no index at all. `EXPLAIN ANALYZE` of this query against production today:

```
Sort  (cost=3267.60..3267.69 rows=37) (actual time=62.735..62.738 rows=1)
  ->  GroupAggregate  (actual time=62.701..62.704 rows=1)
        ->  Nested Loop Left Join  (actual time=1.802..62.650 rows=22)
              ->  Seq Scan on shows s  (actual time=1.740..62.509 rows=1)
                    Filter: ((end_time IS NULL) AND (start_time >= (now() - '7 days'::interval)))
                    Rows Removed by Filter: 72735
                    Buffers: shared hit=1766
              ->  Index Scan using flowsheet_show_id_idx on flowsheet f  (rows=22)
Execution Time: 62.842 ms
```

A partial `(start_time) WHERE end_time IS NULL` index covers under 4% of the table (2,814 of 72,736) and serves the filter, the window bound and the `ORDER BY` together. `jobs/legacy-mirror-reconcile`'s stale-open-show sweep (#2065/#2067/#2068) runs the same bounds nightly and picks it up for free.

Unlike 0148, the in-migration `CREATE INDEX` here is genuinely cheap — a sub-second build, not the multi-minute one over `flowsheet`'s ~2.6M-row heap. The `CONCURRENTLY` command is in the migration's header anyway, since the `AccessExclusiveLock` still pauses `/flowsheet/join` and `/flowsheet/end` for its duration and a deploy can land mid-show.

The plan above also shows the `flowsheet` join already riding `flowsheet_show_id_idx`, which is what lets the counts come from one grouped `LEFT JOIN … GROUP BY` instead of the per-show `getNumberOfEntries` the legacy loop called from inside its iteration.

## Testing

- `tests/unit/routes/flowsheet-operator-close-permissions.route.test.ts` — the permission tier, against the **real** middleware. Integration runs under `AUTH_BYPASS=true`, whose branch short-circuits to `next()` before any permission check, so no integration test can cover this. Mutation-checked: swapping `manage` → `write` turns the `dj`-403 cases red.
- `tests/unit/services/flowsheet.getOpenShows.sql.test.ts` — the rendered statement through drizzle's own dialect, so a reintroduced N+1 or a `LEFT JOIN` silently becoming an `INNER JOIN` (which would drop every zero-entry show — production has one) fails in the unit tier without a live Postgres.
- `tests/unit/services/flowsheet.getOpenShows.test.ts` — the `is_current` / `likely_abandoned` decision and the DJ-name chain.
- `tests/unit/controllers/flowsheet.operatorClose.test.ts` — `window_hours` validation, 404/400 paths, `endShow` reuse.
- `tests/unit/services/flowsheet.endShow.test.ts` — two new cases for the NULL-primary close.
- `tests/integration/flowsheet-open-shows.spec.js` — both endpoints against real Postgres, 14 cases.

Locally: unit **7,987 passed / 461 suites**; integration on a clean `ci:testmock` stack **1,170 passed, 1 failed** — `auth-auto-membership`, which needs `DEFAULT_ORG_SLUG`, absent from the local `.env` and only referenced in a comment in `.env.example`. It touches nothing here. Typecheck, lint (0 errors), `format:check` and `lint:migrations` all clean.

## Notes for the reviewer

- **`groupBy` was added to `tests/mocks/database.mock.ts`.** The shared chain stub didn't model it; `buildOpenShowsQuery` is its first aggregate caller.
- **The integration spec's teardown deletes `show_djs` explicitly.** `schema.ts` declares `onDelete: 'cascade'` on `show_djs.show_id`, but the constraint actually present in the migrated database has no referential action (`confdeltype = 'a'`) and a bare `DELETE FROM shows` raises `show_djs_show_id_shows_id_fk`. Observed while writing this, not assumed. Real schema drift, filed separately — not fixed here.
- **The spec's teardown is load-bearing, not tidiness.** An open show left behind would be `max(shows.id)` for whichever spec runs next, and `joinShow` routes a go-live onto the newest open show — leaving one would reproduce #2232 inside the test suite.
- **No `api.yaml` change.** #2235 was scoped without one, and Backend-Service vendors no generated copy. The two paths still need declaring for #1268 (dj-site) to consume them typed; that's a follow-up in `wxyc-shared`.

## Related

- #2232 (epic) · #2093 (closable on merge) · #2065 / #2067 / #2068 (the detector this gives an action to) · WXYC/dj-site#1268 (the UI)
