### PR TITLE
fix(flowsheet): make Go Live say what it means instead of silently co-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,19 @@ SES_CONFIGURATION_SET_NAME=my-first-configuration-set
 TUBAFRENZY_URL=https://www.wxyc.info
 MIRROR_API_KEY=wxyc-local-dev-mirror-key
 
+### Flowsheet go-live intent (BS#2233)
+# Strict-'true' gate for POST /flowsheet/join's explicit start-vs-join
+# decision. When ON, a DJ going live while a show they are not a member of is
+# still open must send `intent: join` or `intent: takeover`; sending neither is
+# a 409 naming the open show. When OFF (the default, and how this ships) the
+# route ignores both new fields and co-hosts exactly as it always has -- never
+# a 400, never a 409, because auto-dj-orchestrator sends `intent: takeover`
+# before the flip and would crash on either.
+#
+# Deliberately INVERTS the `backend-mirror` convention two lines above, where
+# an unset POSTHOG_API_KEY means "enabled". This one ships dormant.
+FLOWSHEET_TAKEOVER_ENABLED=
+
 ### Request-line ban CRUD (BS#1261)
 # Sent by request-o-matic on every /internal/banned-fingerprints call AND
 # (optionally) on /auth/check-request-ban for rate-limit bucketing. Distinct

--- a/apps/backend/config/flowsheetTakeover.ts
+++ b/apps/backend/config/flowsheetTakeover.ts
@@ -1,0 +1,38 @@
+/**
+ * Configuration for `POST /flowsheet/join`'s explicit start-vs-join decision
+ * (BS#2233, epic BS#2232).
+ *
+ * When enabled, a caller who presses "Go Live" while a show they are not an
+ * active member of is still open must say what they mean: `intent: "join"`
+ * co-hosts, `intent: "takeover"` closes the open show and starts their own,
+ * and no `intent` at all is a 409 carrying the open show's details. When
+ * disabled, `intent` and `expected_show_id` are ignored entirely and the
+ * route behaves exactly as it did before — the silent co-host attachment,
+ * including its bug.
+ *
+ * **Flag-OFF must never 400 or 409.** That is not a nicety, it is the
+ * rollout: `auto-dj-orchestrator` ships `intent: "takeover"` before the flip,
+ * and its `join()` throws on any response body without a show id
+ * (`src/backend/flowsheet-client.ts`), so a 400 on the unrecognized field
+ * would crash that daemon at activation. Ordering accidents between the four
+ * repos in this chain are therefore harmless: BS ships dormant, every client
+ * becomes 409-aware while nothing is sending 409s, and the flip is one env
+ * var. The flag is also the rollback — no redeploy.
+ *
+ * Deliberately does NOT reuse the mirror's `isMirrorEnabled`, which
+ * env-defaults to `true` when `POSTHOG_API_KEY` is unset
+ * (`middleware/legacy/mirror.middleware.ts`). Copying that shape would make
+ * this flag default ON in every environment without a PostHog key — including
+ * the dj-site e2e stack, which sets none — the exact inverse of shipping
+ * dormant.
+ *
+ * The singleton mechanics (strict-`true` parse, lazy cache, `resetConfig` test
+ * hook) come from the shared {@link createEnvFlagConfig} factory. Tests that
+ * mutate `process.env.FLOWSHEET_TAKEOVER_ENABLED` between cases must call
+ * `resetConfig()` so the next `getConfig()` re-reads the env.
+ */
+import { createEnvFlagConfig, type EnvFlagConfig } from './envFlag.js';
+
+export type FlowsheetTakeoverConfig = EnvFlagConfig;
+
+export const { loadConfig, getConfig, resetConfig } = createEnvFlagConfig('FLOWSHEET_TAKEOVER_ENABLED');

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -839,14 +839,34 @@ export type JoinIntent = 'join' | 'takeover';
 const JOIN_INTENTS: readonly JoinIntent[] = ['join', 'takeover'];
 
 /**
+ * Narrow an UNVALIDATED request-body value to {@link JoinIntent}.
+ *
+ * Takes `unknown` on purpose. `JoinRequestBody.intent` is a declaration about
+ * what clients are meant to send, not a fact about what arrived — nothing
+ * validates this route's body — so reading it at its declared type makes
+ * TypeScript narrow to `JoinIntent` and treat the membership check below as a
+ * comparison that cannot fail. It very much can, and if it is ever deleted on
+ * that reasoning `intent: "nonsense"` stops being a 400 and falls through to
+ * the TAKEOVER branch, ending a live DJ's show on a typo. Routing the value
+ * through `unknown` keeps the guard honest and the narrowing real.
+ */
+const isJoinIntent = (value: unknown): value is JoinIntent => (JOIN_INTENTS as readonly unknown[]).includes(value);
+
+/**
  * The 409 a `POST /flowsheet/join` answers with when a show the caller does not
  * belong to is genuinely open and they said nothing about what to do.
  *
  * `dj_name` resolves through the SHARED chain (`dj_name_override` → the linked
- * account's handle → `legacy_dj_name`), the same one `getOnAirDJName` and
- * `getOnAirDJs` use. Hand-joining `auth_user` here would let the prompt show a
- * name that disagrees with the on-air banner rendered beside it — the exact
- * class of divergence this work exists to remove.
+ * account's handle → `legacy_dj_name`) rather than a hand-joined `auth_user`
+ * read, so the prompt names the show the same way every other show-scoped
+ * surface does and cannot drift from them as the chain evolves.
+ *
+ * It does NOT necessarily match the on-air banner, and must not be "fixed" to.
+ * `getOnAirDJName` deliberately departs from this chain in one case (an open
+ * show with no override and no `primary_dj_id` but an active `show_djs`
+ * member), so on exactly the abandoned shows this 409 fires for, the banner
+ * names whoever is at the controls while this names the show's owner. Both are
+ * right, because they answer different questions — see below.
  *
  * Note what that name means: it is the show's OWNER, which for an abandoned
  * show is the DJ who left, not whoever is at the controls. That is the right
@@ -956,9 +976,19 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
   } else {
     // Everything above has been ruled out: a show is genuinely open, it isn't
     // the caller's, and its terminal entry doesn't say it ended. This is the
-    // handoff the incident happened at (BS#2232 — production show 1951224
-    // absorbed five DJs across ten hours while `on_air` named only the first),
-    // and the ONLY branch the intent contract governs.
+    // handoff both BS#2232 incidents happened at, and the ONLY branch the
+    // intent contract governs:
+    //
+    //   - 2026-08-20, show 1951164: a BS-native show (`primary_dj_id` set) ran
+    //     nine hours and absorbed three later DJs as co-hosts while `on_air`
+    //     named its original owner throughout.
+    //   - 2026-08-28, show 1951224: a tubafrenzy-mirrored show (`primary_dj_id`
+    //     NULL, `legacy_dj_name` "dj sue") absorbed a Backend account three
+    //     hours in, and `on_air` named the departed legacy DJ.
+    //
+    // The two are the same routing bug with different banner mechanisms, which
+    // is why this PR carries two fixes: the routing below, and
+    // `getOnAirDJName`'s legacy short-circuit. Neither one subsumes the other.
     //
     // Flag OFF is byte-identical to the pre-BS#2233 behavior, `intent`
     // included: no 400 for an unrecognized value, no 409 for an absent one.
@@ -971,7 +1001,12 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
       return;
     }
 
-    const intent = req.body.intent;
+    // A JSON `null` says exactly what an absent field says — "I have not
+    // chosen" — and it is what an unset optional serializes to from several of
+    // this epic's clients. Fold it into absence BEFORE the union check, or a
+    // caller who has not chosen is told their choice is invalid (400) instead
+    // of being prompted (409), which is the one answer they cannot act on.
+    const intent: unknown = req.body.intent ?? undefined;
 
     // No intent: the caller never chose. Refuse to choose for them, and say
     // which show is in the way so the client can prompt and echo the id back.
@@ -979,7 +1014,7 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
       throw await showAlreadyOpenError(current_show);
     }
 
-    if (!JOIN_INTENTS.includes(intent)) {
+    if (!isJoinIntent(intent)) {
       throw new WxycError(`Bad Request: intent must be one of ${JOIN_INTENTS.join(', ')}`, 400);
     }
 

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -11,6 +11,8 @@ import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import { projectFlowsheetEntry, toDiscogsUnavailableWireFields } from '../utils/flowsheet-projection.js';
 import { getDiscogsUnavailableFlagsById } from '../services/library.service.js';
 import { stashMirrorData } from '../middleware/legacy/mirror.middleware.js';
+import { flowsheetMirror } from '../middleware/legacy/flowsheet.mirror.js';
+import * as flowsheetTakeoverConfig from '../config/flowsheetTakeover.js';
 import WxycError from '../utils/error.js';
 import { INT4_MAX } from '../utils/constants.js';
 
@@ -812,7 +814,57 @@ export type JoinRequestBody = {
    * (`addDJToShow`) because there's no per-co-host override surface today.
    */
   dj_name_override?: string;
+  /**
+   * What the caller means when a show they are not already an active member of
+   * is still open (BS#2233). Consulted ONLY in that case — the guards above it
+   * (an already-closed show, a terminal `show_end` marker, an existing active
+   * membership) all resolve first and never reach this field.
+   */
+  intent?: JoinIntent;
+  /**
+   * The `shows.id` a `takeover` intends to close, echoed from the 409's
+   * `details.show.id`. Compare-and-set: see `joinShow`.
+   */
+  expected_show_id?: number;
 };
