### PR TITLE
fix(auth): veto update-user name writes by value, not key presence

### DIFF
--- a/shared/authentication/src/derive-user-display-name.ts
+++ b/shared/authentication/src/derive-user-display-name.ts
@@ -99,11 +99,21 @@ export function deriveUserNameOnCreate(
  * database, re-creating exactly the hidden-legal-name-copy state this plan
  * exists to close (`auth_user.name` silently holding a legal name again).
  *
- * So: any payload that carries a `name` key is rejected with `false` unless
- * it ALSO carries a `djName` that resolves to a usable handle — in which
+ * The rejection keys on the VALUE, not key presence: that same handler
+ * always builds its adapter payload as `{ name, image, ...additionalFields
+ * }`, so every `/update-user` call reaches this hook with the `name` key
+ * present — value `undefined` whenever the client didn't send one. A
+ * key-presence check therefore vetoes EVERY public profile update (dj-site's
+ * `updateUser({ appSkin })` experience switch was the first casualty);
+ * `undefined` must read as "not supplied". Any non-`undefined` value —
+ * including an explicit `null` — is a supplied value and an attempted
+ * direct write.
+ *
+ * So: any payload that supplies a `name` value is rejected with `false`
+ * unless it ALSO carries a `djName` that resolves to a usable handle — in which
  * case the returned `{ data: { name: handle } }` overrides the
  * client-supplied `name` via the merge contract below. This is deliberately
- * broader than "just don't derive from it": a payload carrying `name`
+ * broader than "just don't derive from it": a payload supplying `name`
  * alongside a blank/'Anonymous' djName is also rejected, closing the trivial
  * bypass of attaching an unusable djName to a bare-name payload to slip past
  * the rejection.
@@ -145,5 +155,5 @@ export function deriveOrRejectUserNameOnUpdate(
 ): { data: { name: string } } | false | undefined {
   const handle = 'djName' in data ? resolveDjDisplayName(data.djName ?? null) : null;
   if (handle !== null) return { data: { name: handle } };
-  return 'name' in data ? false : undefined;
+  return data.name !== undefined ? false : undefined;
 }

--- a/tests/integration/update-user-name-veto.spec.js
+++ b/tests/integration/update-user-name-veto.spec.js
@@ -1,0 +1,145 @@
+/**
+ * Wire spec for the `update.before` name veto (DJ real-name PII safeguards
+ * plan, Track 2b) against the real better-auth `POST /update-user` endpoint.
+ *
+ * Exists because the endpoint's adapter payload is always `{ name, image,
+ * ...additionalFields }` (api/routes/update-user.mjs) — the `name` key is
+ * present on EVERY call, `undefined` when the client didn't send one. The
+ * hook's unit tests exercise the hook with payloads the test author shapes;
+ * only a wire test proves the hook against the payload better-auth actually
+ * builds. The original key-presence veto passed its unit suite while
+ * aborting every public profile update in production (dj-site's
+ * `updateUser({ appSkin })` experience switch was the observable failure).
+ *
+ * A vetoed write is SILENT at the HTTP layer: `updateWithHooks` returns null
+ * and the route falls back to echoing session data with `{ status: true }`,
+ * so every assertion here is against the database row, never the response.
+ *
+ * Follows auth-auto-membership.spec.js's sign-in/cookie/postgres pattern.
+ */
+
+const postgres = require('postgres');
+
+// Structurally non-PII probe values — sentinel-shaped, never a real name.
+const NAME_PROBE = 'VETO-PROBE-NAME-93aF';
+const APPSKIN_PROBE = 'veto-probe-appskin-93af';
+const APPSKIN_PROBE_2 = 'veto-probe-appskin-93af-second';
+
+const USERNAME = 'test_station_manager';
+const PASSWORD = 'testpassword123';
+
+function getAuthBaseUrl() {
+  if (process.env.BETTER_AUTH_URL) {
+    try {
+      return new URL(process.env.BETTER_AUTH_URL).toString().replace(/\/$/, '');
+    } catch {
+      // fall through
+    }
+  }
+  const host = process.env.AUTH_HOST || 'localhost';
+  const port = process.env.AUTH_PORT || process.env.CI_AUTH_PORT || 8083;
+  return `http://${host}:${port}/auth`;
+}
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('POST /update-user name veto (DJ real-name PII safeguards plan, Track 2b)', () => {
+  const authBaseUrl = getAuthBaseUrl();
+  const frontendUrl = process.env.FRONTEND_SOURCE || 'http://localhost:3000';
+  let sql;
+  let cookie;
+  let userId;
+  let originalAppSkin;
+  let originalName;
+
+  async function fetchRow() {
+    const rows = await sql`SELECT id, name, app_skin FROM auth_user WHERE username = ${USERNAME}`;
+    if (rows.length !== 1) {
+      throw new Error(`expected exactly one ${USERNAME} row, got ${rows.length}`);
+    }
+    return rows[0];
+  }
+
+  async function postUpdateUser(body) {
+    const res = await fetch(`${authBaseUrl}/update-user`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        origin: frontendUrl,
+        cookie,
+      },
+      body: JSON.stringify(body),
+    });
+    return res;
+  }
+
+  beforeAll(async () => {
+    sql = makeSql();
+
+    const res = await fetch(`${authBaseUrl}/sign-in/username`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', origin: frontendUrl },
+      body: JSON.stringify({ username: USERNAME, password: PASSWORD }),
+    });
+    if (!res.ok) {
+      throw new Error(`Sign-in failed: ${res.status} ${await res.text()}`);
+    }
+    const cookies = res.headers.getSetCookie();
+    if (!cookies || cookies.length === 0) {
+      throw new Error('No session cookie returned by sign-in');
+    }
+    cookie = cookies.map((c) => c.split(';')[0].trim()).join('; ');
+
+    const row = await fetchRow();
+    userId = row.id;
+    originalAppSkin = row.app_skin;
+    originalName = row.name;
+  });
+
+  afterAll(async () => {
+    // Surgical restore of only what this spec may have changed.
+    if (sql && userId !== undefined && originalAppSkin !== undefined) {
+      await sql`UPDATE auth_user SET app_skin = ${originalAppSkin} WHERE id = ${userId}`;
+    }
+    if (sql) await sql.end();
+  });
+
+  it('persists an unrelated-field update (the appSkin experience switch) despite the endpoint-injected undefined name', async () => {
+    const res = await postUpdateUser({ appSkin: APPSKIN_PROBE });
+    expect(res.ok).toBe(true);
+
+    const row = await fetchRow();
+    expect(row.app_skin).toBe(APPSKIN_PROBE);
+    // The injected `name: undefined` must not have touched name either.
+    expect(row.name).toBe(originalName);
+  });
+
+  it('aborts the entire write when the payload supplies a name — sibling fields do not land', async () => {
+    const res = await postUpdateUser({ name: NAME_PROBE, appSkin: APPSKIN_PROBE_2 });
+    // The veto is silent at the HTTP layer (see file docblock) — the row is
+    // the only honest witness.
+    expect(res.status).toBeLessThan(500);
+
+    const row = await fetchRow();
+    expect(row.name).toBe(originalName);
+    expect(row.app_skin).toBe(APPSKIN_PROBE);
+  });
+
+  it('aborts a bare name-only write', async () => {
+    const res = await postUpdateUser({ name: NAME_PROBE });
+    expect(res.status).toBeLessThan(500);
+
+    const row = await fetchRow();
+    expect(row.name).toBe(originalName);
+  });
+});

