### PR TITLE
fix(legacy-mirror-reconcile): don't adopt a show whose only entries are its own boundary markers

### DIFF
--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -11,11 +11,23 @@
  *   Sweep 1 (create shows): `shows.legacy_show_id IS NULL` +
  *     `primary_dj_id IS NOT NULL` + inside [now-WINDOW, now-SETTLE] +
  *     NOT EXISTS any already-mirrored entry (the all-or-nothing guard —
- *     R4 High #1). Creates the tubafrenzy radioShow and persists
+ *     R4 High #1) + EXISTS a substantive (non-boundary-marker) entry
+ *     (BS#2314). Creates the tubafrenzy radioShow and persists
  *     `legacy_show_id`. The NOT EXISTS guard is load-bearing: a mid-show
  *     flag-flip show whose `addEntry` fired already has a server-side
  *     auto-resolved tubafrenzy show (`mapEntryToTubafrenzy` omits
- *     `radioShowID` when null), so creating another would duplicate.
+ *     `radioShowID` when null), so creating another would duplicate. The
+ *     EXISTS-substantive-entry guard is load-bearing too, for a different
+ *     reason: `jobs/flowsheet-show-split` writes its repaired shows with
+ *     `legacy_show_id = NULL` ON PURPOSE, to keep them outside
+ *     `flowsheet-etl`'s `ON CONFLICT (legacy_show_id) DO UPDATE` (see that
+ *     job's module docblock). Without this guard, a split segment whose DJ
+ *     logged no tracks before the next go-live — its only rows are the
+ *     promoted `show_start` / `show_end` boundary markers, both mirrorable
+ *     and both `legacy_entry_id IS NULL` — sails past the NOT-EXISTS guard
+ *     (nothing is "already mirrored") and gets adopted here, defeating the
+ *     split job's NULL. See `SHOW_BOUNDARY_MARKER_TYPES` below for why this
+ *     is framed as "no substantive entry" rather than "came from a split".
  *
  *   Sweep 2 (entries + signoff): `shows.legacy_show_id IS NOT NULL` +
  *     inside the window + all-or-nothing (EXISTS a NULL-legacy entry AND
@@ -723,6 +735,42 @@ const entryExists = (nullLegacy: boolean) =>
       )
     );
 
+/**
+ * `show_start` / `show_end` ARE mirrorable (unlike `dj_join`/`dj_leave` —
+ * `NON_MIRRORED_MARKER_TYPES` above), so they don't help `entryExists` tell a
+ * show worth creating from one that isn't. But they are still just boundary
+ * bookends, never evidence a set happened: `POST /flowsheet/join` writes a
+ * `show_start` for a show with zero tracks yet, `endShow` writes a `show_end`
+ * for one that never got any, and `jobs/flowsheet-show-split`'s `applySplit`
+ * step 4 promotes a segment's `dj_join`/`dj_leave` into exactly this pair
+ * (BS#2314) — a segment whose DJ logged nothing before the next go-live ends
+ * up with ONLY these two rows, both `legacy_entry_id IS NULL`, so they alone
+ * would satisfy `notExists(entryExists(false))` above and get adopted.
+ *
+ * Deliberately NOT keyed on anything specific to a split-created show (e.g.
+ * `legacy_dj_name IS NULL`, or "started right at another show's `end_time`")
+ * — every one of those is a shape a normal, never-split show can reproduce,
+ * which is exactly the kind of heuristic a future legitimate show could
+ * defeat. This asks the question Sweep 1 should ask regardless of how the
+ * show came to exist: did a set actually happen? A show whose only
+ * mirrorable rows are its own start/end bookends has no set to mirror,
+ * split segment or not — see BS#2314 Option 3 for the "not worth minting
+ * upstream" framing this codifies.
+ */
+const SHOW_BOUNDARY_MARKER_TYPES = ['show_start', 'show_end'] as const;
+
+/** A row that is actual DJ content — a track or a talkset/breakpoint/message note — not a boundary marker. */
+const substantiveEntryType = notInArray(flowsheet.entry_type, [
+  ...NON_MIRRORED_MARKER_TYPES,
+  ...SHOW_BOUNDARY_MARKER_TYPES,
+]);
+
+/** Subquery: does show S have at least one substantive (non-boundary-marker) entry? */
+const hasSubstantiveEntry = db
+  .select({ one: sql`1` })
+  .from(flowsheet)
+  .where(and(eq(flowsheet.show_id, shows.id), substantiveEntryType));
+
 export const selectShowsToCreate = async ({ windowHours, settleMinutes }: WindowOptions): Promise<Show[]> =>
   db
     .select()
