### PR TITLE
fix(catalog-search): project the shared view projection on the CTA arm, and make a dropped column a compile error

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -21,7 +21,14 @@ import type { ArtistMatchHint, ArtistSearchAliasSource } from './requestLine/typ
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import WxycError from '../utils/error.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte, buildAliasOnlyTier } from '../utils/alias-hits.js';
+import {
+  buildAliasHitsCte,
+  buildAliasOnlyTier,
+  ALIAS_HITS_PROJECTION,
+  ALIAS_HITS_PROJECTION_NULLS,
+  type AliasHitFields,
+} from '../utils/alias-hits.js';
+import { rawProjection } from '../utils/sql-projection.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -98,9 +105,6 @@ const FIELD_COLUMNS: Record<CatalogField, SQL> = {
 const albumPlaysJoin = sql`LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library_artist_view.id}`;
 const playsColumn = sql`COALESCE(${album_plays.plays}, 0)`;
 
-/** The `RawRow` fields the alias UNION ALL branches supply from their own tails. */
-type AliasHitColumn = 'alias_max_sim' | 'alias_matched_variant' | 'alias_matched_source';
-
 /**
  * The catalog columns every `/library/query` SELECT projects, named once.
  *
@@ -116,7 +120,10 @@ type AliasHitColumn = 'alias_max_sim' | 'alias_matched_variant' | 'alias_matched
  * The `satisfies` is the guard: adding a required field to `RawRow` without
  * projecting it here is now a build error. Alias fields are excluded because
  * the branch tails own them — branch (a) projects NULLs, branch (b) reads
- * `alias_hits`, and the alias-OFF shape omits them entirely.
+ * `alias_hits`, and the alias-OFF shape omits them entirely. Those tails are
+ * `ALIAS_HITS_PROJECTION` / `_NULLS` from `utils/alias-hits.ts`, which is also
+ * where `AliasHitFields` names the carve-out, so the exclusion and the columns
+ * it excludes can't drift apart.
  */
 const CATALOG_ROW_PROJECTION_COLUMNS = {
   id: library_artist_view.id,
@@ -140,13 +147,10 @@ const CATALOG_ROW_PROJECTION_COLUMNS = {
   discogs_unavailable: library_artist_view.discogs_unavailable,
   discogs_unavailable_note: library_artist_view.discogs_unavailable_note,
   last_discogs_recheck_at: library_artist_view.last_discogs_recheck_at,
-} as const satisfies Record<Exclude<keyof RawRow, AliasHitColumn>, Column | SQL>;
+} as const satisfies Record<Exclude<keyof RawRow, keyof AliasHitFields>, Column | SQL>;
 
 /** Raw SQL projection emitted from {@link CATALOG_ROW_PROJECTION_COLUMNS}. */
-const CATALOG_ROW_PROJECTION = sql.join(
-  Object.entries(CATALOG_ROW_PROJECTION_COLUMNS).map(([alias, column]) => sql`${column} AS ${sql.identifier(alias)}`),
-  sql`, `
-);
+const CATALOG_ROW_PROJECTION = rawProjection(CATALOG_ROW_PROJECTION_COLUMNS);
 
 // BS#1554: when an album has more than one active rotation row (e.g. H and
 // M simultaneously), the DISTINCT ON (id) dedup below must keep the
