### PR TITLE
test(flowsheet): flag-ON integration coverage for takeover, and the six join sites it breaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -574,6 +574,13 @@ jobs:
           # column was previously destructured away, with no gating coverage.
           CATALOG_TRACK_SEARCH_CTA_ENABLED: 'true'
           CATALOG_TRACK_SEARCH_DISCOGS_ENABLED: 'true'
+          # Flowsheet Go-Live Intent (BS#2233/BS#2308): same GHA-vs-compose
+          # parity as the two flags above (dev_env/docker-compose.yml).
+          # Default OFF in prod; CI flips it on so
+          # tests/integration/flowsheet-takeover.spec.js exercises the
+          # routing against real Postgres. Test-coverage decision, not a
+          # rollout.
+          FLOWSHEET_TAKEOVER_ENABLED: 'true'
           # SES has a 200-message/month quota. The auth service (host process
           # here) is the only sendEmail/sendOTPEmail caller; keep real sends
           # off regardless of whether AWS_ACCESS_KEY_ID etc. are ever set on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -575,11 +575,13 @@ jobs:
           CATALOG_TRACK_SEARCH_CTA_ENABLED: 'true'
           CATALOG_TRACK_SEARCH_DISCOGS_ENABLED: 'true'
           # Flowsheet Go-Live Intent (BS#2233/BS#2308): same GHA-vs-compose
-          # parity as the two flags above (dev_env/docker-compose.yml).
-          # Default OFF in prod; CI flips it on so
-          # tests/integration/flowsheet-takeover.spec.js exercises the
-          # routing against real Postgres. Test-coverage decision, not a
-          # rollout.
+          # parity requirement as the flags above (dev_env/docker-compose.yml),
+          # but NOT the same rollout state — those are ON in production, and
+          # this one ships OFF and stays OFF there. CI flips it on only so
+          # tests/integration/flowsheet-takeover.spec.js exercises the routing
+          # against real Postgres. Test-coverage decision, not a rollout.
+          # Must be on the SERVICE env (this step), not the jest runner's: the
+          # suite drives a separately spawned backend over HTTP.
           FLOWSHEET_TAKEOVER_ENABLED: 'true'
           # SES has a 200-message/month quota. The auth service (host process
           # here) is the only sendEmail/sendOTPEmail caller; keep real sends

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -266,6 +266,13 @@ services:
       # tests/integration/library-search-alias.spec.js exercises the LATERAL
       # against a seeded artist_search_alias variant ('Thee Oh Sees' → OHSEES).
       - CATALOG_SEARCH_ALIAS_ENABLED=${CATALOG_SEARCH_ALIAS_ENABLED:-true}
+      # Flowsheet Go-Live Intent (BS#2233/BS#2308): default OFF in prod: a
+      # caller must say `intent: "join"` or `"takeover"` before joining a show
+      # they don't belong to; an absent intent is a 409. CI flips it on so
+      # tests/integration/flowsheet-takeover.spec.js exercises the routing
+      # against real Postgres. This is a test-coverage decision, not a
+      # rollout — see docs/env-vars.md.
+      - FLOWSHEET_TAKEOVER_ENABLED=true
     ports:
       - '${CI_PORT:-8081}:8080'
 

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -266,13 +266,16 @@ services:
       # tests/integration/library-search-alias.spec.js exercises the LATERAL
       # against a seeded artist_search_alias variant ('Thee Oh Sees' → OHSEES).
       - CATALOG_SEARCH_ALIAS_ENABLED=${CATALOG_SEARCH_ALIAS_ENABLED:-true}
-      # Flowsheet Go-Live Intent (BS#2233/BS#2308): default OFF in prod: a
-      # caller must say `intent: "join"` or `"takeover"` before joining a show
-      # they don't belong to; an absent intent is a 409. CI flips it on so
+      # Flowsheet Go-Live Intent (BS#2233/BS#2308). When ON, a caller must say
+      # `intent: "join"` or `"takeover"` before joining a show they don't
+      # belong to; an absent intent is a 409. CI flips it on so
       # tests/integration/flowsheet-takeover.spec.js exercises the routing
-      # against real Postgres. This is a test-coverage decision, not a
-      # rollout — see docs/env-vars.md.
-      - FLOWSHEET_TAKEOVER_ENABLED=true
+      # against real Postgres. This is a test-coverage decision, NOT a rollout:
+      # the flag ships OFF and stays OFF in production — see docs/env-vars.md.
+      # Overridable (like the three flags above) so a developer can reproduce
+      # the flag-OFF production configuration locally; with it off the takeover
+      # spec fails loudly at `.expect(409)` rather than passing vacuously.
+      - FLOWSHEET_TAKEOVER_ENABLED=${FLOWSHEET_TAKEOVER_ENABLED:-true}
     ports:
       - '${CI_PORT:-8081}:8080'
 

