### PR TITLE
fix(privacy): stop the mirror writing legal names into tubafrenzy DJ_HANDLE

### DIFF
--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -2497,8 +2497,20 @@ export const shows = wxyc_schema.table(
     /**
      * On-air DJ alias for the show, sourced from tubafrenzy's
      * `FLOWSHEET_RADIO_SHOW_PROD.DJ_HANDLE` column (NOT `DJ_NAME` — that's the
-     * full real name BS forwards through the legacy mirror as `realName || name`
-     * and surfacing it on the public v2 wire would be PII exposure; see BS#1393).
+     * full real name, still forwarded outbound through the legacy mirror as
+     * `realName || name` pending the `auth_user.name` backfill (Track 2d of
+     * the PII safeguards plan), and surfacing it on the public v2 wire would
+     * be PII exposure; see BS#1393).
+     *
+     * The *outbound* write to tubafrenzy's DJ_HANDLE (`mapShowToTubafrenzy` in
+     * `@wxyc/legacy-mirror`) does not read this column — it's computed fresh
+     * on every call as: per-show override (`dj_name_override`) -> the DJ's
+     * stage handle (`auth_user.dj_name`, via the canonical
+     * `resolveDjDisplayName`) -> `auth_user.username` -> `''`. It NEVER reads
+     * `auth_user.name`: that field used to be the last fallback there and
+     * leaked DJs' legal names into this public field for handle-less DJs
+     * (fixed; see shared/database/src/dj-name.ts:1-13 for why `.name` is
+     * never a valid input to this chain).
      *
      * The marker `flowsheet.dj_name` resolver (apps/backend/routes/internal.route.ts
      * via `resolveShow`'s COALESCE chain) reads this column as the fallback when

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -2502,15 +2502,9 @@ export const shows = wxyc_schema.table(
      * the PII safeguards plan), and surfacing it on the public v2 wire would
      * be PII exposure; see BS#1393).
      *
-     * The *outbound* write to tubafrenzy's DJ_HANDLE (`mapShowToTubafrenzy` in
-     * `@wxyc/legacy-mirror`) does not read this column — it's computed fresh
-     * on every call as: per-show override (`dj_name_override`) -> the DJ's
-     * stage handle (`auth_user.dj_name`, via the canonical
-     * `resolveDjDisplayName`) -> `auth_user.username` -> `''`. It NEVER reads
-     * `auth_user.name`: that field used to be the last fallback there and
-     * leaked DJs' legal names into this public field for handle-less DJs
-     * (fixed; see shared/database/src/dj-name.ts:1-13 for why `.name` is
-     * never a valid input to this chain).
+     * The *outbound* write to tubafrenzy's DJ_HANDLE never reads this column
+     * or `auth_user.name` — see `mapShowToTubafrenzy`'s docblock in
+     * `@wxyc/legacy-mirror` for the resolution chain.
      *
      * The marker `flowsheet.dj_name` resolver (apps/backend/routes/internal.route.ts
      * via `resolveShow`'s COALESCE chain) reads this column as the fallback when

--- a/shared/legacy-mirror/src/http-mirror.ts
+++ b/shared/legacy-mirror/src/http-mirror.ts
@@ -8,6 +8,7 @@
  */
 
 import * as Sentry from '@sentry/node';
+import { resolveDjDisplayName } from '@wxyc/database';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MIRROR_API_KEY = process.env.MIRROR_API_KEY ?? '';
@@ -492,6 +493,7 @@ interface MirrorDJ {
   realName?: string | null;
   djName?: string | null;
   name: string;
+  username?: string | null;
 }
 
 /**
@@ -499,17 +501,35 @@ interface MirrorDJ {
  *
  * `djHandle` picks the per-show override first (BS#1321) so the mirror
  * surface matches every other consumer of `resolveDjNameForShow`. If no
- * override is set, fall back to the DJ's stage handle (`auth_user.dj_name`)
- * and then to their name. `djName` (note: capital N — tubafrenzy's distinct
- * "real-name" field) is always `realName || name`; we don't override it
- * because the upstream surface treats `djName` as "the human behind the
- * mic" rather than "the on-air display name", and the override is the
- * latter, not the former.
+ * override is set, fall back to the DJ's stage handle (`auth_user.dj_name`,
+ * filtered through the canonical `resolveDjDisplayName` — trimmed, and
+ * treating the literal "Anonymous" as absent), and then to `auth_user.username`.
+ * If all three are unusable, `djHandle` is `''` (mirrors the `showName ?? ''`
+ * convention below; unreachable in practice since every provisioned user has
+ * a username and anonymous users cannot own shows).
+ *
+ * `djHandle` NEVER reads `auth_user.name`: that field is written once at
+ * provisioning as `realName || username` and never maintained, making it a
+ * stale, hidden copy of the DJ's legal name (see
+ * shared/database/src/dj-name.ts:1-13). Reading it here used to leak legal
+ * names into tubafrenzy's public `DJ_HANDLE` field for handle-less DJs —
+ * do not re-add it, and do not re-derive the trim/Anonymous logic locally;
+ * always go through `resolveDjDisplayName`.
+ *
+ * `djName` (note: capital N — tubafrenzy's distinct "real-name" field) is
+ * still `realName || name` and is DELIBERATELY left unchanged here: it
+ * targets tubafrenzy's legal-name field, where `name` remains the correct
+ * fallback until the `auth_user.name` backfill (Track 2d of the PII
+ * safeguards plan) makes `realName` reliably populated. We don't fold the
+ * override into `djName` either, because the upstream surface treats
+ * `djName` as "the human behind the mic" rather than "the on-air display
+ * name", and the override is the latter, not the former.
  */
 export function mapShowToTubafrenzy(show: MirrorShow, dj: MirrorDJ): Record<string, unknown> {
   const startMs = show.start_time ? new Date(show.start_time).getTime() : Date.now();
   const override = show.dj_name_override?.trim();
-  const djHandle = override && override.length > 0 ? override : dj.djName || dj.name;
+  const djHandle =
+    override && override.length > 0 ? override : (resolveDjDisplayName(dj.djName ?? null) ?? dj.username ?? '');
   return {
     djName: dj.realName || dj.name,
     djHandle,

--- a/shared/legacy-mirror/src/http-mirror.ts
+++ b/shared/legacy-mirror/src/http-mirror.ts
@@ -528,8 +528,14 @@ interface MirrorDJ {
 export function mapShowToTubafrenzy(show: MirrorShow, dj: MirrorDJ): Record<string, unknown> {
   const startMs = show.start_time ? new Date(show.start_time).getTime() : Date.now();
   const override = show.dj_name_override?.trim();
+  // `.trim() || ''` on the username tail: the schema column is an
+  // unconstrained varchar, so a manually-edited or pre-validation legacy row
+  // could carry padding or pure whitespace — and the docblock's contract is
+  // "if all three are unusable, djHandle is ''". Every current write path
+  // validates usernames against /^[a-zA-Z0-9_.]+$/, so this is a guard, not a
+  // live code path.
   const djHandle =
-    override && override.length > 0 ? override : (resolveDjDisplayName(dj.djName ?? null) ?? dj.username ?? '');
+    override && override.length > 0 ? override : (resolveDjDisplayName(dj.djName ?? null) ?? dj.username?.trim() ?? '');
   return {
     djName: dj.realName || dj.name,
     djHandle,

--- a/shared/legacy-mirror/src/http-mirror.ts
+++ b/shared/legacy-mirror/src/http-mirror.ts
@@ -8,7 +8,7 @@
  */
 
 import * as Sentry from '@sentry/node';
-import { resolveDjDisplayName } from '@wxyc/database';
+import { resolveDjDisplayName, showDjNameOverride } from '@wxyc/database';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MIRROR_API_KEY = process.env.MIRROR_API_KEY ?? '';
@@ -492,6 +492,7 @@ interface MirrorShow {
 interface MirrorDJ {
   realName?: string | null;
   djName?: string | null;
+  /** Read ONLY by the djName (legal-name) forward below; removed at Track 2d or the turndown. Do not add readers. */
   name: string;
   username?: string | null;
 }
@@ -511,10 +512,16 @@ interface MirrorDJ {
  * `djHandle` NEVER reads `auth_user.name`: that field is written once at
  * provisioning as `realName || username` and never maintained, making it a
  * stale, hidden copy of the DJ's legal name (see
- * shared/database/src/dj-name.ts:1-13). Reading it here used to leak legal
- * names into tubafrenzy's public `DJ_HANDLE` field for handle-less DJs —
- * do not re-add it, and do not re-derive the trim/Anonymous logic locally;
- * always go through `resolveDjDisplayName`.
+ * `shared/database/src/dj-name.ts`'s module doc). Reading it here used to
+ * leak legal names into tubafrenzy's public `DJ_HANDLE` field for
+ * handle-less DJs — do not re-add it, and do not re-derive the
+ * trim/Anonymous logic locally; always go through `resolveDjDisplayName`.
+ *
+ * The username tail additionally guards against an unconstrained-varchar
+ * edge case: `auth_user.username` has no DB-level format constraint, so a
+ * manually-edited or pre-validation legacy row could carry padding or pure
+ * whitespace. Every current write path validates usernames against
+ * `/^[a-zA-Z0-9_.]+$/`, so `.trim()` here is a guard, not a live code path.
  *
  * `djName` (note: capital N — tubafrenzy's distinct "real-name" field) is
  * still `realName || name` and is DELIBERATELY left unchanged here: it
@@ -527,15 +534,12 @@ interface MirrorDJ {
  */
 export function mapShowToTubafrenzy(show: MirrorShow, dj: MirrorDJ): Record<string, unknown> {
   const startMs = show.start_time ? new Date(show.start_time).getTime() : Date.now();
-  const override = show.dj_name_override?.trim();
-  // `.trim() || ''` on the username tail: the schema column is an
-  // unconstrained varchar, so a manually-edited or pre-validation legacy row
-  // could carry padding or pure whitespace — and the docblock's contract is
-  // "if all three are unusable, djHandle is ''". Every current write path
-  // validates usernames against /^[a-zA-Z0-9_.]+$/, so this is a guard, not a
-  // live code path.
+  // Unconstrained-varchar / username-trim guard: see this function's docblock above.
   const djHandle =
-    override && override.length > 0 ? override : (resolveDjDisplayName(dj.djName ?? null) ?? dj.username?.trim() ?? '');
+    showDjNameOverride(show.dj_name_override ?? null) ??
+    resolveDjDisplayName(dj.djName ?? null) ??
+    dj.username?.trim() ??
+    '';
   return {
     djName: dj.realName || dj.name,
     djHandle,

--- a/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
@@ -80,8 +80,20 @@ const makeEntry = (over: Partial<FSEntry> = {}): FSEntry =>
     ...over,
   }) as unknown as FSEntry;
 
+// `username` is included because the real `selectDj` selects the full
+// `auth_user` row (`orchestrate.ts` `selectDj`), and the mirror's
+// `djHandle` chain (override -> djName -> username, never `name`) needs it
+// available on this fixture even though `mapShowToTubafrenzy` is mocked in
+// this suite (the chain itself is unit-tested in http.mirror.test.ts).
 const makeDj = (over: Partial<User> = {}): User =>
-  ({ id: 'dj-1', name: 'Real Name', realName: 'Real Name', djName: 'DJ Handle', ...over }) as unknown as User;
+  ({
+    id: 'dj-1',
+    name: 'Real Name',
+    realName: 'Real Name',
+    djName: 'DJ Handle',
+    username: 'dj-handle-user',
+    ...over,
+  }) as unknown as User;
 
 /** jest.fn returning a resolved promise — a non-async wrapper so the fakes
  * don't trip `@typescript-eslint/require-await` (bare async arrow, no await). */

--- a/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts
@@ -80,18 +80,12 @@ const makeEntry = (over: Partial<FSEntry> = {}): FSEntry =>
     ...over,
   }) as unknown as FSEntry;
 
-// `username` is included because the real `selectDj` selects the full
-// `auth_user` row (`orchestrate.ts` `selectDj`), and the mirror's
-// `djHandle` chain (override -> djName -> username, never `name`) needs it
-// available on this fixture even though `mapShowToTubafrenzy` is mocked in
-// this suite (the chain itself is unit-tested in http.mirror.test.ts).
 const makeDj = (over: Partial<User> = {}): User =>
   ({
     id: 'dj-1',
     name: 'Real Name',
     realName: 'Real Name',
     djName: 'DJ Handle',
-    username: 'dj-handle-user',
     ...over,
   }) as unknown as User;
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -1030,11 +1030,7 @@ describe('http.mirror', () => {
     });
 
     it('trims a padded username and empties a whitespace-only one', () => {
-      // The schema column is an unconstrained varchar: every CURRENT write
-      // path validates usernames against /^[a-zA-Z0-9_.]+$/, but a manually
-      // edited or pre-validation legacy row could carry padding or pure
-      // whitespace. The docblock's contract is "if all three are unusable,
-      // djHandle is ''" — a whitespace-only username is unusable.
+      // Unconstrained-varchar / username-trim guard: see mapShowToTubafrenzy's docblock.
       const show = { id: 100, start_time: new Date() };
       expect(
         mapShowToTubafrenzy(show, { realName: null, djName: null, name: 'kate', username: '  kbailey  ' }).djHandle
@@ -1058,25 +1054,35 @@ describe('http.mirror', () => {
     // matrix. Uses obviously-fake sentinel strings per WXYC convention.
     it('never leaks a sentinel legal name planted in name/realName onto djHandle', () => {
       const sentinel = 'SENTINEL Legal Name';
+      // Local factory: every case plants the sentinel in realName/name (the
+      // fields under test) and only varies djName/username, so each case
+      // below shows just what it varies.
+      const sentinelDj = (over: Partial<{ djName: string | null; username: string | null }> = {}) => ({
+        realName: sentinel,
+        djName: sentinel,
+        name: sentinel,
+        username: sentinel,
+        ...over,
+      });
       const cases: Array<{
         show: Parameters<typeof mapShowToTubafrenzy>[0];
         dj: Parameters<typeof mapShowToTubafrenzy>[1];
       }> = [
         {
           show: { id: 1, start_time: new Date(), dj_name_override: 'Guest Host' },
-          dj: { realName: sentinel, djName: sentinel, name: sentinel, username: sentinel },
+          dj: sentinelDj(),
         },
         {
           show: { id: 2, start_time: new Date() },
-          dj: { realName: sentinel, djName: 'DJ Catalyst', name: sentinel, username: sentinel },
+          dj: sentinelDj({ djName: 'DJ Catalyst' }),
         },
         {
           show: { id: 3, start_time: new Date() },
-          dj: { realName: sentinel, djName: null, name: sentinel, username: 'kbailey' },
+          dj: sentinelDj({ djName: null, username: 'kbailey' }),
         },
         {
           show: { id: 4, start_time: new Date() },
-          dj: { realName: sentinel, djName: null, name: sentinel, username: null },
+          dj: sentinelDj({ djName: null, username: null }),
         },
       ];
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -1029,6 +1029,21 @@ describe('http.mirror', () => {
       expect(result.djHandle).toBe('kbailey');
     });
 
+    it('trims a padded username and empties a whitespace-only one', () => {
+      // The schema column is an unconstrained varchar: every CURRENT write
+      // path validates usernames against /^[a-zA-Z0-9_.]+$/, but a manually
+      // edited or pre-validation legacy row could carry padding or pure
+      // whitespace. The docblock's contract is "if all three are unusable,
+      // djHandle is ''" — a whitespace-only username is unusable.
+      const show = { id: 100, start_time: new Date() };
+      expect(
+        mapShowToTubafrenzy(show, { realName: null, djName: null, name: 'kate', username: '  kbailey  ' }).djHandle
+      ).toBe('kbailey');
+      expect(mapShowToTubafrenzy(show, { realName: null, djName: null, name: 'kate', username: '   ' }).djHandle).toBe(
+        ''
+      );
+    });
+
     it('yields empty string when override, handle, and username are all absent', () => {
       const show = { id: 100, start_time: new Date() };
       const dj = { realName: null, djName: null, name: 'kate', username: null };

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -996,14 +996,79 @@ describe('http.mirror', () => {
       expect(result.signonTime).toBe(new Date('2024-02-01T12:00:00Z').getTime());
     });
 
-    it('falls back to name when realName/djName are null', () => {
+    // Negative case for the removed leak: djHandle used to fall through to
+    // `dj.name` (a hidden copy of the DJ's legal name — see
+    // shared/database/src/dj-name.ts:1-13) for handle-less DJs. It must now
+    // fall to `dj.username` instead, and djName (the real-name field) is
+    // untouched by this change.
+    it('falls back to username, never name, when realName/djName are null', () => {
       const show = { id: 100, start_time: new Date() };
-      const dj = { realName: null, djName: null, name: 'kate' };
+      const dj = { realName: null, djName: null, name: 'kate', username: 'kbailey' };
 
       const result = mapShowToTubafrenzy(show, dj);
 
       expect(result.djName).toBe('kate');
-      expect(result.djHandle).toBe('kate');
+      expect(result.djHandle).toBe('kbailey');
+    });
+
+    it('uses the handle via resolveDjDisplayName, ignoring the literal "Anonymous"', () => {
+      const show = { id: 100, start_time: new Date() };
+      const dj = { realName: null, djName: 'Anonymous', name: 'kate', username: 'kbailey' };
+
+      const result = mapShowToTubafrenzy(show, dj);
+
+      expect(result.djHandle).toBe('kbailey');
+    });
+
+    it('falls back to username when the handle is blank', () => {
+      const show = { id: 100, start_time: new Date() };
+      const dj = { realName: null, djName: '   ', name: 'kate', username: 'kbailey' };
+
+      const result = mapShowToTubafrenzy(show, dj);
+
+      expect(result.djHandle).toBe('kbailey');
+    });
+
+    it('yields empty string when override, handle, and username are all absent', () => {
+      const show = { id: 100, start_time: new Date() };
+      const dj = { realName: null, djName: null, name: 'kate', username: null };
+
+      const result = mapShowToTubafrenzy(show, dj);
+
+      expect(result.djHandle).toBe('');
+    });
+
+    // Sentinel: djHandle must never equal a value planted only in
+    // `name`/`realName`, across the override/handle/username/all-absent
+    // matrix. Uses obviously-fake sentinel strings per WXYC convention.
+    it('never leaks a sentinel legal name planted in name/realName onto djHandle', () => {
+      const sentinel = 'SENTINEL Legal Name';
+      const cases: Array<{
+        show: Parameters<typeof mapShowToTubafrenzy>[0];
+        dj: Parameters<typeof mapShowToTubafrenzy>[1];
+      }> = [
+        {
+          show: { id: 1, start_time: new Date(), dj_name_override: 'Guest Host' },
+          dj: { realName: sentinel, djName: sentinel, name: sentinel, username: sentinel },
+        },
+        {
+          show: { id: 2, start_time: new Date() },
+          dj: { realName: sentinel, djName: 'DJ Catalyst', name: sentinel, username: sentinel },
+        },
+        {
+          show: { id: 3, start_time: new Date() },
+          dj: { realName: sentinel, djName: null, name: sentinel, username: 'kbailey' },
+        },
+        {
+          show: { id: 4, start_time: new Date() },
+          dj: { realName: sentinel, djName: null, name: sentinel, username: null },
+        },
+      ];
+
+      for (const { show, dj } of cases) {
+        const result = mapShowToTubafrenzy(show, dj);
+        expect(result.djHandle).not.toBe(sentinel);
+      }
     });
 
     it('defaults optional fields', () => {


### PR DESCRIPTION
Closes #2291.

## What

`mapShowToTubafrenzy` fed tubafrenzy's **public** `DJ_HANDLE` field from `dj.name` whenever a DJ had no stage handle:

```ts
// shared/legacy-mirror/src/http-mirror.ts:512 (before)
const djHandle = override && override.length > 0 ? override : dj.djName || dj.name;
```

`dj.name` is `auth_user.name`, written once at provisioning as `realName || username` and never maintained afterwards — a stale, hidden copy of the DJ's legal name (`shared/database/src/dj-name.ts:1-13`). So every handle-less DJ starting a show published their legal name to wxyc.info, and the flowsheet ETL round-tripped it back into `shows.legacy_dj_name`.

New chain at `http-mirror.ts:531-532`:

```
per-show override -> resolveDjDisplayName(dj.djName ?? null) -> dj.username -> ''
```

`resolveDjDisplayName` is imported from `@wxyc/database` rather than re-derived locally, so the trim + literal-`"Anonymous"` filter stays in one place (the `?? null` coercion is required — the helper is typed `(djName: string | null)` and `MirrorDJ.djName` is optional under this package's `strict: true`). `MirrorDJ` gains `username?: string | null` at `:496`; both callers — `apps/backend/middleware/legacy/flowsheet.mirror.ts:168` and `jobs/legacy-mirror-reconcile/orchestrate.ts:285` — already `select()` the full `auth_user` row, so no query changes.

## Why now

The mirror has days to live before the 2026-08-31 turndown, and this still earns its place: it stops adding rows that the final tubafrenzy dump scrub (#1543) would otherwise have to chase, and stops growing the misattributed share of the `shows.legacy_dj_name` remediation cohort.

This is Track 0 of `plans/dj-name-pii-safeguards.md`, sliced to ship alone. The plan file lands in a sibling PR.

## Deliberate non-changes

- **`http-mirror.ts:534` (`djName: dj.realName || dj.name`) is untouched.** That is tubafrenzy's *separate* `DJ_NAME` legal-name field — the legitimate real-name flow, not the leak. `name` remains the correct fallback there until the `auth_user.name` backfill (Track 2d) makes `real_name` reliably populated, at which point it flips to `realName`-only — or dies with the mirror. Changing it here would touch a field this PR is not about.
- **The all-absent case is pinned to `''`**, matching the sibling `showName ?? ''` convention, rather than left to emerge as `undefined` on a field tubafrenzy treats as required. Unreachable in practice (every provisioned user has a username; anonymous users cannot own shows) — pinned so the behavior is chosen rather than accidental.

The expanded docblock at `:499-527` states both decisions inline, including "do not re-add `name`, do not re-derive the trim/Anonymous logic locally."

## Tests

`tests/unit/middleware/legacy/http.mirror.test.ts`:

- The existing case that pinned the removed behavior (`'falls back to name when realName/djName are null'`, asserting `djHandle === dj.name`) is rewritten as the negative case: it now falls to `username`, and the assertion on `djName` (the real-name field) is retained unchanged to prove that half did not move.
- New coverage for handle-via-`resolveDjDisplayName`, the literal `"Anonymous"` handle, a whitespace-only handle, and all-absent -> `''`.
- **Sentinel test**: plants one obviously-fake sentinel string in `name`/`realName` and asserts `djHandle` never equals it, across the full override/handle/username/all-absent matrix.

`tests/unit/jobs/legacy-mirror-reconcile/orchestrate.test.ts`: the DJ fixture gains `username`, matching what `selectDj`'s full-row `select()` actually returns.

## Docs

Corrects the `shows.legacy_dj_name` docblock at `shared/database/src/schema.ts:2497-2510`, which described the outbound chain this PR removes. A stale doctrine comment on exactly this column is how the previous incident propagated, so it is corrected in the same commit rather than swept later.

## Local checks

```
npm run format:check          All matched files use Prettier code style!
npm run typecheck             clean across all 9 workspaces
npm run lint                  959 problems (0 errors, 959 warnings) — exit 0
npx jest --config jest.unit.config.ts \
  --testPathIgnorePatterns "tests/unit/jobs/flowsheet-etl"
                              Test Suites: 472 passed, 472 total
                              Tests:       8289 passed, 8289 total  — exit 0
npx jest --config jest.unit.config.ts tests/unit/jobs/flowsheet-etl
                              Test Suites: 9 passed, 9 total
                              Tests:       197 passed, 197 total    — exit 0
```

The lint warnings are the pre-existing `security/detect-object-injection` baseline; this branch adds none.