+
+/**
+ * The two things a caller can mean by "Go Live" while somebody else's show is
+ * open. Absence is a THIRD state and deliberately not a member of this union:
+ * it means the caller never chose, and the answer to that is the 409, not a
+ * default. See `apps/backend/config/flowsheetTakeover.ts`.
+ */
+export type JoinIntent = 'join' | 'takeover';
+
+const JOIN_INTENTS: readonly JoinIntent[] = ['join', 'takeover'];
+
+/**
+ * The 409 a `POST /flowsheet/join` answers with when a show the caller does not
+ * belong to is genuinely open and they said nothing about what to do.
+ *
+ * `dj_name` resolves through the SHARED chain (`dj_name_override` → the linked
+ * account's handle → `legacy_dj_name`), the same one `getOnAirDJName` and
+ * `getOnAirDJs` use. Hand-joining `auth_user` here would let the prompt show a
+ * name that disagrees with the on-air banner rendered beside it — the exact
+ * class of divergence this work exists to remove.
+ *
+ * Note what that name means: it is the show's OWNER, which for an abandoned
+ * show is the DJ who left, not whoever is at the controls. That is the right
+ * answer to "whose show am I being asked about", and the wrong answer to "who
+ * is on air" — a client rendering the latter reads `GET /flowsheet/djs-on-air`.
+ * The spec's 409 description says so explicitly.
+ */
+const showAlreadyOpenError = async (show: Show): Promise<WxycError> =>
+  new WxycError('A show is already on air', 409, {
+    code: 'show_already_open',
+    details: {
+      show: {
+        id: show.id,
+        dj_name: await flowsheet_service.resolveDjNameForShow(show),
+        start_time: show.start_time,
+      },
+    },
+  });
 
 /**
  * Maximum length of `dj_name_override`. Absolute ceiling matching both the
@@ -902,10 +954,90 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
     // dj_join marker (the issue's 16:37:59 duplicate-marker trace).
     res.status(200).json({ show_id: current_show.id, dj_id: req.body.dj_id, active: true } satisfies ShowDJ);
   } else {
-    // Override is only consumed on the new-show path. Co-host join uses the
-    // auth_user.dj_name resolution unchanged.
-    const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
-    res.status(200).json(show_dj_instance);
+    // Everything above has been ruled out: a show is genuinely open, it isn't
+    // the caller's, and its terminal entry doesn't say it ended. This is the
+    // handoff the incident happened at (BS#2232 — production show 1951224
+    // absorbed five DJs across ten hours while `on_air` named only the first),
+    // and the ONLY branch the intent contract governs.
+    //
+    // Flag OFF is byte-identical to the pre-BS#2233 behavior, `intent`
+    // included: no 400 for an unrecognized value, no 409 for an absent one.
+    // auto-dj-orchestrator ships `intent: "takeover"` before the flip and its
+    // `join()` throws on a body with no show id, so a 400 here would crash
+    // that daemon at activation. See config/flowsheetTakeover.ts.
+    if (!flowsheetTakeoverConfig.getConfig().enabled) {
+      const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
+      res.status(200).json(show_dj_instance);
+      return;
+    }
+
+    const intent = req.body.intent;
+
+    // No intent: the caller never chose. Refuse to choose for them, and say
+    // which show is in the way so the client can prompt and echo the id back.
+    if (intent === undefined) {
+      throw await showAlreadyOpenError(current_show);
+    }
+
+    if (!JOIN_INTENTS.includes(intent)) {
+      throw new WxycError(`Bad Request: intent must be one of ${JOIN_INTENTS.join(', ')}`, 400);
+    }
+
+    if (intent === 'join') {
+      // Override is only consumed on the new-show path. Co-host join uses the
+      // auth_user.dj_name resolution unchanged.
+      const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
+      res.status(200).json(show_dj_instance);
+      return;
+    }
+
+    // Takeover. Bound to the show the DJ was actually shown: clients poll, so
+    // by the time someone reads the prompt and clicks, the open show may have
+    // moved on. Ending "whatever is open now" would close a show whose name
+    // they never saw, which voids the informed consent the prompt exists to
+    // provide. (The other stale-snapshot case — the expected show having
+    // CLOSED in that window — never reaches here: the first branch above
+    // already routed it to `startShow`, silently, because starting their own
+    // show is the outcome they asked for and re-prompting would put the dialog
+    // on the common one-click path.)
+    if (typeof req.body.expected_show_id !== 'number') {
+      throw new WxycError('Bad Request: intent "takeover" requires expected_show_id', 400);
+    }
+    if (req.body.expected_show_id !== current_show.id) {
+      throw await showAlreadyOpenError(current_show);
+    }
+
+    // `resolveShowEndInstant` (MAX(add_time) floored at start_time), never
+    // `now()`. `now()` is right for a prompt handoff and a lie for an abandoned
+    // one: it would credit a departed DJ with however many hours of dead air
+    // elapsed before the next DJ arrived, and — per `endShow`'s own
+    // EndShowOptions note — sort a `show_end` marker to the top of the public
+    // flowsheet with an interval overlapping every archive day in between. The
+    // derived instant is truthful in both cases, because a prompt handoff's
+    // last logged track IS recent. One rule, correct twice.
+    const endedAt = await flowsheet_service.resolveShowEndInstant(current_show);
+
+    // `endShow` first, and unwrapped: its `WHERE end_time IS NULL`
+    // compare-and-set is what serializes two racing takeovers, so the loser
+    // gets that 400 rather than opening a second show.
+    const closedShow: Show = await flowsheet_service.endShow(current_show, endedAt);
+
+    // The route chains `flowsheetMirror.startShow`, whose response tap will
+    // create the NEW show in tubafrenzy from the body below. The close has to
+    // mirror too, or tubafrenzy keeps a show open that Backend has closed —
+    // the split brain that made this incident ambiguous. It cannot ride a
+    // second tap (both read the same `res.locals.mirrorData`, so an end-tap
+    // would sign off the show that just started), so it is handed the closed
+    // show explicitly and deferred to `res.once('finish')`.
+    flowsheetMirror.scheduleTakeoverSignoff(req, res, closedShow);
+
+    const show_session: Show = await flowsheet_service.startShow(
+      req.body.dj_id,
+      req.body.show_name,
+      req.body.specialty_id,
+      dj_name_override
+    );
+    res.status(200).json(show_session);
   }
 };
 
@@ -1003,7 +1135,52 @@ export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hou
  * force-end therefore cannot write a duplicate marker even if two operators
  * click at the same instant.
  */