--- a/tests/integration/flowsheet-join-after-tubafrenzy-signoff.spec.js
+++ b/tests/integration/flowsheet-join-after-tubafrenzy-signoff.spec.js
@@ -176,10 +176,15 @@ describe('POST /flowsheet/join after a tubafrenzy sign-off (BS#1861)', () => {
 
     try {
       // Secondary DJ joins as a co-host — first join, genuine dj_join marker.
+      // The primary's show is genuinely open and the secondary is not yet a
+      // member, so under FLOWSHEET_TAKEOVER_ENABLED this needs `intent:
+      // 'join'` to say so. The two re-joins below do NOT — each hits
+      // `isDjAlreadyActiveOnShow`'s no-op-200 guard before the intent check
+      // even runs (see joinShow), so they are unaffected by the flag.
       const firstJoin = await request
         .post('/flowsheet/join')
         .set('Authorization', global.secondary_access_token)
-        .send({ dj_id: global.secondary_dj_id });
+        .send({ dj_id: global.secondary_dj_id, intent: 'join' });
       expect(firstJoin.status).toBe(200);
 
       const afterFirstJoin = await sql.unsafe(

--- a/tests/integration/flowsheet-takeover.spec.js
+++ b/tests/integration/flowsheet-takeover.spec.js
@@ -1,0 +1,289 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
+const fls_util = require('../utils/flowsheet_util');
+const { isMockApiAvailable, resetMockApi, getMockRequests } = require('../utils/mock_api');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+// Per-spec sql client. Mirrors the construction in
+// flowsheet-join-after-tubafrenzy-signoff.spec.js / flowsheet.spec.js.
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/**
+ * Integration tests for BS#2233 / BS#2308 / BS#2309: `POST /flowsheet/join`'s
+ * `intent: "takeover"` branch, run with FLOWSHEET_TAKEOVER_ENABLED=true
+ * against real Postgres.
+ *
+ * The flag ships OFF in production (default dormant, see
+ * apps/backend/config/flowsheetTakeover.ts and docs/env-vars.md). Turning it
+ * on here — dev_env/docker-compose.yml's `ci` profile and
+ * .github/workflows/test.yml's "Start services" step — is a decision about
+ * integration TEST COVERAGE, not about the rollout: nothing about this file
+ * enables the feature for real users.
+ *
+ * Mirrors BS#2232's incident shape: a BS-native show (`primary_dj_id` set)
+ * with one active co-host, abandoned without a sign-off. Companion unit
+ * coverage: tests/unit/controllers/flowsheet.joinIntent.test.ts (the routing
+ * table, including the two concurrent-takeover unit cases this file exercises
+ * end-to-end against real Postgres).
+ */
+describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
+  let sql;
+  let mockApiAvailable = false;
+
+  // A third identity, distinct from both fixture DJs. Takeover authorization
+  // is deliberately NOT role-gated beyond flowsheet:write (PR#2308's
+  // "Authorization — decided, not overlooked") — any write-capable DJ can
+  // take over an abandoned show, matching the physical reality that whoever
+  // is in the studio is on air. The seeded fixture pool only carries the two
+  // plain-DJ accounts (test_dj1/test_dj2), already playing the primary/
+  // co-host roles below, so the taker needs someone else. The seeded
+  // station-manager fixture (dev_env/seed_db.sql) fits: a real row with a
+  // resolvable dj_name ("Test SM"), and AUTH_BYPASS's raw-Bearer path
+  // (tests/setup/integration.setup.js, mirrored here) doesn't care about
+  // role — `/flowsheet/join` never checks one beyond flowsheet:write.
+  const TAKER_DJ_ID = 'test-sm-id-0000000000000000001';
+  const TAKER_ACCESS_TOKEN = `Bearer ${TAKER_DJ_ID}`;
+  const TAKER_DJ_NAME = 'Test SM';
+
+  beforeAll(async () => {
+    sql = makeSql();
+    mockApiAvailable = await isMockApiAvailable();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  test(
+    'takeover closes the abandoned show (end_time = last logged add_time, show_end marker, ' +
+      'all show_djs deactivated, dj_leave for the co-host), opens exactly one new show owned by the ' +
+      'caller, signs off tubafrenzy, and on_air/djs-on-air agree afterward',
+    async () => {
+      if (mockApiAvailable) await resetMockApi();
+
+      try {
+        // Seed: primary opens a show, secondary joins as an active co-host —
+        // the incident's shape (BS#2232: an open show plus a guest, nobody
+        // signs off).
+        const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
+          show_name: 'BS#2309 takeover fixture',
+        });
+        const startBody = await startRes.json();
+        const oldShowId = startBody.id;
+
+        await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
+
+        // A logged track. `resolveShowEndInstant` must report ITS add_time as
+        // the close instant, never now() — proven below not by hand-setting
+        // a timestamp, but by a real wait: the assertion is that end_time
+        // equals this row's OWN (database-assigned) add_time and measurably
+        // predates the takeover call by the wait interval.
+        const trackRes = await request
+          .post('/flowsheet')
+          .set('Authorization', global.access_token)
+          .send({ artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' })
+          .expect(201);
+        const [trackRow] = await sql.unsafe(`SELECT add_time FROM ${SCHEMA}.flowsheet WHERE id = $1`, [
+          trackRes.body.id,
+        ]);
+        const lastLoggedAddTime = new Date(trackRow.add_time);
+
+        // The gap that makes "end_time = now()" and "end_time = last logged
+        // add_time" observably different outcomes.
+        await new Promise((r) => setTimeout(r, 1200));
+
+        // The taker sees the show is genuinely open and gets the 409 — the
+        // same prompt the dj-site "Go Live" flow would show — then echoes
+        // its show id back as `expected_show_id`, the compare-and-set
+        // BS#2233 specifies.
+        const conflictRes = await request
+          .post('/flowsheet/join')
+          .set('Authorization', TAKER_ACCESS_TOKEN)
+          .send({ dj_id: TAKER_DJ_ID })
+          .expect(409);
+        expect(conflictRes.body.code).toBe('show_already_open');
+        expect(conflictRes.body.details.show.id).toBe(oldShowId);
+
+        const beforeTakeover = Date.now();
+        const takeoverRes = await request
+          .post('/flowsheet/join')
+          .set('Authorization', TAKER_ACCESS_TOKEN)
+          .send({
+            dj_id: TAKER_DJ_ID,
+            intent: 'takeover',
+            expected_show_id: conflictRes.body.details.show.id,
+            show_name: 'BS#2309 taker show',
+          })
+          .expect(200);
+
+        // Opens exactly one new show, owned by the caller — not a co-host
+        // join into the old one.
+        expect(takeoverRes.body.primary_dj_id).toBe(TAKER_DJ_ID);
+        expect(takeoverRes.body.id).not.toBe(oldShowId);
+        const newShowId = takeoverRes.body.id;
+
+        const [closedShow] = await sql.unsafe(`SELECT end_time FROM ${SCHEMA}.shows WHERE id = $1`, [oldShowId]);
+        expect(closedShow.end_time).not.toBeNull();
+        // The derived instant, byte-equal to the track's own add_time — not
+        // an approximation of it.
+        expect(new Date(closedShow.end_time).getTime()).toBe(lastLoggedAddTime.getTime());
+        // And it demonstrably predates the takeover call by (most of) the
+        // artificial gap above. Byte-equality with a stale timestamp alone
+        // wouldn't rule out a coincidental now()-at-a-different-moment
+        // match; this rules it out.
+        expect(beforeTakeover - new Date(closedShow.end_time).getTime()).toBeGreaterThan(1000);
+
+        // A show_end marker was written, at the same derived instant.
+        const showEndRows = await sql.unsafe(
+          `SELECT add_time FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
+          [oldShowId]
+        );
+        expect(showEndRows.length).toBe(1);
+        expect(new Date(showEndRows[0].add_time).getTime()).toBe(lastLoggedAddTime.getTime());
+
+        // All show_djs deactivated — the primary AND the co-host.
+        const activeMembers = await sql.unsafe(
+          `SELECT dj_id FROM ${SCHEMA}.show_djs WHERE show_id = $1 AND active = true`,
+          [oldShowId]
+        );
+        expect(activeMembers.length).toBe(0);
+
+        // A dj_leave for the co-host — and ONLY the co-host: `endShow` skips
+        // the primary (whose departure is what the show_end marker already
+        // says), so this must be exactly one row, naming the secondary.
+        const djLeaveRows = await sql.unsafe(
+          `SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_leave'`,
+          [oldShowId]
+        );
+        expect(djLeaveRows.length).toBe(1);
+        expect(djLeaveRows[0].dj_name).toBe('Test dj2');
+
+        // The most important assertion in this file — BS#2232's actual
+        // user-visible symptom. Before the routing fix, a silent co-host join
+        // onto an abandoned show left `on_air` naming the departed owner
+        // while `djs-on-air` named whoever had actually shown up. After a
+        // takeover, both endpoints are reading the SAME (new) show and must
+        // agree.
+        const flowsheetRes = await request.get('/flowsheet').query({ limit: 1 }).expect(200);
+        expect(flowsheetRes.body.on_air).toEqual({ dj_name: TAKER_DJ_NAME });
+
+        const djsOnAirRes = await request.get('/flowsheet/djs-on-air').expect(200);
+        expect(djsOnAirRes.body).toEqual([{ id: TAKER_DJ_ID, dj_name: TAKER_DJ_NAME }]);
+
+        // Spelled out explicitly: the two endpoints name the same DJ.
+        expect(flowsheetRes.body.on_air.dj_name).toBe(djsOnAirRes.body[0].dj_name);
+        // And neither still names the departed primary or the co-host —
+        // confirms this is the fix closing the divergence, not a
+        // coincidental match on an unrelated field.
+        expect(flowsheetRes.body.on_air.dj_name).not.toBe('Test dj1');
+        expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.primary_dj_id);
+        expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.secondary_dj_id);
+
+        // The old show's tubafrenzy sign-off. This belongs here, against the
+        // real mirror helper, rather than the dj-site E2E, where tubafrenzy
+        // is a mock. `scheduleTakeoverSignoff` defers to `res.once('finish')`
+        // (fire-and-forget, per BS#2233's "do not await it on the request
+        // path"), so poll briefly rather than asserting immediately.
+        if (mockApiAvailable) {
+          const [oldShowRow] = await sql.unsafe(`SELECT legacy_show_id FROM ${SCHEMA}.shows WHERE id = $1`, [
+            oldShowId,
+          ]);
+
+          const deadline = Date.now() + 4000;
+          let signoffRequests = [];
+          while (Date.now() < deadline) {
+            const tubafrenzyRequests = await getMockRequests('tubafrenzy');
+            signoffRequests = tubafrenzyRequests.filter(
+              (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff')
+            );
+            if (signoffRequests.length > 0) break;
+            await new Promise((r) => setTimeout(r, 100));
+          }
+
+          expect(signoffRequests.length).toBeGreaterThanOrEqual(1);
+          // Correlate to the OLD show's tubafrenzy id when the create-show
+          // mirror tap has already persisted it — signs off the CLOSED show,
+          // never the one that just started (the subtle case PR#2308 calls
+          // out: both taps read the same res.locals.mirrorData key, so a
+          // mis-wired end tap would sign off the wrong show).
+          if (oldShowRow?.legacy_show_id != null) {
+            const oldShowSignoffs = signoffRequests.filter(
+              (r) => r.body && r.body.radioShowId === oldShowRow.legacy_show_id
+            );
+            expect(oldShowSignoffs.length).toBeGreaterThanOrEqual(1);
+          }
+        }
+
+        await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+        void newShowId;
+      } finally {
+        // Best-effort cleanup of both shows so a failed assertion above can't
+        // leak an open show into a later spec (--runInBand shares state).
+        await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+        await fls_util.leave_show(global.primary_dj_id, global.access_token);
+      }
+    }
+  );
+
+  test("two concurrent takeovers of the same show produce exactly one new show; the loser gets endShow's CAS 400", async () => {
+    try {
+      const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
+        show_name: 'BS#2309 concurrent takeover fixture',
+      });
+      const startBody = await startRes.json();
+      const oldShowId = startBody.id;
+
+      // Both requests read the same open show before either commits — the
+      // double-click shape `endShow`'s own compare-and-set comment describes
+      // ("A double-click has both requests reading a live show"), reproduced
+      // here with two genuinely concurrent requests rather than a timing
+      // guess. Same taker for both: the race is on the show's `end_time IS
+      // NULL` CAS, not on caller identity.
+      const [firstRes, secondRes] = await Promise.all([
+        request
+          .post('/flowsheet/join')
+          .set('Authorization', TAKER_ACCESS_TOKEN)
+          .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer A' }),
+        request
+          .post('/flowsheet/join')
+          .set('Authorization', TAKER_ACCESS_TOKEN)
+          .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer B' }),
+      ]);
+
+      const statuses = [firstRes.status, secondRes.status].sort();
+      // One winner (200, a new show), one loser — endShow's own
+      // `WHERE end_time IS NULL` CAS 400, not a second new show.
+      expect(statuses).toEqual([200, 400]);
+
+      const winner = firstRes.status === 200 ? firstRes : secondRes;
+      const loser = firstRes.status === 200 ? secondRes : firstRes;
+      expect(loser.body.message).toBe('Bad Request: No active show session found.');
+
+      // Exactly one show opened by the taker as a result of this race —
+      // `id > oldShowId` scopes to shows created after (and because of) it,
+      // immune to any other fixture the taker owns from an earlier test.
+      const newShowsFromThisRace = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.shows WHERE primary_dj_id = $1 AND id > $2`,
+        [TAKER_DJ_ID, oldShowId]
+      );
+      expect(newShowsFromThisRace.length).toBe(1);
+      expect(newShowsFromThisRace[0].id).toBe(winner.body.id);
+
+      await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+    } finally {
+      await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+      await fls_util.leave_show(global.primary_dj_id, global.access_token);
+    }
+  });
+});

--- a/tests/integration/flowsheet-takeover.spec.js
+++ b/tests/integration/flowsheet-takeover.spec.js
@@ -41,17 +41,19 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
   let sql;
   let mockApiAvailable = false;
 
-  // A third identity, distinct from both fixture DJs. Takeover authorization
-  // is deliberately NOT role-gated beyond flowsheet:write (PR#2308's
-  // "Authorization — decided, not overlooked") — any write-capable DJ can
-  // take over an abandoned show, matching the physical reality that whoever
-  // is in the studio is on air. The seeded fixture pool only carries the two
-  // plain-DJ accounts (test_dj1/test_dj2), already playing the primary/
-  // co-host roles below, so the taker needs someone else. The seeded
-  // station-manager fixture (dev_env/seed_db.sql) fits: a real row with a
-  // resolvable dj_name ("Test SM"), and AUTH_BYPASS's raw-Bearer path
-  // (tests/setup/integration.setup.js, mirrored here) doesn't care about
-  // role — `/flowsheet/join` never checks one beyond flowsheet:write.
+  // A third identity, distinct from both fixture DJs, which are already
+  // playing the primary / co-host roles below. The seeded station-manager
+  // fixture (dev_env/seed_db.sql) is the pick: a real row with a resolvable
+  // dj_name ("Test SM"), and one no other spec mutates — unlike the
+  // deletable/reset fixtures the admin specs target.
+  //
+  // What this deliberately does NOT prove: that takeover is open to any
+  // write-capable DJ. PR#2308 decided takeover is not role-gated beyond
+  // flowsheet:write ("Authorization — decided, not overlooked"), but under
+  // AUTH_BYPASS + NODE_ENV=test `requirePermissions` returns next() before
+  // evaluating any permission, so the taker's role is never checked in this
+  // environment at all. The station-manager role is incidental here, not the
+  // thing under test; the authorization contract is unit-covered.
   const TAKER_DJ_ID = 'test-sm-id-0000000000000000001';
   const TAKER_ACCESS_TOKEN = `Bearer ${TAKER_DJ_ID}`;
   const TAKER_DJ_NAME = 'Test SM';
@@ -59,6 +61,12 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
   beforeAll(async () => {
     sql = makeSql();
     mockApiAvailable = await isMockApiAvailable();
+    if (!mockApiAvailable) {
+      // Say so, matching mirror-http.spec.js. Without this the sign-off
+      // assertions below skip in silence and a misconfigured MOCK_API_URL
+      // reads as a full green pass.
+      console.warn('Skipping tubafrenzy sign-off assertions: mock API server not available');
+    }
   });
 
   afterAll(async () => {
@@ -80,6 +88,13 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
           show_name: 'BS#2309 takeover fixture',
         });
         const startBody = await startRes.json();
+        // Assert the fixture actually STARTED a show rather than no-op-joining
+        // a leaked one. `join_show`'s throw only catches non-2xx: an open show
+        // leaked by an earlier spec returns the no-op-200 `ShowDJ` body, which
+        // carries no `id`, so `oldShowId` would be undefined and the failure
+        // would surface four assertions later against the 409 contract instead
+        // of here. Same guard, same reason, as mirror-http.spec.js's join A.
+        expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
         const oldShowId = startBody.id;
 
         await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
@@ -131,7 +146,6 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
         // join into the old one.
         expect(takeoverRes.body.primary_dj_id).toBe(TAKER_DJ_ID);
         expect(takeoverRes.body.id).not.toBe(oldShowId);
-        const newShowId = takeoverRes.body.id;
 
         const [closedShow] = await sql.unsafe(`SELECT end_time FROM ${SCHEMA}.shows WHERE id = $1`, [oldShowId]);
         expect(closedShow.end_time).not.toBeNull();
@@ -222,11 +236,18 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
               (r) => r.body && r.body.radioShowId === oldShowRow.legacy_show_id
             );
             expect(oldShowSignoffs.length).toBeGreaterThanOrEqual(1);
+          } else {
+            // Say so rather than degrading in silence. Without the id, the only
+            // surviving check is "some sign-off happened", which a mis-wired end
+            // tap signing off the NEW show would satisfy identically — the exact
+            // failure the correlation above exists to catch.
+            console.warn(
+              'Sign-off correlation skipped: shows.legacy_show_id was null for the closed show ' +
+                '(mirror create-tap persist had not landed). Only the weaker "a sign-off occurred" ' +
+                'assertion ran.'
+            );
           }
         }
-
-        await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
-        void newShowId;
       } finally {
         // Best-effort cleanup of both shows so a failed assertion above can't
         // leak an open show into a later spec (--runInBand shares state).
@@ -242,14 +263,31 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
         show_name: 'BS#2309 concurrent takeover fixture',
       });
       const startBody = await startRes.json();
+      // Same fixture guard as the first test — see the comment there.
+      expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
       const oldShowId = startBody.id;
 
       // Both requests read the same open show before either commits — the
       // double-click shape `endShow`'s own compare-and-set comment describes
-      // ("A double-click has both requests reading a live show"), reproduced
-      // here with two genuinely concurrent requests rather than a timing
-      // guess. Same taker for both: the race is on the show's `end_time IS
-      // NULL` CAS, not on caller identity.
+      // ("A double-click has both requests reading a live show"). Same taker
+      // for both: the race is on the show's `end_time IS NULL` CAS, not on
+      // caller identity.
+      //
+      // This is a timing assumption, not an invariant the route guarantees,
+      // so a failure here is worth reading carefully before assuming a
+      // regression. `joinShow`'s first await is `getLatestShow()`; B only has
+      // to finish that read before A's `endShow` UPDATE commits, and A has
+      // three more awaited round trips (`isLatestEntryShowEnd`,
+      // `isDjAlreadyActiveOnShow`, `resolveShowEndInstant`) to get through
+      // first — roughly a 4x margin, which is why this is stable rather than
+      // lucky. Two other interleavings are legal but NOT what we want, and
+      // each has a distinct signature:
+      //   [200, 200] — B read after A's endShow commit but before A's
+      //     startShow INSERT, so B saw a closed show and started its own.
+      //     Two shows from one race; the length assertion below catches it.
+      //   [200, 409] — B read after A's startShow commit, so B's
+      //     expected_show_id no longer matched the open show.
+      // Neither is a flake to paper over: both mean the window widened.
       const [firstRes, secondRes] = await Promise.all([
         request
           .post('/flowsheet/join')
@@ -261,7 +299,7 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
           .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer B' }),
       ]);
 
-      const statuses = [firstRes.status, secondRes.status].sort();
+      const statuses = [firstRes.status, secondRes.status].sort((a, b) => a - b);
       // One winner (200, a new show), one loser — endShow's own
       // `WHERE end_time IS NULL` CAS 400, not a second new show.
       expect(statuses).toEqual([200, 400]);
@@ -280,7 +318,17 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
       expect(newShowsFromThisRace.length).toBe(1);
       expect(newShowsFromThisRace[0].id).toBe(winner.body.id);
 
-      await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+      // The CAS's own symptom, asserted directly rather than inferred from the
+      // show count. What `WHERE end_time IS NULL` exists to prevent (BS#1119)
+      // is the losing request ALSO running endShow's body — two `show_end`
+      // markers on one show and a double tubafrenzy sign-off. "Exactly one new
+      // show" is a downstream consequence of that and would still hold if the
+      // loser had failed for some unrelated reason, so pin the marker count too.
+      const oldShowEndMarkers = await sql.unsafe(
+        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
+        [oldShowId]
+      );
+      expect(oldShowEndMarkers.length).toBe(1);
     } finally {
       await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
       await fls_util.leave_show(global.primary_dj_id, global.access_token);

--- a/tests/integration/flowsheet-takeover.spec.js
+++ b/tests/integration/flowsheet-takeover.spec.js
@@ -69,6 +69,17 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
     }
   });
 
+  // Best-effort cleanup of both shows, so a failed assertion can't leak an
+  // open show into a later spec (--runInBand shares state, and with the flag
+  // on a leaked show turns the next spec's join into a hard throw — see
+  // tests/utils/flowsheet_util.js). `leave_show` never throws, so calling it
+  // unconditionally is safe whether or not the show exists. Same shape as
+  // mirror-http.spec.js's afterEach.
+  afterEach(async () => {
+    await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
   afterAll(async () => {
     if (sql) await sql.end();
   });
@@ -80,258 +91,242 @@ describe('POST /flowsheet/join intent: "takeover" (BS#2233/BS#2308)', () => {
     async () => {
       if (mockApiAvailable) await resetMockApi();
 
-      try {
-        // Seed: primary opens a show, secondary joins as an active co-host —
-        // the incident's shape (BS#2232: an open show plus a guest, nobody
-        // signs off).
-        const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
-          show_name: 'BS#2309 takeover fixture',
-        });
-        const startBody = await startRes.json();
-        // Assert the fixture actually STARTED a show rather than no-op-joining
-        // a leaked one. `join_show`'s throw only catches non-2xx: an open show
-        // leaked by an earlier spec returns the no-op-200 `ShowDJ` body, which
-        // carries no `id`, so `oldShowId` would be undefined and the failure
-        // would surface four assertions later against the 409 contract instead
-        // of here. Same guard, same reason, as mirror-http.spec.js's join A.
-        expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
-        const oldShowId = startBody.id;
+      // Seed: primary opens a show, secondary joins as an active co-host —
+      // the incident's shape (BS#2232: an open show plus a guest, nobody
+      // signs off).
+      const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
+        show_name: 'BS#2309 takeover fixture',
+      });
+      const startBody = await startRes.json();
+      // Assert the fixture actually STARTED a show rather than no-op-joining
+      // a leaked one. `join_show`'s throw only catches non-2xx: an open show
+      // leaked by an earlier spec returns the no-op-200 `ShowDJ` body, which
+      // carries no `id`, so `oldShowId` would be undefined and the failure
+      // would surface four assertions later against the 409 contract instead
+      // of here. Same guard, same reason, as mirror-http.spec.js's join A.
+      expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
+      const oldShowId = startBody.id;
 
-        await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
+      await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
 
-        // A logged track. `resolveShowEndInstant` must report ITS add_time as
-        // the close instant, never now() — proven below not by hand-setting
-        // a timestamp, but by a real wait: the assertion is that end_time
-        // equals this row's OWN (database-assigned) add_time and measurably
-        // predates the takeover call by the wait interval.
-        const trackRes = await request
-          .post('/flowsheet')
-          .set('Authorization', global.access_token)
-          .send({ artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' })
-          .expect(201);
-        const [trackRow] = await sql.unsafe(`SELECT add_time FROM ${SCHEMA}.flowsheet WHERE id = $1`, [
-          trackRes.body.id,
-        ]);
-        const lastLoggedAddTime = new Date(trackRow.add_time);
+      // A logged track. `resolveShowEndInstant` must report ITS add_time as
+      // the close instant, never now() — proven below not by hand-setting
+      // a timestamp, but by a real wait: the assertion is that end_time
+      // equals this row's OWN (database-assigned) add_time and measurably
+      // predates the takeover call by the wait interval.
+      const trackRes = await request
+        .post('/flowsheet')
+        .set('Authorization', global.access_token)
+        .send({ artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' })
+        .expect(201);
+      const [trackRow] = await sql.unsafe(`SELECT add_time FROM ${SCHEMA}.flowsheet WHERE id = $1`, [trackRes.body.id]);
+      const lastLoggedAddTime = new Date(trackRow.add_time);
 
-        // The gap that makes "end_time = now()" and "end_time = last logged
-        // add_time" observably different outcomes.
-        await new Promise((r) => setTimeout(r, 1200));
+      // The gap that makes "end_time = now()" and "end_time = last logged
+      // add_time" observably different outcomes.
+      await new Promise((r) => setTimeout(r, 1200));
 
-        // The taker sees the show is genuinely open and gets the 409 — the
-        // same prompt the dj-site "Go Live" flow would show — then echoes
-        // its show id back as `expected_show_id`, the compare-and-set
-        // BS#2233 specifies.
-        const conflictRes = await request
-          .post('/flowsheet/join')
-          .set('Authorization', TAKER_ACCESS_TOKEN)
-          .send({ dj_id: TAKER_DJ_ID })
-          .expect(409);
-        expect(conflictRes.body.code).toBe('show_already_open');
-        expect(conflictRes.body.details.show.id).toBe(oldShowId);
+      // The taker sees the show is genuinely open and gets the 409 — the
+      // same prompt the dj-site "Go Live" flow would show — then echoes
+      // its show id back as `expected_show_id`, the compare-and-set
+      // BS#2233 specifies.
+      const conflictRes = await request
+        .post('/flowsheet/join')
+        .set('Authorization', TAKER_ACCESS_TOKEN)
+        .send({ dj_id: TAKER_DJ_ID })
+        .expect(409);
+      expect(conflictRes.body.code).toBe('show_already_open');
+      expect(conflictRes.body.details.show.id).toBe(oldShowId);
 
-        const beforeTakeover = Date.now();
-        const takeoverRes = await request
-          .post('/flowsheet/join')
-          .set('Authorization', TAKER_ACCESS_TOKEN)
-          .send({
-            dj_id: TAKER_DJ_ID,
-            intent: 'takeover',
-            expected_show_id: conflictRes.body.details.show.id,
-            show_name: 'BS#2309 taker show',
-          })
-          .expect(200);
+      const beforeTakeover = Date.now();
+      const takeoverRes = await request
+        .post('/flowsheet/join')
+        .set('Authorization', TAKER_ACCESS_TOKEN)
+        .send({
+          dj_id: TAKER_DJ_ID,
+          intent: 'takeover',
+          expected_show_id: conflictRes.body.details.show.id,
+          show_name: 'BS#2309 taker show',
+        })
+        .expect(200);
 
-        // Opens exactly one new show, owned by the caller — not a co-host
-        // join into the old one.
-        expect(takeoverRes.body.primary_dj_id).toBe(TAKER_DJ_ID);
-        expect(takeoverRes.body.id).not.toBe(oldShowId);
+      // Opens exactly one new show, owned by the caller — not a co-host
+      // join into the old one.
+      expect(takeoverRes.body.primary_dj_id).toBe(TAKER_DJ_ID);
+      expect(takeoverRes.body.id).not.toBe(oldShowId);
 
-        const [closedShow] = await sql.unsafe(`SELECT end_time FROM ${SCHEMA}.shows WHERE id = $1`, [oldShowId]);
-        expect(closedShow.end_time).not.toBeNull();
-        // The derived instant, byte-equal to the track's own add_time — not
-        // an approximation of it.
-        expect(new Date(closedShow.end_time).getTime()).toBe(lastLoggedAddTime.getTime());
-        // And it demonstrably predates the takeover call by (most of) the
-        // artificial gap above. Byte-equality with a stale timestamp alone
-        // wouldn't rule out a coincidental now()-at-a-different-moment
-        // match; this rules it out.
-        expect(beforeTakeover - new Date(closedShow.end_time).getTime()).toBeGreaterThan(1000);
+      const [closedShow] = await sql.unsafe(`SELECT end_time FROM ${SCHEMA}.shows WHERE id = $1`, [oldShowId]);
+      expect(closedShow.end_time).not.toBeNull();
+      // The derived instant, byte-equal to the track's own add_time — not
+      // an approximation of it.
+      expect(new Date(closedShow.end_time).getTime()).toBe(lastLoggedAddTime.getTime());
+      // And it demonstrably predates the takeover call by (most of) the
+      // artificial gap above. Byte-equality with a stale timestamp alone
+      // wouldn't rule out a coincidental now()-at-a-different-moment
+      // match; this rules it out.
+      expect(beforeTakeover - new Date(closedShow.end_time).getTime()).toBeGreaterThan(1000);
 
-        // A show_end marker was written, at the same derived instant.
-        const showEndRows = await sql.unsafe(
-          `SELECT add_time FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
-          [oldShowId]
+      // A show_end marker was written, at the same derived instant.
+      const showEndRows = await sql.unsafe(
+        `SELECT add_time FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
+        [oldShowId]
+      );
+      expect(showEndRows.length).toBe(1);
+      expect(new Date(showEndRows[0].add_time).getTime()).toBe(lastLoggedAddTime.getTime());
+
+      // All show_djs deactivated — the primary AND the co-host.
+      const activeMembers = await sql.unsafe(
+        `SELECT dj_id FROM ${SCHEMA}.show_djs WHERE show_id = $1 AND active = true`,
+        [oldShowId]
+      );
+      expect(activeMembers.length).toBe(0);
+
+      // A dj_leave for the co-host — and ONLY the co-host: `endShow` skips
+      // the primary (whose departure is what the show_end marker already
+      // says), so this must be exactly one row, naming the secondary.
+      const djLeaveRows = await sql.unsafe(
+        `SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_leave'`,
+        [oldShowId]
+      );
+      expect(djLeaveRows.length).toBe(1);
+      expect(djLeaveRows[0].dj_name).toBe('Test dj2');
+
+      // The most important assertion in this file — BS#2232's actual
+      // user-visible symptom. Before the routing fix, a silent co-host join
+      // onto an abandoned show left `on_air` naming the departed owner
+      // while `djs-on-air` named whoever had actually shown up. After a
+      // takeover, both endpoints are reading the SAME (new) show and must
+      // agree.
+      const flowsheetRes = await request.get('/flowsheet').query({ limit: 1 }).expect(200);
+      expect(flowsheetRes.body.on_air).toEqual({ dj_name: TAKER_DJ_NAME });
+
+      const djsOnAirRes = await request.get('/flowsheet/djs-on-air').expect(200);
+      expect(djsOnAirRes.body).toEqual([{ id: TAKER_DJ_ID, dj_name: TAKER_DJ_NAME }]);
+
+      // Spelled out explicitly: the two endpoints name the same DJ.
+      expect(flowsheetRes.body.on_air.dj_name).toBe(djsOnAirRes.body[0].dj_name);
+      // And neither still names the departed primary or the co-host —
+      // confirms this is the fix closing the divergence, not a
+      // coincidental match on an unrelated field.
+      expect(flowsheetRes.body.on_air.dj_name).not.toBe('Test dj1');
+      expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.primary_dj_id);
+      expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.secondary_dj_id);
+
+      // The old show's tubafrenzy sign-off. This belongs here, against the
+      // real mirror helper, rather than the dj-site E2E, where tubafrenzy
+      // is a mock. `scheduleTakeoverSignoff` defers to `res.once('finish')`
+      // (fire-and-forget, per BS#2233's "do not await it on the request
+      // path"), so poll briefly rather than asserting immediately.
+      // Nothing below this point can run without the mock tubafrenzy.
+      if (!mockApiAvailable) return;
+
+      const [oldShowRow] = await sql.unsafe(`SELECT legacy_show_id FROM ${SCHEMA}.shows WHERE id = $1`, [oldShowId]);
+
+      const deadline = Date.now() + 4000;
+      let signoffRequests = [];
+      while (Date.now() < deadline) {
+        const tubafrenzyRequests = await getMockRequests('tubafrenzy');
+        signoffRequests = tubafrenzyRequests.filter(
+          (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff')
         );
-        expect(showEndRows.length).toBe(1);
-        expect(new Date(showEndRows[0].add_time).getTime()).toBe(lastLoggedAddTime.getTime());
+        if (signoffRequests.length > 0) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
 
-        // All show_djs deactivated — the primary AND the co-host.
-        const activeMembers = await sql.unsafe(
-          `SELECT dj_id FROM ${SCHEMA}.show_djs WHERE show_id = $1 AND active = true`,
-          [oldShowId]
+      expect(signoffRequests.length).toBeGreaterThanOrEqual(1);
+      // Correlate to the OLD show's tubafrenzy id when the create-show
+      // mirror tap has already persisted it — signs off the CLOSED show,
+      // never the one that just started (the subtle case PR#2308 calls
+      // out: both taps read the same res.locals.mirrorData key, so a
+      // mis-wired end tap would sign off the wrong show).
+      if (oldShowRow?.legacy_show_id != null) {
+        const oldShowSignoffs = signoffRequests.filter(
+          (r) => r.body && r.body.radioShowId === oldShowRow.legacy_show_id
         );
-        expect(activeMembers.length).toBe(0);
-
-        // A dj_leave for the co-host — and ONLY the co-host: `endShow` skips
-        // the primary (whose departure is what the show_end marker already
-        // says), so this must be exactly one row, naming the secondary.
-        const djLeaveRows = await sql.unsafe(
-          `SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'dj_leave'`,
-          [oldShowId]
+        expect(oldShowSignoffs.length).toBeGreaterThanOrEqual(1);
+      } else {
+        // Say so rather than degrading in silence. Without the id, the only
+        // surviving check is "some sign-off happened", which a mis-wired end
+        // tap signing off the NEW show would satisfy identically — the exact
+        // failure the correlation above exists to catch.
+        console.warn(
+          'Sign-off correlation skipped: shows.legacy_show_id was null for the closed show ' +
+            '(mirror create-tap persist had not landed). Only the weaker "a sign-off occurred" ' +
+            'assertion ran.'
         );
-        expect(djLeaveRows.length).toBe(1);
-        expect(djLeaveRows[0].dj_name).toBe('Test dj2');
-
-        // The most important assertion in this file — BS#2232's actual
-        // user-visible symptom. Before the routing fix, a silent co-host join
-        // onto an abandoned show left `on_air` naming the departed owner
-        // while `djs-on-air` named whoever had actually shown up. After a
-        // takeover, both endpoints are reading the SAME (new) show and must
-        // agree.
-        const flowsheetRes = await request.get('/flowsheet').query({ limit: 1 }).expect(200);
-        expect(flowsheetRes.body.on_air).toEqual({ dj_name: TAKER_DJ_NAME });
-
-        const djsOnAirRes = await request.get('/flowsheet/djs-on-air').expect(200);
-        expect(djsOnAirRes.body).toEqual([{ id: TAKER_DJ_ID, dj_name: TAKER_DJ_NAME }]);
-
-        // Spelled out explicitly: the two endpoints name the same DJ.
-        expect(flowsheetRes.body.on_air.dj_name).toBe(djsOnAirRes.body[0].dj_name);
-        // And neither still names the departed primary or the co-host —
-        // confirms this is the fix closing the divergence, not a
-        // coincidental match on an unrelated field.
-        expect(flowsheetRes.body.on_air.dj_name).not.toBe('Test dj1');
-        expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.primary_dj_id);
-        expect(djsOnAirRes.body.map((dj) => dj.id)).not.toContain(global.secondary_dj_id);
-
-        // The old show's tubafrenzy sign-off. This belongs here, against the
-        // real mirror helper, rather than the dj-site E2E, where tubafrenzy
-        // is a mock. `scheduleTakeoverSignoff` defers to `res.once('finish')`
-        // (fire-and-forget, per BS#2233's "do not await it on the request
-        // path"), so poll briefly rather than asserting immediately.
-        if (mockApiAvailable) {
-          const [oldShowRow] = await sql.unsafe(`SELECT legacy_show_id FROM ${SCHEMA}.shows WHERE id = $1`, [
-            oldShowId,
-          ]);
-
-          const deadline = Date.now() + 4000;
-          let signoffRequests = [];
-          while (Date.now() < deadline) {
-            const tubafrenzyRequests = await getMockRequests('tubafrenzy');
-            signoffRequests = tubafrenzyRequests.filter(
-              (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff')
-            );
-            if (signoffRequests.length > 0) break;
-            await new Promise((r) => setTimeout(r, 100));
-          }
-
-          expect(signoffRequests.length).toBeGreaterThanOrEqual(1);
-          // Correlate to the OLD show's tubafrenzy id when the create-show
-          // mirror tap has already persisted it — signs off the CLOSED show,
-          // never the one that just started (the subtle case PR#2308 calls
-          // out: both taps read the same res.locals.mirrorData key, so a
-          // mis-wired end tap would sign off the wrong show).
-          if (oldShowRow?.legacy_show_id != null) {
-            const oldShowSignoffs = signoffRequests.filter(
-              (r) => r.body && r.body.radioShowId === oldShowRow.legacy_show_id
-            );
-            expect(oldShowSignoffs.length).toBeGreaterThanOrEqual(1);
-          } else {
-            // Say so rather than degrading in silence. Without the id, the only
-            // surviving check is "some sign-off happened", which a mis-wired end
-            // tap signing off the NEW show would satisfy identically — the exact
-            // failure the correlation above exists to catch.
-            console.warn(
-              'Sign-off correlation skipped: shows.legacy_show_id was null for the closed show ' +
-                '(mirror create-tap persist had not landed). Only the weaker "a sign-off occurred" ' +
-                'assertion ran.'
-            );
-          }
-        }
-      } finally {
-        // Best-effort cleanup of both shows so a failed assertion above can't
-        // leak an open show into a later spec (--runInBand shares state).
-        await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
-        await fls_util.leave_show(global.primary_dj_id, global.access_token);
       }
     }
   );
 
   test("two concurrent takeovers of the same show produce exactly one new show; the loser gets endShow's CAS 400", async () => {
-    try {
-      const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
-        show_name: 'BS#2309 concurrent takeover fixture',
-      });
-      const startBody = await startRes.json();
-      // Same fixture guard as the first test — see the comment there.
-      expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
-      const oldShowId = startBody.id;
+    const startRes = await fls_util.join_show(global.primary_dj_id, global.access_token, {
+      show_name: 'BS#2309 concurrent takeover fixture',
+    });
+    const startBody = await startRes.json();
+    // Same fixture guard as the first test — see the comment there.
+    expect(startBody.primary_dj_id).toBe(global.primary_dj_id);
+    const oldShowId = startBody.id;
 
-      // Both requests read the same open show before either commits — the
-      // double-click shape `endShow`'s own compare-and-set comment describes
-      // ("A double-click has both requests reading a live show"). Same taker
-      // for both: the race is on the show's `end_time IS NULL` CAS, not on
-      // caller identity.
-      //
-      // This is a timing assumption, not an invariant the route guarantees,
-      // so a failure here is worth reading carefully before assuming a
-      // regression. `joinShow`'s first await is `getLatestShow()`; B only has
-      // to finish that read before A's `endShow` UPDATE commits, and A has
-      // three more awaited round trips (`isLatestEntryShowEnd`,
-      // `isDjAlreadyActiveOnShow`, `resolveShowEndInstant`) to get through
-      // first — roughly a 4x margin, which is why this is stable rather than
-      // lucky. Two other interleavings are legal but NOT what we want, and
-      // each has a distinct signature:
-      //   [200, 200] — B read after A's endShow commit but before A's
-      //     startShow INSERT, so B saw a closed show and started its own.
-      //     Two shows from one race; the length assertion below catches it.
-      //   [200, 409] — B read after A's startShow commit, so B's
-      //     expected_show_id no longer matched the open show.
-      // Neither is a flake to paper over: both mean the window widened.
-      const [firstRes, secondRes] = await Promise.all([
-        request
-          .post('/flowsheet/join')
-          .set('Authorization', TAKER_ACCESS_TOKEN)
-          .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer A' }),
-        request
-          .post('/flowsheet/join')
-          .set('Authorization', TAKER_ACCESS_TOKEN)
-          .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer B' }),
-      ]);
+    // Both requests read the same open show before either commits — the
+    // double-click shape `endShow`'s own compare-and-set comment describes
+    // ("A double-click has both requests reading a live show"). Same taker
+    // for both: the race is on the show's `end_time IS NULL` CAS, not on
+    // caller identity.
+    //
+    // This is a timing assumption, not an invariant the route guarantees,
+    // so a failure here is worth reading carefully before assuming a
+    // regression. `joinShow`'s first await is `getLatestShow()`; B only has
+    // to finish that read before A's `endShow` UPDATE commits, and A has
+    // three more awaited round trips (`isLatestEntryShowEnd`,
+    // `isDjAlreadyActiveOnShow`, `resolveShowEndInstant`) to get through
+    // first — roughly a 4x margin, which is why this is stable rather than
+    // lucky. Two other interleavings are legal but NOT what we want, and
+    // each has a distinct signature:
+    //   [200, 200] — B read after A's endShow commit but before A's
+    //     startShow INSERT, so B saw a closed show and started its own.
+    //     Two shows from one race; the length assertion below catches it.
+    //   [200, 409] — B read after A's startShow commit, so B's
+    //     expected_show_id no longer matched the open show.
+    // Neither is a flake to paper over: both mean the window widened.
+    const [firstRes, secondRes] = await Promise.all([
+      request
+        .post('/flowsheet/join')
+        .set('Authorization', TAKER_ACCESS_TOKEN)
+        .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer A' }),
+      request
+        .post('/flowsheet/join')
+        .set('Authorization', TAKER_ACCESS_TOKEN)
+        .send({ dj_id: TAKER_DJ_ID, intent: 'takeover', expected_show_id: oldShowId, show_name: 'Racer B' }),
+    ]);
 
-      const statuses = [firstRes.status, secondRes.status].sort((a, b) => a - b);
-      // One winner (200, a new show), one loser — endShow's own
-      // `WHERE end_time IS NULL` CAS 400, not a second new show.
-      expect(statuses).toEqual([200, 400]);
+    const statuses = [firstRes.status, secondRes.status].sort((a, b) => a - b);
+    // One winner (200, a new show), one loser — endShow's own
+    // `WHERE end_time IS NULL` CAS 400, not a second new show.
+    expect(statuses).toEqual([200, 400]);
 
-      const winner = firstRes.status === 200 ? firstRes : secondRes;
-      const loser = firstRes.status === 200 ? secondRes : firstRes;
-      expect(loser.body.message).toBe('Bad Request: No active show session found.');
+    const [winner, loser] = firstRes.status === 200 ? [firstRes, secondRes] : [secondRes, firstRes];
+    expect(loser.body.message).toBe('Bad Request: No active show session found.');
 
-      // Exactly one show opened by the taker as a result of this race —
-      // `id > oldShowId` scopes to shows created after (and because of) it,
-      // immune to any other fixture the taker owns from an earlier test.
-      const newShowsFromThisRace = await sql.unsafe(
-        `SELECT id FROM ${SCHEMA}.shows WHERE primary_dj_id = $1 AND id > $2`,
-        [TAKER_DJ_ID, oldShowId]
-      );
-      expect(newShowsFromThisRace.length).toBe(1);
-      expect(newShowsFromThisRace[0].id).toBe(winner.body.id);
+    // Exactly one show opened by the taker as a result of this race —
+    // `id > oldShowId` scopes to shows created after (and because of) it,
+    // immune to any other fixture the taker owns from an earlier test.
+    const newShowsFromThisRace = await sql.unsafe(
+      `SELECT id FROM ${SCHEMA}.shows WHERE primary_dj_id = $1 AND id > $2`,
+      [TAKER_DJ_ID, oldShowId]
+    );
+    expect(newShowsFromThisRace.length).toBe(1);
+    expect(newShowsFromThisRace[0].id).toBe(winner.body.id);
 
-      // The CAS's own symptom, asserted directly rather than inferred from the
-      // show count. What `WHERE end_time IS NULL` exists to prevent (BS#1119)
-      // is the losing request ALSO running endShow's body — two `show_end`
-      // markers on one show and a double tubafrenzy sign-off. "Exactly one new
-      // show" is a downstream consequence of that and would still hold if the
-      // loser had failed for some unrelated reason, so pin the marker count too.
-      const oldShowEndMarkers = await sql.unsafe(
-        `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
-        [oldShowId]
-      );
-      expect(oldShowEndMarkers.length).toBe(1);
-    } finally {
-      await fls_util.leave_show(TAKER_DJ_ID, TAKER_ACCESS_TOKEN);
-      await fls_util.leave_show(global.primary_dj_id, global.access_token);
-    }
+    // The CAS's own symptom, asserted directly rather than inferred from the
+    // show count. What `WHERE end_time IS NULL` exists to prevent (BS#1119)
+    // is the losing request ALSO running endShow's body — two `show_end`
+    // markers on one show and a double tubafrenzy sign-off. "Exactly one new
+    // show" is a downstream consequence of that and would still hold if the
+    // loser had failed for some unrelated reason, so pin the marker count too.
+    const oldShowEndMarkers = await sql.unsafe(
+      `SELECT id FROM ${SCHEMA}.flowsheet WHERE show_id = $1 AND entry_type = 'show_end'`,
+      [oldShowId]
+    );
+    expect(oldShowEndMarkers.length).toBe(1);
   });
 });

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -230,11 +230,19 @@ describe('Join Show', () => {
     // BS#1098: dj_id must match the authenticated caller, so the secondary
     // DJ joins with their own Bearer (raw user-id token, accepted by
     // AUTH_BYPASS — see tests/setup/integration.setup.js).
+    //
+    // This IS the co-host join this describe block exists to exercise — the
+    // primary's show is genuinely open and the secondary is not yet a member
+    // of it, so with FLOWSHEET_TAKEOVER_ENABLED on this is exactly the
+    // BS#2233 "someone else's show is open" branch. `intent: 'join'` says
+    // what the secondary DJ actually means here (co-host), which is what the
+    // pre-#2308 behavior always did silently.
     const res = await request
       .post('/flowsheet/join')
       .set('Authorization', global.secondary_access_token)
       .send({
         dj_id: global.secondary_dj_id,
+        intent: 'join',
       })
       .expect(200);
   });
@@ -335,8 +343,11 @@ describe('Leave Show', () => {
     // Start show
     await fls_util.join_show(global.primary_dj_id, global.access_token);
 
-    // Second DJ joins under their own auth (BS#1098 cross-check).
-    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+    // Second DJ joins under their own auth (BS#1098 cross-check) as a
+    // co-host of the primary's open show — the exact setup this describe
+    // block's tests need to exercise a secondary DJ hitting /flowsheet/end.
+    // `intent: 'join'` says so explicitly under FLOWSHEET_TAKEOVER_ENABLED.
+    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
   });
 
   // Ensure that primary dj ends the show for all show djs
@@ -1420,8 +1431,11 @@ describe('On Air Status', () => {
     test('returns multiple DJs when multiple are on air', async () => {
       // Start a show with primary DJ
       await fls_util.join_show(global.primary_dj_id, global.access_token);
-      // Secondary DJ joins under their own auth (BS#1098 cross-check).
-      await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+      // Secondary DJ joins under their own auth (BS#1098 cross-check) as a
+      // deliberate co-host — this test's whole point is two DJs on air at
+      // once, which is what `intent: 'join'` says under
+      // FLOWSHEET_TAKEOVER_ENABLED.
+      await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
 
       const res = await request.get('/flowsheet/djs-on-air').set('Authorization', global.access_token).expect(200);
 
@@ -1445,8 +1459,11 @@ describe('Retrieve Playlist Object', () => {
     const body = await res.json();
     global.CurrentShowID = body.id;
 
-    // Secondary joins as themselves (BS#1098 cross-check).
-    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+    // Secondary joins as themselves (BS#1098 cross-check), as a co-host —
+    // the test below asserts both DJs appear in `show_djs` and that a
+    // `dj_join` marker is present, so this must be a genuine co-host join.
+    // `intent: 'join'` under FLOWSHEET_TAKEOVER_ENABLED.
+    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, { intent: 'join' });
 
     // Insert entry to for show
     await request

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -258,7 +258,12 @@ describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
     const joinABody = await joinARes.json();
     expect(joinABody.primary_dj_id).toBe(global.primary_dj_id);
 
-    const joinBRes = await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+    // B joins as a guest co-host of A's show — the whole point of this test
+    // is a guest leave vs. a primary end, so B must actually be a co-host.
+    // `intent: 'join'` under FLOWSHEET_TAKEOVER_ENABLED.
+    const joinBRes = await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token, {
+      intent: 'join',
+    });
     expect(joinBRes.status).toBe(200);
 
     const addRes = await request

--- a/tests/utils/flowsheet_util.js
+++ b/tests/utils/flowsheet_util.js
@@ -10,6 +10,15 @@ const url = `${process.env.TEST_HOST}:${process.env.PORT}`;
  * is off: the flag-off branch ignores both fields and co-hosts as it always did.
  * A spec that turns the flag on and joins a secondary DJ onto an already-open
  * show must now say `{ intent: 'join' }`, or it is a 409.
+ *
+ * Throws on a non-2xx response (BS#2309). With the flag off the 409 this
+ * guards against cannot occur, so every pre-existing call site that never
+ * checked the response stayed valid by construction. With the flag on in the
+ * integration environment it can, and a silent 409 used to skip the co-host
+ * setup a test's `beforeEach` was relying on, surfacing as a confusing
+ * assertion failure several lines later — never at the join that actually
+ * failed. Throwing here fails fast, at the join, with the response body that
+ * explains why.
  */
 exports.join_show = async (dj_id, access_token, body = {}) => {
   const res = await fetch(`${url}/flowsheet/join`, {
@@ -23,6 +32,11 @@ exports.join_show = async (dj_id, access_token, body = {}) => {
       ...body,
     }),
   });
+
+  if (!res.ok) {
+    const bodyText = await res.text();
+    throw new Error(`join_show(${dj_id}) failed: ${res.status} ${bodyText}`);
+  }
 
   return res;
 };

--- a/tests/utils/flowsheet_util.js
+++ b/tests/utils/flowsheet_util.js
@@ -19,6 +19,16 @@ const url = `${process.env.TEST_HOST}:${process.env.PORT}`;
  * assertion failure several lines later — never at the join that actually
  * failed. Throwing here fails fast, at the join, with the response body that
  * explains why.
+ *
+ * One consequence worth knowing before debugging a failure: this shifts where
+ * a leaked open show surfaces. A spec that ends leaving someone else's show
+ * open used to be absorbed silently by the next spec's `join_show` (it just
+ * co-hosted). With the flag on and this throw, that next spec's `beforeEach`
+ * now fails outright — so the red suite is the VICTIM of the leak, not its
+ * cause. `metadata.spec.js` and `djs.spec.js` are the likeliest victims: every
+ * one of their joins is a DJ starting its own show, correct as written and
+ * needing no `intent`, but they run after the flowsheet specs. If one of them
+ * fails at a join it never touched, look upstream for the spec that leaked.
  */
 exports.join_show = async (dj_id, access_token, body = {}) => {
   const res = await fetch(`${url}/flowsheet/join`, {


### PR DESCRIPTION
Closes #2309

Adds the flag-ON integration half of #2233's acceptance criteria. #2308 shipped the `intent` / `expected_show_id` routing for `POST /flowsheet/join` with unit coverage only; this turns the flag on **in the integration environment** and adds `tests/integration/flowsheet-takeover.spec.js`, which drives the takeover branch end-to-end against real Postgres.

## The flag stays OFF in production

`FLOWSHEET_TAKEOVER_ENABLED=true` is set in exactly two places, both of which describe the **integration test environment**:

- `dev_env/docker-compose.yml`, the `ci` profile's `backend` service
- `.github/workflows/test.yml`, the "Start services" step

It is set on the **backend service's own runtime env**, not the jest runner's — the suite talks to a separately spawned process over HTTP, so the runner's environment is invisible to the code under test. That distinction is the whole reason this needed its own PR.

**Nothing here changes the rollout.** The flag's default is still OFF, production still ships it OFF, and no user-facing behavior changes. This is a decision about test coverage only. `.env.example` and `apps/backend/config/flowsheetTakeover.ts` are untouched, and the dormant default is what every non-CI environment continues to get.

## The issue's site list was wrong — six sites, not four

The issue predicted four breaking call sites and named `metadata.spec.js` as five of them. That list was written by reading the code. This PR's list was produced empirically: turn the flag on, give `join_show` its throw, run the unmodified suite, and record what actually fails.

The result differs from the prediction in both directions.

### `metadata.spec.js` does not reproduce — zero sites

All nine `join_show` calls there pass **unmodified**. Each is a `beforeEach` that joins `getTestDjId()` — which is `global.secondary_dj_id` — paired with an `afterEach` that ends that same DJ's show. The secondary DJ is therefore always opening and closing *its own* show, never landing on a show someone else has open. The intent contract governs exactly one branch (a show is open, and it isn't the caller's), and these calls never reach it. `mirror-http.spec.js:34` is the same `beforeEach`/`afterEach` shape and is likewise untouched.

### Two real sites the issue missed

Neither appears in the issue, and both are genuine:

- `flowsheet.spec.js`'s "Join Show > Properly Formatted Request" — a **raw `POST /flowsheet/join`**, not a `join_show` call, so a grep for the helper misses it
- `mirror-http.spec.js`'s "guest-DJ leave does not sign off" test

### Per-site audit

All six are in the same routing branch, and all six resolved to `{ intent: 'join' }`. That uniform outcome is a result of the audit, not a substitute for it — a blanket patch would have been correct here **by coincidence**, and would have been wrong the moment one site turned out to be asserting something the 409 makes untrue. Each was checked against what its enclosing test actually asserts:

| # | Site | Verdict | Why |
|---|---|---|---|
| 1 | `flowsheet.spec.js:245` — "Join Show > Properly Formatted Request" (raw POST) | `intent: 'join'` | This *is* the co-host join the `describe` block exists to exercise. The secondary joins the primary's genuinely-open show, which is precisely the #2233 branch. **Missed by the issue.** |
| 2 | `flowsheet.spec.js:350` — "Leave Show" `beforeEach` | `intent: 'join'` | Establishes the co-host the block's tests need in order to have a secondary DJ hit `/flowsheet/end`. See the finding below. |
| 3 | `flowsheet.spec.js:1438` — "returns multiple DJs when multiple are on air" | `intent: 'join'` | The test's entire point is two DJs on air simultaneously. A 409 here leaves one DJ and the assertion fails several lines later for an unrelated-looking reason. |
| 4 | `flowsheet.spec.js:1466` — "Retrieve Playlist Object" `beforeEach` | `intent: 'join'` | The test asserts both DJs appear in `show_djs` *and* that a `dj_join` marker exists, so this has to be a real co-host join. |
| 5 | `mirror-http.spec.js:265` — "endShow mirror shape guard on guest-DJ leave (BS#1119)" | `intent: 'join'` | The test contrasts a guest *leave* against a primary *end*; B must actually be a co-host for the distinction to exist. **Missed by the issue.** |
| 6 | `flowsheet-join-after-tubafrenzy-signoff.spec.js:187` — first join | `intent: 'join'` **on the first join only** | See "option (c)" below. |

### The strongest finding: a `beforeEach` that never checked its own setup

`flowsheet.spec.js`'s "Leave Show" `beforeEach` claims to join a second DJ as a co-host. **None of its three tests depend on that co-host existing:**

- "Properly formatted request" — the primary ends the show; the co-host is irrelevant
- "Forbidden when `dj_id` does not match" — primary's token, `dj_id: 1000`, expects 403 before any membership check
- "No Active Show Session" — the primary ends the show first, so `showMemberMiddleware` sees an empty member list and returns 400 whether or not the secondary ever joined

So with the flag on and no throw, that join would 409, the "co-host" would never join, the `beforeEach`'s stated setup would be a lie — and all three tests would still pass green. The suite would have reported success over a silently degraded fixture. **The throw on non-2xx is what surfaced this**; it is the reason that change belongs with this one rather than being deferred.

### `flowsheet-join-after-tubafrenzy-signoff.spec.js`, option (c)

Only the **first** join needed the intent. The two re-joins after it are unaffected, because they hit `isDjAlreadyActiveOnShow`'s no-op-200 guard in `joinShow` — branch (c) — which returns before the intent check is ever reached. Marking them would have implied a contract they never touch.

## `end_time` is the last logged track's `add_time`, not `now()`

`resolveShowEndInstant` derives the close instant from `MAX(add_time)` floored at `start_time`. The test proves this with a **real 1200 ms wait** rather than a hand-set timestamp:

1. Log a track and read back its database-assigned `add_time`.
2. Wait 1200 ms.
3. Take over, and assert `shows.end_time` is **byte-equal** to that track's own `add_time`.
4. Assert `end_time` predates the takeover call by more than 1000 ms.

Step 4 is what makes step 3 load-bearing. Byte-equality alone would not exclude a coincidental `now()` that happened to land on the same value; the measured gap does. The `show_end` marker is asserted at the same derived instant.

## Also covered

- **`on_air` / `djs-on-air` agree afterward.** This is #2232's actual user-visible symptom — the divergence where `on_air` named the departed owner while `djs-on-air` named whoever had shown up. Asserted positively (both name the taker) and negatively (neither still names the primary or the co-host).
- **The old show is closed properly**: `end_time` set, one `show_end` marker, all `show_djs` deactivated, and exactly one `dj_leave` — for the co-host only, since `endShow` skips the primary whose departure the `show_end` marker already records.
- **Exactly one new show opens**, owned by the caller.
- **The tubafrenzy sign-off**, against the real mirror helper rather than the dj-site E2E where tubafrenzy is a mock. Correlated to the *old* show's `legacy_show_id`, which guards the subtle failure #2308 calls out: both mirror taps read the same `res.locals.mirrorData` key, so a mis-wired end tap would sign off the show that just started.
- **Two concurrent takeovers** produce exactly one new show; the loser gets `endShow`'s compare-and-set 400. Driven with two genuinely parallel requests rather than a timing guess.

## Verification

Six suites, clean database, flag on:

```
Test Suites: 6 passed, 6 total
Tests:       111 passed, 111 total
```

`flowsheet-takeover`, `flowsheet-join-after-tubafrenzy-signoff`, `flowsheet`, `metadata`, `djs`, `mirror-http`.

## Related

- #2232 (epic), #2233, #2308
