### PR TITLE
Skip a deploy target that has no root Dockerfile instead of failing the whole run

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -203,6 +203,36 @@ jobs:
               echo "Range genuinely unavailable; falling back to all targets."
             fi
 
+            # A retired job keeps its workspace (its source stays in the tree
+            # for the documented precondition-guard pattern, and its unit
+            # tests still import it) but loses its root Dockerfile, which is
+            # what stops `Manual Build & Deploy` producing a runnable image.
+            # `turbo ls --affected` has no notion of that: it still reports
+            # the workspace, the matrix still schedules a `build`, and
+            # `docker/build-push-action` hard-fails on the missing file --
+            # which fails the whole run and SKIPS `deploy`, so an unrelated
+            # target riding the same merge never ships. That is what happened
+            # on 9fbbc636 (BS#2281): two retired jobs' guards were touched,
+            # both builds died on `no such file or directory`, and the deploy
+            # job was skipped.
+            #
+            # Drop those targets here instead, and WARN per target rather than
+            # dropping silently -- deleting the Dockerfile of a job that
+            # should still deploy is a real mistake, and it must stay visible
+            # in the run summary. The `inputs.target` path above is
+            # deliberately NOT filtered: an operator who explicitly dispatches
+            # a retired target should get the loud build failure, which is the
+            # refusal the retirement was designed around.
+            BUILDABLE='[]'
+            for TARGET in $(echo "$TARGETS" | jq -r '.[]'); do
+              if [ -f "Dockerfile.$TARGET" ]; then
+                BUILDABLE=$(echo "$BUILDABLE" | jq -c --arg t "$TARGET" '. + [$t]')
+              else
+                echo "::warning title=Skipping target with no Dockerfile::$TARGET changed but has no root Dockerfile.$TARGET, so it cannot be built; skipping it rather than failing the whole deploy. If this target is meant to deploy, restore its Dockerfile."
+              fi
+            done
+            TARGETS="$BUILDABLE"
+
             if [ "$TARGETS" = "[]" ] || [ -z "$TARGETS" ]; then
               echo "No affected app targets found."
               echo "TARGETS=[]" >> $GITHUB_OUTPUT

--- a/tests/unit/scripts/deploy-affected-targets.test.ts
+++ b/tests/unit/scripts/deploy-affected-targets.test.ts
@@ -131,4 +131,35 @@ describe('the deploy matrix is scoped to what the merge changed (BS#2264)', () =
     expect(setup).toContain('merge-base --is-ancestor');
     expect(setup).toMatch(/exit 1/);
   });
+
+  it('skips an affected target that has no root Dockerfile', () => {
+    // A retired job keeps its workspace -- its source stays in the tree for
+    // the precondition-guard pattern and its unit tests still import it --
+    // but loses `Dockerfile.<name>`, which is what stops `Manual Build &
+    // Deploy` producing a runnable image. turbo still reports the workspace
+    // as affected, so without this filter the matrix schedules a `build`
+    // that hard-fails on the missing file, which fails the run and SKIPS
+    // `deploy` -- taking every unrelated target on the same merge down with
+    // it. Happened on 9fbbc636 (BS#2281).
+    expect(setup).toContain('Dockerfile.$TARGET');
+    expect(setup).toMatch(/BUILDABLE/);
+  });
+
+  it('warns per skipped target rather than dropping it silently', () => {
+    // Deleting the Dockerfile of a job that SHOULD still deploy is a real
+    // mistake, and a silent filter would make it look like a clean deploy --
+    // the same "over-deploying looks exactly like working" shape that let
+    // BS#2264 survive five months, inverted.
+    expect(setup).toContain('::warning title=Skipping target with no Dockerfile');
+  });
+
+  it('leaves the explicit workflow_dispatch target unfiltered', () => {
+    // An operator who dispatches a retired target by name should get the
+    // loud build failure -- that refusal is the point of removing the
+    // Dockerfile. Only the auto-detected matrix is filtered, so the filter
+    // must sit inside the `else` branch, after turbo has produced TARGETS.
+    const dispatchArm = setup.slice(0, setup.indexOf('Detecting affected app targets'));
+    expect(dispatchArm).toContain('Using provided target');
+    expect(dispatchArm).not.toContain('BUILDABLE');
+  });
 });


### PR DESCRIPTION
## The failure

The `9fbbc636` auto-deploy (the BS#2281 dj-name scrub merge) **failed, and skipped `deploy` entirely**:

```
ERROR: failed to build: failed to solve: failed to read dockerfile:
open Dockerfile.legacy-dj-name-remediation: no such file or directory
```

Two `build` matrix jobs died that way — `legacy-dj-name-remediation` and `flowsheet-dj-name-backfill` — and `deploy` needs every build to succeed, so nothing shipped from that commit.

## Why those Dockerfiles are gone, and why that was right

#2316 deleted them on purpose. Both jobs fill `flowsheet.dj_name WHERE dj_name IS NULL` from the `shows` join, which re-attributes a guest DJ's row to the primary DJ and reverses the privacy scrub that same PR shipped. Removing the root Dockerfile is the second of two stops: the runtime refusal stops an image already in ECR, and the missing Dockerfile stops `Manual Build & Deploy` producing a new one.

What the retirement did not account for is that a retired job **keeps its workspace**. Its source stays in the tree — `docs/migrations.md` and `docs/backfill-precondition-assertions.md` both cite the `0053 → backfill → 0054` chain as the canonical precondition-guard pattern, and its unit tests still import the module. So `turbo ls --affected` still reports the package, the matrix still schedules a `build`, and `docker/build-push-action` hard-fails on the missing file.

Any future commit touching either directory would have done the same thing. This was not a one-off.

## The blast radius is the point

A failed build of a *retired* job fails the whole run, and `deploy` is skipped — so an unrelated target riding the same merge silently never ships. On `9fbbc636` that was the dj-name scrub's own merge.

## The fix

Filter the auto-detected matrix to targets that actually have a `Dockerfile.<target>`, and **warn per dropped target** rather than dropping silently. Deleting the Dockerfile of a job that *should* still deploy is a real mistake, and a silent filter would make it look like a clean deploy — the "over-deploying looks exactly like working" shape from BS#2264, inverted. That file already exists because that shape survived five months undetected.

The `inputs.target` path is **deliberately not filtered**. An operator who explicitly dispatches a retired target by name should get the loud build failure; that refusal is the whole point of removing the Dockerfile.

## Tests

Extends the BS#2264 workflow-text test rather than adding a file. Two of the three new assertions fail against the pre-fix YAML (verified by reverting it); the third pins the filter's placement inside the auto-detect arm so a later edit cannot slide it into the dispatch arm and quietly neuter the manual-dispatch refusal.

## Recovery

No re-run of `9fbbc636` is needed. The SSE guard from #2317 deployed cleanly on its own merge (`d9427ce1`), the scrub job's image built and pushed successfully in the failed run, and #2316 changed no `apps/backend` code — so there is nothing stranded. This PR's own merge will be the first deploy to exercise the filter.

## Related

- #2316 — the merge that surfaced this; deleted the two Dockerfiles
- #2317 — the SSE guard, deployed cleanly beforehand
- BS#2264 — the affected-target detection work this test file and guard belong to
