### PR TITLE
Run the full unit suite in CI instead of Jest's affected-tests mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,6 +259,22 @@ jobs:
         run: node scripts/check-auth-tables-doc.mjs
 
   # Unit tests - runs affected tests only
+  # Runs the WHOLE unit suite, deliberately -- do not reintroduce Jest's
+  # affected-tests mode (`--changedSince`) here. Selection is built from the
+  # module dependency graph, so a spec that reads a source file as text
+  # (`fs.readFileSync`) instead of importing it has no edge and is never
+  # selected by a change to the file it guards. Measured on BS#2249: a change
+  # to `shared/database/src/schema.ts` selected 250 suites and only 3 of the
+  # 31 `tests/unit/database/schema.*` specs written to guard that very file;
+  # `shared/authentication/src/auth.definition.ts` selected 1 suite and none
+  # of its 5 guards. That hole let BS#2246 merge green while breaking 5
+  # assertions in `schema.fk-cascades.test.ts`.
+  #
+  # The optimization was also buying nothing. This job gates no other job
+  # (`Integration-Tests` needs `[detect-changes, lint-and-typecheck]`), and it
+  # runs alongside `lint-and-typecheck`, which is consistently ~2x longer. The
+  # full suite costs roughly +30s of runner time inside a minute of existing
+  # slack, and the repo is public, so those minutes are free.
   unit-tests:
     needs: detect-changes
     if: needs.detect-changes.outputs.src == 'true'
@@ -266,8 +282,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0 # Need full history for --changedSince
 
       - name: Set Up Node.js
         uses: actions/setup-node@v7
