### PR TITLE
fix(enrichment-worker): require a streaming URL before the cache-first pre-check skips LML

### DIFF
--- a/apps/enrichment-worker/precheck.ts
+++ b/apps/enrichment-worker/precheck.ts
@@ -42,6 +42,50 @@
  * explicit `'unresolved'` does. See `enrich.ts` for the merge logic that
  * writes these columns and the shared per-album `streaming_reask_attempts`
  * counter.
+ *
+ * BS#2295 (streaming-columns gate). Load-bearing artwork/discogs alone is
+ * not sufficient either: an album whose `album_metadata` row carries
+ * `artwork_url` (or `discogs_url`) but none of the five streaming columns
+ * (`spotify_url` / `apple_music_url` / `youtube_music_url` / `bandcamp_url` /
+ * `soundcloud_url`) used to skip the LML call anyway, and
+ * `finalizeFromCachedMetadata` then flips the flowsheet row to a terminal
+ * `'enriched_match'` WITHOUT ever writing those columns — every client
+ * reading that row got five permanent nulls. This is a standing prod
+ * backlog, not a hypothetical — measured at 4 of 152 recent track rows, all
+ * with `artwork_url` present and `discogs_url` NULL. Today's match-write
+ * path (`enrich.ts#upsertMatchedAlbumMetadata`) always lands at least one
+ * streaming column (a verified URL or a synthesized search fallback)
+ * alongside `artwork_url`, so it is not the writer that produced them;
+ * which path did is not established, and the gate deliberately does not
+ * care — it keys on the shape, so it also floors any future writer that
+ * persists a load-bearing match without the streaming columns. The skip
+ * therefore also requires at least one streaming URL column to be non-null;
+ * a row with artwork/discogs but zero streaming URLs falls through to the
+ * normal LML path so it gets a real chance to fill them. This does not widen the #1747 amplifier: an album with load-bearing
+ * artwork/discogs AND at least one streaming URL is still skipped, so the
+ * common already-enriched case pays no extra LML calls.
+ *
+ * Note that this conjunct is deliberately UNBOUNDED, unlike the BS#1915
+ * re-ask gate sitting beside it, which is capped by
+ * `streaming_reask_attempts`. The reason the two differ: #1915 re-asks a
+ * question that can legitimately keep coming back unanswered (a service
+ * that simply has no match for this album), so it needs a cap or it asks
+ * forever. This gate's question is answered by construction on the FIRST
+ * fall-through — both write arms in `enrich.ts` populate
+ * `youtube_music_url` and `soundcloud_url` unconditionally from
+ * `synthesizeSearchUrls` (the match arm at `upsertMatchedAlbumMetadata`, and
+ * the linked no-match arm) — so the qualifying population is self-draining
+ * and a cap would only serve to re-freeze rows the fix exists to unfreeze.
+ *
+ * The one shape that could defeat that: both write arms carry
+ * `setWhere: album_metadata.updated_at < NOW()`, so a row whose `updated_at`
+ * is not strictly in the past (clock skew on the writing host, an
+ * out-of-band backfill stamping a future timestamp) makes the whole conflict
+ * `SET` a no-op — `artwork_url` survives, the five streaming columns stay
+ * NULL, and the row re-calls LML on every play with nothing to stop it.
+ * That is a defect in the write guard rather than in this gate, and the
+ * fix belongs there; recorded here so a future reader tracing per-play LML
+ * calls back to this predicate finds the actual culprit.
  */
 
 import { and, eq, isNotNull, or, sql } from 'drizzle-orm';
