### PR TITLE
test(schema): re-home the five FKs #2239 de-declared under the NO ACTION block

### DIFF
--- a/tests/unit/database/schema.fk-cascades.test.ts
+++ b/tests/unit/database/schema.fk-cascades.test.ts
@@ -34,6 +34,13 @@ function expectOnDelete(tableVar: string, columnDbName: string, expectedAction: 
   expect(block).toContain(`'${expectedAction}'`);
 }
 
+function expectNoOnDelete(tableVar: string, columnDbName: string) {
+  const block = getColumnBlock(tableVar, columnDbName);
+  expect(block).not.toBeNull();
+  expect(block).toContain('.references(');
+  expect(block).not.toContain('onDelete');
+}
+
 describe('FK cascade/set-null rules in schema.ts', () => {
   describe('should use onDelete: "set null"', () => {
     it('schedule.assigned_dj_id → user.id', () => {
@@ -42,10 +49,6 @@ describe('FK cascade/set-null rules in schema.ts', () => {
 
     it('schedule.assigned_dj_id2 → user.id', () => {
       expectOnDelete('schedule', 'assigned_dj_id2', 'set null');
-    });
-
-    it('schedule.specialty_id → specialty_shows.id', () => {
-      expectOnDelete('schedule', 'specialty_id', 'set null');
     });
 
     it('shows.primary_dj_id → user.id', () => {
@@ -78,28 +81,51 @@ describe('FK cascade/set-null rules in schema.ts', () => {
       expectOnDelete('reviews', 'album_id', 'cascade');
     });
 
-    it('genre_artist_crossreference.artist_id → artists.id', () => {
-      expectOnDelete('genre_artist_crossreference', 'artist_id', 'cascade');
-    });
-
-    it('genre_artist_crossreference.genre_id → genres.id', () => {
-      expectOnDelete('genre_artist_crossreference', 'genre_id', 'cascade');
-    });
-
-    it('artist_library_crossreference.artist_id → artists.id', () => {
-      expectOnDelete('artist_library_crossreference', 'artist_id', 'cascade');
-    });
-
     it('artist_library_crossreference.library_id → library.id', () => {
       expectOnDelete('artist_library_crossreference', 'library_id', 'cascade');
-    });
-
-    it('show_djs.show_id → shows.id', () => {
-      expectOnDelete('show_djs', 'show_id', 'cascade');
     });
   });
 
   describe('should NOT have onDelete (intentional NO ACTION)', () => {
+    // The five below were DE-DECLARED by WXYC/Backend-Service#2239. schema.ts
+    // used to claim CASCADE (or SET NULL, for schedule.specialty_id) on each,
+    // but every one of them is plain NO ACTION in production and in a CI
+    // database built from the migration chain from empty -- no migration ever
+    // created them any other way. #2239 corrected schema.ts to describe what
+    // the database actually enforces rather than patching the database to
+    // match a declaration nothing relied on: no code path in apps/ or shared/
+    // deletes a shows, artists, genres, or specialty_shows row, so adding the
+    // cascades would have armed five destructive deletes across decades of
+    // flowsheet and library history for zero callers.
+    //
+    // These assertions are the reason the decision cannot silently rot back.
+    // If a future change genuinely needs one of these to cascade, add the
+    // cascade in the PR that introduces the delete path, update the matching
+    // case here, and pair it with a migration -- the deployed constraint has
+    // to move too. Do not simply re-add `onDelete` to schema.ts; that is the
+    // exact drift #2239 existed to remove, and the integration guard at
+    // tests/integration/fk-on-delete-general-guard.spec.js will fail on it.
+
+    it('schedule.specialty_id → specialty_shows.id (#2239)', () => {
+      expectNoOnDelete('schedule', 'specialty_id');
+    });
+
+    it('genre_artist_crossreference.artist_id → artists.id (#2239)', () => {
+      expectNoOnDelete('genre_artist_crossreference', 'artist_id');
+    });
+
+    it('genre_artist_crossreference.genre_id → genres.id (#2239)', () => {
+      expectNoOnDelete('genre_artist_crossreference', 'genre_id');
+    });
+
+    it('artist_library_crossreference.artist_id → artists.id (#2239)', () => {
+      expectNoOnDelete('artist_library_crossreference', 'artist_id');
+    });
+
+    it('show_djs.show_id → shows.id (#2239)', () => {
+      expectNoOnDelete('show_djs', 'show_id');
+    });
+
     it('library.artist_id → artists.id', () => {
       const block = getColumnBlock('library', 'artist_id');
       expect(block).not.toBeNull();


### PR DESCRIPTION
Fixes red `main`.

## What broke

[#2246](https://github.com/WXYC/Backend-Service/pull/2246) removed five false `onDelete` declarations from `schema.ts` ([#2239](https://github.com/WXYC/Backend-Service/issues/2239)) but left `tests/unit/database/schema.fk-cascades.test.ts` asserting they were still present. The suite fails on `main` at `ddfa9445` with 5 failures.

## Why CI said green, and why that generalizes

The `unit-tests` job runs Jest in affected-tests mode — its log ends `Ran all test suites related to changed files`. This spec reads the schema as text:

```ts
const schemaSource = fs.readFileSync(path.resolve(__dirname, "../../../shared/database/src/schema.ts"), "utf-8");
```

There is no `import`, so no edge in Jest's dependency graph, so editing `schema.ts` never marks this spec as related and it was never selected. #2246's run executed **244 suites / 4917 tests**; the full suite is **462 / 8050**. Any test that guards a file it does not import sits in the same blind spot — filed separately as [#2249](https://github.com/WXYC/Backend-Service/issues/2249), since fixing the selection mechanism is a bigger decision than fixing this spec.

## The fix re-homes rather than deletes

The spec already had a `should NOT have onDelete (intentional NO ACTION)` block, which is precisely where these five belong now. Moving them there keeps the test's protective value, pointed the other way: it **pins** #2239's decision and fails if someone re-adds a cascade to `schema.ts` without also moving the deployed constraint. Deleting the assertions would have left that decision unguarded at the unit level, which is how it drifted in the first place.

A comment at the block records why the five are NO ACTION and what to do if one genuinely needs to cascade later (add it in the PR that introduces the delete path, pair it with a migration, update the case here).

`artist_library_crossreference.library_id` deliberately **stays** under `cascade` — #2239 did not touch it, and migration `0147` ([BS#2112](https://github.com/WXYC/Backend-Service/issues/2112)) repaired that constraint to `CASCADE` in the database, so the declaration is accurate.

Also adds an `expectNoOnDelete` helper mirroring the existing `expectOnDelete`; the NO ACTION block was repeating the same four lines per case.

## Verification

- This spec: **19/19**, unchanged total (was 14 passed / 5 failed).
- Full unit suite: **462 suites / 8050 tests, 0 failures** — confirming this was the only breakage affected-mode was hiding.

Refs #2239, #2246. Related: #2249.