@@ -299,14 +313,8 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Run affected unit tests
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            npx jest --config jest.unit.config.ts --changedSince=origin/${{ github.base_ref }} --coverage --passWithNoTests
-          else
-            # workflow_dispatch: run all unit tests
-            npm run test:unit:coverage
-          fi
+      - name: Run unit tests
+        run: npm run test:unit:coverage
 
       - name: Upload Coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,6 @@ jobs:
       - name: Auth-tables doc drift (BS#1573)
         run: node scripts/check-auth-tables-doc.mjs
 
-  # Unit tests - runs affected tests only
   # Runs the WHOLE unit suite, deliberately -- do not reintroduce Jest's
   # affected-tests mode (`--changedSince`) here. Selection is built from the
   # module dependency graph, so a spec that reads a source file as text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,6 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 
 1. **detect-changes** — Paths-filter identifies what changed (apps, jobs, shared, tests, db-init)
 2. **lint-and-typecheck** — `typecheck` + `lint` + `format:check` + `build`
-3. **unit-tests** — Runs affected tests only (`--changedSince=origin/<base>` on PRs)
+3. **unit-tests** — Runs the full unit suite (`npm run test:unit:coverage`). Deliberately _not_ Jest's affected-tests mode: selection comes from the module dependency graph, so the ~52 specs that read a source file as text (`fs.readFileSync`) instead of importing it are invisible to a change in the file they guard (BS#2249). The job gates nothing and finishes well inside `lint-and-typecheck`, so the full run is effectively free. `tests/unit/scripts/ci-unit-tests-full-suite.test.ts` pins this.
 4. **integration-tests** — Only if apps/jobs/shared/tests change. Docker images cached by commit SHA in ECR.
 5. **migrate-dryrun** — Only when `db-init` paths change. Restores latest RDS snapshot, runs `dryrun-migrate.mjs`, tears down. Catches data-shape preconditions at PR-review time. Detail in [`deploy.md`](deploy.md).

--- a/tests/unit/scripts/ci-unit-tests-full-suite.test.ts
+++ b/tests/unit/scripts/ci-unit-tests-full-suite.test.ts
@@ -35,19 +35,37 @@ const packageJsonPath = path.join(repoRoot, 'package.json');
 const workflow = fs.readFileSync(workflowPath, 'utf-8');
 
 /**
- * Slice the `unit-tests:` job out of the workflow: from its key to the next
- * top-level job key (two-space indent followed by a name and a colon).
+ * Slice the `unit-tests:` job out of the workflow: from its key to the first
+ * following line at two-space indent, which is where the next job's block
+ * begins. Terminating on the next job *key* is not enough -- jobs here are
+ * introduced by their own `  #` comment block, which would then be pulled
+ * into this job's slice and could both satisfy a `toContain` that this job
+ * does not actually satisfy and trip the forbidden-flag assertions on text
+ * belonging to a different job. Every line of a job's own body is indented
+ * four spaces or more, so two spaces is unambiguously a boundary.
  */
 function extractUnitTestsJob(): string {
   const start = workflow.indexOf('\n  unit-tests:');
-  expect(start).toBeGreaterThan(-1);
+  if (start === -1) {
+    throw new Error(
+      `No \`unit-tests:\` job in ${workflowPath}. If the job was renamed, update this ` +
+        `guard and check that branch protection's required-check name moved with it.`
+    );
+  }
   const rest = workflow.slice(start + 1);
-  const next = rest.slice(1).search(/\n {2}[A-Za-z][\w-]*:\n/);
+  const next = rest.slice(1).search(/\n {2}(#|[A-Za-z])/);
   return next === -1 ? rest : rest.slice(0, next + 1);
 }
 
 describe('CI unit-tests job runs the full suite (BS#2249)', () => {
   const job = extractUnitTestsJob();
+
+  it('extracts only the unit-tests job', () => {
+    expect(job).toContain('unit-tests:');
+    // The next job's leading comment must not have been swallowed.
+    expect(job).not.toContain('Integration tests');
+    expect(job).toContain('Upload Coverage');
+  });
 
   it.each([
     ['--changedSince', 'selects by dependency graph; blind to text-reading specs'],

--- a/tests/unit/scripts/ci-unit-tests-full-suite.test.ts
+++ b/tests/unit/scripts/ci-unit-tests-full-suite.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Pin that CI's `unit-tests` job runs the WHOLE unit suite, never Jest's
+ * affected-tests mode (BS#2249).
+ *
+ * Jest builds `--changedSince` / `--onlyChanged` selection from the module
+ * dependency graph. A spec that reads a source file as text
+ * (`fs.readFileSync`) rather than importing it has no edge to that file, so
+ * changing the file never marks the spec as related and the spec does not run
+ * on the PR that breaks it. This repo leans on that pattern heavily — ~52
+ * specs under `tests/unit/` import nothing but `fs` and `path`, including 31
+ * `tests/unit/database/schema.*` specs, 5 guards over
+ * `shared/authentication/src/auth.definition.ts`, and this file.
+ *
+ * Measured when the mode was removed: a change to
+ * `shared/database/src/schema.ts` selected 250 suites and only 3 of its 31
+ * guards. That is how BS#2246 merged green while breaking 5 assertions in
+ * `tests/unit/database/schema.fk-cascades.test.ts`, which is the spec that
+ * exists to hold BS#2239's decision in place.
+ *
+ * The mode was also not buying time: `unit-tests` gates no other job
+ * (`Integration-Tests` needs `[detect-changes, lint-and-typecheck]`) and runs
+ * beside `lint-and-typecheck`, which is consistently about twice as long.
+ *
+ * Source-grep test (no docker, no PG) — same style as the adjacent
+ * `lml-limiter-test-env.test.ts` and `ci-env-surface-parity.test.ts`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const workflowPath = path.join(repoRoot, '.github/workflows/test.yml');
+const packageJsonPath = path.join(repoRoot, 'package.json');
+
+const workflow = fs.readFileSync(workflowPath, 'utf-8');
+
+/**
+ * Slice the `unit-tests:` job out of the workflow: from its key to the next
+ * top-level job key (two-space indent followed by a name and a colon).
+ */
+function extractUnitTestsJob(): string {
+  const start = workflow.indexOf('\n  unit-tests:');
+  expect(start).toBeGreaterThan(-1);
+  const rest = workflow.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[A-Za-z][\w-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe('CI unit-tests job runs the full suite (BS#2249)', () => {
+  const job = extractUnitTestsJob();
+
+  it.each([
+    ['--changedSince', 'selects by dependency graph; blind to text-reading specs'],
+    ['--onlyChanged', 'same selection mechanism as --changedSince'],
+    ['--findRelatedTests', 'same selection mechanism as --changedSince'],
+    ['--passWithNoTests', 'only meaningful under selection; the full suite always has tests'],
+  ])('does not use %s (%s)', (flag) => {
+    expect(job).not.toContain(flag);
+  });
+
+  it('invokes the full-suite npm script', () => {
+    expect(job).toContain('npm run test:unit:coverage');
+  });
+
+  it('does not branch its test command on the event type', () => {
+    // The removed version ran affected tests on `pull_request` and the full
+    // suite on `workflow_dispatch`, so the manual run was the only one that
+    // could catch a text-reading regression -- one day late, via the nightly.
+    expect(job).not.toMatch(/github\.event_name.*pull_request/);
+  });
+});
+
+describe('the full-suite npm script really is unfiltered (BS#2249)', () => {
+  const scripts = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')).scripts as Record<string, string>;
+
+  it.each(['test:unit', 'test:unit:coverage'])('%s carries no selection flag', (name) => {
+    const script = scripts[name];
+    expect(script).toBeDefined();
+    expect(script).toMatch(/jest --config jest\.unit\.config\.ts/);
+    expect(script).not.toMatch(/--changedSince|--onlyChanged|--findRelatedTests|--testPathPattern/);
+  });
+});


### PR DESCRIPTION
Closes #2249.

## The defect

The `unit-tests` job ran `jest --changedSince=origin/<base>` on PRs. Jest builds that selection from the **module dependency graph**, so a spec that reads a source file as text (`fs.readFileSync`) rather than `import`ing it has no edge to that file and is never selected by a change to the file it guards.

## The audit (#2249 acceptance criterion 2)

**69 specs** under `tests/unit/` read source as text. **52 of them import nothing but `fs` and `path`** — zero edges to the code they guard:

| Guarded surface | Text-reading specs |
|---|---|
| `shared/database/src/schema.ts` | **31** |
| `shared/authentication/src/auth.definition.ts` | 5 |
| `dev_env/docker-compose.yml`, `Dockerfile.*`, `.github/workflows/test.yml` | 8 |
| `apps/backend/services/*.ts`, `jobs/*/job.ts`, `scripts/*.mjs` | ~15 |

Measured against the real resolver:

```
--findRelatedTests shared/database/src/schema.ts                  → 250 suites, 3 of 31 schema.* guards
--findRelatedTests shared/authentication/src/auth.definition.ts   →   1 suite,  0 of 5 guards
```

Volume is not the signal. A change to `schema.ts` selects 250 suites and still misses 28 of the 31 specs written to guard `schema.ts` — a big green number is exactly what the failure mode looks like. That is how #2246 merged green while breaking 5 assertions in `tests/unit/database/schema.fk-cascades.test.ts`, the spec that holds #2239's per-constraint decision in place. The nightly full-suite run was the only backstop, one day late.

## Proof the fix closes it (#2249 acceptance criterion 1)

Re-added `{ onDelete: 'cascade' }` to `show_djs.show_id` — reverting #2250's fix — and ran both commands against that tree:

| Command | Result |
|---|---|
| **Old:** `jest --changedSince=origin/main --coverage --passWithNoTests` | 250 suites, 4978 tests, **all pass — exit 0** |
| **New:** `npm run test:unit:coverage` | 1 failed suite, **exit 1** |

The failure is the assertion that should have caught it:

```
● FK cascade/set-null rules in schema.ts › should NOT have onDelete (intentional NO ACTION) › show_djs.show_id → shows.id (#2239)
    Expected substring: not "onDelete"
```

`schema.ts` was restored afterwards; it is untouched in this diff.

## Why option 1, and what it costs

`unit-tests` **gates no other job** — `Integration-Tests` needs `[detect-changes, lint-and-typecheck]` — and it runs beside `lint-and-typecheck`, which is consistently about twice as long:

| | |
|---|---|
| `unit-tests`, recent runs | 45–91 s |
| `lint-and-typecheck`, same runs | 113–154 s |
| Largest observed affected run | 252 suites / 5002 tests in 38.3 s |
| Full suite (this PR), locally | 472 suites / 8181 tests in ~32 s |

So the change adds roughly +30 s of runner time inside a minute of slack on a job that is not on the critical path, and the repo is public, so those minutes are free. The run still ends when `Integration-Tests` does, ~3 minutes later.

The issue's options 2 (union in a fixed list) and 3 (give the specs a real import edge) were rejected: both reintroduce a list somebody has to remember to maintain — the same rot that let a *second* set of five FKs drift underneath BS#1126's hardcoded regression spec, which is why #2239 shipped a general guard instead of another allowlist. Neither buys anything, because there is no time to protect.

## Changes

- `.github/workflows/test.yml` — the job runs `npm run test:unit:coverage` unconditionally; drops `fetch-depth: 0` (existed only to give `--changedSince` history) and `--passWithNoTests` (only meaningful under selection). A comment records the measurements so the optimization is not reintroduced as an obvious win.
- `tests/unit/scripts/ci-unit-tests-full-suite.test.ts` — new guard asserting the job carries no selection flag, does not branch on `github.event_name`, and that `test:unit` / `test:unit:coverage` are unfiltered. Verified it fails (3 assertions) when `--changedSince` is put back. It is itself a text-reading spec, which is now safe precisely because the full suite always runs.
- `docs/testing.md` — corrects the CI description, which still described affected-tests mode.

## Local verification

`format:check` clean · `lint` 0 errors (917 pre-existing warnings) · `typecheck` clean · full unit suite **472 suites / 8181 tests green**.

One unrelated observation worth its own ticket: `Install Dependencies` ran `npm ci` on **13 of 13** recent distinct branches, including branches that never touched `package-lock.json`. The `node_modules` cache never restores, costing 25–34 s per run — more than the entire optimization this PR removes was saving.

## Related

- #2249 — this issue
- #2246 / #2250 / #2239 — the change whose breakage the gap hid, and its fix