@@ -733,7 +781,8 @@ export const selectShowsToCreate = async ({ windowHours, settleMinutes }: Window
         isNotNull(shows.primary_dj_id),
         lt(shows.start_time, settleCeiling(settleMinutes)),
         gt(shows.start_time, windowFloor(windowHours)),
-        notExists(entryExists(false))
+        notExists(entryExists(false)),
+        exists(hasSubstantiveEntry)
       )
     )
     .orderBy(asc(shows.start_time));

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -18,16 +18,12 @@
  *     auto-resolved tubafrenzy show (`mapEntryToTubafrenzy` omits
  *     `radioShowID` when null), so creating another would duplicate. The
  *     EXISTS-substantive-entry guard is load-bearing too, for a different
- *     reason: `jobs/flowsheet-show-split` writes its repaired shows with
- *     `legacy_show_id = NULL` ON PURPOSE, to keep them outside
- *     `flowsheet-etl`'s `ON CONFLICT (legacy_show_id) DO UPDATE` (see that
- *     job's module docblock). Without this guard, a split segment whose DJ
- *     logged no tracks before the next go-live — its only rows are the
- *     promoted `show_start` / `show_end` boundary markers, both mirrorable
- *     and both `legacy_entry_id IS NULL` — sails past the NOT-EXISTS guard
- *     (nothing is "already mirrored") and gets adopted here, defeating the
- *     split job's NULL. See `SHOW_BOUNDARY_MARKER_TYPES` below for why this
- *     is framed as "no substantive entry" rather than "came from a split".
+ *     reason: it stops an empty `jobs/flowsheet-show-split` segment — one
+ *     whose only rows are its promoted `show_start`/`show_end` bookends —
+ *     from being adopted here and defeating that job's deliberate
+ *     `legacy_show_id = NULL`. See `SHOW_BOUNDARY_MARKER_TYPES` below for
+ *     the mechanism, why it is framed as "no substantive entry" rather
+ *     than "came from a split", and what it does not close.
  *
  *   Sweep 2 (entries + signoff): `shows.legacy_show_id IS NOT NULL` +
  *     inside the window + all-or-nothing (EXISTS a NULL-legacy entry AND

--- a/jobs/legacy-mirror-reconcile/orchestrate.ts
+++ b/jobs/legacy-mirror-reconcile/orchestrate.ts
@@ -756,6 +756,27 @@ const entryExists = (nullLegacy: boolean) =>
  * mirrorable rows are its own start/end bookends has no set to mirror,
  * split segment or not — see BS#2314 Option 3 for the "not worth minting
  * upstream" framing this codifies.
+ *
+ * The four excluded types are exactly the ones a SERVER writes unbidden.
+ * `talkset` / `breakpoint` / `message` stay substantive because on this write
+ * path they only ever arrive via `POST /flowsheet` with a message body
+ * (`inferMessageEntryType`) — a DJ pressing a button on air, which is
+ * evidence of a set even when no track was logged. tubafrenzy's automatic
+ * top-of-hour breakpoints come in through the `/internal` webhook already
+ * carrying a `legacy_entry_id`, so they fail `notExists(entryExists(false))`
+ * one guard earlier and never reach this one. If a BS-side writer ever starts
+ * POSTing a breakpoint on a timer — dj-site, or `auto-dj-orchestrator` once
+ * it deploys — that premise dies and `breakpoint` belongs in the excluded set.
+ *
+ * Scope, stated honestly: this closes the EMPTY split segment, not every
+ * split segment. One whose entries are all still un-mirrored (`backend-mirror`
+ * off for that DJ during the set) is substantive, and Sweep 1 will still adopt
+ * it and re-admit it to `flowsheet-etl`'s upsert scope. Closing that too needs
+ * a provenance mark on the show itself — BS#2314 Option 1, a migration — which
+ * this deliberately does not take on. The guard is also Sweep 1's alone:
+ * `selectPartialShows` keeps counting the bookends on purpose, because a show
+ * whose `show_start` mirrored and whose `show_end` did not is a genuinely
+ * half-written upstream copy someone should fix, however little else it holds.
  */
 const SHOW_BOUNDARY_MARKER_TYPES = ['show_start', 'show_end'] as const;
 

--- a/tests/integration/legacy-mirror-reconcile.spec.js
+++ b/tests/integration/legacy-mirror-reconcile.spec.js
@@ -89,6 +89,18 @@ describe('legacy-mirror-reconcile selection SQL (BS#1707)', () => {
   // row in each (sub)query — `shows` has no such column.
   const MIRRORABLE = `entry_type NOT IN ('dj_join', 'dj_leave')`;
 
+  // Twin of orchestrate.ts `substantiveEntryType` (SHOW_BOUNDARY_MARKER_TYPES,
+  // BS#2314): `show_start`/`show_end` ARE mirrorable (unlike dj_join/dj_leave)
+  // but are still just boundary bookends, never evidence a set happened.
+  // `jobs/flowsheet-show-split` promotes a segment's dj_join/dj_leave into
+  // exactly this pair when the DJ logged no tracks before the next go-live
+  // (see that job's module docblock — its shows are written legacy_show_id
+  // NULL ON PURPOSE, to stay outside flowsheet-etl's upsert). Without this
+  // guard such a segment's only rows — both mirrorable, both
+  // legacy_entry_id NULL — would satisfy the NOT EXISTS guard below and get
+  // adopted by sweep 1, defeating that NULL. See show L.
+  const SUBSTANTIVE = `entry_type NOT IN ('dj_join', 'dj_leave', 'show_start', 'show_end')`;
+
   const selectShowsToCreate = async () =>
     (
       await sql.unsafe(
@@ -98,6 +110,7 @@ describe('legacy-mirror-reconcile selection SQL (BS#1707)', () => {
            AND s.start_time < now() - (interval '1 minute' * $1::int)
            AND s.start_time > now() - (interval '1 hour' * $2::int)
            AND NOT EXISTS (SELECT 1 FROM "${SCHEMA}".flowsheet f WHERE f.show_id = s.id AND f.legacy_entry_id IS NOT NULL AND ${MIRRORABLE})
+           AND EXISTS     (SELECT 1 FROM "${SCHEMA}".flowsheet f WHERE f.show_id = s.id AND ${SUBSTANTIVE})
            AND s.id = ANY($3)
          ORDER BY s.start_time ASC`,
         [SETTLE_MINUTES, WINDOW_HOURS, allShowIds]
@@ -247,6 +260,17 @@ describe('legacy-mirror-reconcile selection SQL (BS#1707)', () => {
     await seedEntry(showIds.K, 1, { legacyEntryId: LEGACY_ENTRY_SEQ++ });
     await seedEntry(showIds.K, 2);
 
+    // L — split-shaped, no tracks (BS#2314): no tubafrenzy show, DJ set, in
+    //     window, past settle, otherwise identical to A's create-candidate
+    //     shape — EXCEPT its only entries are the show_start/show_end pair
+    //     `flowsheet-show-split` promotes from a segment's dj_join/dj_leave
+    //     when the DJ logged no tracks before the next go-live. Both are
+    //     mirrorable and both legacy_entry_id NULL, so the pre-existing NOT
+    //     EXISTS guard alone would admit it; must be excluded from sweep 1.
+    await seedShow('L', { startExpr: "now() - interval '2 hours'" });
+    await seedEntry(showIds.L, 1, { entryType: 'show_start' });
+    await seedEntry(showIds.L, 2, { entryType: 'show_end' });
+
     allShowIds = Object.values(showIds);
   });
 
@@ -258,6 +282,22 @@ describe('legacy-mirror-reconcile selection SQL (BS#1707)', () => {
   it('sweep 1 selects only the all-or-nothing, in-window, past-settle, DJ-owned show', async () => {
     const ids = await selectShowsToCreate();
     expect(ids).toEqual([showIds.A]);
+  });
+
+  it('excludes a split-shaped show whose only entries are its own show_start/show_end markers (BS#2314)', async () => {
+    // Show L has no tubafrenzy show, a DJ, and is otherwise in every way a
+    // sweep-1 create candidate — the ONLY thing distinguishing it from A is
+    // that its two entries are boundary markers, not tracks. Must not be
+    // selected, regardless of the all-or-nothing NOT EXISTS guard (which L
+    // also satisfies, since neither marker is mirrored).
+    const ids = await selectShowsToCreate();
+    expect(ids).not.toContain(showIds.L);
+
+    // And L is not reported partial either — it has no orphan (or mirrored)
+    // SUBSTANTIVE entry, so this isn't the all-or-nothing partial case, it's
+    // "nothing to mirror at all".
+    const partials = await selectPartialShows();
+    expect(partials.map((p) => p.show_id)).not.toContain(showIds.L);
   });
 
   it('sweep 2 selects only the all-or-nothing show that already has a tubafrenzy show', async () => {

--- a/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
@@ -118,8 +118,12 @@ describe('selectShowsToCreate — genuinely rendered predicate (BS#2314)', () =>
   it('requires a substantive entry to exist, alongside the pre-existing all-or-nothing guard', async () => {
     await selectShowsToCreate(OPTIONS);
 
+    // `__builders` accumulates for the module's lifetime (it already holds the
+    // module-load-time `hasSubstantiveEntry` builder before any test runs), so
+    // take the LAST `shows`-scoped one — a `find` would hand a future second
+    // case this one's SQL and pass green against the wrong query.
     const builders = (db as unknown as MockDb).__builders;
-    const outer = builders.find((b) => b._table === shows);
+    const outer = builders.findLast((b) => b._table === shows);
     if (!outer) throw new Error('expected an outer builder scoped to `shows`');
 
     const { sql: text, params } = dialect.sqlToQuery(outer._where as Parameters<typeof dialect.sqlToQuery>[0]);
@@ -127,9 +131,14 @@ describe('selectShowsToCreate — genuinely rendered predicate (BS#2314)', () =>
     // Both correlated subqueries are present, AND-ed alongside the window/
     // settle/DJ bounds — not a sibling OR, not dropped, not swapped for one
     // another. `notExists(...)` is the pre-existing guard (BS#1707 R4 High
-    // #1); `exists(...)` is the new BS#2314 guard.
-    expect(text).toContain('not exists (select 1 from');
-    expect(text).toContain('exists (select 1 from');
+    // #1); `exists(...)` is the new BS#2314 guard. Counted rather than
+    // `toContain`-ed: `'not exists (select 1 from'` CONTAINS
+    // `'exists (select 1 from'`, so a bare `toContain` for the new guard stays
+    // green off the old guard's match alone when the new clause is deleted.
+    // `?? []` so a missing clause reports "expected length 1, received 0"
+    // rather than a TypeError on `String.match`'s null.
+    expect(text.match(/not exists \(select 1 from/g) ?? []).toHaveLength(1);
+    expect(text.match(/(?<!not )exists \(select 1 from/g) ?? []).toHaveLength(1);
 
     // The new guard's subquery is scoped to the SAME show (correlated on
     // shows.id, not a free-standing count) and excludes all four boundary-

--- a/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
@@ -104,7 +104,7 @@ jest.mock('@wxyc/database', () => {
 });
 
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { db, shows, flowsheet } from '@wxyc/database';
+import { db, shows } from '@wxyc/database';
 import { selectShowsToCreate, type WindowOptions } from '../../../../jobs/legacy-mirror-reconcile/orchestrate';
 
 type Builder = { _table: unknown; _where: unknown };
@@ -123,7 +123,7 @@ describe('selectShowsToCreate — genuinely rendered predicate (BS#2314)', () =>
     // take the LAST `shows`-scoped one — a `find` would hand a future second
     // case this one's SQL and pass green against the wrong query.
     const builders = (db as unknown as MockDb).__builders;
-    const outer = builders.findLast((b) => b._table === shows);
+    const outer = builders.filter((b) => b._table === shows).at(-1);
     if (!outer) throw new Error('expected an outer builder scoped to `shows`');
 
     const { sql: text, params } = dialect.sqlToQuery(outer._where as Parameters<typeof dialect.sqlToQuery>[0]);
@@ -156,11 +156,5 @@ describe('selectShowsToCreate — genuinely rendered predicate (BS#2314)', () =>
     // `notInArray` binds its values as individual params, not one array
     // param — this pins the exact widened list landed in the right place.
     expect(params).toEqual([15, 48, 'dj_join', 'dj_leave', 'dj_join', 'dj_leave', 'show_start', 'show_end']);
-
-    // Sanity: two distinct subquery builders were built against `flowsheet`
-    // (not the same one read twice), proving the fresh-builder-per-call fake
-    // actually exercised both real subqueries rather than one shared mock.
-    const flowsheetBuilders = builders.filter((b) => b._table === flowsheet);
-    expect(flowsheetBuilders.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
+++ b/tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Genuine-rendered-SQL pin for `selectShowsToCreate`'s BS#2314 guard: Sweep 1
+ * must not adopt a show whose only mirrorable rows are its own `show_start` /
+ * `show_end` boundary markers — the shape a `jobs/flowsheet-show-split`
+ * segment has when its DJ logged no tracks before the next go-live (see that
+ * job's module docblock for why its shows are written `legacy_show_id =
+ * NULL` on purpose, and `orchestrate.ts`'s `SHOW_BOUNDARY_MARKER_TYPES`
+ * comment for why the fix is framed as "no substantive entry" rather than
+ * "came from a split").
+ *
+ * WHY THIS RENDERS REAL SQL RATHER THAN ASSERTING ON PORT FAKES:
+ * `orchestrate.test.ts` drives `runReconcile` through fully-faked
+ * `ReconcilePorts`, so `selectShowsToCreate`'s own predicate is never
+ * exercised there — a fake `selectShowsToCreate` returning `[]` would pass
+ * whether or not the real guard exists. The actual behavioral pin (does a
+ * split-shaped show get selected against a live planner) lives in
+ * `tests/integration/legacy-mirror-reconcile.spec.js`'s hand-written SQL
+ * twin (updated alongside this file for BS#2314). This unit test closes the
+ * gap the `stale-open-shows-sql.test.ts` docblock describes for the sibling
+ * BS#2065 query: it renders the REAL, unmodified `selectShowsToCreate` WHERE
+ * clause through drizzle's own dialect, so a regression to the new guard (or
+ * to its placement inside the AND-chain) fails fast in the unit tier without
+ * a live Postgres.
+ *
+ * `jest.unit.config.ts` unconditionally redirects `@wxyc/database` to a
+ * chain-returning stub whose `shows`/`flowsheet` are plain string maps, not
+ * real drizzle `Column` objects — real `and`/`exists`/`notExists`/`eq`/`sql`
+ * can't compose a genuine `SQL` AST from them. This file overrides that ONE
+ * mock (`jest.mock('@wxyc/database', ...)` with an explicit factory, which
+ * takes precedence for every consumer in this file's module registry,
+ * including `orchestrate.ts`'s own import) to supply the REAL schema via
+ * `jest.requireActual`.
+ *
+ * The trickier half: `selectShowsToCreate`'s WHERE clause embeds TWO
+ * correlated subqueries built via `db.select({one: sql\`1\`}).from(flowsheet)
+ * .where(...)` (`entryExists(false)` — the pre-existing all-or-nothing guard
+ * — and the new `hasSubstantiveEntry`). `exists()`/`notExists()` just splice
+ * the subquery object into a template (`sql\`exists ${subquery}\``), and
+ * drizzle recognizes it as embeddable SQL via `isSQLWrapper` — a plain
+ * `typeof value.getSQL === 'function'` duck-type check. So the fake `db`
+ * below returns a FRESH builder object per `.select()` call (never one
+ * shared/reused chain — two subqueries built in the same WHERE clause would
+ * otherwise clobber each other's captured `.from()`/`.where()` state), and
+ * each builder implements `getSQL()` by genuinely rendering its own captured
+ * table + condition via the real `sql` tag. That produces an honest nested
+ * `SELECT 1 FROM ... WHERE ...` AST, not a stub — the same trick
+ * `stale-open-shows-sql.test.ts` uses for its `Column`/`Table` objects,
+ * extended one level deeper for subquery builders.
+ */
+
+jest.unmock('drizzle-orm');
+
+jest.mock('@wxyc/database', () => {
+  const realSchema = jest.requireActual('../../../../shared/database/src/schema');
+  // `orchestrate.ts` also references `lastLoggedShowEntryOrderBySql` at
+  // module scope (the BS#2065 detector's `newestEntryType`/`newestEntryAt`,
+  // evaluated at import time regardless of which export this file exercises)
+  // — same real helper `stale-open-shows-sql.test.ts` supplies.
+  const realOrderBy = jest.requireActual('../../../../shared/database/src/last-logged-show-entry');
+  const { sql } = jest.requireActual('drizzle-orm');
+
+  const builders: Array<{ _table: unknown; _where: unknown }> = [];
+
+  const makeBuilder = () => {
+    const builder: {
+      _table: unknown;
+      _where: unknown;
+      from: (table: unknown) => typeof builder;
+      where: (cond: unknown) => typeof builder;
+      orderBy: (...args: unknown[]) => typeof builder;
+      getSQL: () => unknown;
+    } = {
+      _table: undefined,
+      _where: undefined,
+      from(table: unknown) {
+        builder._table = table;
+        return builder;
+      },
+      where(cond: unknown) {
+        builder._where = cond;
+        return builder;
+      },
+      orderBy() {
+        return builder;
+      },
+      getSQL() {
+        return sql`select 1 from ${builder._table} where ${builder._where}`;
+      },
+    };
+    builders.push(builder);
+    return builder;
+  };
+
+  const db = {
+    select: () => makeBuilder(),
+    // Exposed so the test can find the specific builder it wants (outer vs.
+    // subquery) by which table it was `.from(...)`'d against, without
+    // reaching for an out-of-scope closure variable (disallowed inside a
+    // `jest.mock` factory).
+    __builders: builders,
+  };
+
+  return { ...realSchema, ...realOrderBy, db };
+});
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db, shows, flowsheet } from '@wxyc/database';
+import { selectShowsToCreate, type WindowOptions } from '../../../../jobs/legacy-mirror-reconcile/orchestrate';
+
+type Builder = { _table: unknown; _where: unknown };
+type MockDb = { __builders: Builder[] };
+
+const OPTIONS: WindowOptions = { windowHours: 48, settleMinutes: 15 };
+const SCHEMA_NAME = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const dialect = new PgDialect();
+
+describe('selectShowsToCreate — genuinely rendered predicate (BS#2314)', () => {
+  it('requires a substantive entry to exist, alongside the pre-existing all-or-nothing guard', async () => {
+    await selectShowsToCreate(OPTIONS);
+
+    const builders = (db as unknown as MockDb).__builders;
+    const outer = builders.find((b) => b._table === shows);
+    if (!outer) throw new Error('expected an outer builder scoped to `shows`');
+
+    const { sql: text, params } = dialect.sqlToQuery(outer._where as Parameters<typeof dialect.sqlToQuery>[0]);
+
+    // Both correlated subqueries are present, AND-ed alongside the window/
+    // settle/DJ bounds — not a sibling OR, not dropped, not swapped for one
+    // another. `notExists(...)` is the pre-existing guard (BS#1707 R4 High
+    // #1); `exists(...)` is the new BS#2314 guard.
+    expect(text).toContain('not exists (select 1 from');
+    expect(text).toContain('exists (select 1 from');
+
+    // The new guard's subquery is scoped to the SAME show (correlated on
+    // shows.id, not a free-standing count) and excludes all four boundary-
+    // marker types — dj_join/dj_leave (never mirrored at all) AND
+    // show_start/show_end (mirrorable, but never evidence a set happened).
+    // Order matters: `notInArray`'s spread is
+    // `[...NON_MIRRORED_MARKER_TYPES, ...SHOW_BOUNDARY_MARKER_TYPES]`.
+    expect(text).toContain(`"${SCHEMA_NAME}"."flowsheet"."show_id" = "${SCHEMA_NAME}"."shows"."id"`);
+    expect(text).toContain(`"${SCHEMA_NAME}"."flowsheet"."entry_type" not in`);
+
+    // Bound params, in position: settleMinutes, windowHours, then the
+    // pre-existing guard's entry-type exclusion (dj_join/dj_leave only —
+    // untouched, proving this guard did not silently widen too), then the
+    // new guard's exclusion of all four boundary-marker types. Each
+    // `notInArray` binds its values as individual params, not one array
+    // param — this pins the exact widened list landed in the right place.
+    expect(params).toEqual([15, 48, 'dj_join', 'dj_leave', 'dj_join', 'dj_leave', 'show_start', 'show_end']);
+
+    // Sanity: two distinct subquery builders were built against `flowsheet`
+    // (not the same one read twice), proving the fresh-builder-per-call fake
+    // actually exercised both real subqueries rather than one shared mock.
+    const flowsheetBuilders = builders.filter((b) => b._table === flowsheet);
+    expect(flowsheetBuilders.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #2314

## The hole

`jobs/flowsheet-show-split` (#2310 / #2311) writes every show it creates with `legacy_show_id = NULL` **on purpose**. That NULL is what keeps those repaired shows outside `jobs/flowsheet-etl`'s `ON CONFLICT (legacy_show_id) DO UPDATE`, so a later ETL pass can't overwrite the repair from tubafrenzy.

`jobs/legacy-mirror-reconcile`'s Sweep 1 selects on exactly that NULL. Its guard against grabbing a split-created show is incidental: `notExists(entryExists(false))` — "no entry of a mirrorable type already carries a `legacy_entry_id`". A split segment normally inherits tracks that were mirrored and back-stamped, so that guard trips and the show is skipped. It is why the 2026-08-28 run against show `1951224` was unaffected — all five segments carried mirrored tracks.

It stops holding for a segment whose DJ hit Go Live and logged nothing before the next DJ took over. That segment's only rows are the `show_start` / `show_end` pair `applySplit` promotes from its `dj_join` / `dj_leave`. `mirrorableEntryType` excludes only `dj_join` / `dj_leave`, so **promoting a marker moves it into the mirrorable set** — both rows are mirrorable and both are `legacy_entry_id IS NULL`. Nothing is "already mirrored", the guard passes, Sweep 1 calls `mirrorCreateShow` and persists a `legacy_show_id`. The show is now inside `flowsheet-etl`'s upsert scope, and tubafrenzy has a show for a split the job deliberately chose not to reflect upstream.

## The fix

`selectShowsToCreate` now ANDs a second correlated subquery alongside the pre-existing one: `exists(hasSubstantiveEntry)` — the show must have at least one entry that is not a boundary marker (`dj_join`, `dj_leave`, `show_start`, `show_end`).

This is the issue's Option 3, and the design choice is the interesting part. The obvious alternative is to **tag shows by provenance** — mark the ones the split job made, and exclude on the mark. That needs either a migration for a dedicated column, or a heuristic over existing columns (`legacy_dj_name IS NULL`, "started at another show's `end_time`", `primary_dj_id` set while `legacy_show_id` is NULL). Every one of those heuristics is a shape a normal, never-split show can also produce, so each one is a future false positive or false negative waiting to happen, and the migration is real schema weight for a job that stops mattering after the tubafrenzy Milestone 1 date.

The guard instead asks a **provenance-independent** question that Sweep 1 arguably should have been asking all along: *did a set actually happen here?* A show whose only mirrorable rows are its own start/end bookends has no set to mirror, however it came to exist. No migration, no heuristic, and nothing to unwind when the split job is retired.

## This is deliberately broader than "exclude split-created shows"

Worth being explicit: the guard does not only stop the split case. It also stops Sweep 1 minting a tubafrenzy show for a **genuinely non-split** show with zero logged entries — a DJ who signed on and off without logging anything, whose show holds only its own `show_start` / `show_end`.

That widening is intentional and is endorsed by the issue's own Option 3 write-up: *"a show with no tracks is not a show worth minting upstream."* The acceptance criterion that constrains the widening still holds — a genuinely unmirrored show that **does** have entries is still adopted, which is what the pre-existing `sweep 1 selects only the all-or-nothing, in-window, past-settle, DJ-owned show` test pins.

## What it does not close

The other direction, stated as plainly: this closes the **empty** split segment, not every split segment. A segment whose entries are all still un-mirrored — `backend-mirror` was off for that DJ during the set, or a transient tubafrenzy failure ate the entry calls — is substantive, so Sweep 1 will still adopt it and re-admit it to `flowsheet-etl`'s upsert scope. The issue's End-state sentence ("never adopted ... regardless") is strictly stronger than Option 3 can deliver; closing that last case needs a provenance mark on the show, which is Option 1 and a migration. The `SHOW_BOUNDARY_MARKER_TYPES` docblock says so in the code rather than leaving a reader to infer that the hole is shut.

## Where the line is drawn

The `entry_type` enum has eight values. Four are boundary markers and are excluded; `track`, `talkset`, `breakpoint` and `message` all count as substantive. On this write path those last three come only from `POST /flowsheet` with a message body (`inferMessageEntryType`) — a DJ pressing a button while on the air — so they are evidence of a set in the way a server-written bookend is not. tubafrenzy's auto-generated top-of-hour breakpoints arrive through the `/internal` webhook already carrying a `legacy_entry_id`, which disqualifies the show at `notExists(entryExists(false))` before this guard is ever reached.

## Tests

- `tests/integration/legacy-mirror-reconcile.spec.js` — the hand-written SQL twin gains the same `AND EXISTS` clause, plus fixture show `L`: split-shaped, in window, past settle, DJ-owned, and identical to the create-candidate show `A` in every respect **except** that its only two entries are a `show_start` / `show_end` pair. A new case asserts `L` is neither selected by Sweep 1 nor reported partial (it has no orphan *substantive* entry, so this is "nothing to mirror at all", not the all-or-nothing partial case).
- `tests/unit/jobs/legacy-mirror-reconcile/select-shows-to-create-sql.test.ts` — new. `orchestrate.test.ts` drives `runReconcile` through fully-faked `ReconcilePorts`, so `selectShowsToCreate`'s own predicate is never exercised there; a fake returning `[]` would pass with or without the guard. This file renders the real, unmodified WHERE clause through drizzle's own dialect (the pattern `stale-open-shows-sql.test.ts` established for the sibling BS#2065 query) and pins both subqueries, their AND-chain placement, and the exact bound-parameter list — so a regression fails in the unit tier without a live Postgres.

Verified locally against a real Postgres: 7/7 in the integration spec, and reverting only the twin's new clause turns the new case **and** the pre-existing sweep-1 equality assertion red, so the fixture is a genuine pin rather than a tautology.

## Related

- #2314 — this issue
- #2310 / #2311 — `jobs/flowsheet-show-split`, the job whose `legacy_show_id = NULL` this protects
- #1707 — `jobs/legacy-mirror-reconcile`, the job being changed