-export const forceEndShow: RequestHandler<{ id: string }, unknown, unknown, { force?: string }> = async (req, res) => {
+/**
+ * The instant `force-end` stamps: the operator's `ended_at` when they supplied
+ * one, otherwise the show's own last logged entry.
+ *
+ * The derived instant is the right default and the wrong answer often enough to
+ * need an override — a DJ who stopped logging at 9pm and stayed on the air
+ * until 11pm leaves a show whose flowsheet cannot say so, and the operator can.
+ *
+ * Bounded on BOTH ends because each bound protects a public read. Below
+ * `start_time` yields `end_time < start_time`, an interval that cannot overlap
+ * anything, which hides the show from `GET /flowsheet/range` on the very day it
+ * aired (the same hazard `resolveShowEndInstant`'s own floor exists for). Above
+ * `now` yields a show claiming to have ended in the future, which sorts a
+ * `show_end` marker above every real entry on the public flowsheet. Out of
+ * range is a 400, never a silent clamp: an operator who mistypes a date should
+ * learn that, not get a different answer than they asked for.
+ */
+const resolveForceEndInstant = async (raw: unknown, show: Show): Promise<Date> => {
+  if (raw === undefined || raw === null) {
+    return flowsheet_service.resolveShowEndInstant(show);
+  }
+  // Only a string. `new Date(1755000000000)` parses an epoch happily, and a
+  // caller who sent a number meant something the contract does not offer.
+  if (typeof raw !== 'string') {
+    throw new WxycError('Bad Request: ended_at must be an ISO-8601 date-time string', 400);
+  }
+  const endedAt = new Date(raw);
+  if (Number.isNaN(endedAt.getTime())) {
+    throw new WxycError('Bad Request: ended_at must be an ISO-8601 date-time string', 400);
+  }
+  const startedAt = new Date(show.start_time);
+  if (endedAt.getTime() < startedAt.getTime()) {
+    throw new WxycError("Bad Request: ended_at must be at or after the show's start_time", 400);
+  }
+  if (endedAt.getTime() > Date.now()) {
+    throw new WxycError('Bad Request: ended_at must not be in the future', 400);
+  }
+  return endedAt;
+};
+
+export const forceEndShow: RequestHandler<
+  { id: string },
+  unknown,
+  { ended_at?: unknown } | undefined,
+  { force?: string }
+> = async (req, res) => {
   if (!/^\d+$/.test(req.params.id)) {
     throw new WxycError('Bad Request: show id must be a positive integer', 400);
   }
@@ -1040,8 +1217,9 @@ export const forceEndShow: RequestHandler<{ id: string }, unknown, unknown, { fo
     }
   }
 
-  // The instant the show actually stopped, not `now()` — see `endShow`.
-  const endedAt = await flowsheet_service.resolveShowEndInstant(show);
+  // The instant the show actually stopped, not `now()` — see `endShow`. An
+  // operator may override it within `[start_time, now]`.
+  const endedAt = await resolveForceEndInstant(req.body?.ended_at, show);
 
   const finalizedShow: Show = await flowsheet_service.endShow(show, endedAt);
   res.status(200).json(finalizedShow);

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -1,10 +1,15 @@
-import { QueryParams } from '../../controllers/flowsheet.controller';
+import type { QueryParams } from '../../controllers/flowsheet.controller';
 import { db } from '@wxyc/database';
 import { user, flowsheet, shows, FSEntry, Show } from '@wxyc/database';
 import { and, eq, isNull } from 'drizzle-orm';
 import * as Sentry from '@sentry/node';
-import { Request } from 'express';
-import { createBackendMirrorMiddleware, createHttpMirrorMiddleware } from './mirror.middleware.js';
+import { Request, Response } from 'express';
+import {
+  createBackendMirrorMiddleware,
+  createHttpMirrorMiddleware,
+  isMirrorEnabled,
+  type MirrorFlagRequest,
+} from './mirror.middleware.js';
 import { safeSql, safeSqlNum, toMs } from './utilities.mirror.js';
 import {
   mirrorCreateEntry,
@@ -189,26 +194,81 @@ const startShow = createHttpMirrorMiddleware<Show>(
   { shouldMirror: isShowPayload, resolveFlagIdentity: showFlagIdentity }
 );
 
+/**
+ * Sign one closed show off in tubafrenzy and mirror its `show_end` marker.
+ *
+ * Extracted from the `endShow` response tap so `POST /flowsheet/join`'s
+ * takeover branch can close a show through the identical sequence. Chaining
+ * `flowsheetMirror.endShow` onto `/join` instead is the trap: both taps read
+ * the SAME `res.locals.mirrorData` key under the same `isShowPayload` gate, so
+ * on a takeover both would receive the payload of the show that just STARTED
+ * and the end-tap would sign off the live broadcast.
+ *
+ * Takes the closed `Show` and resolves the tubafrenzy id itself rather than
+ * accepting one. `getCachedShowId` is module-private and is the *primary*
+ * source whenever `startShow`'s `legacy_show_id` persist failed, so a caller
+ * passing a pre-resolved id would silently drop the cache lookup and
+ * mis-target the sign-off.
+ */
+const mirrorShowSignoff = async (show: Show): Promise<void> => {
+  const endMs = toMs(show.end_time ?? Date.now());
+
+  // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
+  const tubafrenzyShowId = getCachedShowId(show.id) ?? show.legacy_show_id;
+
+  // No tubafrenzy show to sign off or hang the END_OF_SHOW entry off (the
+  // startShow mirror failed, or this process never saw it and the persist
+  // failed too). Both arms skip together; legacy-mirror-reconcile heals it.
+  if (tubafrenzyShowId == null) return;
+
+  await mirrorSignoffShow(tubafrenzyShowId, endMs);
+  await mirrorAnnouncementEntry(show.id, 'show_end', tubafrenzyShowId);
+};
+
 export const endShow = createHttpMirrorMiddleware<Show>(
-  async (_req, show) => {
-    // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
-    // as this registration's shouldMirror gate — a guest leave never reaches
-    // this handler (and never pays the PostHog flag round-trip).
-    const endMs = toMs(show.end_time ?? Date.now());
-
-    // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
-    const tubafrenzyShowId = getCachedShowId(show.id) ?? show.legacy_show_id;
-
-    // No tubafrenzy show to sign off or hang the END_OF_SHOW entry off (the
-    // startShow mirror failed, or this process never saw it and the persist
-    // failed too). Both arms skip together; legacy-mirror-reconcile heals it.
-    if (tubafrenzyShowId == null) return;
-
-    await mirrorSignoffShow(tubafrenzyShowId, endMs);
-    await mirrorAnnouncementEntry(show.id, 'show_end', tubafrenzyShowId);
-  },
+  // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
+  // as this registration's shouldMirror gate — a guest leave never reaches
+  // this handler (and never pays the PostHog flag round-trip).
+  async (_req, show) => mirrorShowSignoff(show),
   { shouldMirror: isShowPayload, resolveFlagIdentity: showFlagIdentity }
 );
+
+/**
+ * Queue the tubafrenzy sign-off for a show `POST /flowsheet/join` closed as
+ * part of a takeover (BS#2233).
+ *
+ * The takeover ends one show and starts another in a single request, but the
+ * route can only carry ONE response-tap payload — the new show, which
+ * `flowsheetMirror.startShow` needs. The close therefore mirrors from here,
+ * with the closed `Show` passed explicitly.
+ *
+ * Deferred to `res.once('finish')` rather than awaited inline, matching both
+ * mirror factories. Awaiting would put tubafrenzy's HTTP latency on the
+ * go-live path, and a tubafrenzy outage would 500 the takeover *after*
+ * `endShow` already committed `end_time` — stranding the DJ off air with no
+ * show, a worse version of the bug being fixed.
+ *
+ * Deliberately NOT gated on `res.statusCode`, which is where this departs from
+ * the taps. A tap decides whether a mutation happened by reading the status
+ * code; here the close has ALREADY COMMITTED before this is called, so a later
+ * failure in the same request (`startShow` throwing, say) changes nothing
+ * about whether tubafrenzy needs to hear about it. Skipping the sign-off on a
+ * non-2xx would leave exactly the BS-closed/tubafrenzy-open split brain that
+ * produced this incident's ambiguity.
+ */
+export const scheduleTakeoverSignoff = (req: MirrorFlagRequest, res: Response, closedShow: Show): void => {
+  res.once('finish', () => {
+    void (async () => {
+      try {
+        if (!(await isMirrorEnabled(req, () => Promise.resolve(showFlagIdentity(closedShow))))) return;
+        await mirrorShowSignoff(closedShow);
+      } catch (e) {
+        console.error('Error in takeover sign-off mirror:', e);
+        Sentry.captureException(e, { tags: { subsystem: 'legacy-mirror', variant: 'http' } });
+      }
+    })();
+  });
+};
 
 const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   const startMs = entry?.add_time ? new Date(entry.add_time).getTime() : Date.now();
@@ -560,5 +620,8 @@ export const flowsheetMirror = {
   addEntry,
   updateEntry,
   deleteEntry,
+  // Not a middleware: the takeover branch calls this directly. See its
+  // docstring for why the sign-off cannot ride a second response tap.
+  scheduleTakeoverSignoff,
   /*changeOrder,*/
 };

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -229,7 +229,7 @@ export const endShow = createHttpMirrorMiddleware<Show>(
   // BS#1119's ShowDJ-vs-Show discrimination lives in `isShowPayload`, passed
   // as this registration's shouldMirror gate — a guest leave never reaches
   // this handler (and never pays the PostHog flag round-trip).
-  async (_req, show) => mirrorShowSignoff(show),
+  (_req, show) => mirrorShowSignoff(show),
   { shouldMirror: isShowPayload, resolveFlagIdentity: showFlagIdentity }
 );
 

--- a/apps/backend/middleware/legacy/mirror.middleware.ts
+++ b/apps/backend/middleware/legacy/mirror.middleware.ts
@@ -4,6 +4,14 @@ import { MirrorCommandQueue } from './commandqueue.mirror';
 import { getPostHogClient } from '../../utils/posthog.js';
 
 /**
+ * The only parts of a request this gate reads. Narrowed from `Request` so a
+ * controller holding a route-typed `Request<object, object, Body>` — which is
+ * not assignable to the default `ParamsDictionary`-keyed one — can call it
+ * without a cast (BS#2233's takeover branch).
+ */
+export type MirrorFlagRequest = Pick<Request, 'auth' | 'ip'>;
+
+/**
  * Check the PostHog `backend-mirror` feature flag. If PostHog is not
  * configured (no API key), the mirror is enabled by default so that
  * local development and E2E tests work without external dependencies.
@@ -20,7 +28,10 @@ import { getPostHogClient } from '../../utils/posthog.js';
  * pre-BS#1119-follow-up `req.user?.id` read meant every evaluation fell back to
  * req.ip, one EC2-local value.
  */
-async function isMirrorEnabled(req: Request, resolveShowIdentity?: () => Promise<string | null>): Promise<boolean> {
+export async function isMirrorEnabled(
+  req: MirrorFlagRequest,
+  resolveShowIdentity?: () => Promise<string | null>
+): Promise<boolean> {
   if (!process.env.POSTHOG_API_KEY) {
     console.log('[mirror] enabled=true source=env-default');
     return true;

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1782,12 +1782,19 @@ export const ANONYMOUS_ON_AIR_NAME = 'WXYC';
  * case to `null` was the "AUTO DJ while a human DJ is live" bug for handleless
  * sign-ons.
  *
- * Deliberately does NOT consult the `show_djs` join table the way
+ * Does NOT derive the name from the `show_djs` join table the way
  * `getDJsInCurrentShow`/`getOnAirStatusForDJ` do: tubafrenzy-mirrored shows have
  * no `show_djs` rows (the DJ has no Backend-Service account), so a join-table
  * read reports automation for essentially every legacy live show — the same
  * class of bug. `legacy_dj_name` is the authoritative identity for those shows,
  * and `resolveDjNameForShow` already reads it.
+ *
+ * It does consult the join table in ONE narrow case (BS#2233): a show with no
+ * override and no `primary_dj_id`, where the chain would otherwise fall through
+ * to `legacy_dj_name` even though `show_djs` holds an active account member.
+ * See the comment at the branch. That is a preference between two identities
+ * this function already had access to, not a return to deriving from the join
+ * table — a show with no account rows still resolves exactly as before.
  *
  * Known limitation (inherited from the `getLatestShow`-based on-air endpoints):
  * legacy/tubafrenzy shows are created open (`end_time: null`) and closed later by
@@ -1801,11 +1808,57 @@ export const ANONYMOUS_ON_AIR_NAME = 'WXYC';
  *   `ANONYMOUS_ON_AIR_NAME` when the open show has no resolvable name — or
  *   `null` only when no show is open (automation).
  */
+/**
+ * The display name of an active `show_djs` member of `showId`, or null when the
+ * show has no account members with a resolvable handle.
+ *
+ * Ordered by `auth_user.id` purely for determinism — `show_djs` carries no join
+ * timestamp and no serial id, so there is no "who arrived first" to read
+ * (BS#2237). With no `primary_dj_id` to prefer, any stable order beats a
+ * plan-dependent one.
+ *
+ * Scoped to the LIVE on-air read. Deliberately not folded into
+ * `resolveDjNameForShow`, which also feeds the archive and the write path:
+ * changing the shared chain would rewrite the names on historical shows.
+ */
+const activeMemberOnAirName = async (showId: number): Promise<string | null> => {
+  const members = await getDJsInShow(showId, true);
+  const named = members
+    .slice()
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+    .map((m) => resolveDjDisplayName((m.djName as string | null | undefined) ?? null))
+    .filter((name): name is string => !!name && name.trim().length > 0);
+  return named[0] ?? null;
+};
+
 export const getOnAirDJName = async (): Promise<string | null> => {
   const latest_show = await getLatestShow();
   if (!latest_show || latest_show.end_time !== null) {
     return null;
   }
+
+  // The one place this read departs from the shared chain (BS#2233).
+  //
+  // With no override and no `primary_dj_id`, `resolveDjNameForShow`
+  // short-circuits to `shows.legacy_dj_name` — the handle of whoever tubafrenzy
+  // recorded when the show opened. That is the correct answer for a legacy show
+  // with no Backend accounts on it (the DJ MONSTER case this function was
+  // written for), and the wrong one the moment a real account joins that show:
+  // `show_djs` then holds someone who is demonstrably at the controls, while
+  // the banner keeps naming a DJ who may have left hours ago. `djs-on-air`
+  // already prefers account rows for exactly this reason (`getOnAirDJs`), so
+  // before this the two on-air endpoints disagreed on precisely the shows where
+  // the answer mattered.
+  //
+  // Only consulted in that short-circuit: an override is operator-supplied and
+  // outranks everything, and a linked primary DJ is a real answer from the
+  // chain. So a BS-native show pays no extra query.
+  const hasOverride = showDjNameOverride((latest_show.dj_name_override as string | null | undefined) ?? null) !== null;
+  if (!hasOverride && (latest_show.primary_dj_id as string | null | undefined) == null) {
+    const memberName = await activeMemberOnAirName(latest_show.id);
+    if (memberName) return memberName;
+  }
+
   const resolved = (await resolveDjNameForShow(latest_show))?.trim();
   return resolved && resolved.length > 0 ? resolved : ANONYMOUS_ON_AIR_NAME;
 };

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1817,6 +1817,12 @@ export const ANONYMOUS_ON_AIR_NAME = 'WXYC';
  * (BS#2237). With no `primary_dj_id` to prefer, any stable order beats a
  * plan-dependent one.
  *
+ * The comparison is a plain relational one, NOT `localeCompare`: the sort's
+ * only job is to be the same on every host, and `localeCompare` without an
+ * explicit locale is collation-dependent, so it would make the banner's choice
+ * of DJ depend on the container's ICU data — the one property this sort exists
+ * to guarantee.
+ *
  * Scoped to the LIVE on-air read. Deliberately not folded into
  * `resolveDjNameForShow`, which also feeds the archive and the write path:
  * changing the shared chain would rewrite the names on historical shows.
@@ -1824,11 +1830,10 @@ export const ANONYMOUS_ON_AIR_NAME = 'WXYC';
 const activeMemberOnAirName = async (showId: number): Promise<string | null> => {
   const members = await getDJsInShow(showId, true);
   const named = members
-    .slice()
-    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
-    .map((m) => resolveDjDisplayName((m.djName as string | null | undefined) ?? null))
-    .filter((name): name is string => !!name && name.trim().length > 0);
-  return named[0] ?? null;
+    .map((m) => ({ id: String(m.id), name: resolveDjDisplayName((m.djName as string | null | undefined) ?? null) }))
+    .filter((m): m is { id: string; name: string } => !!m.name && m.name.trim().length > 0)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return named[0]?.name ?? null;
 };
 
 export const getOnAirDJName = async (): Promise<string | null> => {
@@ -1946,6 +1951,14 @@ export const getDJsInShow = async (show_id: number, activeOnly: boolean): Promis
   const dj_ids = showDJsInstance.map((dj) => {
     return dj.dj_id;
   });
+
+  // Drizzle compiles `inArray(col, [])` to a literal `false`, so without this
+  // the no-members case still pays a round trip to a query that cannot return
+  // a row. It is the COMMON case, not a corner: every tubafrenzy-mirrored show
+  // has zero `show_djs` rows, and BS#2233 put this call on `getOnAirDJName`'s
+  // path — which `GET /flowsheet` and the v2 playlist proxy both run per
+  // request.
+  if (dj_ids.length === 0) return [];
 
   return await db.select().from(user).where(inArray(user.id, dj_ids));
 };

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -140,6 +140,16 @@ Runtime vars supplied at `docker run --env-file .env` (all four have historicall
 - `POSTHOG_API_KEY` — Personal/project API key for the per-DJ `backend-mirror` flag gate. When unset the mirror is enabled by default (dev/E2E convention), exactly like the live path. The cron `shutdown()`s the `posthog-node` client in `finally` (posthog-node's background flush timers would otherwise hang a short-lived container on exit).
 - `SENTRY_DSN` — Sentry project DSN. The moved `http-mirror` client reports mirror-call failures to Sentry directly, and the reconcile's detection signal (orphan-count threshold + per-show partial-mirror report) emits `captureMessage` warnings. Without a DSN the SDK silently no-ops; provision it so the self-heal is observable.
 
+## Flowsheet Go-Live Intent
+
+- `FLOWSHEET_TAKEOVER_ENABLED` (default `false`, BS#2233) — Strict `=== 'true'` gate (via `apps/backend/config/flowsheetTakeover.ts`'s `createEnvFlagConfig`, the same factory `CRITIC_REVIEWS_ENABLED` and `DONATE_ENABLED` use) for `POST /flowsheet/join`'s explicit start-vs-join decision. ON: a caller going live while a show they are not an active member of is still open must send `intent: "join"` (co-host) or `intent: "takeover"` (close it, start their own, `expected_show_id` required); sending neither is a `409 show_already_open` carrying `{ id, dj_name, start_time }`. OFF: `intent` and `expected_show_id` are ignored entirely and the route co-hosts as it always has.
+
+  **Flag-OFF must never 400 or 409, and that is load-bearing rather than cosmetic.** `auto-dj-orchestrator` ships `intent: "takeover"` before the flip, and its `join()` throws on any response body without a show id, so a 400 on the unrecognized field would crash that daemon at activation. It is also what lets the four repos in this chain deploy in any order: BS ships dormant, every client becomes 409-aware while nothing is emitting 409s, and the flip is one env var. The flag is the rollback too — no redeploy.
+
+  **It deliberately inverts the `backend-mirror` convention documented at the top of this section** ("when unset the mirror is enabled by default"). `isMirrorEnabled` returns `true` when `POSTHOG_API_KEY` is absent, which is right for the mirror and would be exactly wrong here: no CI or e2e environment sets a PostHog key, so copying that shape would ship this live everywhere it was supposed to be dormant.
+
+  Not in `set-ec2-env-var.yml`'s allowlist, so lighting it up takes the same two options `WXYC_REVIEWS_ENABLED` documents above: add the key to that workflow's `env:` block and its `case`, or edit `~/.env` on the host over SSH and recreate the backend container. Recreate, never restart.
+
 ## Metadata Services
 
 - `LIBRARY_METADATA_URL` — library-metadata-lookup base URL (e.g. `http://localhost:8001`). Required for proxy endpoints, metadata enrichment, and track search. All Discogs access is routed through LML. Do not include the `/api/v1` path prefix; the LML client adds it automatically.

--- a/tests/unit/controllers/flowsheet.joinIntent.test.ts
+++ b/tests/unit/controllers/flowsheet.joinIntent.test.ts
@@ -4,9 +4,16 @@
  * The routing this file pins is the shared fix for both BS#2232 incidents: a
  * DJ pressing "Go Live" while somebody else's show is still open used to be
  * silently attached to that show as a co-host. On 2026-08-20 show 1951164 ran
- * nine hours and absorbed three later DJs; on 2026-08-28 show 1951224 absorbed
- * one three hours in. In both cases the public on-air name kept reading the
- * departed DJ's handle.
+ * nine hours and absorbed three later DJs; on 2026-08-28 show 1951224 ran ten
+ * hours and absorbed four — DJ String Theory at 14:02, Panzón at 16:02, dj
+ * eureka! at 18:03 and Dj xD at 21:00 PDT, plus a 3.6-second toggle blip — for
+ * 143 entries under one departed DJ's name. In both cases the public on-air
+ * name kept reading the departed DJ's handle.
+ *
+ * Measure 1951224 from that pre-repair shape, not from the show as it stands:
+ * `jobs/flowsheet-show-split` has since split it into five shows, so the
+ * surviving 1951224 row now runs 11:02–14:02 with one boundary and reads as a
+ * far smaller incident than it was.
  *
  * The two shows differ in HOW the banner went wrong, which is why the fix has
  * two halves. 1951164 is BS-native (`primary_dj_id` set), so `on_air` resolved

--- a/tests/unit/controllers/flowsheet.joinIntent.test.ts
+++ b/tests/unit/controllers/flowsheet.joinIntent.test.ts
@@ -1,11 +1,20 @@
 /**
  * `POST /flowsheet/join`'s explicit start-vs-join decision (BS#2233).
  *
- * The routing this file pins is the whole fix for BS#2232: a DJ pressing "Go
- * Live" while somebody else's show is still open used to be silently attached
- * to that show as a co-host. Production show 1951224 collected five DJs that
- * way over ten hours while the public on-air name read the first DJ's handle
- * the entire time.
+ * The routing this file pins is the shared fix for both BS#2232 incidents: a
+ * DJ pressing "Go Live" while somebody else's show is still open used to be
+ * silently attached to that show as a co-host. On 2026-08-20 show 1951164 ran
+ * nine hours and absorbed three later DJs; on 2026-08-28 show 1951224 absorbed
+ * one three hours in. In both cases the public on-air name kept reading the
+ * departed DJ's handle.
+ *
+ * The two shows differ in HOW the banner went wrong, which is why the fix has
+ * two halves. 1951164 is BS-native (`primary_dj_id` set), so `on_air` resolved
+ * the owner's account handle. 1951224 is tubafrenzy-mirrored (`primary_dj_id`
+ * NULL, `legacy_dj_name` "dj sue"), so `on_air` short-circuited to the legacy
+ * handle — the case `flowsheet.getOnAirDJName.test.ts` pins. This file covers
+ * the routing that stops the co-host attachment in the first place; neither
+ * half subsumes the other.
  *
  * The existing BS#1098 / #1295 / #1861 / #2065 cases live in
  * `flowsheet.controller.test.ts` and are deliberately not restated here — this
@@ -46,14 +55,22 @@ import { joinShow } from '../../../apps/backend/controllers/flowsheet.controller
 import { resetConfig } from '../../../apps/backend/config/flowsheetTakeover';
 import WxycError from '../../../apps/backend/utils/error';
 
+// Production show 1951224 as it actually is: tubafrenzy-mirrored, so
+// `primary_dj_id` is NULL and the identity lives in `legacy_dj_name`. That
+// shape matters — it is the one where `resolveDjNameForShow` short-circuits to
+// the legacy handle, so the 409's name and the on-air banner's name are
+// resolved by different rules (see `showAlreadyOpenError`). Giving this
+// fixture a `primary_dj_id` would model the easy case under the hard case's id.
 const OPEN_SHOW = {
   id: 1951224,
-  primary_dj_id: 'dj-sue',
-  start_time: new Date('2026-08-28T15:00:00.000Z'),
+  primary_dj_id: null,
+  legacy_dj_name: 'dj sue',
+  start_time: new Date('2026-08-28T18:02:34.234Z'),
   end_time: null,
 };
 
-const LAST_LOGGED = new Date('2026-08-28T17:41:00.000Z');
+// The show's last logged track, which is what `resolveShowEndInstant` derives.
+const LAST_LOGGED = new Date('2026-08-28T20:49:08.792Z');
 
 const createMockRes = () => {
   const res: Partial<Response> = {};
@@ -131,9 +148,12 @@ describe('joinShow — an open show the caller does not belong to', () => {
     expect(mockStartShow).not.toHaveBeenCalled();
   });
 
-  // Not a hand-joined `user` read: the modal renders beside a banner fed by
-  // the same chain, and two different resolutions of one show's name is the
-  // class of divergence this work exists to remove.
+  // Not a hand-joined `user` read: the prompt names the show the same way
+  // every other show-scoped surface does. Note this is NOT the same answer as
+  // the on-air banner for an abandoned legacy show — `getOnAirDJName` prefers
+  // an active `show_djs` member there, and deliberately so. The prompt names
+  // the show's OWNER ("whose show am I being asked about"); the banner names
+  // whoever is at the controls.
   it('resolves the 409 dj_name through the shared show-name chain', async () => {
     const res = createMockRes();
 
@@ -150,6 +170,21 @@ describe('joinShow — an open show the caller does not belong to', () => {
     expect(mockAddDJToShow).toHaveBeenCalledWith('dj-eureka', expect.objectContaining({ id: OPEN_SHOW.id }));
     expect(mockEndShow).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  // A JSON `null` is what an unset optional serializes to from several of this
+  // epic's clients, and it says the same thing an absent field says. Answering
+  // it with a 400 would tell a caller who has not chosen that their choice is
+  // invalid — the one response a client cannot turn into a prompt.
+  it('409s on an explicit null intent, exactly as it does on an absent one', async () => {
+    const res = createMockRes();
+
+    const err = await joinShow(makeReq({ intent: null }), res, next).catch((e: unknown) => e);
+
+    expect((err as WxycError).statusCode).toBe(409);
+    expect((err as WxycError).code).toBe('show_already_open');
+    expect(mockAddDJToShow).not.toHaveBeenCalled();
+    expect(mockEndShow).not.toHaveBeenCalled();
   });
 
   it('400s an unrecognized intent', async () => {
@@ -267,7 +302,7 @@ describe('joinShow — takeover', () => {
   // outcome they asked for is already true. Re-prompting here would be the
   // dialog firing on the common one-click path.
   it('starts the new show silently when the expected show closed while the dialog was open', async () => {
-    mockGetLatestShow.mockResolvedValue({ ...OPEN_SHOW, end_time: new Date('2026-08-28T17:45:00.000Z') });
+    mockGetLatestShow.mockResolvedValue({ ...OPEN_SHOW, end_time: new Date('2026-08-28T21:02:58.418Z') });
     const res = createMockRes();
 
     await joinShow(makeReq({ intent: 'takeover', expected_show_id: OPEN_SHOW.id }), res, next);

--- a/tests/unit/controllers/flowsheet.joinIntent.test.ts
+++ b/tests/unit/controllers/flowsheet.joinIntent.test.ts
@@ -1,0 +1,317 @@
+/**
+ * `POST /flowsheet/join`'s explicit start-vs-join decision (BS#2233).
+ *
+ * The routing this file pins is the whole fix for BS#2232: a DJ pressing "Go
+ * Live" while somebody else's show is still open used to be silently attached
+ * to that show as a co-host. Production show 1951224 collected five DJs that
+ * way over ten hours while the public on-air name read the first DJ's handle
+ * the entire time.
+ *
+ * The existing BS#1098 / #1295 / #1861 / #2065 cases live in
+ * `flowsheet.controller.test.ts` and are deliberately not restated here — this
+ * file mocks the same service module with the extra functions the takeover
+ * branch needs, and covers only the new decision.
+ */
+import { jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockStartShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockAddDJToShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockEndShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockIsLatestEntryShowEnd = jest.fn<() => Promise<boolean>>();
+const mockIsDjAlreadyActiveOnShow = jest.fn<() => Promise<boolean>>();
+const mockCloseShowFromTerminalShowEndMarker = jest.fn<() => Promise<number>>();
+const mockResolveShowEndInstant = jest.fn<() => Promise<Date>>();
+const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: mockGetLatestShow,
+  startShow: mockStartShow,
+  addDJToShow: mockAddDJToShow,
+  endShow: mockEndShow,
+  isLatestEntryShowEnd: mockIsLatestEntryShowEnd,
+  isDjAlreadyActiveOnShow: mockIsDjAlreadyActiveOnShow,
+  closeShowFromTerminalShowEndMarker: mockCloseShowFromTerminalShowEndMarker,
+  resolveShowEndInstant: mockResolveShowEndInstant,
+  resolveDjNameForShow: mockResolveDjNameForShow,
+}));
+
+const mockScheduleTakeoverSignoff = jest.fn();
+jest.mock('../../../apps/backend/middleware/legacy/flowsheet.mirror', () => ({
+  flowsheetMirror: { scheduleTakeoverSignoff: mockScheduleTakeoverSignoff },
+}));
+
+import { joinShow } from '../../../apps/backend/controllers/flowsheet.controller';
+import { resetConfig } from '../../../apps/backend/config/flowsheetTakeover';
+import WxycError from '../../../apps/backend/utils/error';
+
+const OPEN_SHOW = {
+  id: 1951224,
+  primary_dj_id: 'dj-sue',
+  start_time: new Date('2026-08-28T15:00:00.000Z'),
+  end_time: null,
+};
+
+const LAST_LOGGED = new Date('2026-08-28T17:41:00.000Z');
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.locals = {} as Response['locals'];
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  res.once = jest.fn().mockReturnValue(res) as unknown as Response['once'];
+  return res;
+};
+
+const makeReq = (body: Record<string, unknown>): Request =>
+  ({ auth: { id: 'dj-eureka' }, body: { dj_id: 'dj-eureka', ...body } }) as unknown as Request;
+
+const next = jest.fn() as unknown as NextFunction;
+
+const enableTakeover = (on: boolean) => {
+  if (on) {
+    process.env.FLOWSHEET_TAKEOVER_ENABLED = 'true';
+  } else {
+    delete process.env.FLOWSHEET_TAKEOVER_ENABLED;
+  }
+  resetConfig();
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLatestShow.mockResolvedValue(OPEN_SHOW);
+  mockIsLatestEntryShowEnd.mockResolvedValue(false);
+  mockIsDjAlreadyActiveOnShow.mockResolvedValue(false);
+  mockCloseShowFromTerminalShowEndMarker.mockResolvedValue(0);
+  mockResolveShowEndInstant.mockResolvedValue(LAST_LOGGED);
+  mockResolveDjNameForShow.mockResolvedValue('dj sue');
+  mockStartShow.mockResolvedValue({ id: 1951225, primary_dj_id: 'dj-eureka' });
+  mockAddDJToShow.mockResolvedValue({ show_id: OPEN_SHOW.id, dj_id: 'dj-eureka', active: true });
+  mockEndShow.mockResolvedValue({ ...OPEN_SHOW, end_time: LAST_LOGGED });
+  enableTakeover(true);
+});
+
+afterAll(() => enableTakeover(false));
+
+describe('joinShow — the flag is the rollout, and OFF means byte-identical', () => {
+  // The contract PR 4 of the epic's chain depends on: auto-dj-orchestrator
+  // ships `intent: "takeover"` BEFORE the flag is flipped, and a 400 on the
+  // unrecognized field would crash that daemon on start. Flag OFF must ignore
+  // `intent` entirely — never a 400, never a 409.
+  it.each([undefined, 'join', 'takeover', 'nonsense'])(
+    'flag OFF + intent=%p co-hosts exactly as it does today',
+    async (intent) => {
+      enableTakeover(false);
+      const res = createMockRes();
+
+      await joinShow(makeReq(intent === undefined ? {} : { intent, expected_show_id: OPEN_SHOW.id }), res, next);
+
+      expect(mockAddDJToShow).toHaveBeenCalledWith('dj-eureka', expect.objectContaining({ id: OPEN_SHOW.id }));
+      expect(mockEndShow).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    }
+  );
+});
+
+describe('joinShow — an open show the caller does not belong to', () => {
+  it('409s with the show details when no intent was sent', async () => {
+    const res = createMockRes();
+
+    const err = await joinShow(makeReq({}), res, next).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(WxycError);
+    expect((err as WxycError).statusCode).toBe(409);
+    expect((err as WxycError).code).toBe('show_already_open');
+    expect((err as WxycError).details).toEqual({
+      show: { id: OPEN_SHOW.id, dj_name: 'dj sue', start_time: OPEN_SHOW.start_time },
+    });
+    expect(mockAddDJToShow).not.toHaveBeenCalled();
+    expect(mockEndShow).not.toHaveBeenCalled();
+    expect(mockStartShow).not.toHaveBeenCalled();
+  });
+
+  // Not a hand-joined `user` read: the modal renders beside a banner fed by
+  // the same chain, and two different resolutions of one show's name is the
+  // class of divergence this work exists to remove.
+  it('resolves the 409 dj_name through the shared show-name chain', async () => {
+    const res = createMockRes();
+
+    await joinShow(makeReq({}), res, next).catch(() => undefined);
+
+    expect(mockResolveDjNameForShow).toHaveBeenCalledWith(expect.objectContaining({ id: OPEN_SHOW.id }));
+  });
+
+  it('co-hosts on intent="join", writing one dj_join through the unchanged path', async () => {
+    const res = createMockRes();
+
+    await joinShow(makeReq({ intent: 'join' }), res, next);
+
+    expect(mockAddDJToShow).toHaveBeenCalledWith('dj-eureka', expect.objectContaining({ id: OPEN_SHOW.id }));
+    expect(mockEndShow).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('400s an unrecognized intent', async () => {
+    const res = createMockRes();
+
+    const err = await joinShow(makeReq({ intent: 'end_it_all' }), res, next).catch((e: unknown) => e);
+
+    expect((err as WxycError).statusCode).toBe(400);
+    expect(mockAddDJToShow).not.toHaveBeenCalled();
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+});
+
+describe('joinShow — takeover', () => {
+  it('closes the open show and starts a new one for the caller, in that order', async () => {
+    const res = createMockRes();
+    const order: string[] = [];
+    mockEndShow.mockImplementation(() => {
+      order.push('endShow');
+      return Promise.resolve({ ...OPEN_SHOW, end_time: LAST_LOGGED });
+    });
+    mockStartShow.mockImplementation(() => {
+      order.push('startShow');
+      return Promise.resolve({ id: 1951225, primary_dj_id: 'dj-eureka' });
+    });
+
+    await joinShow(makeReq({ intent: 'takeover', expected_show_id: OPEN_SHOW.id }), res, next);
+
+    expect(order).toEqual(['endShow', 'startShow']);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ id: 1951225, primary_dj_id: 'dj-eureka' });
+  });
+
+  /**
+   * `now()` is right for a prompt handoff and a lie for an abandoned one — it
+   * would credit a departed DJ with however many hours of dead air elapsed
+   * before the next DJ arrived, and (per `endShow`'s own EndShowOptions note)
+   * put a `show_end` marker at the top of the public flowsheet.
+   * `resolveShowEndInstant` is truthful in both cases, because a prompt
+   * handoff's last logged track IS recent. One rule, correct twice.
+   */
+  it('closes at the show’s last logged entry, never at now()', async () => {
+    const res = createMockRes();
+
+    await joinShow(makeReq({ intent: 'takeover', expected_show_id: OPEN_SHOW.id }), res, next);
+
+    expect(mockResolveShowEndInstant).toHaveBeenCalledWith(expect.objectContaining({ id: OPEN_SHOW.id }));
+    expect(mockEndShow).toHaveBeenCalledWith(expect.objectContaining({ id: OPEN_SHOW.id }), LAST_LOGGED);
+  });
+
+  it('carries the caller’s show_name, specialty_id and dj_name_override onto the new show', async () => {
+    const res = createMockRes();
+
+    await joinShow(
+      makeReq({
+        intent: 'takeover',
+        expected_show_id: OPEN_SHOW.id,
+        show_name: 'Night Shift',
+        specialty_id: 7,
+        dj_name_override: 'eureka!',
+      }),
+      res,
+      next
+    );
+
+    expect(mockStartShow).toHaveBeenCalledWith('dj-eureka', 'Night Shift', 7, 'eureka!');
+  });
+
+  // The sign-off has to name the show that CLOSED. Handing the mirror the new
+  // show would sign off the broadcast that just started — the failure the
+  // response-tap middleware cannot avoid, which is why the takeover branch
+  // calls the mirror directly instead of chaining `flowsheetMirror.endShow`.
+  it('mirrors the sign-off for the CLOSED show, never the new one', async () => {
+    const res = createMockRes();
+    const finalized = { ...OPEN_SHOW, end_time: LAST_LOGGED, legacy_show_id: 172773 };
+    mockEndShow.mockResolvedValue(finalized);
+
+    await joinShow(makeReq({ intent: 'takeover', expected_show_id: OPEN_SHOW.id }), res, next);
+
+    expect(mockScheduleTakeoverSignoff).toHaveBeenCalledWith(expect.anything(), res, finalized);
+  });
+
+  it('400s a takeover with no expected_show_id', async () => {
+    const res = createMockRes();
+
+    const err = await joinShow(makeReq({ intent: 'takeover' }), res, next).catch((e: unknown) => e);
+
+    expect((err as WxycError).statusCode).toBe(400);
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Clients poll, so the DJ reads a snapshot. If the show moved on between the
+   * prompt and the click, ending "whatever is open now" would close a show the
+   * DJ was never shown — the informed consent the prompt exists to provide,
+   * silently voided.
+   */
+  it('re-409s and closes nothing when expected_show_id no longer names the open show', async () => {
+    const res = createMockRes();
+
+    const err = await joinShow(makeReq({ intent: 'takeover', expected_show_id: 1951220 }), res, next).catch(
+      (e: unknown) => e
+    );
+
+    expect((err as WxycError).statusCode).toBe(409);
+    expect((err as WxycError).details).toEqual({
+      show: { id: OPEN_SHOW.id, dj_name: 'dj sue', start_time: OPEN_SHOW.start_time },
+    });
+    expect(mockEndShow).not.toHaveBeenCalled();
+    expect(mockStartShow).not.toHaveBeenCalled();
+  });
+
+  // The stale-snapshot case that is NOT an error: the DJ asked for "my own
+  // show", the outgoing DJ signed off while the dialog was on screen, and the
+  // outcome they asked for is already true. Re-prompting here would be the
+  // dialog firing on the common one-click path.
+  it('starts the new show silently when the expected show closed while the dialog was open', async () => {
+    mockGetLatestShow.mockResolvedValue({ ...OPEN_SHOW, end_time: new Date('2026-08-28T17:45:00.000Z') });
+    const res = createMockRes();
+
+    await joinShow(makeReq({ intent: 'takeover', expected_show_id: OPEN_SHOW.id }), res, next);
+
+    expect(mockEndShow).not.toHaveBeenCalled();
+    expect(mockStartShow).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('joinShow — the cases that must never prompt', () => {
+  it('starts a show with no prompt when nothing is open', async () => {
+    mockGetLatestShow.mockResolvedValue(undefined);
+    const res = createMockRes();
+
+    await joinShow(makeReq({}), res, next);
+
+    expect(mockStartShow).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  // BS#1861 arm (c). A DJ re-pressing their own toggle is a retry, not a
+  // handoff; prompting them would put the dialog on the most common path.
+  it('returns the existing membership when the caller is already active on the show', async () => {
+    mockIsDjAlreadyActiveOnShow.mockResolvedValue(true);
+    const res = createMockRes();
+
+    await joinShow(makeReq({}), res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ show_id: OPEN_SHOW.id, dj_id: 'dj-eureka', active: true });
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  // BS#1861 arm (b): a show whose terminal entry is a `show_end` marker is
+  // demonstrably over even while `end_time` reads NULL. The intent branch runs
+  // strictly after that guard, so it can neither observe nor weaken it.
+  it('starts a show with no prompt when the open show’s terminal entry is a show_end marker', async () => {
+    mockIsLatestEntryShowEnd.mockResolvedValue(true);
+    const res = createMockRes();
+
+    await joinShow(makeReq({}), res, next);
+
+    expect(mockCloseShowFromTerminalShowEndMarker).toHaveBeenCalledWith(OPEN_SHOW.id);
+    expect(mockStartShow).toHaveBeenCalled();
+    expect(mockAddDJToShow).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -53,8 +53,8 @@ const {
   resolveShowEndInstant: mockResolveShowEndInstant,
 } = service;
 
-const makeReq = (query: Record<string, string> = {}, params: Record<string, string> = {}) =>
-  ({ query, params }) as unknown as Request;
+const makeReq = (query: Record<string, string> = {}, params: Record<string, string> = {}, body?: unknown) =>
+  ({ query, params, body }) as unknown as Request;
 
 beforeEach(() => resetFlowsheetServiceMock(service, END_INSTANT));
 
@@ -263,4 +263,86 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
     await expect(forceEndShow(makeReq({}, { id }), res, next)).rejects.toThrow('show id must be a positive integer');
     expect(mockGetShowById).not.toHaveBeenCalled();
   });
+});
+
+/**
+ * The derived instant is the right default and the wrong answer often enough
+ * to need an override: a DJ who stopped logging at 9pm and stayed on the air
+ * until 11pm leaves a show whose flowsheet cannot say so. The operator can.
+ *
+ * Bounded on both ends, because both bounds protect a public read. Below
+ * `start_time` produces an interval that cannot overlap its own airdate, which
+ * hides the show from `GET /flowsheet/range` on the very day it aired; above
+ * `now` produces a show that claims to have ended in the future.
+ */
+describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', () => {
+  const openShow = {
+    id: 1951164,
+    primary_dj_id: 'dj-1',
+    start_time: new Date('2026-08-20T18:00:00.000Z'),
+    end_time: null,
+  };
+
+  beforeEach(() => {
+    mockGetShowById.mockResolvedValue(openShow);
+    mockEndShow.mockResolvedValue({ ...openShow, end_time: END_INSTANT });
+  });
+
+  it('uses the supplied instant instead of the derived one', async () => {
+    const operatorInstant = new Date('2026-08-20T23:30:00.000Z');
+    const { res, statusMock } = createMockRes();
+
+    await forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: operatorInstant.toISOString() }), res, next);
+
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, operatorInstant);
+    expect(statusMock).toHaveBeenCalledWith(200);
+  });
+
+  it('falls back to the derived instant when ended_at is absent', async () => {
+    const { res } = createMockRes();
+
+    await forceEndShow(makeReq({}, { id: '1951164' }, {}), res, next);
+
+    expect(mockResolveShowEndInstant).toHaveBeenCalledWith(openShow);
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, END_INSTANT);
+  });
+
+  it('accepts an instant exactly at start_time', async () => {
+    const { res } = createMockRes();
+
+    await forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: openShow.start_time.toISOString() }), res, next);
+
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, openShow.start_time);
+  });
+
+  it('400s an instant before start_time without closing the show', async () => {
+    const { res } = createMockRes();
+
+    await expect(
+      forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T17:59:59.000Z' }), res, next)
+    ).rejects.toThrow(WxycError);
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  it('400s an instant in the future without closing the show', async () => {
+    const { res } = createMockRes();
+    const future = new Date(Date.now() + 60_000).toISOString();
+
+    await expect(forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: future }), res, next)).rejects.toThrow(
+      WxycError
+    );
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  it.each(['yesterday', '', '2026-13-45T00:00:00Z', 1_755_000_000_000])(
+    '400s an unparseable ended_at %p',
+    async (raw) => {
+      const { res } = createMockRes();
+
+      await expect(forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: raw }), res, next)).rejects.toThrow(
+        WxycError
+      );
+      expect(mockEndShow).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/tests/unit/services/flowsheet.getOnAirDJName.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJName.test.ts
@@ -25,14 +25,14 @@ const chain = mockDb._chain;
 // Queue the next value the terminal `.limit()` resolves to. Left unqueued, the
 // default mock returns the chain itself, so getLatestShow() yields undefined.
 const queueLimit = (rows: unknown[]) => chain.limit.mockResolvedValueOnce(rows);
-// getDJsInShow's two terminal `.where()` reads (the show_djs join, then the
-// user lookup). Only consumed on the BS#2233 branch below — a show carrying an
-// override or a linked primary DJ never reaches it.
+// getDJsInShow's terminal `.where()` reads: the show_djs join, then — only if
+// that returned members — the user lookup. Both are consumed on the BS#2233
+// branch below; a show carrying an override or a linked primary DJ never
+// reaches either.
 const queueWhere = (rows: unknown[]) => chain.where.mockResolvedValueOnce(rows);
-const queueNoActiveMembers = () => {
-  queueWhere([]);
-  queueWhere([]);
-};
+// An empty show_djs join short-circuits inside getDJsInShow, so the user
+// lookup is never issued and only ONE value is needed here.
+const queueNoActiveMembers = () => queueWhere([]);
 
 describe('getOnAirDJName', () => {
   beforeEach(() => {

--- a/tests/unit/services/flowsheet.getOnAirDJName.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJName.test.ts
@@ -25,6 +25,14 @@ const chain = mockDb._chain;
 // Queue the next value the terminal `.limit()` resolves to. Left unqueued, the
 // default mock returns the chain itself, so getLatestShow() yields undefined.
 const queueLimit = (rows: unknown[]) => chain.limit.mockResolvedValueOnce(rows);
+// getDJsInShow's two terminal `.where()` reads (the show_djs join, then the
+// user lookup). Only consumed on the BS#2233 branch below — a show carrying an
+// override or a linked primary DJ never reaches it.
+const queueWhere = (rows: unknown[]) => chain.where.mockResolvedValueOnce(rows);
+const queueNoActiveMembers = () => {
+  queueWhere([]);
+  queueWhere([]);
+};
 
 describe('getOnAirDJName', () => {
   beforeEach(() => {
@@ -35,6 +43,7 @@ describe('getOnAirDJName', () => {
     queueLimit([
       { id: 1950003, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'DJ MONSTER' },
     ]);
+    queueNoActiveMembers();
 
     expect(await getOnAirDJName()).toBe('DJ MONSTER');
   });
@@ -51,6 +60,7 @@ describe('getOnAirDJName', () => {
     // human is still live, so the banner must read "WXYC", not falsely claim
     // automation (which is what a null return renders as "AUTO DJ" downstream).
     queueLimit([{ id: 3, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: null }]);
+    queueNoActiveMembers();
 
     expect(await getOnAirDJName()).toBe(ANONYMOUS_ON_AIR_NAME);
   });
@@ -59,6 +69,7 @@ describe('getOnAirDJName', () => {
     // resolveDjNameForShow can return an empty or whitespace legacy_dj_name
     // verbatim; that is still an anonymous human, not automation.
     queueLimit([{ id: 6, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: '   ' }]);
+    queueNoActiveMembers();
 
     expect(await getOnAirDJName()).toBe(ANONYMOUS_ON_AIR_NAME);
   });
@@ -96,5 +107,52 @@ describe('getOnAirDJName', () => {
   it('returns null when there is no latest show at all', async () => {
     // No queued value → getLatestShow() resolves undefined.
     expect(await getOnAirDJName()).toBeNull();
+  });
+
+  /**
+   * BS#2233. `resolveDjNameForShow` short-circuits to `legacy_dj_name` the
+   * moment `primary_dj_id` is NULL, so a legacy show that a real DJ has since
+   * joined kept naming whoever tubafrenzy recorded when it opened — while
+   * `GET /flowsheet/djs-on-air`, which prefers account rows, named the DJ
+   * actually at the controls. Two on-air endpoints, two answers, disagreeing
+   * on exactly the shows where it matters.
+   */
+  describe('an ownerless show with an active account member', () => {
+    it('names the active member, not the legacy handle the departed DJ left behind', async () => {
+      queueLimit([
+        { id: 1951224, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'dj sue' },
+      ]);
+      queueWhere([{ dj_id: 'user-9', active: true }]);
+      queueWhere([{ id: 'user-9', djName: 'eureka!' }]);
+
+      expect(await getOnAirDJName()).toBe('eureka!');
+    });
+
+    it('falls back to legacy_dj_name when the only active member has no resolvable handle', async () => {
+      // "Anonymous" is filtered by resolveDjDisplayName, so the member
+      // contributes no name and the legacy identity is still the best answer.
+      queueLimit([
+        { id: 1951224, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'dj sue' },
+      ]);
+      queueWhere([{ dj_id: 'user-9', active: true }]);
+      queueWhere([{ id: 'user-9', djName: 'Anonymous' }]);
+
+      expect(await getOnAirDJName()).toBe('dj sue');
+    });
+
+    it('still lets an operator-supplied override win, without a join-table read', async () => {
+      queueLimit([
+        {
+          id: 1951224,
+          end_time: null,
+          primary_dj_id: null,
+          dj_name_override: 'Guest Host',
+          legacy_dj_name: 'dj sue',
+        },
+      ]);
+
+      expect(await getOnAirDJName()).toBe('Guest Host');
+      expect(chain.where).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/services/flowsheet.getOnAirDJs.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJs.test.ts
@@ -11,11 +11,16 @@
  * `resolveDjNameForShow` with a null id (BS#1547).
  *
  * Mock mechanics: getLatestShow → getNShows(1) terminates in `.limit()`.
- * getDJsInShow issues two queries that terminate in `.where()` (the show_djs
- * join, then the user lookup), so those are queued on the separate `.where`
- * once-queue. resolveDjNameForShow only queries (via `.limit(1)`) when a primary
- * DJ is present; the legacy branch here has `primary_dj_id: null`, so it
+ * getDJsInShow issues up to two queries that terminate in `.where()` — the
+ * show_djs join, then the user lookup, which is SKIPPED when the join returned
+ * no rows — so those are queued on the separate `.where` once-queue.
+ * resolveDjNameForShow only queries (via `.limit(1)`) when a primary DJ is
+ * present; the legacy branch here has `primary_dj_id: null`, so it
  * short-circuits to `legacy_dj_name` with no extra query.
+ *
+ * Queue exactly as many values as the case consumes. `jest.clearAllMocks()`
+ * does NOT drain `mockResolvedValueOnce` queues, so a value queued and left
+ * unconsumed leaks into the NEXT test and shifts every read after it by one.
  */
 import { jest } from '@jest/globals';
 
@@ -39,8 +44,7 @@ describe('getOnAirDJs', () => {
     queueLimit([
       { id: 1950003, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'DJ MONSTER' },
     ]);
-    queueWhere([]); // show_djs join: no account rows
-    queueWhere([]); // user lookup over the (empty) dj_ids
+    queueWhere([]); // show_djs join: no account rows — getDJsInShow stops here
 
     expect(await getOnAirDJs()).toEqual([{ id: null, dj_name: 'DJ MONSTER' }]);
   });
@@ -102,8 +106,7 @@ describe('getOnAirDJs', () => {
 
   it('returns [] for an open legacy show with no resolvable DJ name (no show_djs, null legacy_dj_name)', async () => {
     queueLimit([{ id: 5, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: null }]);
-    queueWhere([]); // show_djs join
-    queueWhere([]); // user lookup
+    queueWhere([]); // show_djs join — no account rows, so no user lookup follows
 
     expect(await getOnAirDJs()).toEqual([]);
   });

--- a/tests/utils/flowsheet_util.js
+++ b/tests/utils/flowsheet_util.js
@@ -1,7 +1,17 @@
 // This function is assuming the /flowsheet/join enpoint is working properly
 const url = `${process.env.TEST_HOST}:${process.env.PORT}`;
 
-exports.join_show = async (dj_id, access_token) => {
+/**
+ * `POST /flowsheet/join`.
+ *
+ * `body` folds extra request fields in — today `intent` and `expected_show_id`
+ * (BS#2233). Callers that send neither get byte-identical behavior to before,
+ * which is what keeps every existing spec valid while `FLOWSHEET_TAKEOVER_ENABLED`
+ * is off: the flag-off branch ignores both fields and co-hosts as it always did.
+ * A spec that turns the flag on and joins a secondary DJ onto an already-open
+ * show must now say `{ intent: 'join' }`, or it is a 409.
+ */
+exports.join_show = async (dj_id, access_token, body = {}) => {
   const res = await fetch(`${url}/flowsheet/join`, {
     method: 'POST',
     headers: {
@@ -10,6 +20,7 @@ exports.join_show = async (dj_id, access_token) => {
     },
     body: JSON.stringify({
       dj_id: dj_id,
+      ...body,
     }),
   });
 


### PR DESCRIPTION
Server half of [#2232](https://github.com/WXYC/Backend-Service/issues/2232). Depends on [WXYC/wxyc-shared#415](https://github.com/WXYC/wxyc-shared/pull/415) publishing the contract; the code here compiles without it (the two new fields are plain TS types on the request body), but the spec should land first.

Closes #2233

## The bug

`joinShow` decided start-vs-join on `current_show?.end_time !== null` and nothing else. A DJ who walks out without signing off leaves their show open indefinitely, so every DJ who presses "Go Live" afterwards is silently attached to it as a guest. It happened twice:

| | 2026-08-20, show `1951164` | 2026-08-28, show `1951224` |
|---|---|---|
| origin | BS-native | tubafrenzy-mirrored |
| `primary_dj_id` | **set** | **NULL** (`legacy_dj_name` `"dj sue"`) |
| absorbed | three later DJs over nine hours | four Backend accounts over ten hours |
| how `on_air` went wrong | resolved the owner's `auth_user.dj_name` | short-circuited to `legacy_dj_name` |
| fixed by | the routing change | **`getOnAirDJName`** |

Same routing bug, two different banner mechanisms — which is why this PR carries two fixes and **neither subsumes the other**. (A unit fixture used to encode `1951224` with a non-null `primary_dj_id`, which is precisely the shape where `resolveDjNameForShow` does *not* short-circuit — modelling the easy case under the hard case's id. Corrected. **Do not re-derive 1951224's size from live data**: `jobs/flowsheet-show-split` has since cut it into five shows, so the surviving row runs 11:02–14:02 and reads as a much smaller incident than it was. As it happened it ran ten hours and absorbed DJ String Theory, Panzón, dj eureka! and Dj xD, reaching 143 entries. `primary_dj_id` being NULL there is still checkable with `GET /flowsheet/show-info?show_id=1951224`.)

BS#1861's two guards and BS#2065's opportunistic close both key on a `show_end` marker *existing*, so neither fires in the case where nobody signed off at all.

## Routing

Order matters, and the three existing guards keep running first and unchanged:

| condition | outcome |
|---|---|
| no open show, or `end_time` set, or terminal entry is `show_end` | `startShow` — no prompt, ever |
| caller already an active member (BS#1861 arm c) | 200 with the existing membership — no prompt |
| **flag OFF** | `addDJToShow`, `intent` ignored entirely |
| open show, no `intent` | **409** `show_already_open` + `details.show = { id, dj_name, start_time }` |
| `intent: "join"` | `addDJToShow` — today's path, now chosen |
| `intent: "takeover"` + matching `expected_show_id` | `endShow` then `startShow` |
| `intent: "takeover"`, `expected_show_id` missing / unrecognized `intent` | 400 |
| `expected_show_id` names a different show | re-409, nothing closed |

Only a genuinely-open show belonging to someone else reaches the intent branch. If the dialog fires at every scheduled 2-hour handoff, the design is wrong — after this, a properly handed-off slot has no open show at all.

## Three things worth reviewing closely

**The close uses `resolveShowEndInstant`, not `now()`.** `now()` is right for a prompt handoff and a lie for an abandoned one: it credits a departed DJ with however many hours of dead air elapsed before the next DJ arrived, and — per `endShow`'s own `EndShowOptions` note — sorts a `show_end` marker to the top of the public flowsheet with an interval overlapping every archive day in between. The derived instant is truthful in *both* cases, because a prompt handoff's last logged track is recent. One rule, correct twice.

**`expected_show_id` is a compare-and-set, and its two stale-snapshot cases resolve differently.** Clients poll, so the DJ acts on a snapshot. A *different* show now open is a fresh 409 with fresh details and nothing closed — otherwise the DJ ends a show whose name they never saw, which voids the informed consent the prompt exists to provide. The expected show having *closed* in that window is not an error at all: the first guard already routed it to `startShow`, silently, because starting their own show is exactly what they asked for and re-prompting would put the dialog on the common path.

**The tubafrenzy sign-off could not ride a second response tap, and this is the subtle one.** `flowsheetMirror.startShow` and `flowsheetMirror.endShow` are both `createHttpMirrorMiddleware` taps reading the *same* `res.locals.mirrorData` key under the same `isShowPayload` gate. Chaining the end-tap onto `/join` would hand it the payload of the show that just *started* and sign off the live broadcast. So:

- the sign-off body is extracted into `mirrorShowSignoff`, called by both the tap and the takeover branch, so they cannot drift;
- it takes the closed `Show` and resolves the tubafrenzy id itself — `getCachedShowId(show.id) ?? show.legacy_show_id`, where the cache is the *primary* source whenever `startShow`'s persist failed, and is module-private. A pre-resolved id would silently mis-target;
- `scheduleTakeoverSignoff` defers it to `res.once('finish')`. Awaiting inline would put tubafrenzy latency on the go-live path, and a tubafrenzy outage would 500 the takeover *after* `endShow` committed `end_time` — stranding the DJ off air with no show;
- it is deliberately **not** gated on `res.statusCode`, which is where it departs from the taps. A tap uses the status code to decide whether a mutation happened; here the close has already committed before it is called, so skipping on a non-2xx would leave exactly the BS-closed / tubafrenzy-open split brain that made this incident ambiguous.

`isMirrorEnabled` is exported for it, with its parameter narrowed to `MirrorFlagRequest = Pick<Request, 'auth' | 'ip'>` — the only two fields it reads — so a controller holding a route-typed `Request<object, object, Body>` can call it without a cast. The takeover's own gate is a separate flag; a `backend-mirror` flip must not toggle this feature.

## Authorization — decided, not overlooked

`/join` is gated only by `requirePermissions({ flowsheet: ['write'] })`, so `takeover` makes "end another DJ's show" reachable by any write-capable DJ. That is the point. tubafrenzy's `EndShowServlet` took `radioShowID` as a request parameter with no ownership or role check, and its Backend replacement `forceEndShow` is `flowsheet: ['manage']`-gated — which silently dropped a capability every signed-on DJ had. There is no staleness threshold either: a timer has to guess, and a badly-chosen one kills a live show whose DJ is simply between tracks.

## Rollout — `FLOWSHEET_TAKEOVER_ENABLED`, default OFF

Flag OFF ignores `intent` and `expected_show_id` entirely and preserves today's routing byte for byte — **never a 400, never a 409**. That is not politeness, though the original reason given here was wrong in both halves and is corrected: `auto-dj-orchestrator`'s `join()` sends `{ dj_id, show_name }` and **no `intent` at all** (`src/backend/flowsheet-client.ts`, whose own comment says the `intent` / `expected_show_id` contract is still future work), and its `request()` throws on any non-2xx — `if (!resp.ok) throw`, not on a missing show id.

That inverts where the risk lives. Flag OFF is not merely harmless for Auto-DJ, it is the thing keeping it working: **flipping the flag ON breaks Auto-DJ activation**, because an intent-less join against an open show becomes a 409, `request()` throws, and activation fails in exactly the abandoned-show case Auto-DJ exists to cover. Tracked as WXYC/auto-dj-orchestrator#36, which must land before the flip. The blast radius is bounded today only because auto-dj-orchestrator has never been deployed (deploy epic auto-dj-orchestrator#26), so this is a gate on its first deploy rather than a live outage.

Flag OFF also makes deploy order between the four repos harmless.

Built on `createEnvFlagConfig` (strict `=== 'true'`, lazily cached, `resetConfig()` for tests) rather than the mirror's `isMirrorEnabled`, which env-defaults to **ON** when `POSTHOG_API_KEY` is unset. Copying that shape would have shipped this live in every environment without a PostHog key — including the dj-site e2e stack, which sets none. Documented in `docs/env-vars.md` (new "Flowsheet Go-Live Intent" section, which says out loud that it inverts the `backend-mirror` line) and `.env.example`.

## Also in this PR

**`POST /flowsheet/shows/:id/force-end` takes an optional `ended_at`**, bounded `>= start_time` and `<= now`, 400 outside that — never a silent clamp. The derived instant is the right default and the wrong answer for a DJ who stopped logging an hour before they actually went off the air; the bounds are there because each one protects a public read (below `start_time` hides the show from `GET /flowsheet/range` on its own airdate; above `now` sorts its marker above every real entry).

**`getOnAirDJName` stops naming a DJ who left.** `resolveDjNameForShow` short-circuits to `shows.legacy_dj_name` whenever `primary_dj_id` is NULL, so an ownerless show that a real account has since joined kept reporting the handle tubafrenzy recorded when it opened — while `GET /flowsheet/djs-on-air`, which prefers account rows, named whoever was actually at the controls. Two on-air endpoints, two answers, disagreeing on exactly the shows where it mattered. The fix is scoped to the live read and to that one short-circuit: an override still wins outright with no extra query, a linked primary DJ still resolves from the chain, and a legacy show with no account rows still returns `legacy_dj_name` (the DJ MONSTER case is pinned). **`resolveDjNameForShow` itself is untouched** — it also feeds the archive and the write path, and changing it would rewrite historical show names.

## Testing

`npm run test:unit` — 8694 passing, 495 suites. `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, `npm run check:auth-tables-doc` all clean.

New `tests/unit/controllers/flowsheet.joinIntent.test.ts` covers the routing table above plus: the flag-OFF dormancy pinned across all four `intent` values including an unrecognized one; `endShow` before `startShow` in that order; the close instant being the derived one and never `now()`; the sign-off receiving the **closed** show and never the new one; the takeover carrying `show_name` / `specialty_id` / `dj_name_override` through; and the three must-never-prompt cases.

`flowsheet.operatorClose.test.ts` gains the `ended_at` bounds (at `start_time` accepted, before it rejected, future rejected, four unparseable forms rejected, absent falls back to derived). `flowsheet.getOnAirDJName.test.ts` gains the ownerless-show-with-a-member case, the unresolvable-member fallback, and a no-extra-query assertion for the override path.

`tests/utils/flowsheet_util.js`'s `join_show` takes an optional extra-fields object. Callers that pass nothing are byte-identical, which is what keeps all ~30 existing call sites valid while the flag is off.

## Deliberately not here

**The flag-ON integration spec** (`tests/integration/flowsheet-takeover.spec.js`) and the four secondary-DJ join sites it would break. Turning `FLOWSHEET_TAKEOVER_ENABLED=true` in the integration environment converts `flowsheet.spec.js:339`, `:1424`, `:1449` and the `metadata.spec.js` sites into 409s, which is a prerequisite change worth its own review rather than a tail on this one — and the integration environment should mirror production, where this ships off. Filed as a follow-up and linked below.

I also left `join_show` returning non-2xx responses unasserted rather than making it throw, as #2233 suggests: with the flag off the 409 it guards against cannot occur, and the throw would change behavior for every existing caller. It belongs with the flag-ON spec.


## Review pass

- **`intent: null` is a 409, not a 400.** An explicit null says what an absent field says, and is what an unset optional serializes to from several of this epic's clients. It was reaching the union check and drawing a 400 — the one answer a client cannot turn into a prompt.
- **The intent guard's narrowing was not real.** `req.body.intent` was read at its declared type, so TypeScript believed `JOIN_INTENTS.includes(intent)` could not fail. Nothing validates this route's body; had that check been deleted on the compiler's word, `intent: "nonsense"` would have fallen through to the **takeover** branch and ended a live DJ's show on a typo. Now reads through `unknown` behind an `isJoinIntent` type guard.
- **`getDJsInShow` no longer issues a query that cannot return a row.** Drizzle compiles `inArray(col, [])` to a literal `false`, so a show with zero `show_djs` rows still paid a round trip — the common case, since every tubafrenzy-mirrored show has none, and this PR put that call on `getOnAirDJName`'s path (run per request by `GET /flowsheet` and the v2 playlist proxy). Two `getOnAirDJs` cases had queued a mock value for the now-absent query; `jest.clearAllMocks()` does not drain `mockResolvedValueOnce` queues, so those were leaking into the next test.
- **`activeMemberOnAirName` tie-breaks deterministically.** `localeCompare` without an explicit locale is collation-dependent, so the banner's choice among co-hosts could have varied with the container's ICU data — the one property that sort exists to provide.

### Mirror reasoning: checked, and it holds

The `res.once('finish')` deferral survives scrutiny. Both finish handlers (the `flowsheetMirror.startShow` tap, registered by the route chain, and `scheduleTakeoverSignoff`, registered by the controller) suspend at `isMirrorEnabled`, so they run concurrently rather than in registration order — but nothing depends on that order: `mirrorSignoffShow` takes an explicit `radioShowId` and `mirrorAnnouncementEntry` an explicit `tubafrenzyShowId`, so the sign-off cannot re-target the show that just started, and the two `getCachedShowId` entries are keyed by distinct Backend show ids. tubafrenzy holds two open shows for the width of one request; the final state is correct either way.

Not gating on `res.statusCode` is right for the reason given: `endShow` has already committed when `scheduleTakeoverSignoff` is called, and if `endShow` throws, the schedule never happens at all. A later failure in the same request leaves BS and tubafrenzy agreeing that the show is closed, which is the outcome that matters.