--- a/tests/unit/authentication/derive-user-display-name.test.ts
+++ b/tests/unit/authentication/derive-user-display-name.test.ts
@@ -119,4 +119,31 @@ describe('deriveOrRejectUserNameOnUpdate', () => {
     const result = deriveOrRejectUserNameOnUpdate({ name: 'Some Real Name', djName: 'Anonymous' });
     expect(result).toBe(false);
   });
+
+  // better-auth's public POST /update-user handler (api/routes/update-user.mjs)
+  // always builds its adapter payload as `{ name, image, ...additionalFields }`
+  // — so EVERY update through that endpoint reaches this hook with the `name`
+  // key present, value `undefined` whenever the client didn't send one. The
+  // veto must therefore key on the VALUE, never on key presence: an undefined
+  // `name` is "not supplied", not an attempted write. Regression test for the
+  // key-presence veto that aborted every profile update (dj-site's
+  // `updateUser({ appSkin })` experience switch included).
+  it('no-ops on the endpoint-injected undefined name (unrelated-field update)', () => {
+    const result = deriveOrRejectUserNameOnUpdate({
+      name: undefined,
+      image: undefined,
+      appSkin: 'classic',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('derives the handle when the endpoint-injected undefined name rides along with a usable djName', () => {
+    const result = deriveOrRejectUserNameOnUpdate({ name: undefined, djName: 'DJ Jazzy Jane' });
+    expect(result).toEqual({ data: { name: 'DJ Jazzy Jane' } });
+  });
+
+  it('still rejects an explicit null name (a supplied value, not an absent one)', () => {
+    const result = deriveOrRejectUserNameOnUpdate({ name: null });
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #2299.

## What

`deriveOrRejectUserNameOnUpdate` (the `databaseHooks.user.update.before` name choke point from #2297) rejected on `'name' in data` — key presence. better-auth's public `POST /update-user` handler always builds its adapter payload as `{ name, image, ...additionalFields }`, so every public profile update carried `name: undefined` and was vetoed wholesale. Live regression: dj-site's `updateUser({ appSkin })` experience switch silently no-ops (the veto returns 200 — `updateWithHooks` yields null and the route echoes session data), which is how WXYC/dj-site#1279's E2E rerun caught it.

The veto now keys on the value: `data.name !== undefined ? false : undefined`. `undefined` reads as "not supplied"; any supplied value — explicit `null` included — is still an attempted direct write and aborts the whole payload. Rejection of real `name` writes, the derivation from a usable payload `djName`, and all #2297 behavior are otherwise unchanged.

## Tests

- **Unit** (failing-first): the endpoint-injected `{ name: undefined, image: undefined, appSkin }` shape must no-op; `{ name: undefined, djName }` still derives; explicit `null` still rejects. 20/20 in the hook suite, 8630/8630 across the unit tier.
- **Wire** (`tests/integration/update-user-name-veto.spec.js`): through the real auth service, asserting against the `auth_user` row because a vetoed write is silent at the HTTP layer — an `{ appSkin }`-only update persists; a payload supplying `name` aborts entirely, sibling fields included.