@@ -51,11 +95,13 @@ import { isBandcampReaskEnabled, resolveComposer, STREAMING_REASK_ATTEMPT_CAP, t
 
 /**
  * True when the album already has a persisted, load-bearing Discogs match in
- * `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND no
- * streaming field is still bounded-re-ask-eligible (BS#1915 — see file
- * header). False when the row is missing, all-null, a search-URL-only shell
- * (BS#1089 guard), or carries an `'unresolved'` streaming field under the
- * attempt cap, so the caller re-calls LML and the row self-heals.
+ * `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND at least one
+ * of the five streaming URL columns is non-null (BS#2295 — see file header)
+ * AND no streaming field is still bounded-re-ask-eligible (BS#1915 — see
+ * file header). False when the row is missing, all-null, a search-URL-only
+ * shell (BS#1089 guard), a load-bearing match with zero streaming columns
+ * populated (BS#2295), or carries an `'unresolved'` streaming field under
+ * the attempt cap, so the caller re-calls LML and the row self-heals.
  *
  * Only linked rows (flowsheet `album_id` non-null) have an `album_metadata`
  * row to consult; the caller gates on that before invoking this.
@@ -88,6 +134,17 @@ export async function hasLoadBearingAlbumMetadata(albumId: number): Promise<bool
     ),
     false
   )`;
+  // BS#2295: a confirmed load-bearing match (artwork/discogs) is not "done"
+  // unless at least one of the five streaming columns actually carries a
+  // value — see the file header for why a load-bearing-only row must fall
+  // through to LML instead of freezing a terminal status with five nulls.
+  const hasAnyStreamingUrl = or(
+    isNotNull(album_metadata.spotify_url),
+    isNotNull(album_metadata.apple_music_url),
+    isNotNull(album_metadata.youtube_music_url),
+    isNotNull(album_metadata.bandcamp_url),
+    isNotNull(album_metadata.soundcloud_url)
+  );
   const rows = await db
     .select({ album_id: album_metadata.album_id })
     .from(album_metadata)
@@ -95,6 +152,7 @@ export async function hasLoadBearingAlbumMetadata(albumId: number): Promise<bool
       and(
         eq(album_metadata.album_id, albumId),
         or(isNotNull(album_metadata.artwork_url), isNotNull(album_metadata.discogs_url)),
+        hasAnyStreamingUrl,
         sql`NOT ${needsStreamingReask}`
       )
     )

--- a/apps/enrichment-worker/streaming-reask.ts
+++ b/apps/enrichment-worker/streaming-reask.ts
@@ -60,14 +60,31 @@ export interface StreamingReaskCandidate {
  * (`artwork_url` OR `discogs_url` non-null — this sweep only upgrades
  * already-matched albums, never mints a new match) AND have at least one
  * streaming field `'unresolved'` under `STREAMING_REASK_ATTEMPT_CAP`.
- * Mirrors `precheck.ts`'s gate predicate (the two must stay in lockstep —
- * this is the positive form of that negative gate) including the same
- * `COALESCE(..., false)` guard against SQL's three-valued logic silently
+ * Mirrors the BS#1915 half of `precheck.ts`'s gate predicate — those two
+ * must stay in lockstep, this being the positive form of that negative gate
+ * — including the same `COALESCE(..., false)` guard against SQL's
+ * three-valued logic silently
  * dropping rows whose status columns are all still NULL... except here
  * NULL columns correctly never qualify a row (a never-consulted service
  * isn't a reason to re-ask), so the guard only matters for the base
  * artwork/discogs predicate interacting with an all-NULL streaming state —
  * kept for defense-in-depth and literal parity with precheck.ts.
+ *
+ * `precheck.ts`'s BS#2295 conjunct (skip also requires at least one of the
+ * five streaming URL columns to be non-null) is deliberately NOT mirrored
+ * here, so the lockstep is with that file's #1915 half only. This sweep
+ * re-opens rows that WERE asked and came back `unresolved`; the BS#2295
+ * cohort is the rows that were never asked at all — artwork present, all
+ * five streaming columns NULL, all three status columns NULL — which have
+ * no `unresolved` verdict for this query to key on and no attempt counter
+ * to bound a sweep against. That cohort is reached by the two mechanisms
+ * BS#2295 specifies instead: the pre-check gate re-opens each row the next
+ * time its album is played, and a one-shot drain heals the standing
+ * backlog. Consequence to know: an album in that shape which is never
+ * played again is invisible to this sweep and stays frozen until the drain
+ * runs. Widening the sweep to cover it would need a bound of its own — see
+ * `precheck.ts`'s header on why that gate is unbounded and why a shared
+ * `streaming_reask_attempts` cap is the wrong instrument for it.
  */
 export async function findUnresolvedStreamingCandidates(limit: number): Promise<StreamingReaskCandidate[]> {
   // Bandcamp re-ask de-freeze (ENRICHMENT_BANDCAMP_REASK): the plain

--- a/tests/integration/enrichment-worker-cache-precheck.spec.js
+++ b/tests/integration/enrichment-worker-cache-precheck.spec.js
@@ -4,7 +4,8 @@
  *
  * B1 reads `album_metadata` for a linked flowsheet row's album BEFORE calling
  * LML and skips the call only when a load-bearing field (`artwork_url` /
- * `discogs_url`) is already non-null. This spec validates the exact SQL
+ * `discogs_url`) is already non-null AND (BS#2295) at least one of the five
+ * streaming URL columns is non-null. This spec validates the exact SQL
  * predicate that decision keys on, against the live `album_metadata` table
  * (FK to `library`, PK on `album_id`, the real column NULLability).
  *
@@ -15,6 +16,15 @@
  * forever. The predicate under test MUST return false for such a shell (and
  * for an all-null row, and for a missing row) so the worker re-calls LML and
  * the row self-heals — and true ONLY when a real, persisted match is present.
+ *
+ * A second regression this locks down is BS#2295: a load-bearing match with
+ * zero streaming columns populated used to skip anyway, and
+ * `finalizeFromCachedMetadata` then stamped a terminal `enriched_match`
+ * without ever writing those columns — five permanent nulls for every
+ * client. The predicate MUST return false for that shape too (see the
+ * describe block below) so the row falls through to LML and gets a real
+ * chance to fill them, while an album that also carries at least one
+ * streaming URL stays skipped (the #1747 amplifier guarantee).
  *
  * Pure SQL — does NOT import `apps/enrichment-worker/precheck.ts`. The
  * integration runner is babel-jest with no TS support (drizzle-orm + ts-jest
@@ -30,6 +40,7 @@
  *
  * @see WXYC/Backend-Service#1747
  * @see WXYC/Backend-Service#1089
+ * @see WXYC/Backend-Service#2295
  */
 
 const { getTestDb } = require('../utils/db');
@@ -73,23 +84,28 @@ describe('enrichment-worker cache-first pre-check predicate (real PG)', () => {
     // Pool is shared with the rest of the integration suite; do NOT close it.
   });
 
-  test('SKIP: non-null artwork_url is load-bearing → true', async () => {
+  test('SKIP: non-null artwork_url is load-bearing, with a streaming URL present → true', async () => {
+    // BS#2295: load-bearing alone is no longer sufficient (see the dedicated
+    // describe block below) — this fixture also carries a streaming column so
+    // it still pins the amplifier-preserving "true" case.
     const albumId = await insertLibraryAlbum(sql, 'artwork');
     insertedAlbumIds.push(albumId);
     await sql`
-      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', NOW())
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, spotify_url, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', NOW())
     `;
 
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
   });
 
-  test('SKIP: non-null discogs_url is load-bearing → true', async () => {
+  test('SKIP: non-null discogs_url is load-bearing, with a streaming URL present → true', async () => {
+    // BS#2295: same amplifier-preserving pin as above, keyed on the other
+    // load-bearing column.
     const albumId = await insertLibraryAlbum(sql, 'discogs');
     insertedAlbumIds.push(albumId);
     await sql`
-      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, discogs_url, updated_at)
-      VALUES (${albumId}, 'https://www.discogs.com/release/12345', NOW())
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, discogs_url, spotify_url, updated_at)
+      VALUES (${albumId}, 'https://www.discogs.com/release/12345', 'https://open.spotify.com/search/Stereolab', NOW())
     `;
 
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
@@ -162,6 +178,106 @@ describe('enrichment-worker cache-first pre-check predicate (real PG)', () => {
 });
 
 /**
+ * BS#2295 — streaming-columns gate. A confirmed load-bearing match
+ * (`artwork_url` OR `discogs_url`) is not "done" on its own: an album whose
+ * `album_metadata` row carries one of those but none of the five streaming
+ * URL columns used to skip the LML call anyway, and
+ * `finalizeFromCachedMetadata` then stamped the flowsheet row terminal
+ * (`enriched_match`) without ever writing those columns — permanent
+ * five-null streaming URLs for every client. This is the exact shape
+ * measured in the issue (4 of 152 recent track rows, all `artwork_url`
+ * present / `discogs_url` NULL / all five streaming columns NULL).
+ *
+ * The fix must NOT widen the #1747 amplifier: an album that already carries
+ * a load-bearing match AND at least one streaming URL stays skipped, so the
+ * common already-enriched case pays no extra LML calls.
+ *
+ * @see WXYC/Backend-Service#2295
+ * @see WXYC/Backend-Service#1747
+ */
+describe('enrichment-worker cache-first pre-check predicate — BS#2295 streaming-columns gate (real PG)', () => {
+  let sql;
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  // The exact frozen shape from the issue: a linked album with a real
+  // Discogs match but zero streaming columns. Before BS#2295 every row here
+  // read true (skip) and the flowsheet row froze on enriched_match with five
+  // null streaming URLs forever. Both load-bearing columns are written
+  // explicitly (NULL where absent) so the fixture states the whole
+  // load-bearing shape rather than leaving half of it implied.
+  test.each([
+    ['artwork-only', 'https://i.discogs.com/b1/cover.jpg', null],
+    ['discogs-only', null, 'https://www.discogs.com/release/99999'],
+    ['both-load-bearing', 'https://i.discogs.com/b1/cover.jpg', 'https://www.discogs.com/release/99999'],
+  ])(
+    'NEWLY ASKED: %s, all five streaming columns NULL → false (worker calls LML)',
+    async (slug, artworkUrl, discogsUrl) => {
+      const albumId = await insertLibraryAlbum(sql, slug + '-no-streaming');
+      insertedAlbumIds.push(albumId);
+      await sql`
+        INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, discogs_url, updated_at)
+        VALUES (${albumId}, ${artworkUrl}, ${discogsUrl}, NOW())
+      `;
+
+      expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+    }
+  );
+
+  test.each([
+    ['spotify_url', 'https://open.spotify.com/search/Stereolab'],
+    ['apple_music_url', 'https://music.apple.com/album/aluminum-tunes'],
+    ['youtube_music_url', 'https://music.youtube.com/search?q=Stereolab'],
+    ['bandcamp_url', 'https://stereolab.bandcamp.com/album/aluminum-tunes'],
+    ['soundcloud_url', 'https://soundcloud.com/search?q=Stereolab'],
+  ])('STILL SKIPPED (amplifier guarantee): artwork_url present + %s alone → true', async (column, url) => {
+    // Pins the still-skipped case explicitly, one streaming column at a
+    // time: a load-bearing match with EXACTLY ONE streaming URL populated
+    // must still skip LML, preserving the #1747 amplifier fix for the
+    // common already-enriched case.
+    const albumId = await insertLibraryAlbum(sql, 'still-skipped-' + column);
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, ${sql(column)}, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', ${url}, NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('SELF-HEAL flip: a load-bearing/no-streaming row flips true once LML fills a streaming URL', async () => {
+    // End-to-end of the BS#2295 self-heal contract: the frozen shape reads
+    // false (worker re-calls LML), then once the normal match-write path
+    // fills in a streaming column alongside the existing artwork, the
+    // predicate reads true (subsequent plays skip).
+    const albumId = await insertLibraryAlbum(sql, 'streaming-heal-flip-2295');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', NOW())
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET spotify_url = 'https://open.spotify.com/search/Stereolab', updated_at = NOW()
+       WHERE album_id = ${albumId}
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+});
+
+/**
  * BS#1915 — bounded self-heal of unresolved streaming links. Load-bearing
  * artwork/discogs alone is no longer sufficient to call a row "done": a
  * streaming field still `unresolved` and under the attempt cap must ALSO
@@ -190,10 +306,15 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
   test('SELF-HEAL: load-bearing artwork present but apple_music unresolved under the cap → false (worker re-asks)', async () => {
     const albumId = await insertLibraryAlbum(sql, 'streaming-unresolved-under-cap');
     insertedAlbumIds.push(albumId);
+    // BS#2295: a streaming URL (spotify_url) is included so this fixture
+    // isolates the re-ask gate under test from the separate
+    // streaming-columns-presence gate. Without it this test would read false
+    // via BS#2295 alone and stop exercising `needsStreamingReask` at all —
+    // it is the ONLY false-arm coverage the BS#1915 gate has.
     await sql`
       INSERT INTO ${sql(SCHEMA)}.album_metadata
-        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 0, NOW())
+        (album_id, artwork_url, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', 'unresolved', 0, NOW())
     `;
 
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
@@ -202,10 +323,13 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
   test('BOUNDED: the same unresolved field stops being re-ask-eligible once the attempt cap is hit → true', async () => {
     const albumId = await insertLibraryAlbum(sql, 'streaming-unresolved-at-cap');
     insertedAlbumIds.push(albumId);
+    // BS#2295: a streaming URL (spotify_url) is included so this fixture
+    // isolates the attempt-cap logic under test from the separate
+    // streaming-columns-presence gate (see that describe block).
     await sql`
       INSERT INTO ${sql(SCHEMA)}.album_metadata
-        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 3, NOW())
+        (album_id, artwork_url, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', 'unresolved', 3, NOW())
     `;
 
     // No unbounded re-ask loop: attempts >= STREAMING_REASK_ATTEMPT_CAP (3)
@@ -216,10 +340,11 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
   test('TERMINAL: an absent streaming field is never re-asked, regardless of the attempt count', async () => {
     const albumId = await insertLibraryAlbum(sql, 'streaming-absent');
     insertedAlbumIds.push(albumId);
+    // BS#2295: a streaming URL is included for the same isolation reason.
     await sql`
       INSERT INTO ${sql(SCHEMA)}.album_metadata
-        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'absent', 0, NOW())
+        (album_id, artwork_url, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', 'absent', 0, NOW())
     `;
 
     // 'absent' is terminal — negative-cached, never re-asked, preserving the
@@ -232,10 +357,11 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
     insertedAlbumIds.push(albumId);
     // apple_music_status left NULL — the key-omission convention for
     // "never consulted." Must NOT be treated as re-ask-eligible the way
-    // 'unresolved' is.
+    // 'unresolved' is. BS#2295: a streaming URL is included for the same
+    // isolation reason as the two tests above.
     await sql`
-      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', NOW())
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, spotify_url, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', NOW())
     `;
 
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
@@ -244,10 +370,14 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
   test('ANY-FIELD: one unresolved-under-cap field blocks "done" even when the other two are resolved', async () => {
     const albumId = await insertLibraryAlbum(sql, 'streaming-mixed-verdicts');
     insertedAlbumIds.push(albumId);
+    // BS#2295: `spotify_url` accompanies the 'verified' spotify_status --
+    // both because a verified verdict without a URL is a shape no writer
+    // produces, and so the expected false is attributable to the unresolved
+    // apple_music field under test rather than to the streaming-columns gate.
     await sql`
       INSERT INTO ${sql(SCHEMA)}.album_metadata
-        (album_id, artwork_url, spotify_status, bandcamp_status, apple_music_status, streaming_reask_attempts, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'verified', 'absent', 'unresolved', 1, NOW())
+        (album_id, artwork_url, spotify_url, spotify_status, bandcamp_status, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/album/aluminum-tunes', 'verified', 'absent', 'unresolved', 1, NOW())
     `;
 
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
@@ -256,10 +386,14 @@ describe('enrichment-worker cache-first pre-check predicate — BS#1915 streamin
   test('SELF-HEAL flip: unresolved-under-cap flips to verified → predicate flips false → true', async () => {
     const albumId = await insertLibraryAlbum(sql, 'streaming-heal-flip');
     insertedAlbumIds.push(albumId);
+    // BS#2295: a streaming URL is present from the start so the opening
+    // false comes from the unresolved-under-cap verdict, not from the
+    // streaming-columns gate -- otherwise the UPDATE below would flip the
+    // predicate for two reasons at once and pin neither.
     await sql`
       INSERT INTO ${sql(SCHEMA)}.album_metadata
-        (album_id, artwork_url, apple_music_status, streaming_reask_attempts, updated_at)
-      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'unresolved', 1, NOW())
+        (album_id, artwork_url, spotify_url, apple_music_status, streaming_reask_attempts, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', 'https://open.spotify.com/search/Stereolab', 'unresolved', 1, NOW())
     `;
     expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
 

--- a/tests/utils/enrichment-precheck.js
+++ b/tests/utils/enrichment-precheck.js
@@ -11,13 +11,21 @@
  * predicate is chased through one file.
  *
  * The predicate is the load-bearing test the worker uses to decide whether to
- * skip the LML call. Skip (return true) requires BOTH:
+ * skip the LML call. Skip (return true) requires ALL THREE:
  *   1. A confirmed load-bearing Discogs match — `artwork_url` OR
  *      `discogs_url` is non-null. The four synthesized search-URL columns
  *      are deliberately NOT part of this — a search-URL-only shell is the
  *      BS#1089 poisoned-null shape that must keep re-calling LML to
  *      self-heal.
- *   2. BS#1915: no streaming field is still `unresolved` under the attempt
+ *   2. BS#2295: at least one of the five streaming URL columns
+ *      (`spotify_url` / `apple_music_url` / `youtube_music_url` /
+ *      `bandcamp_url` / `soundcloud_url`) is non-null. A row with a
+ *      load-bearing match but zero streaming columns used to skip anyway,
+ *      and `finalizeFromCachedMetadata` then stamped a terminal
+ *      `enriched_match` without ever writing those columns — permanent
+ *      five-null streaming URLs for every client. This condition sends that
+ *      shape through the normal LML path instead.
+ *   3. BS#1915: no streaming field is still `unresolved` under the attempt
  *      cap. `spotify_status` / `apple_music_status` / `bandcamp_status`
  *      `= 'unresolved'` AND `streaming_reask_attempts < STREAMING_REASK_ATTEMPT_CAP`
  *      on ANY of the three blocks the skip (re-ask instead), so a transient
@@ -37,7 +45,8 @@ const STREAMING_REASK_ATTEMPT_CAP = 3;
 
 /**
  * Return true iff the album already has a persisted load-bearing Discogs
- * match in `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND no
+ * match in `album_metadata` (`artwork_url` OR `discogs_url` non-null) AND at
+ * least one of the five streaming URL columns is non-null (BS#2295) AND no
  * streaming field is still bounded-re-ask-eligible (BS#1915).
  *
  * @param {import('postgres').Sql} sql - the shared test pool from `getTestDb()`.
@@ -60,6 +69,17 @@ async function hasLoadBearingMetadata(sql, albumId) {
       FROM ${sql(SCHEMA)}.album_metadata
      WHERE album_id = ${albumId}
        AND (artwork_url IS NOT NULL OR discogs_url IS NOT NULL)
+       -- BS#2295: a load-bearing match alone isn't "done" -- the row also
+       -- needs at least one streaming URL column populated, or it falls
+       -- through to LML instead of freezing a terminal enriched_match with
+       -- five null streaming URLs. See the module doc comment.
+       AND (
+         spotify_url IS NOT NULL
+         OR apple_music_url IS NOT NULL
+         OR youtube_music_url IS NOT NULL
+         OR bandcamp_url IS NOT NULL
+         OR soundcloud_url IS NOT NULL
+       )
        -- COALESCE(..., false) is load-bearing, not decorative: SQL's
        -- three-valued logic makes NULL = 'unresolved' evaluate to NULL
        -- (not false), so for the common case of all three status columns


### PR DESCRIPTION
Closes #2295.

## What was wrong

`hasLoadBearingAlbumMetadata` skipped the LML call whenever `artwork_url OR discogs_url` was non-null. `finalizeFromCachedMetadata` then flipped the flowsheet row to a terminal `enriched_match` and — correctly, given the skip meant there was nothing new to write — performed no `album_metadata` write at all. An album that acquired `artwork_url` from a path that didn't also land streaming URLs was therefore frozen in that shape for the life of the album: every client read a terminal status asserting "this album is enriched" alongside five null streaming URLs, and nothing ever re-opened the row.

Measured at **4 of the last 152 prod track rows** (2.6%), all with `artwork_url` present, `discogs_url` null, and all five streaming columns null. iOS makes it permanent rather than merely empty — `PlaycutMetadataResolver.resolve` short-circuits on terminal status (WXYC/wxyc-ios-64#685) and `shouldObserveEnrichment` returns false, so neither the proxy request nor the enrichment-repair subscription is possible on that path.

## The fix

The skip now also requires at least one of `spotify_url` / `apple_music_url` / `youtube_music_url` / `bandcamp_url` / `soundcloud_url` to be non-null. A load-bearing row with zero streaming columns falls through to the normal LML path and gets a real chance to fill them.

The #1747 amplifier guarantee is preserved and separately pinned: an album with a load-bearing match **and** at least one streaming URL is still skipped, so the common already-enriched case pays no extra LML calls. The gate is strictly narrower than what it replaces, so the BS#1089 poisoned-shell guard is untouched.

Forward fix only. Issue part 2 — the one-shot drain that heals the existing frozen rows — mutates production data and is deliberately not in this PR. Until it runs, the four rows in the issue table stay grey unless those albums are played again.

## Two adjacent things this made untrue, now corrected

**The unbounded conjunct.** The BS#1915 re-ask gate next door is capped by `streaming_reask_attempts`; this one is not, and the header now says why rather than leaving it to be rediscovered. #1915 re-asks a question that can legitimately keep coming back unanswered, so it needs a cap. This gate's question is answered by construction on the first fall-through — both write arms in `enrich.ts` populate `youtube_music_url` and `soundcloud_url` unconditionally from `synthesizeSearchUrls` — so the qualifying population is self-draining and a cap would only re-freeze the rows the fix exists to unfreeze. The one shape that could defeat that is the `setWhere: updated_at < NOW()` guard turning the whole conflict `SET` into a no-op; that's recorded in the header too, pointing at the write guard rather than at this predicate.

**The sweep's lockstep claim.** `findUnresolvedStreamingCandidates` documented itself as the positive form of this predicate. After this change that's true only of the #1915 half, so the docstring now scopes the claim and states the consequence: an album in the BS#2295 shape carries no `unresolved` verdict for the sweep to key on and no counter to bound a sweep against, so if it is never played again it stays frozen until the drain runs.

## Tests

New `BS#2295 streaming-columns gate` describe block against real PG: the frozen shape reads false (parameterized over artwork-only / discogs-only / both), a load-bearing row with exactly one streaming column reads true (parameterized over all five columns), and the false→true self-heal flip is pinned end to end.

Eight pre-existing fixtures across the base and BS#1915 blocks had no streaming column populated and would have started returning their expected value via the *new* conjunct rather than the clause they were written to test. They each gained one. Verified by mutation rather than by inspection:

- delete the `NOT needsStreamingReask` clause from the mirror → exactly 4 tests fail (the two #1915 false-arms, the #1915 heal-flip, and the Bandcamp de-freeze), matching `origin/main`'s score. As committed before this pass it was 2 of 4.
- delete the new BS#2295 conjunct → exactly the 4 tests that assert it fail.

## Verification

`typecheck`, `lint` (0 errors), `format:check`, `check:docs`, `check:lml-callers`, `check:better-auth-mock-sync`, `check:auth-tables-doc`, `lint:migrations`, `lint:env` all pass. Unit suite: 8539 passed / 484 suites. Integration run against the local Docker CI stack: every enrichment-worker suite passes, including `enrichment-worker-streaming-reask.spec.js`.

Four unrelated suites (`metadata`, `metadata-lml`, `lml-coordinator`, `flowsheet`) fail locally on 401/400 from the flowsheet write path — a local credential-role gap, not a regression. Confirmed by running the same four against a detached `origin/main` on the same freshly-seeded database: **86 failures on both**, identical.

Worth knowing before merge: this repo's Actions budget was blocking job starts earlier this week (jobs present as `steps: []` with no log, evidence only in the check-run annotation). If CI here shows that shape, it is a budget block rather than a test failure, and the local results above are what stands behind the change.
