### PR TITLE
chore(deps): bump @wxyc/shared to ^4.1.0 across the four workspace manifests

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -20,7 +20,7 @@
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
     "@wxyc/observability": "^1.0.0",
-    "@wxyc/shared": "^3.5.0",
+    "@wxyc/shared": "^4.1.0",
     "better-auth": "^1.6.26",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,7 +25,7 @@
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
     "@wxyc/observability": "^1.0.0",
-    "@wxyc/shared": "^3.5.0",
+    "@wxyc/shared": "^4.1.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
         "@wxyc/observability": "^1.0.0",
-        "@wxyc/shared": "^3.5.0",
+        "@wxyc/shared": "^4.1.0",
         "better-auth": "^1.6.26",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -112,7 +112,7 @@
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
         "@wxyc/observability": "^1.0.0",
-        "@wxyc/shared": "^3.5.0",
+        "@wxyc/shared": "^4.1.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.19.0",
@@ -6450,9 +6450,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "3.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.5.0/7fcc3eaf9c87383cc82d2c7f90a87bbdee77becc",
-      "integrity": "sha512-R8ziGiqNbJNuhiedSWgq+xaNYRE+Wwvo9Gl2kyQG4tqS9+pA9ig/CT/F4oiIPnehV5Blvt8QbWrfgU4bExjCrQ==",
+      "version": "4.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/4.1.0/cd129532df5782044467db10c8dd0e91648b0547",
+      "integrity": "sha512-Onouu4bGBL9sVVLIhzLy72+jDg/JBTkNH88XF+4x5A101eq747vmyD/nfXNo1Q21SciMc+KTWWP/QFmtN/6WRA==",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -14705,7 +14705,7 @@
         "@aws-sdk/client-ses": "^3.1106.0",
         "@sentry/node": "^10.69.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^3.5.0",
+        "@wxyc/shared": "^4.1.0",
         "better-auth": "^1.6.26",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -14752,7 +14752,7 @@
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@sentry/node": "^10.69.0",
-        "@wxyc/shared": "^3.5.0"
+        "@wxyc/shared": "^4.1.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1106.0",
     "@sentry/node": "^10.69.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^3.5.0",
+    "@wxyc/shared": "^4.1.0",
     "better-auth": "^1.6.26",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.69.0",
-    "@wxyc/shared": "^3.5.0"
+    "@wxyc/shared": "^4.1.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",


### PR DESCRIPTION
Closes #2243

## What changed

`@wxyc/shared` moves from `^3.5.0` to `^4.1.0` in the four workspace manifests that depend on it, plus the lockfile:

- `apps/backend/package.json`
- `apps/auth/package.json`
- `shared/authentication/package.json`
- `shared/lml-client/package.json`
- `package-lock.json`

No source changes were required. The diff against `main` is 5 files, 11 insertions, 11 deletions, and nothing else.

## Why this was stuck

A caret range cannot accept a new major, so `^3.5.0` froze this repo at 3.5.0 across three `@wxyc/shared` releases — in the repo that *implements* the contract those releases declare. Each further release widens the eventual jump.

## Why the bump is safe

`@wxyc/shared` 4.0.0 was a major only because two path-pruning commits removed exported symbols: `WeeklySchedule`, `DJ`, `DayOfWeek`, and the `testDJ` / `createTestDJ` test helpers. It was not a behavioural break.

That audit was re-run on this branch rather than taken on faith. Searching `apps/` and `shared/` for each removed symbol returns zero references:

| symbol | references in this repo |
|---|---|
| `WeeklySchedule` | 0 |
| `DayOfWeek` | 0 |
| `createTestDJ` | 0 |
| `testDJ` | 0 |
| `DJ` (as an import from `@wxyc/shared`) | 0 |

`WXYC/dj-site#1270` crossed the same major with a manifest-and-lockfile-only change and no source edits.

## Why `^4.1.0` and not `^4.0.0`

4.1.0 is the currently published version. A caret accepts it under either floor, but pinning the floor at the version that was actually installed, built and tested is the more honest record of what this change was verified against.

## Verification

**The Docker image build passed locally.** `npm run ci:testmock` built the deploy image to completion (`naming to docker.io/library/wxyc_backend_service:ci done`). This is the load-bearing local check for this particular change: **no CI workflow in this repo builds these images**, so a workspace dependency change can pass every PR check and still break the deploy build. That specific failure mode is the one thing local verification catches here, and it did not occur.

**The local integration suite was red: 918 passed, 258 failed across 18 suites.** Not burying that. The conclusion is that these failures are environmental rather than caused by this bump, on four independent grounds:

1. `@wxyc/shared` does not appear in any failure message, and neither does any of the five symbols 4.0.0 removed. Zero occurrences across all 258 failures.
2. The failure signature is HTTP-status mismatches — 54x "expected 201, got 403", 84x "Received: 403", 64x "Received: 401" — scattered across 18 unrelated domains: flowsheet, library, metadata, discogs, request-line, slack-webhook, mirror-http, compilation-tracks. Scatter across unrelated domains is the signature of shared show/session state on a reused database, not of a type or symbol regression, which would cluster.
3. The run used a database volume that a previous run had already used. This repo's `ci:testmock` is an `&&` chain, so a failed run skips teardown and its data survives to poison the next run.
4. `main` is currently green in GitHub Actions, including the Nightly Full Test Suite, which exercises these same integration suites.

**GitHub Actions CI on this PR is the authoritative clean-environment check.** The local run is not a pass and is not being presented as one. If CI reproduces these integration failures, the environmental explanation above is wrong and this PR should not merge on the strength of it.

## Not in scope

Compile-linking controller responses to the generated DTOs is deliberately excluded and tracked separately in #2244. It is a boundary design change, not a dependency bump: the service layer's `OpenShow.start_time` is a `Date` while the contract declares `string` / `date-time`, so compile-linking them forces an explicit serialization step.