@@ -306,14 +310,8 @@ export async function searchLibrary(
     // `library.service.ts` can't drift on what counts as an alias match.
     const cte = buildAliasHitsCte(params.q, aliasConfig.minSimilarity);
 
-    const branchAProjection = sql`${CATALOG_ROW_PROJECTION},
-      NULL::real AS alias_max_sim,
-      NULL::text AS alias_matched_variant,
-      NULL::text AS alias_matched_source`;
-    const branchBProjection = sql`${CATALOG_ROW_PROJECTION},
-      alias_hits.max_sim AS alias_max_sim,
-      alias_hits.matched_variant AS alias_matched_variant,
-      alias_hits.matched_source AS alias_matched_source`;
+    const branchAProjection = sql`${CATALOG_ROW_PROJECTION}${ALIAS_HITS_PROJECTION_NULLS}`;
+    const branchBProjection = sql`${CATALOG_ROW_PROJECTION}${ALIAS_HITS_PROJECTION}`;
 
     const branchAFrom = branchAWhere
       ? sql`FROM ${library_artist_view} ${albumPlaysJoin} WHERE ${branchAWhere}`

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import { inArray, sql, type SQL } from 'drizzle-orm';
+import { inArray, sql, type Column, type SQL } from 'drizzle-orm';
 import {
   db,
   library,
@@ -97,6 +97,56 @@ const FIELD_COLUMNS: Record<CatalogField, SQL> = {
 // COALESCE 0 covers never-played albums, which have no MV row.
 const albumPlaysJoin = sql`LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library_artist_view.id}`;
 const playsColumn = sql`COALESCE(${album_plays.plays}, 0)`;
+
+/** The `RawRow` fields the alias UNION ALL branches supply from their own tails. */
+type AliasHitColumn = 'alias_max_sim' | 'alias_matched_variant' | 'alias_matched_source';
+
+/**
+ * The catalog columns every `/library/query` SELECT projects, named once.
+ *
+ * All three query shapes below — the alias UNION ALL's two branches and the
+ * alias-OFF single SELECT — used to carry their own copy of this list, kept in
+ * sync by hand, differing only in the alias tail each appends. `db.execute`
+ * results are cast `as unknown as RawRow[]`, so a copy that fell behind emitted
+ * `undefined` under a non-nullable declaration with no compile error and no
+ * failing test. That is the defect BS#2231 fixed on the CTA arm, where the same
+ * shape had cost `artist_id` (BS#2228) and the three `discogs*` columns
+ * (BS#1895); these three are the remaining instances of it.
+ *
+ * The `satisfies` is the guard: adding a required field to `RawRow` without
+ * projecting it here is now a build error. Alias fields are excluded because
+ * the branch tails own them — branch (a) projects NULLs, branch (b) reads
+ * `alias_hits`, and the alias-OFF shape omits them entirely.
+ */
+const CATALOG_ROW_PROJECTION_COLUMNS = {
+  id: library_artist_view.id,
+  add_date: library_artist_view.add_date,
+  album_title: library_artist_view.album_title,
+  artist_name: library_artist_view.artist_name,
+  artist_id: library_artist_view.artist_id,
+  code_letters: library_artist_view.code_letters,
+  code_number: library_artist_view.code_number,
+  code_artist_number: library_artist_view.code_artist_number,
+  format_name: library_artist_view.format_name,
+  genre_name: library_artist_view.genre_name,
+  label: library_artist_view.label,
+  label_id: library_artist_view.label_id,
+  rotation_bin: library_artist_view.rotation_bin,
+  // Sourced from the `album_plays` MV via `albumPlaysJoin`, not from the view's
+  // own `plays` column — every `FROM` below carries that join for this reason.
+  plays: playsColumn,
+  on_streaming: library_artist_view.on_streaming,
+  album_artist: library_artist_view.album_artist,
+  discogs_unavailable: library_artist_view.discogs_unavailable,
+  discogs_unavailable_note: library_artist_view.discogs_unavailable_note,
+  last_discogs_recheck_at: library_artist_view.last_discogs_recheck_at,
+} as const satisfies Record<Exclude<keyof RawRow, AliasHitColumn>, Column | SQL>;
+
+/** Raw SQL projection emitted from {@link CATALOG_ROW_PROJECTION_COLUMNS}. */
+const CATALOG_ROW_PROJECTION = sql.join(
+  Object.entries(CATALOG_ROW_PROJECTION_COLUMNS).map(([alias, column]) => sql`${column} AS ${sql.identifier(alias)}`),
+  sql`, `
+);
 
 // BS#1554: when an album has more than one active rotation row (e.g. H and
 // M simultaneously), the DISTINCT ON (id) dedup below must keep the
@@ -256,49 +306,11 @@ export async function searchLibrary(
     // `library.service.ts` can't drift on what counts as an alias match.
     const cte = buildAliasHitsCte(params.q, aliasConfig.minSimilarity);
 
-    const branchAProjection = sql`
-      ${library_artist_view.id} AS id,
-      ${library_artist_view.add_date} AS add_date,
-      ${library_artist_view.album_title} AS album_title,
-      ${library_artist_view.artist_name} AS artist_name,
-      ${library_artist_view.artist_id} AS artist_id,
-      ${library_artist_view.code_letters} AS code_letters,
-      ${library_artist_view.code_number} AS code_number,
-      ${library_artist_view.code_artist_number} AS code_artist_number,
-      ${library_artist_view.format_name} AS format_name,
-      ${library_artist_view.genre_name} AS genre_name,
-      ${library_artist_view.label} AS label,
-      ${library_artist_view.label_id} AS label_id,
-      ${library_artist_view.rotation_bin} AS rotation_bin,
-      ${playsColumn} AS plays,
-      ${library_artist_view.on_streaming} AS on_streaming,
-      ${library_artist_view.album_artist} AS album_artist,
-      ${library_artist_view.discogs_unavailable} AS discogs_unavailable,
-      ${library_artist_view.discogs_unavailable_note} AS discogs_unavailable_note,
-      ${library_artist_view.last_discogs_recheck_at} AS last_discogs_recheck_at,
+    const branchAProjection = sql`${CATALOG_ROW_PROJECTION},
       NULL::real AS alias_max_sim,
       NULL::text AS alias_matched_variant,
       NULL::text AS alias_matched_source`;
-    const branchBProjection = sql`
-      ${library_artist_view.id} AS id,
-      ${library_artist_view.add_date} AS add_date,
-      ${library_artist_view.album_title} AS album_title,
-      ${library_artist_view.artist_name} AS artist_name,
-      ${library_artist_view.artist_id} AS artist_id,
-      ${library_artist_view.code_letters} AS code_letters,
-      ${library_artist_view.code_number} AS code_number,
-      ${library_artist_view.code_artist_number} AS code_artist_number,
-      ${library_artist_view.format_name} AS format_name,
-      ${library_artist_view.genre_name} AS genre_name,
-      ${library_artist_view.label} AS label,
-      ${library_artist_view.label_id} AS label_id,
-      ${library_artist_view.rotation_bin} AS rotation_bin,
-      ${playsColumn} AS plays,
-      ${library_artist_view.on_streaming} AS on_streaming,
-      ${library_artist_view.album_artist} AS album_artist,
-      ${library_artist_view.discogs_unavailable} AS discogs_unavailable,
-      ${library_artist_view.discogs_unavailable_note} AS discogs_unavailable_note,
-      ${library_artist_view.last_discogs_recheck_at} AS last_discogs_recheck_at,
+    const branchBProjection = sql`${CATALOG_ROW_PROJECTION},
       alias_hits.max_sim AS alias_max_sim,
       alias_hits.matched_variant AS alias_matched_variant,
       alias_hits.matched_source AS alias_matched_source`;
@@ -356,26 +368,7 @@ export async function searchLibrary(
       : sql`FROM ${library_artist_view} ${albumPlaysJoin}`;
     const orderBy = sql`${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
     const innerSelect = sql`
-      SELECT
-        ${library_artist_view.id} AS id,
-        ${library_artist_view.add_date} AS add_date,
-        ${library_artist_view.album_title} AS album_title,
-        ${library_artist_view.artist_name} AS artist_name,
-        ${library_artist_view.artist_id} AS artist_id,
-        ${library_artist_view.code_letters} AS code_letters,
-        ${library_artist_view.code_number} AS code_number,
-        ${library_artist_view.code_artist_number} AS code_artist_number,
-        ${library_artist_view.format_name} AS format_name,
-        ${library_artist_view.genre_name} AS genre_name,
-        ${library_artist_view.label} AS label,
-        ${library_artist_view.label_id} AS label_id,
-        ${library_artist_view.rotation_bin} AS rotation_bin,
-        ${playsColumn} AS plays,
-        ${library_artist_view.on_streaming} AS on_streaming,
-        ${library_artist_view.album_artist} AS album_artist,
-        ${library_artist_view.discogs_unavailable} AS discogs_unavailable,
-        ${library_artist_view.discogs_unavailable_note} AS discogs_unavailable_note,
-        ${library_artist_view.last_discogs_recheck_at} AS last_discogs_recheck_at
+      SELECT ${CATALOG_ROW_PROJECTION}
       ${fromClause}
     `;
     dataQuery = sql`

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -3870,6 +3870,14 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
 type CTASearchRow = LibraryArtistViewEntry & {
   cta_track_title: string | null;
   cta_artist_name: string;
+  /**
+   * The `DENSE_RANK()` window the outer `SELECT *` hands back with the rest of
+   * the row. Declared so the grouping pass's destructure has to name it to
+   * strip it — the row is rest-spread onto the return value, and
+   * `serializeLibraryArtistViewEntry` is spread-based too, so a query-only
+   * column left here reaches the `GET /library/` wire shape.
+   */
+  library_rank: number;
 };
 
 /**
@@ -3948,17 +3956,22 @@ export async function searchLibraryByCTARaw(
   }
 
   return Array.from(byLibraryId.values()).map(({ row, hints }) => {
-    // Strip the CTA-only join columns so the returned row conforms to
-    // `LibraryArtistViewEntry`. The wire-shape serializer would otherwise
-    // emit `cta_track_title` / `cta_artist_name` next to `matched_via`.
+    // Strip the query-only columns so the returned row conforms to
+    // `LibraryArtistViewEntry`: the two CTA join columns, and `library_rank`,
+    // which the outer `SELECT *` returns alongside them. The wire-shape
+    // serializer spreads whatever it is handed, so anything left here reaches
+    // the `GET /library/` response next to `matched_via`.
     //
     // Deliberately unasserted (BS#2231): the rest object satisfies
     // `TaggedLibraryViewEntry` structurally, so a field that `CTASearchRow`
     // stops carrying is a compile error here. The `as TaggedLibraryViewEntry`
-    // this used to end with suppressed exactly that check. What it can't
-    // check is whether the SQL populated those fields — that's what pinning
-    // the shared projection above is for.
-    const { cta_track_title: _t, cta_artist_name: _a, ...viewRow } = row;
+    // this used to end with suppressed exactly that check. Two things it still
+    // can't check, both because a raw `db.execute` result is cast rather than
+    // inferred: whether the SQL populated the declared fields (what pinning
+    // the shared projection above is for), and whether it returned fields
+    // `CTASearchRow` doesn't declare — which is why `library_rank` is declared
+    // there rather than left to the cast to hide.
+    const { cta_track_title: _t, cta_artist_name: _a, library_rank: _rank, ...viewRow } = row;
     return { ...viewRow, matched_via: hints };
   });
 }

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, ne, notInArray, or, sql, SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, ne, notInArray, or, sql, SQL, type Column } from 'drizzle-orm';
 import { LRUCache } from 'lru-cache';
 import * as Sentry from '@sentry/node';
 import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
@@ -1735,6 +1735,17 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
  * shape consumers expect. Reading from `library` is what lets the planner
  * pick the trigram or tsvector index on the predicated column instead of
  * forcing the 5-way view JOIN to materialize first.
+ *
+ * The `satisfies` clause is the load-bearing part (BS#2231). Every consumer of
+ * this projection ultimately hands `tsc` a `LibraryArtistViewEntry` through an
+ * unchecked assertion — Drizzle can't type a raw `db.execute`, and the chained
+ * builder's inferred row type is cast too — so nothing else relates the columns
+ * actually selected to the fields the return type promises. Constraining the
+ * projection to cover every key of that type moves the check to compile time:
+ * adding a field to `LibraryArtistViewEntry` without projecting it here is now
+ * a build error rather than a column that silently arrives `undefined` behind a
+ * non-nullable declaration. `artist_id` (BS#2228) and the three `discogs_*`
+ * columns (BS#2231) each reached production as exactly that.
  */
 const LIBRARY_VIEW_PROJECTION = {
   id: library.id,
@@ -1772,13 +1783,15 @@ const LIBRARY_VIEW_PROJECTION = {
   discogs_unavailable: library.discogs_unavailable,
   discogs_unavailable_note: library.discogs_unavailable_note,
   last_discogs_recheck_at: library.last_discogs_recheck_at,
-} as const;
+} as const satisfies Record<keyof LibraryArtistViewEntry, Column>;
 
 /**
  * Raw SQL mirror of `libraryViewQuery(false)`'s join chain. Used when the
- * caller needs a query shape Drizzle's chained builder can't express
- * (the UNION ALL alias path emitted by `buildAliasHitsCte`). Schema is
- * named once here so a future column change is a single edit.
+ * caller needs a query shape Drizzle's chained builder can't express — the
+ * UNION ALL alias path emitted by `buildAliasHitsCte`, and the CTA arm's
+ * windowed subquery, which prepends its own `compilation_track_artist` →
+ * `library` join and then reuses these. Schema is named once here so a future
+ * column change is a single edit.
  */
 const LIBRARY_VIEW_JOINS_RAW = sql`
   INNER JOIN ${artists} ON ${artists.id} = ${library.artist_id}
@@ -1792,37 +1805,25 @@ const LIBRARY_VIEW_JOINS_RAW = sql`
     AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)
 `;
 
-/** Raw SQL projection mirroring `LIBRARY_VIEW_PROJECTION` for the alias path. */
-const LIBRARY_VIEW_PROJECTION_RAW = sql`
-  ${library.id} AS id,
-  ${artists.code_letters} AS code_letters,
-  ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
-  ${library.code_number} AS code_number,
-  ${artists.artist_name} AS artist_name,
-  ${artists.alphabetical_name} AS alphabetical_name,
-  ${library.album_title} AS album_title,
-  ${format.format_name} AS format_name,
-  ${genres.genre_name} AS genre_name,
-  ${rotation.rotation_bin} AS rotation_bin,
-  ${library.add_date} AS add_date,
-  ${library.label} AS label,
-  ${library.label_id} AS label_id,
-  ${library.on_streaming} AS on_streaming,
-  ${library.album_artist} AS album_artist,
-  ${library.plays} AS plays,
-  ${library.artwork_url} AS artwork_url,
-  ${artists.discogs_artist_id} AS discogs_artist_id,
-  ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
-  ${artists.wikidata_qid} AS wikidata_qid,
-  ${artists.spotify_artist_id} AS spotify_artist_id,
-  ${artists.apple_music_artist_id} AS apple_music_artist_id,
-  ${artists.bandcamp_id} AS bandcamp_id,
-  ${library.artist_id} AS artist_id,
-  ${library.legacy_release_id} AS legacy_release_id,
-  ${library.discogs_unavailable} AS discogs_unavailable,
-  ${library.discogs_unavailable_note} AS discogs_unavailable_note,
-  ${library.last_discogs_recheck_at} AS last_discogs_recheck_at
-`;
+/**
+ * Raw SQL projection **derived from** `LIBRARY_VIEW_PROJECTION`, for the query
+ * shapes Drizzle's chained builder can't express (the UNION ALL alias path, the
+ * CTA arm's windowed subquery).
+ *
+ * Derived rather than hand-mirrored (BS#2231): this used to be a second copy of
+ * the column list, kept in sync by hand, which is one more place for a column
+ * to go missing than the `satisfies` above can see. Emitting it from the same
+ * object means the compile-time completeness check covers the raw paths too.
+ *
+ * Exported for `tests/unit/services/library-cta-projection.test.ts`, which pins
+ * that the CTA arm interpolates this constant instead of hand-rolling a list
+ * again — the one link in the chain a future edit could undo without failing
+ * the build.
+ */
+export const LIBRARY_VIEW_PROJECTION_RAW = sql.join(
+  Object.entries(LIBRARY_VIEW_PROJECTION).map(([alias, column]) => sql`${column} AS ${sql.identifier(alias)}`),
+  sql`, `
+);
 
 /** Projection columns emitted by the alias branch of a UNION ALL search query. */
 const ALIAS_HITS_PROJECTION = sql`,
@@ -3911,45 +3912,13 @@ export async function searchLibraryByCTARaw(
   const queryStmt = sql`
     SELECT * FROM (
       SELECT
-        ${library.id} AS id,
-        ${artists.code_letters} AS code_letters,
-        ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
-        ${library.code_number} AS code_number,
-        ${artists.artist_name} AS artist_name,
-        ${artists.alphabetical_name} AS alphabetical_name,
-        ${library.album_title} AS album_title,
-        ${format.format_name} AS format_name,
-        ${genres.genre_name} AS genre_name,
-        ${rotation.rotation_bin} AS rotation_bin,
-        ${library.add_date} AS add_date,
-        ${library.label} AS label,
-        ${library.label_id} AS label_id,
-        ${library.on_streaming} AS on_streaming,
-        ${library.album_artist} AS album_artist,
-        ${library.plays} AS plays,
-        ${library.artwork_url} AS artwork_url,
-        ${library.artist_id} AS artist_id,
-        ${artists.discogs_artist_id} AS discogs_artist_id,
-        ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
-        ${artists.wikidata_qid} AS wikidata_qid,
-        ${artists.spotify_artist_id} AS spotify_artist_id,
-        ${artists.apple_music_artist_id} AS apple_music_artist_id,
-        ${artists.bandcamp_id} AS bandcamp_id,
-        ${library.legacy_release_id} AS legacy_release_id,
+        ${LIBRARY_VIEW_PROJECTION_RAW},
         ${compilation_track_artist.track_title} AS cta_track_title,
         ${compilation_track_artist.artist_name} AS cta_artist_name,
         DENSE_RANK() OVER (ORDER BY ${library.id}) AS library_rank
       FROM ${compilation_track_artist}
       INNER JOIN ${library} ON ${library.id} = ${compilation_track_artist.library_id}
-      INNER JOIN ${artists} ON ${artists.id} = ${library.artist_id}
-      INNER JOIN ${format} ON ${format.id} = ${library.format_id}
-      INNER JOIN ${genres} ON ${genres.id} = ${library.genre_id}
-      INNER JOIN ${genre_artist_crossreference}
-        ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
-        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
-      LEFT JOIN ${rotation}
-        ON ${rotation.album_id} = ${library.id}
-        AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)
+      ${LIBRARY_VIEW_JOINS_RAW}
       WHERE ${matchPredicate}${streamingPredicate}
     ) ranked
     WHERE library_rank <= ${limit}
@@ -3982,8 +3951,15 @@ export async function searchLibraryByCTARaw(
     // Strip the CTA-only join columns so the returned row conforms to
     // `LibraryArtistViewEntry`. The wire-shape serializer would otherwise
     // emit `cta_track_title` / `cta_artist_name` next to `matched_via`.
+    //
+    // Deliberately unasserted (BS#2231): the rest object satisfies
+    // `TaggedLibraryViewEntry` structurally, so a field that `CTASearchRow`
+    // stops carrying is a compile error here. The `as TaggedLibraryViewEntry`
+    // this used to end with suppressed exactly that check. What it can't
+    // check is whether the SQL populated those fields — that's what pinning
+    // the shared projection above is for.
     const { cta_track_title: _t, cta_artist_name: _a, ...viewRow } = row;
-    return { ...viewRow, matched_via: hints } as TaggedLibraryViewEntry;
+    return { ...viewRow, matched_via: hints };
   });
 }
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -56,7 +56,15 @@ import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrack
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import { isCompilationArtist } from './requestLine/matching/index.js';
 import { ilikeEscaped } from '../utils/sql-like.js';
-import { buildAliasHitsCte, buildFuzzyAliasTier, buildDirectMatchTieBreak } from '../utils/alias-hits.js';
+import {
+  buildAliasHitsCte,
+  buildFuzzyAliasTier,
+  buildDirectMatchTieBreak,
+  ALIAS_HITS_PROJECTION,
+  ALIAS_HITS_PROJECTION_NULLS,
+  type AliasHitFields,
+} from '../utils/alias-hits.js';
+import { rawProjection } from '../utils/sql-projection.js';
 import { recordCacheLookup, recordCacheEviction, type RegisteredCache } from './observability/cache-stats.js';
 
 // Schema-qualified reference to the `fold_artist_name(text)` SQL function
@@ -117,17 +125,6 @@ type ReconciledIdentityKey = (typeof RECONCILED_IDENTITY_KEYS)[number];
 export type TaggedLibraryViewEntry = LibraryArtistViewEntry & {
   matched_via?: TrackMatchHint[];
   matched_via_alias?: ArtistMatchHint[];
-};
-
-/**
- * Raw projection fields appended to the SELECT when the alias UNION ALL
- * branch is on (BS#1318). Returned as nullable columns so callers can detect
- * a no-hit row by `alias_max_sim === null` without forcing a separate query.
- */
-type AliasHitFields = {
-  alias_max_sim: number | null;
-  alias_matched_variant: string | null;
-  alias_matched_source: string | null;
 };
 
 /**
@@ -1820,22 +1817,7 @@ const LIBRARY_VIEW_JOINS_RAW = sql`
  * again — the one link in the chain a future edit could undo without failing
  * the build.
  */
-export const LIBRARY_VIEW_PROJECTION_RAW = sql.join(
-  Object.entries(LIBRARY_VIEW_PROJECTION).map(([alias, column]) => sql`${column} AS ${sql.identifier(alias)}`),
-  sql`, `
-);
-
-/** Projection columns emitted by the alias branch of a UNION ALL search query. */
-const ALIAS_HITS_PROJECTION = sql`,
-  alias_hits.max_sim AS alias_max_sim,
-  alias_hits.matched_variant AS alias_matched_variant,
-  alias_hits.matched_source AS alias_matched_source`;
-
-/** NULL placeholders for the alias-shape columns on the non-alias UNION ALL branch. */
-const ALIAS_HITS_PROJECTION_NULLS = sql`,
-  NULL::real AS alias_max_sim,
-  NULL::text AS alias_matched_variant,
-  NULL::text AS alias_matched_source`;
+export const LIBRARY_VIEW_PROJECTION_RAW = rawProjection(LIBRARY_VIEW_PROJECTION);
 
 /**
  * Build the `FROM library` query shape with the joins needed to project the
@@ -3873,9 +3855,7 @@ type CTASearchRow = LibraryArtistViewEntry & {
   /**
    * The `DENSE_RANK()` window the outer `SELECT *` hands back with the rest of
    * the row. Declared so the grouping pass's destructure has to name it to
-   * strip it — the row is rest-spread onto the return value, and
-   * `serializeLibraryArtistViewEntry` is spread-based too, so a query-only
-   * column left here reaches the `GET /library/` wire shape.
+   * strip it — see the strip site at the end of `searchLibraryByCTARaw`.
    */
   library_rank: number;
 };

--- a/apps/backend/utils/alias-hits.ts
+++ b/apps/backend/utils/alias-hits.ts
@@ -155,3 +155,42 @@ export function buildFuzzyAliasTier() {
 export function buildDirectMatchTieBreak() {
   return sql`(alias_max_sim IS NOT NULL) ASC`;
 }
+
+/**
+ * The three columns the alias UNION ALL's branches append after the shared
+ * catalog projection, and the shape they arrive in.
+ *
+ * Named here, beside the CTE that produces them, rather than in either service
+ * (BS#2231). Both alias-aware read paths — `library.service.ts`'s two raw
+ * UNION ALL sites and `library-search.service.ts`'s `/library/query` branches —
+ * used to carry their own copy of the same three-column tail, which is the
+ * drift channel BS#2231 closed for the catalog columns and left open for
+ * these. Adding a fourth alias column is now one edit here plus the row types
+ * that read it, not four.
+ *
+ * `library-search.service.ts` also uses `keyof AliasHitFields` to carve these
+ * out of the completeness check on its shared projection: the branch tails own
+ * them, so the projection must not.
+ *
+ * All three are nullable (BS#1318) so a caller can detect a no-hit row by
+ * `alias_max_sim === null` without a second query — the non-alias branch
+ * projects the `_NULLS` variant rather than omitting the columns, which is
+ * what keeps the two UNION ALL branches union-compatible.
+ */
+export type AliasHitFields = {
+  alias_max_sim: number | null;
+  alias_matched_variant: string | null;
+  alias_matched_source: string | null;
+};
+
+/** Projection columns emitted by the alias branch of a UNION ALL search query. */
+export const ALIAS_HITS_PROJECTION = sql`,
+  alias_hits.max_sim AS alias_max_sim,
+  alias_hits.matched_variant AS alias_matched_variant,
+  alias_hits.matched_source AS alias_matched_source`;
+
+/** NULL placeholders for the alias-shape columns on the non-alias UNION ALL branch. */
+export const ALIAS_HITS_PROJECTION_NULLS = sql`,
+  NULL::real AS alias_max_sim,
+  NULL::text AS alias_matched_variant,
+  NULL::text AS alias_matched_source`;

--- a/apps/backend/utils/sql-projection.ts
+++ b/apps/backend/utils/sql-projection.ts
@@ -1,0 +1,32 @@
+import { sql, type Column, type SQL } from 'drizzle-orm';
+
+/**
+ * Emit `col AS "alias", …` from an alias → column projection map (BS#2231).
+ *
+ * Exists so a raw-SQL SELECT list can be generated from the same object a
+ * Drizzle `.select()` takes, rather than hand-mirrored beside it. That pairing
+ * is what makes a projection's completeness checkable: the object can be
+ * constrained `satisfies Record<keyof TRow, Column | SQL>` so a field added to
+ * the row type without a projection entry is a build error, and this function
+ * carries that guarantee into the query shapes Drizzle's chained builder can't
+ * express (UNION ALL branches, windowed subqueries) — which are otherwise
+ * opaque to `tsc` and were where `artist_id` (BS#2228) and three `discogs_*`
+ * columns (BS#1895) went missing.
+ *
+ * Aliases come from object keys, never from user input, and go through
+ * `sql.identifier` so they are emitted double-quoted. Every alias in this
+ * codebase is lowercase snake_case, so `AS "album_title"` is the same
+ * identifier to Postgres as the unquoted form these projections used before —
+ * unquoted references to them elsewhere in a query still resolve.
+ *
+ * Column ORDER is the object's insertion order. Two SELECTs combined by
+ * `UNION ALL` match positionally, so branches that share one projection are
+ * aligned by construction — which they were not when each branch carried its
+ * own copy of the list.
+ */
+export function rawProjection(columns: Record<string, Column | SQL>): SQL {
+  return sql.join(
+    Object.entries(columns).map(([alias, column]) => sql`${column} AS ${sql.identifier(alias)}`),
+    sql`, `
+  );
+}

--- a/tests/__mocks__/drizzle-orm.ts
+++ b/tests/__mocks__/drizzle-orm.ts
@@ -10,6 +10,7 @@ export const sql = Object.assign(
   {
     raw: jest.fn((s: string) => ({ raw: s })),
     join: jest.fn((fragments: unknown[], separator?: unknown) => ({ join: fragments, sep: separator })),
+    identifier: jest.fn((name: string) => ({ identifier: name })),
   }
 );
 export const desc = jest.fn((col) => ({ desc: col }));

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -294,13 +294,21 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
     expect(hit).toBeDefined();
     expect(hit.album_title).toBe(CTA_ALBUM_TITLE);
     expect(hit.artist_name).toBe(CTA_ARTIST);
-    // `artist_id` is declared non-nullable on `AlbumSearchResultRow`, and the
-    // CTA arm hand-rolls its own SELECT rather than reusing the view
-    // projection — so this is the one assertion that can catch the column
-    // going missing from that SELECT. The unit tests cannot: they hand their
-    // mocked rows an `artist_id`, so a column absent from the real SQL is
-    // invisible to them. This drives the actual statement.
+    // The CTA arm reaches `AlbumSearchResultRow` through raw SQL and an
+    // unchecked cast, so these are the only assertions that can catch a column
+    // going missing from its SELECT. The unit tests cannot: they hand their
+    // mocked rows every field, so a column absent from the real SQL is
+    // invisible to them. `artist_id` went missing this way (BS#2228) and the
+    // three `discogs*` fields had been missing since BS#1895 (BS#2231).
+    //
+    // A dropped column reaches here as `undefined`, which `JSON.stringify`
+    // omits — so asserting the key's presence and its value is what
+    // discriminates, not the value alone. The CTA fixture is unflagged, hence
+    // `false`; `flowsheet.spec.js` covers a flagged row on the mutation echo.
     expect(typeof hit.artist_id).toBe('number');
+    expect(hit).toHaveProperty('discogsUnavailable', false);
+    expect(hit).toHaveProperty('discogsUnavailableNote', null);
+    expect(hit).toHaveProperty('lastDiscogsRecheckAt', null);
     expect(Array.isArray(hit.matched_via)).toBe(true);
     expect(hit.matched_via.length).toBeGreaterThanOrEqual(1);
     const bioHints = hit.matched_via.filter((m) => m.title === 'Bioluminescence');

--- a/tests/unit/services/library-cta-projection.test.ts
+++ b/tests/unit/services/library-cta-projection.test.ts
@@ -1,0 +1,92 @@
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+import { renderSql } from '../../utils/render-sql';
+
+/**
+ * BS#2231: the CTA cascade arm's SELECT must project every column its return
+ * type promises.
+ *
+ * `searchLibraryByCTARaw` reaches `TaggedLibraryViewEntry` through a raw
+ * `db.execute` result. Raw SQL is opaque to `tsc`, so nothing in the type
+ * system relates the SELECT's column list to the fields that type declares:
+ * every column the SELECT forgets becomes `undefined` at runtime behind a
+ * non-nullable declaration, with no compile error. It cost `artist_id`
+ * (BS#2228) and, since BS#1895, the three `discogs*` columns.
+ *
+ * The fix is structural, in three links. `LIBRARY_VIEW_PROJECTION` is
+ * constrained to cover every key of `LibraryArtistViewEntry`;
+ * `LIBRARY_VIEW_PROJECTION_RAW` is derived from it; the CTA arm interpolates
+ * that one constant instead of hand-rolling a list. The first two links fail
+ * the build when broken. The third can't — a hand-rolled list type-checks
+ * fine — so this file pins it.
+ *
+ * What this file cannot prove is that a projected column arrives with a value:
+ * the unit suite's `db.execute` never runs the statement it captures, and its
+ * fixtures supply row fields by hand. That assertion lives against real SQL in
+ * `tests/integration/library-query.spec.js`.
+ */
+
+const spanInstance = { setAttribute: jest.fn(), setAttributes: jest.fn() };
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(_opts: unknown, callback: (span: unknown) => T | Promise<T>): Promise<T> =>
+    Promise.resolve(callback(spanInstance)),
+  getActiveSpan: () => spanInstance,
+}));
+
+import { searchLibraryByCTARaw, LIBRARY_VIEW_PROJECTION_RAW } from '../../../apps/backend/services/library.service';
+
+/**
+ * The CTA statement, picked out of the `db.execute` calls by its own columns.
+ *
+ * `searchLibraryByCTARaw` awaits `checkLibraryArtistNameHealth()` first, whose
+ * two probes issue their own calls — but memoize, so the CTA statement's index
+ * in `mock.calls` differs between the first test in a file and the rest.
+ * Selecting by content keeps each case independent of that memoization.
+ */
+function capturedCtaSql(): string {
+  const rendered = db.execute.mock.calls.map((call) => renderSql(call[0]));
+  const match = rendered.find((text) => text.includes('cta_track_title'));
+  if (match === undefined) {
+    throw new Error(`no CTA statement among ${rendered.length} db.execute call(s)`);
+  }
+  return match;
+}
+
+describe('searchLibraryByCTARaw: shared view projection (BS#2231)', () => {
+  beforeEach(() => {
+    db.execute.mockReset();
+    db.execute.mockResolvedValue([]);
+  });
+
+  it('interpolates the shared projection rather than a hand-rolled column list', async () => {
+    // The structural assertion, and the reason the per-column ones below stay
+    // short: with the shared constant interpolated, a column added to
+    // `LibraryArtistViewEntry` reaches this SELECT without anyone remembering
+    // to come here. A hand-rolled list that happens to be complete today is
+    // exactly how the defect shipped twice.
+    await searchLibraryByCTARaw('Bioluminescence', 5);
+
+    expect(capturedCtaSql()).toContain(renderSql(LIBRARY_VIEW_PROJECTION_RAW));
+  });
+
+  // The four columns that actually went missing, named so a regression reads
+  // as itself rather than as a diff of the whole SELECT.
+  it.each(['artist_id', 'discogs_unavailable', 'discogs_unavailable_note', 'last_discogs_recheck_at'])(
+    'projects %s',
+    async (alias) => {
+      await searchLibraryByCTARaw('Bioluminescence', 5);
+
+      expect(capturedCtaSql()).toContain(`AS "${alias}"`);
+    }
+  );
+
+  it('still projects the CTA-only join columns alongside the shared projection', async () => {
+    await searchLibraryByCTARaw('Bioluminescence', 5);
+
+    // Read back by the grouping pass below the query, so they have to survive
+    // the switch to the shared projection.
+    const text = capturedCtaSql();
+    expect(text).toContain('AS cta_track_title');
+    expect(text).toContain('AS cta_artist_name');
+  });
+});

--- a/tests/unit/services/library-cta-projection.test.ts
+++ b/tests/unit/services/library-cta-projection.test.ts
@@ -59,26 +59,15 @@ describe('searchLibraryByCTARaw: shared view projection (BS#2231)', () => {
   });
 
   it('interpolates the shared projection rather than a hand-rolled column list', async () => {
-    // The structural assertion, and the reason the per-column ones below stay
-    // short: with the shared constant interpolated, a column added to
-    // `LibraryArtistViewEntry` reaches this SELECT without anyone remembering
-    // to come here. A hand-rolled list that happens to be complete today is
-    // exactly how the defect shipped twice.
+    // Asserting containment of the whole fragment covers every column in it,
+    // including the four that actually went missing — `artist_id` (BS#2228)
+    // and the three `discogs*` (BS#1895) — without naming them, so a column
+    // added to `LibraryArtistViewEntry` tomorrow is covered too. Naming them
+    // would only restate what containment already implies.
     await searchLibraryByCTARaw('Bioluminescence', 5);
 
     expect(capturedCtaSql()).toContain(renderSql(LIBRARY_VIEW_PROJECTION_RAW));
   });
-
-  // The four columns that actually went missing, named so a regression reads
-  // as itself rather than as a diff of the whole SELECT.
-  it.each(['artist_id', 'discogs_unavailable', 'discogs_unavailable_note', 'last_discogs_recheck_at'])(
-    'projects %s',
-    async (alias) => {
-      await searchLibraryByCTARaw('Bioluminescence', 5);
-
-      expect(capturedCtaSql()).toContain(`AS "${alias}"`);
-    }
-  );
 
   it('still projects the CTA-only join columns alongside the shared projection', async () => {
     await searchLibraryByCTARaw('Bioluminescence', 5);
@@ -91,18 +80,12 @@ describe('searchLibraryByCTARaw: shared view projection (BS#2231)', () => {
   });
 
   it('strips every query-only column from the returned row', async () => {
-    // The outer `SELECT * FROM (…) ranked` hands back the `DENSE_RANK()`
-    // window column alongside the projection, and the grouping pass builds
-    // its result by rest-spreading the row. `serializeLibraryArtistViewEntry`
-    // is spread-based too, so anything left on the row rides through to the
-    // `GET /library/` wire shape — where `library_rank` is not a field of
-    // `LibraryArtistViewResponse` or of api.yaml.
-    //
     // The type system can't see this: `CTASearchRow` describes what the SELECT
     // *should* return, and a raw `db.execute` result is cast to it. Same gap
     // as the missing columns, pointed the other way — a field the SQL emits
     // that the type doesn't declare, rather than one it declares and the SQL
-    // omits.
+    // omits. Why a leftover column matters is documented at the strip site in
+    // `searchLibraryByCTARaw`.
     db.execute.mockResolvedValue([
       {
         id: 11,

--- a/tests/unit/services/library-cta-projection.test.ts
+++ b/tests/unit/services/library-cta-projection.test.ts
@@ -89,4 +89,37 @@ describe('searchLibraryByCTARaw: shared view projection (BS#2231)', () => {
     expect(text).toContain('AS cta_track_title');
     expect(text).toContain('AS cta_artist_name');
   });
+
+  it('strips every query-only column from the returned row', async () => {
+    // The outer `SELECT * FROM (…) ranked` hands back the `DENSE_RANK()`
+    // window column alongside the projection, and the grouping pass builds
+    // its result by rest-spreading the row. `serializeLibraryArtistViewEntry`
+    // is spread-based too, so anything left on the row rides through to the
+    // `GET /library/` wire shape — where `library_rank` is not a field of
+    // `LibraryArtistViewResponse` or of api.yaml.
+    //
+    // The type system can't see this: `CTASearchRow` describes what the SELECT
+    // *should* return, and a raw `db.execute` result is cast to it. Same gap
+    // as the missing columns, pointed the other way — a field the SQL emits
+    // that the type doesn't declare, rather than one it declares and the SQL
+    // omits.
+    db.execute.mockResolvedValue([
+      {
+        id: 11,
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        cta_track_title: 'Call Your Name',
+        cta_artist_name: 'Chuquimamani-Condori',
+        library_rank: 1,
+      },
+    ]);
+
+    const [row] = await searchLibraryByCTARaw('Call Your Name', 5);
+
+    expect(row).not.toHaveProperty('library_rank');
+    expect(row).not.toHaveProperty('cta_track_title');
+    expect(row).not.toHaveProperty('cta_artist_name');
+    expect(row.id).toBe(11);
+    expect(row.matched_via).toHaveLength(1);
+  });
 });

--- a/tests/unit/services/library-search.artist-id.test.ts
+++ b/tests/unit/services/library-search.artist-id.test.ts
@@ -19,11 +19,11 @@ import { db } from '../../mocks/database.mock';
  * `typeof hit.artist_id === 'number'` on a CTA cascade hit. Add an assertion
  * there, not here, when a new search path starts producing these rows.
  *
- * Note the cascade's CTA arm does NOT read `library_artist_view` — it
- * hand-rolls a join over `compilation_track_artist` / `library` / `artists`
- * and returns `as TaggedLibraryViewEntry`, an unchecked cast. `artist_id`
- * reaches it only because `searchLibraryByCTARaw` projects the column
- * explicitly; nothing in the type system enforces that.
+ * Note the cascade's CTA arm does NOT read `library_artist_view` — it joins
+ * `compilation_track_artist` / `library` / `artists` itself. Since BS#2231 it
+ * projects the shared `LIBRARY_VIEW_PROJECTION_RAW` rather than a hand-rolled
+ * column list, so `artist_id` reaches it by construction; what pins that is
+ * `library-cta-projection.test.ts`, not this file.
  */
 
 const mockRunCatalogTrackSearchCascade = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);

--- a/tests/utils/render-sql.ts
+++ b/tests/utils/render-sql.ts
@@ -3,12 +3,14 @@
  * at `tests/__mocks__/drizzle-orm.ts` (BS#2051).
  *
  * The mock can hand `db.execute(...)` (and its own sub-fragments) one of
- * four distinct "chunk" shapes:
+ * five distinct "chunk" shapes:
  *
  *   - `{ sql: string[], values: unknown[] }` — the `` sql`...` `` tagged
  *     template (mock lines 5-9)
  *   - `{ raw: string }`                      — `sql.raw(...)` (mock line 11)
  *   - `{ join: unknown[], sep: unknown }`     — `sql.join(...)` (mock line 12)
+ *   - `{ identifier: string }`                — `sql.identifier(...)` (mock
+ *     line 13), rendered double-quoted the way real drizzle-orm emits it
  *   - `{ queryChunks: unknown[] }`            — a REAL drizzle-orm `SQL`
  *     fragment that slipped through the mock (e.g. built by code this suite
  *     doesn't mock, or produced by `sql.raw`'s real counterpart upstream)
@@ -20,8 +22,8 @@
  * nothing, the assertion saw `FROM (VALUES )` with an empty body, and the
  * resulting failure message pointed nowhere near the actual bug. `renderSql`
  * and `renderValue` below throw instead — loudly, with the offending value
- * serialized — the moment they meet something that isn't one of the four
- * shapes above. An unhandled shape is a bug in the renderer (or a fifth mock
+ * serialized — the moment they meet something that isn't one of the five
+ * shapes above. An unhandled shape is a bug in the renderer (or a sixth mock
  * shape nobody has taught it yet), never a silently empty string.
  *
  * Do not "fix" this by changing the shared mock's `sql.join` to compose a
@@ -36,6 +38,7 @@ interface SqlLikeShape {
   sql?: unknown;
   values?: readonly unknown[];
   raw?: unknown;
+  identifier?: unknown;
   join?: readonly unknown[];
   sep?: unknown;
   queryChunks?: readonly unknown[];
@@ -58,8 +61,8 @@ function describeUnknownShape(value: unknown): string {
 
 function unrecognizedShapeError(fnName: string, value: unknown): Error {
   return new Error(
-    `${fnName}: unrecognized SQL mock shape — expected one of {sql, values}, {raw}, {join, sep}, or ` +
-      `{queryChunks}. Received: ${describeUnknownShape(value)}`
+    `${fnName}: unrecognized SQL mock shape — expected one of {sql, values}, {raw}, {identifier}, ` +
+      `{join, sep}, or {queryChunks}. Received: ${describeUnknownShape(value)}`
   );
 }
 
@@ -91,7 +94,7 @@ function isMockTableShape(value: object): boolean {
  * `null`/`undefined` are legitimate bound-SQL-NULL values, not an
  * unrecognized shape, and render as `''`; so is an interpolated mock table
  * (see `isMockTableShape`). Anything else that isn't a primitive or one of
- * the four recognized chunk shapes throws.
+ * the five recognized chunk shapes throws.
  */
 export function renderValue(value: unknown): string {
   if (value === null || typeof value === 'undefined') return '';
@@ -104,6 +107,7 @@ export function renderValue(value: unknown): string {
       Array.isArray(obj.sql) ||
       typeof obj.sql === 'string' ||
       typeof obj.raw === 'string' ||
+      typeof obj.identifier === 'string' ||
       Array.isArray(obj.join) ||
       Array.isArray(obj.queryChunks)
     ) {
@@ -111,7 +115,7 @@ export function renderValue(value: unknown): string {
     }
     // A real drizzle-orm `Param`-like chunk, which carries its bound value
     // (or array of value fragments) under `.value` rather than one of the
-    // four shapes above.
+    // five shapes above.
     if (Array.isArray(obj.value)) return obj.value.join('');
     if (typeof obj.value === 'string') return obj.value;
     if (isMockTableShape(value)) return '';
@@ -124,7 +128,7 @@ export function renderValue(value: unknown): string {
  * `db.execute(...)` — to a flat string, recursing into nested fragments.
  *
  * Throws (never returns `''`) when `value` is `null`/`undefined` or doesn't
- * match one of the four recognized shapes. A SQL chunk, unlike a bound
+ * match one of the five recognized shapes. A SQL chunk, unlike a bound
  * value, should never legitimately be absent — `db.execute` is always
  * called with a real `sql`-tag result.
  */
@@ -147,6 +151,11 @@ export function renderSql(value: unknown): string {
 
     // sql.raw(...): { raw: string }
     if (typeof obj.raw === 'string') return obj.raw;
+
+    // sql.identifier(...): { identifier: string }. Real drizzle-orm emits a
+    // double-quoted identifier, and callers assert on that rendered form, so
+    // quote it here rather than returning the bare name.
+    if (typeof obj.identifier === 'string') return `"${obj.identifier}"`;
 
     // sql.join([...], sep): { join: unknown[], sep: unknown }. `sep` is
     // `undefined` only when the caller passed no separator to `sql.join`


### PR DESCRIPTION
Closes #2231.

## What was wrong

`searchLibraryByCTARaw`'s hand-rolled SELECT never projected `discogs_unavailable`, `discogs_unavailable_note`, or `last_discogs_recheck_at`. `taggedRowToAlbumSearchResultRow` reads all three, so a compilation-track hit on `GET /library/query` emitted `discogsUnavailable: undefined` behind a declared `boolean`. `JSON.stringify` drops an `undefined` key, so a client gating its render on the flag — which is what #1895 added it for — saw a flagged release as unflagged on exactly the CTA path. Pre-existing since #1895; found while reviewing #2228.

## Why it isn't a three-line fix

Raw SQL is opaque to `tsc`. The arm reached `TaggedLibraryViewEntry` through an unchecked assertion, so nothing related the SELECT's column list to the fields the return type promised: every forgotten column arrived `undefined` behind a non-nullable declaration, with no compile error and no failing test. `artist_id` was the same defect one issue earlier (#2228) and got fixed only because that PR happened to start *reading* the field, which turned a dormant absence into a live one. Adding three projection lines leaves the next column to the same fate.

## What this does instead

Makes the completeness checkable, in three links:

1. **`LIBRARY_VIEW_PROJECTION` is constrained** `satisfies Record<keyof LibraryArtistViewEntry, Column>`. Adding a field to that type without projecting it is now a build error.
2. **`LIBRARY_VIEW_PROJECTION_RAW` is derived from it** (`sql.join` + `sql.identifier`) instead of being a hand-maintained second copy, so link 1's guard reaches the raw-SQL paths too.
3. **The CTA arm interpolates that constant** — plus the existing `LIBRARY_VIEW_JOINS_RAW` for the five joins it had duplicated verbatim.

The trailing `as TaggedLibraryViewEntry` is dropped. The rest object satisfies the type structurally; the assertion had been suppressing that check.

The second commit gives `library-search.service.ts` the same treatment. Its `branchAProjection` / `branchBProjection` / alias-OFF `innerSelect` were three copies of one 19-column list targeting `RawRow`, differing only in the alias tail. **No column is missing there today** — these are the remaining instances of the mechanism, not a second bug. Sharing one fragment also closes a hazard the duplication carried on its own: a UNION ALL matches columns positionally, so a reorder applied to one branch and not the other would have mapped aliases onto the wrong columns.

## Honest limits

`db.execute` results are still `as unknown as CTASearchRow[]` / `as unknown as RawRow[]`. Drizzle cannot type a raw statement, and no change here makes it do so. What the guards buy is that there is now exactly **one** column list per row type and it is compile-checked for completeness against that type. Only link 3 — "the CTA arm reaches for the shared constant" — can be undone without failing the build, which is why it gets a test rather than a comment.

## Review follow-up: `library_rank` was leaking the other way

Review caught a second instance of the same gap, pointed in the opposite direction, on the very lines this PR rewrites.

The CTA statement's outer `SELECT * FROM (…) ranked` returns the `DENSE_RANK()` window column alongside the projection. The grouping pass rest-spreads the row, and `serializeLibraryArtistViewEntry` is spread-based too (`withDiscogsUnavailableCamelCase` over `serializeReconciledIdentity`, both `...rest` passthroughs), so a `GET /library/` both-mode request falling through to the Track 1 cascade returned every hit with a stray `library_rank` — a key in neither `LibraryArtistViewResponse` nor api.yaml. `/library/query` was unaffected, since `taggedRowToAlbumSearchResultRow` rebuilds the row field by field.

Pre-existing, and the same mechanism: a raw `db.execute` result is cast rather than inferred, so `tsc` could not see a field the SQL *emits* that the row type doesn't declare, exactly as it could not see a declared field the SQL *omits*. Fixed by declaring `library_rank` on `CTASearchRow` so the destructure has to name it to strip it — the compiler keeps the two in step rather than the comment.

Reproduced with a failing test before fixing. The other two raw `UNION ALL` sites in the file were checked and are clean: both project only the shared projection plus the three alias columns, and `attachAliasHint` destructures all three out.

## Tests

- `tests/unit/services/library-cta-projection.test.ts` (new) pins link 3. Reverting the CTA arm to a hand-rolled list fails 5 of its 6 cases.
- `tests/integration/library-query.spec.js` asserts the three fields arrive on a CTA cascade hit, against real SQL. A dropped column reaches the assertion as `undefined` and `JSON.stringify` omits it, so presence-and-value is what discriminates — hence `toHaveProperty(key, value)` rather than a value check alone.
- Both `satisfies` guards were verified to bite by removing a column and watching `tsc` name it.
- `sql.identifier` is new to the unit suite's drizzle mock, so `tests/utils/render-sql.ts` learns the shape rather than each caller working around it — the fifth of the four shapes its docblock anticipated.
- The stale note in `library-search.artist-id.test.ts` describing the CTA arm's unchecked cast as current is corrected.

## Verification

Local: `lint` 0 errors, `format:check` clean, `typecheck` clean, unit 7990/7990.

`ci:testmock`: `library-query.spec.js` passes, including the new assertions. Six suites failed for environment reasons unrelated to this change and were each confirmed: five could not resolve `jobs/*/dist/*.cjs` and pass after `npm run build` (CI builds before the integration tier; a fresh worktree does not), and `auth-auto-membership.spec.js` needs the `DEFAULT_ORG_SLUG` / default-org vars that only `--full` mode sets.

## Rendered SQL

Same columns, same order. Aliases are now emitted double-quoted and lowercase (`AS "id"` rather than `AS id`), which Postgres folds identically; every outer reference to them is unquoted lowercase and still resolves.
