### PR TITLE
feat(digital-archive): inventory the auto-DJ Space and bind candidate albums

### DIFF
--- a/Dockerfile.digital-archive-bind
+++ b/Dockerfile.digital-archive-bind
@@ -1,0 +1,36 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+WORKDIR /digital-archive-bind-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/digital-archive-bind ./jobs/digital-archive-bind
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/digital-archive-bind
+
+#Production stage
+FROM node:24-alpine AS prod
+
+WORKDIR /digital-archive-bind
+
+COPY ./package* ./
+COPY ./jobs/digital-archive-bind/package* ./jobs/digital-archive-bind/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./digital-archive-bind-builder/jobs/digital-archive-bind/dist ./jobs/digital-archive-bind/dist
+COPY --from=builder ./digital-archive-bind-builder/shared/database/dist ./shared/database/dist
+
+# One-shot inventory + review-CSV round trip. Statement timeout raised above
+# the 5s API default: the matcher's candidate load is a single SELECT over
+# the whole `library` table (tens of thousands of rows), not a per-row read.
+ENV DB_APPLICATION_NAME=wxyc-digital-archive-bind
+ENV DB_STATEMENT_TIMEOUT_MS=60000
+
+# ENTRYPOINT + empty CMD so docker-level args (--apply, --export, --import,
+# --rebind-keys) pass through to the job rather than replacing the launcher.
+ENTRYPOINT ["node", "/digital-archive-bind/jobs/digital-archive-bind/dist/job.js"]
+CMD []

--- a/jobs/digital-archive-bind/README.md
+++ b/jobs/digital-archive-bind/README.md
@@ -76,10 +76,9 @@ docker run --rm --env-file .env -v "$PWD:/out" <image> --import /out/review.csv
 
 | var                                                 | default                               | meaning                                                                                 |
 | --------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_ACCESS_KEY_ID`     | —                                     | required; DigitalOcean Spaces read-only key                                             |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET_ACCESS_KEY` | —                                     | required                                                                                |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT`          | `https://nyc3.digitaloceanspaces.com` | S3-compatible endpoint                                                                  |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_REGION`            | `nyc3`                                |                                                                                         |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_KEY_ID`            | —                                     | required; DigitalOcean Spaces **read-only** key                                          |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET`            | —                                     | required                                                                                |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT`          | `https://nyc3.digitaloceanspaces.com` | S3-compatible endpoint; the SigV4 region is derived from its first host label            |
 | `DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET`            | `wxyc`                                |                                                                                         |
 | `AZURACAST_API_KEY`                                 | unset                                 | when set, tags come from AzuraCast's media API instead of the ID3v2 ranged-GET fallback |
 | `AZURACAST_BASE_URL`                                | `https://remote.wxyc.org`             | AzuraCast host (behind Cloudflare Access)                                               |

--- a/jobs/digital-archive-bind/README.md
+++ b/jobs/digital-archive-bind/README.md
@@ -74,14 +74,14 @@ docker run --rm --env-file .env -v "$PWD:/out" <image> --import /out/review.csv
 
 ## Environment
 
-| var                                                 | default                               | meaning                                                                                 |
-| --------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_KEY_ID`            | —                                     | required; DigitalOcean Spaces **read-only** key                                          |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET`            | —                                     | required                                                                                |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT`          | `https://nyc3.digitaloceanspaces.com` | S3-compatible endpoint; the SigV4 region is derived from its first host label            |
-| `DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET`            | `wxyc`                                |                                                                                         |
-| `AZURACAST_API_KEY`                                 | unset                                 | when set, tags come from AzuraCast's media API instead of the ID3v2 ranged-GET fallback |
-| `AZURACAST_BASE_URL`                                | `https://remote.wxyc.org`             | AzuraCast host (behind Cloudflare Access)                                               |
+| var                                        | default                               | meaning                                                                                 |
+| ------------------------------------------ | ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_KEY_ID`   | —                                     | required; DigitalOcean Spaces **read-only** key                                         |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET`   | —                                     | required                                                                                |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT` | `https://nyc3.digitaloceanspaces.com` | S3-compatible endpoint; the SigV4 region is derived from its first host label           |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET`   | `wxyc`                                |                                                                                         |
+| `AZURACAST_API_KEY`                        | unset                                 | when set, tags come from AzuraCast's media API instead of the ID3v2 ranged-GET fallback |
+| `AZURACAST_BASE_URL`                       | `https://remote.wxyc.org`             | AzuraCast host (behind Cloudflare Access)                                               |
 
 The `DIGITAL_ARCHIVE_STORE_AZURACAST_*` naming matches `digital_asset_store.name = 'azuracast'` and the env var convention WXYC/Backend-Service#2320's allowlist uses (`DIGITAL_ARCHIVE_STORE_<UPPERCASE_NAME>_*`).
 

--- a/jobs/digital-archive-bind/README.md
+++ b/jobs/digital-archive-bind/README.md
@@ -1,0 +1,101 @@
+# digital-archive-bind
+
+One-shot inventory + bind job (BS#2319, epic [WXYC/wxyc-dj-ios#135](https://github.com/WXYC/wxyc-dj-ios/issues/135) digital archive). Scans the AzuraCast auto-DJ media Space read-only, reads ID3 tags, groups files into candidate albums, matches them against `rotation`/`library`, and writes `digital_asset` (`needs_review`) + `digital_asset_file` rows for a human to review via a CSV round trip.
+
+Dry-run by default. `--apply` writes. It never writes to the Space.
+
+## Why
+
+The auto-DJ Space holds ~23.5k audio objects in ~4,000–4,500 albums with no `library.id` anywhere — the object keys are inconsistent (`rotation/Heavy/01_take_a_number.mp3` beside `rotation/Heavy/roméo_poirier_-_off_the_record_-_03_langsam.mp3`), but the ID3 tags are reliable. The manifest tables from [WXYC/Backend-Service#2318](https://github.com/WXYC/Backend-Service/issues/2318) are empty until something inventories the store, and the playback endpoint ([WXYC/Backend-Service#2320](https://github.com/WXYC/Backend-Service/issues/2320)) serves only `status = 'bound'` rows — nothing is playable until this runs.
+
+## Pipeline
+
+1. **Inventory** (`store.ts`) — paginated `ListObjectsV2` over the whole bucket, read-only by construction (see "Read-only, enforced" below).
+2. **Classify** (`classify.ts`) — skip `.albumart/`, `.covers/`, `.waveforms/`, `station IDs/`, `test/`, `shows/`, directory markers, and non-audio extensions; keep `library/freeform/`, `library/recently_rotated/`, and `rotation/{Heavy,Medium,Light,Singles}/`. `mp3`/`aac`/`flac`/`m4a`/`wav` are all in scope.
+3. **Tags** (`tags.ts`) — AzuraCast's media API (`GET /api/station/main/files`) when `AZURACAST_API_KEY` is set, else a per-file 256KB ranged-GET ID3v2 parse (`id3.ts`, ID3v2.3/2.4, no third-party dependency).
+4. **Group** (`group.ts`) — files sharing normalized `(album_artist ?? artist, album)` become one candidate album, split further by disc number (a multi-disc set is one candidate per disc, since `digital_asset`'s unique key includes `disc_number`).
+5. **Match** (`match.ts`, `candidates.ts`) — rotation-derived prefixes (`recently_rotated/`, `rotation/{bin}/`) match against `rotation` first; `freeform/` matches against `library`. Two tiers, exact then a deterministic punctuation/diacritic-folded "fuzzy" tier (never a similarity score — see `normalize.ts`'s header for why). An exact-tier ambiguity is never given a second chance at the fuzzy tier.
+6. **Write** (`write.ts`) — plan and execute the DB writes. See "Per-slot rule" below.
+7. **Review** (`csv.ts`, `review.ts`) — `--export`/`--import` round-trip the review CSV.
+
+## Per-slot rule
+
+The upsert key is `(library_id, provenance, disc_number)`; `provenance` is always `'rotation_upload'` here. `digital_asset_store.name` is `'azuracast'`.
+
+| existing slot  | what happens                                                                                                                                                                                              |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| none           | insert `needs_review`                                                                                                                                                                                     |
+| `needs_review` | untouched — a re-run is a no-op                                                                                                                                                                           |
+| `rejected`     | skipped, but **always reported** with its object keys + slot. `--rebind-keys <file>` re-opens it for exactly the object keys named in that file, regardless of the prior rejection.                       |
+| `bound`        | **never written, under any flag.** The candidate's object keys are compared against the bound asset's `digital_asset_file` rows; a mismatch is reported as drift (a live-playout file replaced or moved). |
+
+Both defaults are deliberately conservative: neither writes into a slot a human already decided, and a blocked or drifted candidate is never silently indistinguishable from "nothing found." See BS#2319's issue comments 1 and 2 for the full reasoning — they supersede parts of the original issue body and are the actual spec this job implements.
+
+A fifth case the per-slot rule table doesn't cover: two _different_ candidate groups in the **same run** can resolve to the same empty slot — a `freeform/` copy and a `rotation/Heavy/` copy of the same album both present in the Space at once. The first one seen is queued for insert; the rest are reported as a same-run collision and left unwritten, since a plain multi-row `INSERT` would otherwise hit the unique index and abort the whole batch rather than just the duplicate.
+
+## Watermark cost
+
+Migration 0159 attaches `touch_library_watermark` to `digital_asset` `FOR EACH STATEMENT` on INSERT / `UPDATE OF status, library_id` / DELETE / TRUNCATE. Every advance forces every device to re-download the full gzipped NDJSON catalog and rebuild its FTS5 index, so the write phase costs **at most one INSERT statement and one UPDATE statement per `--apply` run**, never one per album:
+
+- All new-slot inserts land in one multi-row `INSERT`.
+- All `--rebind-keys` reopens land in one multi-row `UPDATE`.
+- `digital_asset_file` carries no trigger, so its writes are free to batch however is convenient.
+
+A plain `--apply` run (no `--rebind-keys` matches) costs exactly one advance. A run that also reopens rejected slots costs at most two. The whole inventory/tag-read/match pass runs with no open transaction — the DB write is the last, short step, once everything is already in memory.
+
+## Read-only, enforced
+
+`store.ts` imports exactly `S3Client`, `ListObjectsV2Command`, and `GetObjectCommand` from `@aws-sdk/client-s3` — no `Put*`/`Delete*`/`Copy*`/`*MultipartUpload*` command anywhere in this job. `tests/unit/jobs/digital-archive-bind/store.test.ts` greps the module's own source for those names, so a future edit that adds a write command fails a test rather than failing silently.
+
+## Running
+
+```bash
+# Size the run. Zero writes.
+docker run --rm --env-file .env <image>
+
+# Write it.
+docker run --rm --env-file .env <image> --apply
+
+# Recover an orphan the merge.ts collision-DELETE left behind (see the
+# per-slot rule above) -- rebind.txt is one object key per line, `#` comments allowed.
+docker run --rm --env-file .env -v "$PWD/rebind.txt:/rebind.txt" <image> --apply --rebind-keys /rebind.txt
+
+# Export the needs_review cohort for review.
+docker run --rm --env-file .env -v "$PWD:/out" <image> --export /out/review.csv
+
+# Hand review.csv to a reviewer. They fill the `decision` column with
+# `bound` or `rejected` (and optionally `note`), leaving undecided rows blank.
+
+# Write the reviewer's decisions back. Only needs_review rows can transition.
+docker run --rm --env-file .env -v "$PWD:/out" <image> --import /out/review.csv
+```
+
+`--export`/`--import` make no S3 calls and run no inventory scan — they read/write `digital_asset` directly.
+
+## Environment
+
+| var                                                 | default                               | meaning                                                                                 |
+| --------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_ACCESS_KEY_ID`     | —                                     | required; DigitalOcean Spaces read-only key                                             |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET_ACCESS_KEY` | —                                     | required                                                                                |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT`          | `https://nyc3.digitaloceanspaces.com` | S3-compatible endpoint                                                                  |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_REGION`            | `nyc3`                                |                                                                                         |
+| `DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET`            | `wxyc`                                |                                                                                         |
+| `AZURACAST_API_KEY`                                 | unset                                 | when set, tags come from AzuraCast's media API instead of the ID3v2 ranged-GET fallback |
+| `AZURACAST_BASE_URL`                                | `https://remote.wxyc.org`             | AzuraCast host (behind Cloudflare Access)                                               |
+
+The `DIGITAL_ARCHIVE_STORE_AZURACAST_*` naming matches `digital_asset_store.name = 'azuracast'` and the env var convention WXYC/Backend-Service#2320's allowlist uses (`DIGITAL_ARCHIVE_STORE_<UPPERCASE_NAME>_*`).
+
+**The AzuraCast API response shape in `tags.ts` is best-effort** from the issue body's own description ("returns artist/title/album/length/path per file") and has not been verified against a live `remote.wxyc.org` response. A field AzuraCast doesn't actually send resolves to `null`, which `group.ts` already treats as "ungroupable" rather than misbinding — so an unverified mapping degrades to more files needing the ID3 fallback, not a wrong bind. Verify the field mapping against a real response before the first prod run with the key set.
+
+## Tests
+
+- `tests/unit/jobs/digital-archive-bind/classify.test.ts` — the skip-list / content-prefix classification.
+- `tests/unit/jobs/digital-archive-bind/id3.test.ts` — the ID3v2 parser against hand-built fixture headers (full tag, no track number, `TPOS` disc, UTF-16, NUL padding, truncated buffer).
+- `tests/unit/jobs/digital-archive-bind/normalize.test.ts`, `match.test.ts` — the grouping/matching keys and matcher precedence (exact beats fuzzy; an exact-tier ambiguity never falls through to fuzzy).
+- `tests/unit/jobs/digital-archive-bind/group.test.ts` — album grouping, including the per-disc split.
+- `tests/unit/jobs/digital-archive-bind/csv.test.ts` — the review CSV export/import round trip.
+- `tests/unit/jobs/digital-archive-bind/plan-writes.test.ts` — the per-slot rule (pure planner, no DB).
+- `tests/unit/jobs/digital-archive-bind/store.test.ts` — MD5-from-ETag, and the read-only import guard.
+- `tests/unit/jobs/digital-archive-bind/report.test.ts` — the summary report never silently drops a blocked/drifted row.
+- `tests/integration/digital-archive-bind-write.spec.js` — the real `write.ts`/`match.ts`/`candidates.ts` functions against a real Postgres: a fixture album matched against seeded `library`/`rotation` rows produces the expected `needs_review` row, a re-run is a no-op, and `applyReviewDecisions` flips exactly the rows it's given, only from `needs_review`.

--- a/jobs/digital-archive-bind/candidates.ts
+++ b/jobs/digital-archive-bind/candidates.ts
@@ -1,0 +1,36 @@
+/**
+ * Match-target loaders for step 4: one query per table, sweeping the whole
+ * candidate population into memory once. Same shape as
+ * `jobs/album-reviews-etl/link.ts`'s "ONE query sweeps `library`" precedent
+ * -- the population is tens of thousands of rows, not millions, and
+ * matching per-candidate against an in-memory array is cheap next to a
+ * per-file round trip against Postgres.
+ */
+
+import { isNotNull } from 'drizzle-orm';
+import { db, library, rotation } from '@wxyc/database';
+import type { LibraryCandidateRow, RotationCandidateRow } from './match.js';
+
+/** `rotation` rows with a resolved `album_id` -- an unlinked row can't produce a `library_id`. */
+export const loadRotationCandidates = async (): Promise<RotationCandidateRow[]> => {
+  const rows = await db
+    .select({ libraryId: rotation.album_id, artistName: rotation.artist_name, albumTitle: rotation.album_title })
+    .from(rotation)
+    .where(isNotNull(rotation.album_id));
+  return rows
+    .filter((r): r is typeof r & { libraryId: number } => r.libraryId !== null)
+    .map((r) => ({ libraryId: r.libraryId, artistName: r.artistName, albumTitle: r.albumTitle }));
+};
+
+export const loadLibraryCandidates = async (): Promise<LibraryCandidateRow[]> => {
+  const rows = await db
+    .select({
+      libraryId: library.id,
+      artistName: library.artist_name,
+      albumArtist: library.album_artist,
+      alternateArtistName: library.alternate_artist_name,
+      albumTitle: library.album_title,
+    })
+    .from(library);
+  return rows;
+};

--- a/jobs/digital-archive-bind/classify.ts
+++ b/jobs/digital-archive-bind/classify.ts
@@ -1,0 +1,70 @@
+/**
+ * Read-only classification of a Space object key (BS#2319 §"Where"): which
+ * objects are library content worth inventorying, and which are noise the
+ * job must skip. Pure and side-effect-free so the skip rules are unit
+ * testable without touching S3.
+ *
+ * Content prefixes (issue body): `library/freeform/` (full albums,
+ * `Artist/Album/NN track.ext`), `library/recently_rotated/` (flat,
+ * `artist_-_album_-_NN_title.ext`), `rotation/{Heavy,Medium,Light,Singles}/`
+ * (flat, inconsistent). Everything else — named skip prefixes, directory
+ * markers, non-audio extensions, or simply outside those prefixes — is
+ * skipped and reported, never silently dropped (the run summary counts each
+ * skip reason).
+ *
+ * codec allowlist is `[mp3, aac, flac, m4a, wav]` (wxyc-shared 1.50.0 /
+ * `digital_asset_file.codec`, pinned by issue comment 4 — m4a and wav are IN
+ * SCOPE, not skipped, despite an earlier draft of the skip list).
+ */
+
+export type SkipReason = 'directory-marker' | 'skip-prefix' | 'non-audio-extension' | 'not-content-prefix';
+
+export type ContentKind = 'freeform' | 'recently_rotated' | 'rotation_bin';
+
+export type ClassifiedObject =
+  { kind: 'skip'; reason: SkipReason } | { kind: 'content'; contentKind: ContentKind; codec: string };
+
+/** `digital_asset_file.codec` vocabulary, keyed by lowercased file extension. */
+export const AUDIO_EXTENSION_CODEC: Readonly<Record<string, string>> = {
+  mp3: 'mp3',
+  aac: 'aac',
+  flac: 'flac',
+  m4a: 'm4a',
+  wav: 'wav',
+};
+
+/** Non-library-content prefixes named explicitly in the issue body. */
+const SKIP_PREFIXES: readonly string[] = ['.albumart/', '.covers/', '.waveforms/', 'station IDs/', 'test/', 'shows/'];
+
+const ROTATION_BINS: readonly string[] = ['Heavy', 'Medium', 'Light', 'Singles'];
+
+const FREEFORM_PREFIX = 'library/freeform/';
+const RECENTLY_ROTATED_PREFIX = 'library/recently_rotated/';
+
+export const classifyObjectKey = (objectKey: string): ClassifiedObject => {
+  if (objectKey.endsWith('/')) return { kind: 'skip', reason: 'directory-marker' };
+  if (SKIP_PREFIXES.some((prefix) => objectKey.startsWith(prefix))) {
+    return { kind: 'skip', reason: 'skip-prefix' };
+  }
+
+  const extensionMatch = /\.([a-zA-Z0-9]+)$/.exec(objectKey);
+  const extension = extensionMatch ? extensionMatch[1].toLowerCase() : '';
+  const codec = AUDIO_EXTENSION_CODEC[extension];
+  if (!codec) return { kind: 'skip', reason: 'non-audio-extension' };
+
+  if (objectKey.startsWith(FREEFORM_PREFIX)) return { kind: 'content', contentKind: 'freeform', codec };
+  if (objectKey.startsWith(RECENTLY_ROTATED_PREFIX)) return { kind: 'content', contentKind: 'recently_rotated', codec };
+  for (const bin of ROTATION_BINS) {
+    if (objectKey.startsWith(`rotation/${bin}/`)) return { kind: 'content', contentKind: 'rotation_bin', codec };
+  }
+
+  return { kind: 'skip', reason: 'not-content-prefix' };
+};
+
+/**
+ * Match precedence (issue step 4): rotation-derived prefixes
+ * (`recently_rotated/`, `rotation/{bin}/`) match against `rotation` first;
+ * `freeform/` matches against `library`.
+ */
+export const isRotationDerived = (contentKind: ContentKind): boolean =>
+  contentKind === 'recently_rotated' || contentKind === 'rotation_bin';

--- a/jobs/digital-archive-bind/csv.ts
+++ b/jobs/digital-archive-bind/csv.ts
@@ -1,0 +1,149 @@
+/**
+ * Review CSV round trip (BS#2319 step 5). No external CSV dependency --
+ * eleven fixed columns don't earn one, and a hand-rolled RFC4180-ish
+ * encode/decode is easy to keep correct for the one hazard that matters
+ * here: artist/album titles routinely carry commas.
+ *
+ * `--export <path>` writes one row per `needs_review` asset: asset id, the
+ * raw tags the bind decision was made against, the proposed library id +
+ * artist/title, `bind_note`, and which content prefix it came from. Two
+ * columns are the reviewer's to fill: `decision` (`bound` | `rejected`) and
+ * `note`. `--import <path>` reads exactly those two columns back; every
+ * other value is round-tripped for the reviewer's benefit only and is never
+ * re-read as an instruction -- the library id, tags, etc. are not
+ * reassignable via the CSV, only accept/reject.
+ *
+ * Any `decision` value other than exactly `bound` or `rejected` (case- and
+ * whitespace-sensitive: blank, `maybe`, a stray typo) is a no-op row -- the
+ * whole point of a CSV review is that "not yet decided" is the default, and
+ * a fuzzy decision parser would risk silently transitioning a row the
+ * reviewer never actually looked at.
+ */
+
+const COLUMNS = [
+  'asset_id',
+  'library_id',
+  'disc_number',
+  'provenance',
+  'content_kind',
+  'bind_note',
+  'proposed_artist',
+  'proposed_album_title',
+  'tag_artist',
+  'tag_album',
+  'object_keys',
+  'decision',
+  'note',
+] as const;
+
+export interface ReviewRow {
+  assetId: number;
+  libraryId: number;
+  discNumber: number;
+  provenance: string;
+  contentKind: string;
+  bindNote: string;
+  proposedArtist: string;
+  proposedAlbumTitle: string;
+  tagArtist: string;
+  tagAlbum: string;
+  objectKeys: string[];
+}
+
+export interface ReviewDecision {
+  assetId: number;
+  decision: 'bound' | 'rejected';
+  note: string;
+}
+
+const OBJECT_KEY_SEPARATOR = '; ';
+
+const csvField = (value: string): string => (/[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value);
+
+export const exportReviewCsv = (rows: readonly ReviewRow[]): string => {
+  const lines = [COLUMNS.join(',')];
+  for (const row of rows) {
+    const cells = [
+      String(row.assetId),
+      String(row.libraryId),
+      String(row.discNumber),
+      row.provenance,
+      row.contentKind,
+      row.bindNote,
+      row.proposedArtist,
+      row.proposedAlbumTitle,
+      row.tagArtist,
+      row.tagAlbum,
+      row.objectKeys.join(OBJECT_KEY_SEPARATOR),
+      '', // decision -- the reviewer's to fill
+      '', // note -- the reviewer's to fill
+    ];
+    lines.push(cells.map(csvField).join(','));
+  }
+  return lines.join('\n');
+};
+
+/** One logical CSV row -> its raw string cells, honoring quoted commas/newlines. */
+const parseCsvRows = (text: string): string[][] => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"' && text[i + 1] === '"') {
+        cell += '"';
+        i++;
+      } else if (c === '"') {
+        inQuotes = false;
+      } else {
+        cell += c;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      row.push(cell);
+      cell = '';
+    } else if (c === '\n' || c === '\r') {
+      if (c === '\r' && text[i + 1] === '\n') i++;
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = '';
+    } else {
+      cell += c;
+    }
+  }
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows.filter((r) => !(r.length === 1 && r[0] === ''));
+};
+
+export const importReviewCsv = (csvText: string): ReviewDecision[] => {
+  const rows = parseCsvRows(csvText);
+  if (rows.length === 0) return [];
+
+  const header = rows[0];
+  const assetIdIdx = header.indexOf('asset_id');
+  const decisionIdx = header.indexOf('decision');
+  const noteIdx = header.indexOf('note');
+  if (assetIdIdx === -1 || decisionIdx === -1) return [];
+
+  const decisions: ReviewDecision[] = [];
+  for (const cells of rows.slice(1)) {
+    const rawDecision = cells[decisionIdx];
+    if (rawDecision !== 'bound' && rawDecision !== 'rejected') continue;
+
+    const assetId = Number.parseInt(cells[assetIdIdx], 10);
+    if (!Number.isInteger(assetId)) continue;
+
+    decisions.push({ assetId, decision: rawDecision, note: noteIdx === -1 ? '' : (cells[noteIdx] ?? '') });
+  }
+  return decisions;
+};

--- a/jobs/digital-archive-bind/group.ts
+++ b/jobs/digital-archive-bind/group.ts
@@ -1,0 +1,65 @@
+/**
+ * Album grouping (BS#2319 step 3): files sharing normalized
+ * `(album_artist ?? artist, album)` become one candidate album, further
+ * split by disc number since `digital_asset`'s unique key is
+ * `(library_id, provenance, disc_number)`.
+ *
+ * Content kind is part of the grouping key too, even though the issue's
+ * grouping step doesn't name it: `contentKind` decides which table the
+ * matcher tries (`rotation` vs `library`, step 4), and two objects that
+ * happen to share tags but live under different content prefixes are
+ * physically different uploads, not the same album split across
+ * directories in practice.
+ */
+
+import { albumGroupKey, artistFoldKey } from './normalize.js';
+import type { CandidateAlbum, InventoryFile } from './types.js';
+import { normalizeAlbumTitle } from '@wxyc/database';
+
+export interface GroupResult {
+  albums: CandidateAlbum[];
+  /** Files whose tags carry no usable artist AND album -- can't be grouped. */
+  ungroupable: InventoryFile[];
+}
+
+const isBlank = (s: string | null | undefined): boolean => !s || s.trim().length === 0;
+
+export const groupIntoAlbums = (files: readonly InventoryFile[]): GroupResult => {
+  const groups = new Map<string, CandidateAlbum>();
+  const ungroupable: InventoryFile[] = [];
+
+  for (const file of files) {
+    const { tags } = file;
+    const artist = tags.albumArtist ?? tags.artist;
+    if (isBlank(artist) || isBlank(tags.album)) {
+      ungroupable.push(file);
+      continue;
+    }
+
+    const discNumber = tags.disc ?? 1;
+    const key = `${file.contentKind}::${albumGroupKey(tags.albumArtist, tags.artist, tags.album)}::disc${discNumber}`;
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.files.push(file);
+      continue;
+    }
+
+    groups.set(key, {
+      contentKind: file.contentKind,
+      artistFoldKey: artistFoldKey(artist),
+      albumNormKey: normalizeAlbumTitle(tags.album),
+      discNumber,
+      displayArtist: artist as string,
+      displayAlbum: tags.album as string,
+      files: [file],
+    });
+  }
+
+  const albums = [...groups.values()];
+  for (const album of albums) {
+    album.files.sort((a, b) => (a.tags.track ?? 0) - (b.tags.track ?? 0) || a.objectKey.localeCompare(b.objectKey));
+  }
+
+  return { albums, ungroupable };
+};

--- a/jobs/digital-archive-bind/id3.ts
+++ b/jobs/digital-archive-bind/id3.ts
@@ -163,7 +163,13 @@ export const parseId3v2 = (buf: Buffer): Id3Tags => {
     const truncated = bodyEnd - bodyStart < frameSize;
 
     const field = WANTED_FRAMES[frameId];
-    if (field) {
+    // A frame whose body the ranged GET cut short is DROPPED, never
+    // half-decoded. Assigning the partial text would put a silently wrong
+    // value into grouping and fuzzy matching -- "Artist Whose Tag Overruns"
+    // arriving as "Art" would split an album across two groups, or match the
+    // wrong library row, with nothing to indicate it happened. A null is
+    // merely `ungroupable`, which the report surfaces. Fail closed.
+    if (field && !truncated) {
       const text = decodeTextFrame(buf.subarray(bodyStart, bodyEnd));
       if (text.length > 0) {
         if (NUMERIC_FIELDS.has(field)) {

--- a/jobs/digital-archive-bind/id3.ts
+++ b/jobs/digital-archive-bind/id3.ts
@@ -1,0 +1,183 @@
+/**
+ * Minimal ID3v2 tag parser (BS#2319 "no-key fallback"): reads the leading
+ * bytes of a `store.ts` 256KB ranged GET and extracts the seven frames the
+ * job needs -- TIT2/TPE1/TALB/TPE2/TRCK/TPOS/TLEN -- without pulling in a
+ * third-party ID3 library.
+ *
+ * Scope is ID3v2.3 and ID3v2.4 (4-byte frame IDs, matching the frame names
+ * the issue names verbatim). ID3v2.2 (3-byte IDs like TT2) is out of scope
+ * -- unrecognized major versions degrade to all-null tags rather than
+ * throwing, since a file this job can't tag-read is simply reported
+ * unmatched, not a crash.
+ *
+ * Total over its input by construction: every read is bounds-checked
+ * against the buffer length, so a 256KB-truncated ranged GET (a tag whose
+ * declared size exceeds what was fetched) yields whatever frames fit in the
+ * bytes actually read rather than throwing.
+ */
+
+export interface Id3Tags {
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  albumArtist: string | null;
+  track: number | null;
+  disc: number | null;
+  durationMs: number | null;
+}
+
+const emptyTags = (): Id3Tags => ({
+  title: null,
+  artist: null,
+  album: null,
+  albumArtist: null,
+  track: null,
+  disc: null,
+  durationMs: null,
+});
+
+/** Frame IDs this job reads, mapped to their `Id3Tags` field. */
+const WANTED_FRAMES: Readonly<Record<string, keyof Id3Tags>> = {
+  TIT2: 'title',
+  TPE1: 'artist',
+  TALB: 'album',
+  TPE2: 'albumArtist',
+  TRCK: 'track',
+  TPOS: 'disc',
+  TLEN: 'durationMs',
+};
+
+const NUMERIC_FIELDS = new Set<keyof Id3Tags>(['track', 'disc', 'durationMs']);
+
+const FRAME_ID_PATTERN = /^[A-Z0-9]{4}$/;
+
+const readSynchsafe = (buf: Buffer, offset: number): number =>
+  ((buf[offset] & 0x7f) << 21) |
+  ((buf[offset + 1] & 0x7f) << 14) |
+  ((buf[offset + 2] & 0x7f) << 7) |
+  (buf[offset + 3] & 0x7f);
+
+/** v2.3 frame sizes are plain big-endian; v2.4 frame sizes are synchsafe. */
+const readFrameSize = (buf: Buffer, offset: number, major: number): number =>
+  major >= 4 ? readSynchsafe(buf, offset) : buf.readUInt32BE(offset);
+
+const swapUtf16 = (buf: Buffer): Buffer => {
+  const evenLength = buf.length - (buf.length % 2);
+  const out = Buffer.alloc(evenLength);
+  for (let i = 0; i < evenLength; i += 2) {
+    out[i] = buf[i + 1];
+    out[i + 1] = buf[i];
+  }
+  return out;
+};
+
+/**
+ * Decode a text-information frame body: leading encoding byte (0 latin1, 1
+ * UTF-16 with BOM, 2 UTF-16BE without BOM, 3 UTF-8), trailing NUL padding
+ * and whitespace stripped.
+ */
+const decodeTextFrame = (body: Buffer): string => {
+  if (body.length === 0) return '';
+  const encoding = body[0];
+  const raw = body.subarray(1);
+
+  let text: string;
+  switch (encoding) {
+    case 0x01: {
+      // UTF-16 with a leading BOM. A BE BOM (0xFE 0xFF) needs a byte swap
+      // first -- Node has no native "utf16be" decoder.
+      const hasBeBom = raw.length >= 2 && raw[0] === 0xfe && raw[1] === 0xff;
+      const withoutBom = raw.length >= 2 ? raw.subarray(2) : raw;
+      text = (hasBeBom ? swapUtf16(withoutBom) : withoutBom).toString('utf16le');
+      break;
+    }
+    case 0x02:
+      text = swapUtf16(raw).toString('utf16le');
+      break;
+    case 0x03:
+      text = raw.toString('utf8');
+      break;
+    case 0x00:
+    default:
+      text = raw.toString('latin1');
+      break;
+  }
+
+  return stripTrailingNul(text).trim();
+};
+
+/**
+ * Trailing NUL padding is part of the ID3v2 text-frame spec, not stray
+ * whitespace -- `Buffer#toString` does not stop at a NUL byte the way a C
+ * string would, so the padding survives decode and has to be stripped
+ * explicitly. Character-code comparison rather than a regex literal
+ * containing a NUL byte, which editor/transport tooling has a habit of
+ * mangling silently.
+ */
+const NUL_CHAR_CODE = 0;
+
+const stripTrailingNul = (text: string): string => {
+  let end = text.length;
+  while (end > 0 && text.charCodeAt(end - 1) === NUL_CHAR_CODE) end--;
+  return text.slice(0, end);
+};
+
+/** TRCK/TPOS are "N" or "N/M"; TLEN is a plain millisecond count. */
+const parseLeadingInt = (text: string): number | null => {
+  const match = /^\s*(\d+)/.exec(text);
+  return match ? Number.parseInt(match[1], 10) : null;
+};
+
+export const parseId3v2 = (buf: Buffer): Id3Tags => {
+  if (buf.length < 10 || buf.toString('latin1', 0, 3) !== 'ID3') return emptyTags();
+
+  const major = buf[3];
+  if (major !== 3 && major !== 4) return emptyTags();
+
+  const flags = buf[5];
+  const tagSize = readSynchsafe(buf, 6);
+  const tagEnd = Math.min(buf.length, 10 + tagSize);
+
+  let offset = 10;
+
+  // Extended header (flag bit 0x40): skip it. v2.3's size field excludes
+  // itself; v2.4's includes itself -- best-effort, since no fixture in
+  // this job's population is known to carry one.
+  if (flags & 0x40) {
+    if (offset + 4 > buf.length) return emptyTags();
+    const extSize = major === 4 ? readSynchsafe(buf, offset) : buf.readUInt32BE(offset);
+    offset += major === 4 ? extSize : 4 + extSize;
+  }
+
+  const tags = emptyTags();
+
+  while (offset + 10 <= tagEnd && offset + 10 <= buf.length) {
+    const frameId = buf.toString('latin1', offset, offset + 4);
+    if (!FRAME_ID_PATTERN.test(frameId)) break; // padding, or not a frame at all
+
+    const frameSize = readFrameSize(buf, offset + 4, major);
+    const bodyStart = offset + 10;
+    if (bodyStart >= buf.length) break; // nothing left to read
+
+    const bodyEnd = Math.min(buf.length, bodyStart + frameSize);
+    const truncated = bodyEnd - bodyStart < frameSize;
+
+    const field = WANTED_FRAMES[frameId];
+    if (field) {
+      const text = decodeTextFrame(buf.subarray(bodyStart, bodyEnd));
+      if (text.length > 0) {
+        if (NUMERIC_FIELDS.has(field)) {
+          const parsed = parseLeadingInt(text);
+          if (parsed !== null) (tags as unknown as Record<string, number>)[field] = parsed;
+        } else {
+          (tags as unknown as Record<string, string>)[field] = text;
+        }
+      }
+    }
+
+    if (truncated) break; // this was the last frame the ranged GET could reach
+    offset = bodyEnd;
+  }
+
+  return tags;
+};

--- a/jobs/digital-archive-bind/job.ts
+++ b/jobs/digital-archive-bind/job.ts
@@ -1,0 +1,118 @@
+/**
+ * One-shot CLI entrypoint (BS#2319): inventory the AzuraCast DigitalOcean
+ * Space, group + match files into albums, and write `digital_asset`
+ * (`needs_review`) + `digital_asset_file` candidate rows for human review.
+ * Dry-run by default; `--apply` writes.
+ *
+ * Four modes, mutually exclusive:
+ *   (no flags)                the inventory/match dry run -- reports what
+ *                              WOULD be written, writes nothing.
+ *   --apply                   the same run, for real.
+ *   --apply --rebind-keys F   the same run, and object keys listed in file
+ *                              F re-open their slot even if it's `rejected`
+ *                              (the merge.ts collision-DELETE recovery path;
+ *                              never overrides a `bound` slot).
+ *   --export <path>           write every `needs_review` asset to a review
+ *                              CSV. No inventory scan, no S3 access.
+ *   --import <path>           read a reviewed CSV back and flip exactly the
+ *                              rows marked `bound`/`rejected`. No inventory
+ *                              scan, no S3 access.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { captureError, closeLogger, initLogger, log } from './logger.js';
+import { runInventoryAndBind, closeDatabase } from './orchestrate.js';
+import { formatSummary } from './report.js';
+import { exportReviewCsv, importReviewCsv } from './csv.js';
+import { applyReviewDecisions } from './write.js';
+import { loadNeedsReviewRows } from './review.js';
+
+const JOB_NAME = 'digital-archive-bind';
+
+const flagValue = (name: string): string | undefined => {
+  const args = process.argv.slice(2);
+  const i = args.indexOf(name);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const hasFlag = (name: string): boolean => process.argv.slice(2).includes(name);
+
+const loadRebindKeys = (path: string): Set<string> => {
+  const text = readFileSync(path, 'utf8');
+  const keys = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+  return new Set(keys);
+};
+
+const runExport = async (outPath: string): Promise<void> => {
+  const rows = await loadNeedsReviewRows();
+  writeFileSync(outPath, exportReviewCsv(rows));
+  log('info', 'export', `wrote ${rows.length} needs_review row(s) to ${outPath}`, { rows: rows.length, path: outPath });
+};
+
+const runImport = async (inPath: string): Promise<void> => {
+  const text = readFileSync(inPath, 'utf8');
+  const decisions = importReviewCsv(text);
+  const result = await applyReviewDecisions(decisions);
+  log('info', 'import', `applied ${result.rowsUpdated} decision(s) from ${inPath}`, {
+    bound_attempted: result.boundAttempted,
+    rejected_attempted: result.rejectedAttempted,
+    rows_updated: result.rowsUpdated,
+    path: inPath,
+  });
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    const exportPath = flagValue('--export');
+    const importPath = flagValue('--import');
+
+    if (exportPath) {
+      await runExport(exportPath);
+      return;
+    }
+    if (importPath) {
+      await runImport(importPath);
+      return;
+    }
+
+    const apply = hasFlag('--apply');
+    const rebindKeysPath = flagValue('--rebind-keys');
+    const rebindKeys = rebindKeysPath ? loadRebindKeys(rebindKeysPath) : new Set<string>();
+
+    log('info', 'init', `${JOB_NAME} initialized`, { apply, rebind_keys_count: rebindKeys.size });
+
+    const summary = await runInventoryAndBind({ apply, rebindKeys });
+    const text = formatSummary(summary);
+    console.log(text);
+    log('info', apply ? 'apply' : 'dry_run', `${JOB_NAME} finished`, {
+      files_seen: summary.filesSeen,
+      albums_grouped: summary.albumsGrouped,
+      matched_exact: summary.matchedExact,
+      matched_fuzzy: summary.matchedFuzzy,
+      ambiguous: summary.ambiguous,
+      unmatched: summary.unmatched,
+      inserted: summary.inserted,
+      reopened: summary.reopened,
+      rejected_blocked: summary.rejectedBlocked.length,
+      bound_drift: summary.boundDrift.length,
+      same_run_collision: summary.sameRunCollision.length,
+    });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabase();
+    await closeLogger();
+  }
+};
+
+// Guard the auto-invoke so the unit suite's module load doesn't fire a
+// stray run against the mocked DB. Mirrors `jobs/artwork-provenance-remediation/job.ts`.
+if (process.env.NODE_ENV !== 'test') {
+  void main();
+}

--- a/jobs/digital-archive-bind/logger.ts
+++ b/jobs/digital-archive-bind/logger.ts
@@ -1,0 +1,76 @@
+/**
+ * Observability for digital-archive-bind: Sentry init + JSON logs.
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/logger.ts` verbatim — every
+ * one-shot job carries its own copy so its build graph is independent of
+ * sibling jobs. Phase A foundation contract (issue #538): every log line
+ * carries the four tags `repo`, `tool`, `step`, `run_id`.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 1;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/digital-archive-bind/match.ts
+++ b/jobs/digital-archive-bind/match.ts
@@ -1,0 +1,108 @@
+/**
+ * Matcher (BS#2319 step 4): resolve a `CandidateAlbum` to exactly one
+ * `library.id`, against `rotation` for rotation-derived content and against
+ * `library` for `freeform/` content (`classify.isRotationDerived` decides
+ * which caller uses which).
+ *
+ * Two tiers, EXACT then FUZZY, exact-first is load-bearing (the
+ * `jobs/album-reviews-etl/link.ts` precedent this mirrors): the fuzzy tier
+ * is strictly a coarsening of the exact one, so an ambiguity the exact tier
+ * already sees can only stay ambiguous or resolve wrongly if fuzzy-matched
+ * anyway -- it must never be given the chance. An exact-tier ambiguity is
+ * therefore returned immediately, without trying fuzzy at all.
+ *
+ * "Fuzzy" here is deterministic punctuation/diacritic folding
+ * (`relaxedAlbumKey`), never a similarity score -- see `normalize.ts`'s
+ * header for why a scored matcher was deliberately not built.
+ */
+
+import { normalizeAlbumTitle } from '@wxyc/database';
+import { artistFoldKey, relaxedAlbumKey } from './normalize.js';
+import type { CandidateAlbum, MatchResult } from './types.js';
+
+export interface RotationCandidateRow {
+  libraryId: number;
+  artistName: string | null;
+  albumTitle: string | null;
+}
+
+export interface LibraryCandidateRow {
+  libraryId: number;
+  artistName: string | null;
+  albumArtist: string | null;
+  alternateArtistName: string | null;
+  albumTitle: string | null;
+}
+
+const distinctLibraryIds = (ids: readonly number[]): number[] => [...new Set(ids)];
+
+const resolveFromIds = (ids: readonly number[], tier: 'exact' | 'fuzzy'): MatchResult | null => {
+  const distinct = distinctLibraryIds(ids);
+  if (distinct.length === 0) return null;
+  if (distinct.length > 1) return { kind: 'ambiguous', libraryIds: distinct };
+  return { kind: 'matched', libraryId: distinct[0], tier, note: tier === 'exact' ? 'exact' : 'fuzzy:relaxed-key' };
+};
+
+export const matchRotation = (candidate: CandidateAlbum, rows: readonly RotationCandidateRow[]): MatchResult => {
+  const exactIds = rows
+    .filter(
+      (r) =>
+        foldEq(r.artistName, candidate.artistFoldKey) && r.albumTitle && normEq(r.albumTitle, candidate.albumNormKey)
+    )
+    .map((r) => r.libraryId);
+  const exact = resolveFromIds(exactIds, 'exact');
+  if (exact) return exact;
+
+  const fuzzyIds = rows
+    .filter(
+      (r) =>
+        foldEq(r.artistName, candidate.artistFoldKey) &&
+        r.albumTitle &&
+        relaxedAlbumKey(r.albumTitle) === relaxedAlbumKeyForCandidate(candidate)
+    )
+    .map((r) => r.libraryId);
+  const fuzzy = resolveFromIds(fuzzyIds, 'fuzzy');
+  if (fuzzy) return fuzzy;
+
+  return { kind: 'unmatched' };
+};
+
+export const matchLibrary = (candidate: CandidateAlbum, rows: readonly LibraryCandidateRow[]): MatchResult => {
+  const exactIds = rows
+    .filter(
+      (r) =>
+        (foldEq(r.artistName, candidate.artistFoldKey) || foldEq(r.albumArtist, candidate.artistFoldKey)) &&
+        r.albumTitle &&
+        normEq(r.albumTitle, candidate.albumNormKey)
+    )
+    .map((r) => r.libraryId);
+  const exact = resolveFromIds(exactIds, 'exact');
+  if (exact) return exact;
+
+  const candidateRelaxed = relaxedAlbumKeyForCandidate(candidate);
+  const fuzzyIds = rows
+    .filter(
+      (r) =>
+        (foldEq(r.artistName, candidate.artistFoldKey) ||
+          foldEq(r.albumArtist, candidate.artistFoldKey) ||
+          foldEq(r.alternateArtistName, candidate.artistFoldKey)) &&
+        r.albumTitle &&
+        relaxedAlbumKey(r.albumTitle) === candidateRelaxed
+    )
+    .map((r) => r.libraryId);
+  const fuzzy = resolveFromIds(fuzzyIds, 'fuzzy');
+  if (fuzzy) return fuzzy;
+
+  return { kind: 'unmatched' };
+};
+
+// `candidate.artistFoldKey` is already a fold key; `row.artistName` is raw
+// text straight from the DB, so it needs folding at compare time.
+const foldEq = (raw: string | null, candidateFoldKey: string): boolean => artistFoldKey(raw) === candidateFoldKey;
+
+const normEq = (raw: string, candidateNormKey: string): boolean => normalizeAlbumTitle(raw) === candidateNormKey;
+
+// `candidate.albumNormKey` is already `normalizeAlbumTitle` output;
+// `relaxedAlbumKey` further folds it -- computed once per candidate call
+// rather than once per row, matching `link.ts`'s "once per candidate" note.
+const relaxedAlbumKeyForCandidate = (candidate: CandidateAlbum): string => relaxedAlbumKey(candidate.albumNormKey);

--- a/jobs/digital-archive-bind/normalize.ts
+++ b/jobs/digital-archive-bind/normalize.ts
@@ -1,0 +1,50 @@
+/**
+ * Job-local normalization keys for grouping and matching (BS#2319 step 3/4).
+ *
+ * THE FOLD IS IMPORTED, NOT REIMPLEMENTED -- the same
+ * `jobs/album-reviews-etl/link.ts` `relaxedAlbumKey` precedent this job
+ * follows verbatim. `foldArtistName` (NFD, strip combining marks, lowercase
+ * -- the SQL twin of `wxyc_schema.fold_artist_name`) and `normalizeAlbumTitle`
+ * (lowercase, drop featuring/edition cruft, collapse whitespace) are both
+ * exported by `@wxyc/database`; only the punctuation collapse below is
+ * job-local.
+ *
+ * The grouping key and the matcher's EXACT tier both compare
+ * `foldArtistName(artist)` + `normalizeAlbumTitle(album)`. The matcher's
+ * FUZZY tier additionally folds the album leg through `relaxedAlbumKey`
+ * (reduce every run of non-alphanumerics to a single separator), exactly the
+ * two-tier shape `link.ts` measured on prod: +146 links, zero new ambiguity,
+ * and explicitly NOT a trigram/similarity score -- that was measured and
+ * REJECTED there (false positives at 0.84-0.88 similarity on sequel titles
+ * like "Black Metal 2" -> "Black Metal"). This job reuses that same
+ * conservative, deterministic two-tier shape rather than re-deriving a
+ * scored fuzzy matcher from the issue body's looser "score in bind_note"
+ * language -- the codebase's own measured precedent for this exact problem
+ * postdates and supersedes it.
+ */
+
+import { foldArtistName, normalizeAlbumTitle } from '@wxyc/database';
+
+const NON_ALPHANUMERIC_RUN = /[^\p{L}\p{N}]+/gu;
+
+export const relaxedAlbumKey = (normalizedTitle: string | null | undefined): string =>
+  foldArtistName(normalizedTitle ?? '')
+    .replace(NON_ALPHANUMERIC_RUN, ' ')
+    .trim();
+
+/** Fold key for the grouping/matching artist leg. */
+export const artistFoldKey = (artist: string | null | undefined): string => foldArtistName(artist ?? '');
+
+/**
+ * Grouping key for step 3: normalized `(album_artist ?? artist, album)`.
+ * `::` is safe as a separator -- neither leg can contain it after folding.
+ */
+export const albumGroupKey = (
+  albumArtist: string | null | undefined,
+  artist: string | null | undefined,
+  album: string | null | undefined
+): string => {
+  const artistPart = artistFoldKey(albumArtist ?? artist);
+  const albumPart = normalizeAlbumTitle(album ?? '');
+  return `${artistPart}::${albumPart}`;
+};

--- a/jobs/digital-archive-bind/orchestrate.ts
+++ b/jobs/digital-archive-bind/orchestrate.ts
@@ -1,0 +1,156 @@
+/**
+ * Whole-run orchestration for the inventory/match/write pipeline
+ * (`--apply` / `--rebind-keys`). `--export`/`--import` are separate
+ * commands in `job.ts` that skip this module entirely -- they read/write
+ * `digital_asset` directly via `review.ts`, independent of any inventory
+ * scan.
+ *
+ * Everything the write phase needs is gathered into memory BEFORE
+ * `write.ts` is called (comment 3's other half of the watermark
+ * constraint): the S3 walk + tag reads + matching happen first, with no
+ * open transaction, and the DB write is the last, short step.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { loadLibraryCandidates, loadRotationCandidates } from './candidates.js';
+import { classifyObjectKey, isRotationDerived } from './classify.js';
+import { groupIntoAlbums } from './group.js';
+import { matchLibrary, matchRotation } from './match.js';
+import type { RunSummary } from './report.js';
+import { createStoreClient, listAllObjects, loadStoreConfigFromEnv, md5FromETag } from './store.js';
+import { fetchAzuraCastTags, resolveTagsForFile } from './tags.js';
+import type { CandidateAlbum, InventoryFile, MatchedAlbum } from './types.js';
+import { ensureStore, executeWrites, loadBoundFileKeys, loadExistingSlots, planWrites } from './write.js';
+
+export interface RunOptions {
+  apply: boolean;
+  rebindKeys: ReadonlySet<string>;
+}
+
+const AZURACAST_BASE_URL = process.env.AZURACAST_BASE_URL || 'https://remote.wxyc.org';
+
+const buildInventory = async (): Promise<{ files: InventoryFile[]; skippedByReason: Record<string, number> }> => {
+  const storeConfig = loadStoreConfigFromEnv();
+  const client = createStoreClient(storeConfig);
+
+  const azuraCastTags = process.env.AZURACAST_API_KEY
+    ? await fetchAzuraCastTags(AZURACAST_BASE_URL, process.env.AZURACAST_API_KEY)
+    : null;
+
+  const skippedByReason: Record<string, number> = {};
+  const files: InventoryFile[] = [];
+
+  for await (const object of listAllObjects(client, storeConfig.bucket)) {
+    const classified = classifyObjectKey(object.key);
+    if (classified.kind === 'skip') {
+      skippedByReason[classified.reason] = (skippedByReason[classified.reason] ?? 0) + 1;
+      continue;
+    }
+
+    const tags = await resolveTagsForFile(client, storeConfig.bucket, object.key, azuraCastTags);
+    files.push({
+      objectKey: object.key,
+      contentKind: classified.contentKind,
+      codec: classified.codec,
+      bytes: object.bytes,
+      md5: md5FromETag(object.etag),
+      tags,
+    });
+  }
+
+  return { files, skippedByReason };
+};
+
+const matchAlbums = async (
+  albums: readonly CandidateAlbum[]
+): Promise<{
+  matched: MatchedAlbum[];
+  matchedExact: number;
+  matchedFuzzy: number;
+  ambiguous: number;
+  unmatched: number;
+}> => {
+  const [rotationCandidates, libraryCandidates] = await Promise.all([
+    loadRotationCandidates(),
+    loadLibraryCandidates(),
+  ]);
+
+  const matched: MatchedAlbum[] = [];
+  let matchedExact = 0;
+  let matchedFuzzy = 0;
+  let ambiguous = 0;
+  let unmatched = 0;
+
+  for (const album of albums) {
+    const result = isRotationDerived(album.contentKind)
+      ? matchRotation(album, rotationCandidates)
+      : matchLibrary(album, libraryCandidates);
+    if (result.kind === 'matched') {
+      matched.push({ candidate: album, libraryId: result.libraryId, tier: result.tier, bindNote: result.note });
+      if (result.tier === 'exact') matchedExact++;
+      else matchedFuzzy++;
+    } else if (result.kind === 'ambiguous') {
+      ambiguous++;
+    } else {
+      unmatched++;
+    }
+  }
+
+  return { matched, matchedExact, matchedFuzzy, ambiguous, unmatched };
+};
+
+export const runInventoryAndBind = async (options: RunOptions): Promise<RunSummary> => {
+  const { files, skippedByReason } = await buildInventory();
+  const { albums, ungroupable } = groupIntoAlbums(files);
+  const { matched, matchedExact, matchedFuzzy, ambiguous, unmatched } = await matchAlbums(albums);
+
+  let inserted = 0;
+  let reopened = 0;
+  let rejectedBlocked: import('./write.js').RejectedBlocked[] = [];
+  let boundDrift: import('./write.js').BoundDrift[] = [];
+  let sameRunCollision: import('./write.js').SameRunCollision[] = [];
+
+  if (matched.length > 0) {
+    const libraryIds = [...new Set(matched.map((m) => m.libraryId))];
+    const existingSlots = await loadExistingSlots(libraryIds);
+    const boundAssetIds = existingSlots.filter((s) => s.status === 'bound').map((s) => s.id);
+    const boundFileKeys = await loadBoundFileKeys(boundAssetIds);
+
+    const plan = planWrites(matched, existingSlots, boundFileKeys, options.rebindKeys);
+    rejectedBlocked = plan.rejectedBlocked;
+    boundDrift = plan.boundDrift;
+    sameRunCollision = plan.sameRunCollision;
+
+    if (options.apply) {
+      const storeId = await ensureStore();
+      const counts = await executeWrites(plan, storeId);
+      inserted = counts.inserted;
+      reopened = counts.reopened;
+    } else {
+      inserted = plan.toInsert.length;
+      reopened = plan.rejectedReopened.length;
+    }
+  }
+
+  const totalSkipped = Object.values(skippedByReason).reduce((a, b) => a + b, 0);
+
+  return {
+    mode: options.apply ? 'apply' : 'dry-run',
+    filesSeen: files.length + totalSkipped,
+    skippedByReason,
+    albumsGrouped: albums.length,
+    ungroupableFiles: ungroupable.length,
+    matchedExact,
+    matchedFuzzy,
+    ambiguous,
+    unmatched,
+    inserted,
+    reopened,
+    rejectedBlocked,
+    boundDrift,
+    sameRunCollision,
+  };
+};
+
+/** Re-exported so `job.ts` doesn't need its own `@wxyc/database` import just for teardown. */
+export const closeDatabase = closeDatabaseConnection;

--- a/jobs/digital-archive-bind/package.json
+++ b/jobs/digital-archive-bind/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/digital-archive-bind",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot inventory + bind job (BS#2319, epic WXYC/wxyc-dj-ios#135 digital archive): read-only scan of the AzuraCast DigitalOcean Space, group files into albums by ID3 tag, match against rotation/library, and write digital_asset(needs_review) + digital_asset_file candidate rows for human review via a CSV round-trip. Dry-run by default; --apply writes.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_digital_archive_bind:ci -f ../../Dockerfile.digital-archive-bind ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1121.0",
+    "@sentry/node": "^10.70.0",
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/digital-archive-bind/report.ts
+++ b/jobs/digital-archive-bind/report.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure formatter for the run summary (step 6: "a summary report (files seen
+ * / skipped by rule / grouped albums / exact / fuzzy / unmatched, by
+ * prefix)"). Kept separate from `orchestrate.ts` so the output shape is
+ * unit-testable without a database or an S3 client.
+ */
+
+import type { BoundDrift, RejectedBlocked, SameRunCollision } from './write.js';
+
+export interface RunSummary {
+  mode: 'dry-run' | 'apply';
+  filesSeen: number;
+  skippedByReason: Record<string, number>;
+  albumsGrouped: number;
+  ungroupableFiles: number;
+  matchedExact: number;
+  matchedFuzzy: number;
+  ambiguous: number;
+  unmatched: number;
+  inserted: number;
+  reopened: number;
+  rejectedBlocked: RejectedBlocked[];
+  boundDrift: BoundDrift[];
+  sameRunCollision: SameRunCollision[];
+}
+
+export const formatSummary = (summary: RunSummary): string => {
+  const lines: string[] = [];
+  lines.push(`=== digital-archive-bind (${summary.mode.toUpperCase()}) ===`);
+  lines.push(`files seen:        ${summary.filesSeen}`);
+  for (const [reason, count] of Object.entries(summary.skippedByReason).sort()) {
+    lines.push(`  skipped (${reason}): ${count}`);
+  }
+  lines.push(`albums grouped:    ${summary.albumsGrouped}`);
+  lines.push(`ungroupable files: ${summary.ungroupableFiles}`);
+  lines.push(`matched exact:     ${summary.matchedExact}`);
+  lines.push(`matched fuzzy:     ${summary.matchedFuzzy}`);
+  lines.push(`ambiguous:         ${summary.ambiguous}`);
+  lines.push(`unmatched:         ${summary.unmatched}`);
+  lines.push(
+    summary.mode === 'apply'
+      ? `inserted (needs_review): ${summary.inserted}`
+      : `would insert (needs_review): ${summary.inserted}`
+  );
+  if (summary.reopened > 0 || summary.rejectedBlocked.length > 0) {
+    lines.push(
+      summary.mode === 'apply'
+        ? `reopened (--rebind-keys): ${summary.reopened}`
+        : `would reopen (--rebind-keys): ${summary.reopened}`
+    );
+  }
+
+  if (summary.rejectedBlocked.length > 0) {
+    lines.push('');
+    lines.push(
+      `blocked by a prior rejection (${summary.rejectedBlocked.length}) -- rerun with --rebind-keys to override:`
+    );
+    for (const r of summary.rejectedBlocked) {
+      lines.push(`  library_id=${r.libraryId} disc=${r.discNumber}: ${r.objectKeys.join(', ')}`);
+    }
+  }
+
+  if (summary.boundDrift.length > 0) {
+    lines.push('');
+    lines.push(
+      `bound slots whose files drifted from what's playable (${summary.boundDrift.length}) -- human call, nothing written:`
+    );
+    for (const d of summary.boundDrift) {
+      lines.push(`  asset_id=${d.assetId} library_id=${d.libraryId} disc=${d.discNumber}`);
+      lines.push(`    bound:     ${d.boundKeys.join(', ')}`);
+      lines.push(`    candidate: ${d.candidateKeys.join(', ')}`);
+    }
+  }
+
+  if (summary.sameRunCollision.length > 0) {
+    lines.push('');
+    lines.push(
+      `two candidates in this run wanted the same slot (${summary.sameRunCollision.length}) -- only the first was queued, the rest are unwritten:`
+    );
+    for (const c of summary.sameRunCollision) {
+      lines.push(`  library_id=${c.libraryId} disc=${c.discNumber}: ${c.objectKeys.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n');
+};

--- a/jobs/digital-archive-bind/review.ts
+++ b/jobs/digital-archive-bind/review.ts
@@ -1,0 +1,82 @@
+/**
+ * CSV/DB glue for step 5's `--export`/`--import`. Deliberately separate
+ * from `write.ts` (the match-write planner) -- this module reads back what
+ * was already written, on its own schedule, independent of an inventory
+ * run.
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+import { db, digital_asset, digital_asset_file, library } from '@wxyc/database';
+import { classifyObjectKey } from './classify.js';
+import type { ReviewDecision, ReviewRow } from './csv.js';
+import { PROVENANCE } from './write.js';
+
+/**
+ * Every `needs_review` asset this job owns, joined to its files and its
+ * `library` row. `content_kind` (the CSV's "prefix" column) has no column
+ * of its own on either table -- it is re-derived from an object key via
+ * `classifyObjectKey`, the same function that decided it during inventory.
+ */
+export const loadNeedsReviewRows = async (): Promise<ReviewRow[]> => {
+  const assets = await db
+    .select({
+      id: digital_asset.id,
+      libraryId: digital_asset.library_id,
+      discNumber: digital_asset.disc_number,
+      bindNote: digital_asset.bind_note,
+    })
+    .from(digital_asset)
+    .where(and(eq(digital_asset.provenance, PROVENANCE), eq(digital_asset.status, 'needs_review')));
+
+  if (assets.length === 0) return [];
+
+  const assetIds = assets.map((a) => a.id);
+  const files = await db
+    .select({
+      assetId: digital_asset_file.asset_id,
+      objectKey: digital_asset_file.object_key,
+      tagArtist: digital_asset_file.tag_artist,
+      tagAlbum: digital_asset_file.tag_album,
+    })
+    .from(digital_asset_file)
+    .where(inArray(digital_asset_file.asset_id, assetIds));
+
+  const filesByAsset = new Map<number, typeof files>();
+  for (const f of files) {
+    const list = filesByAsset.get(f.assetId) ?? [];
+    list.push(f);
+    filesByAsset.set(f.assetId, list);
+  }
+
+  const libraryIds = [...new Set(assets.map((a) => a.libraryId))];
+  const libraryRows =
+    libraryIds.length === 0
+      ? []
+      : await db
+          .select({ id: library.id, artistName: library.artist_name, albumTitle: library.album_title })
+          .from(library)
+          .where(inArray(library.id, libraryIds));
+  const libraryById = new Map(libraryRows.map((r) => [r.id, r]));
+
+  return assets.map((a) => {
+    const assetFiles = filesByAsset.get(a.id) ?? [];
+    const lib = libraryById.get(a.libraryId);
+    const classified = assetFiles[0] ? classifyObjectKey(assetFiles[0].objectKey) : null;
+
+    return {
+      assetId: a.id,
+      libraryId: a.libraryId,
+      discNumber: a.discNumber,
+      provenance: PROVENANCE,
+      contentKind: classified?.kind === 'content' ? classified.contentKind : 'unknown',
+      bindNote: a.bindNote ?? '',
+      proposedArtist: lib?.artistName ?? '',
+      proposedAlbumTitle: lib?.albumTitle ?? '',
+      tagArtist: assetFiles[0]?.tagArtist ?? '',
+      tagAlbum: assetFiles[0]?.tagAlbum ?? '',
+      objectKeys: assetFiles.map((f) => f.objectKey),
+    };
+  });
+};
+
+export type { ReviewDecision };

--- a/jobs/digital-archive-bind/store.ts
+++ b/jobs/digital-archive-bind/store.ts
@@ -52,8 +52,7 @@ const requireEnv = (name: string): string => {
  * back to `us-east-1` rather than throwing.
  */
 export const loadStoreConfigFromEnv = (): StoreConfig => {
-  const endpoint =
-    process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT || 'https://nyc3.digitaloceanspaces.com';
+  const endpoint = process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT || 'https://nyc3.digitaloceanspaces.com';
   return {
     endpoint,
     region: new URL(endpoint).hostname.split('.')[0] || 'us-east-1',

--- a/jobs/digital-archive-bind/store.ts
+++ b/jobs/digital-archive-bind/store.ts
@@ -32,17 +32,36 @@ const requireEnv = (name: string): string => {
 
 /**
  * `digital_asset_store.name` is `'azuracast'` (issue comment 1), so its
- * store-scoped env vars are `DIGITAL_ARCHIVE_STORE_AZURACAST_*` --
- * `WXYC/Backend-Service#2320`'s allowlist convention, which this job's
- * writer has to agree with.
+ * store-scoped env vars are `DIGITAL_ARCHIVE_STORE_AZURACAST_*`.
+ *
+ * **The four names below are `#2320`'s, exactly** -- `_ENDPOINT` / `_BUCKET`
+ * / `_KEY_ID` / `_SECRET`, matching `readStoreEnvConfig` in
+ * `apps/backend/services/digital-archive-store.service.ts`. That agreement is
+ * operational, not cosmetic: `.github/workflows/set-ec2-env-var.yml` carries
+ * an **allowlist** of names it will push to EC2, and only those four are on
+ * it. A reader-specific spelling (this job once used `_ACCESS_KEY_ID` /
+ * `_SECRET_ACCESS_KEY`) has no provisioning path at all, so an operator who
+ * followed `docs/env-vars.md`'s light-up procedure would have the secrets set
+ * and still hit `… is not configured` before listing a single object.
+ *
+ * `region` is likewise **derived from the endpoint** rather than read from a
+ * fifth var, for the same reason and by the same rule as the presigner: a
+ * DigitalOcean Spaces endpoint is `https://<region>.digitaloceanspaces.com`,
+ * so the region SigV4 needs is that first host label. Region only shapes the
+ * signature, never which bucket is hit, so an unrecognized host shape falls
+ * back to `us-east-1` rather than throwing.
  */
-export const loadStoreConfigFromEnv = (): StoreConfig => ({
-  endpoint: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT || 'https://nyc3.digitaloceanspaces.com',
-  region: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_REGION || 'nyc3',
-  bucket: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET || 'wxyc',
-  accessKeyId: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_ACCESS_KEY_ID'),
-  secretAccessKey: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET_ACCESS_KEY'),
-});
+export const loadStoreConfigFromEnv = (): StoreConfig => {
+  const endpoint =
+    process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT || 'https://nyc3.digitaloceanspaces.com';
+  return {
+    endpoint,
+    region: new URL(endpoint).hostname.split('.')[0] || 'us-east-1',
+    bucket: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET || 'wxyc',
+    accessKeyId: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_KEY_ID'),
+    secretAccessKey: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET'),
+  };
+};
 
 export const createStoreClient = (config: StoreConfig): S3Client =>
   new S3Client({

--- a/jobs/digital-archive-bind/store.ts
+++ b/jobs/digital-archive-bind/store.ts
@@ -5,7 +5,7 @@
  * imports exactly `S3Client`, `ListObjectsV2Command`, and `GetObjectCommand`
  * from `@aws-sdk/client-s3` -- no `Put*`/`Delete*`/`Copy*`/`*MultipartUpload*`
  * command is imported anywhere in this job, and
- * `tests/unit/jobs/digital-archive-bind/store-read-only.test.ts` greps this
+ * `tests/unit/jobs/digital-archive-bind/store.test.ts` greps this
  * file's own source for those names so a future edit can't reintroduce one
  * silently.
  *

--- a/jobs/digital-archive-bind/store.ts
+++ b/jobs/digital-archive-bind/store.ts
@@ -1,0 +1,103 @@
+/**
+ * Read-only DigitalOcean Spaces client (BS#2319 constraints: "Read-only
+ * against the Space -- GET/LIST only; a write-capable code path must not
+ * exist"). Enforced by construction, not just by convention: this file
+ * imports exactly `S3Client`, `ListObjectsV2Command`, and `GetObjectCommand`
+ * from `@aws-sdk/client-s3` -- no `Put*`/`Delete*`/`Copy*`/`*MultipartUpload*`
+ * command is imported anywhere in this job, and
+ * `tests/unit/jobs/digital-archive-bind/store-read-only.test.ts` greps this
+ * file's own source for those names so a future edit can't reintroduce one
+ * silently.
+ *
+ * S3-compatible endpoint per the issue body: `forcePathStyle: false`
+ * (DigitalOcean Spaces uses virtual-hosted-style bucket addressing, unlike
+ * MinIO-style path addressing).
+ */
+
+import { GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
+
+export interface StoreConfig {
+  endpoint: string;
+  region: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not configured`);
+  return value;
+};
+
+/**
+ * `digital_asset_store.name` is `'azuracast'` (issue comment 1), so its
+ * store-scoped env vars are `DIGITAL_ARCHIVE_STORE_AZURACAST_*` --
+ * `WXYC/Backend-Service#2320`'s allowlist convention, which this job's
+ * writer has to agree with.
+ */
+export const loadStoreConfigFromEnv = (): StoreConfig => ({
+  endpoint: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_ENDPOINT || 'https://nyc3.digitaloceanspaces.com',
+  region: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_REGION || 'nyc3',
+  bucket: process.env.DIGITAL_ARCHIVE_STORE_AZURACAST_BUCKET || 'wxyc',
+  accessKeyId: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_ACCESS_KEY_ID'),
+  secretAccessKey: requireEnv('DIGITAL_ARCHIVE_STORE_AZURACAST_SECRET_ACCESS_KEY'),
+});
+
+export const createStoreClient = (config: StoreConfig): S3Client =>
+  new S3Client({
+    endpoint: config.endpoint,
+    region: config.region,
+    forcePathStyle: false,
+    credentials: { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey },
+  });
+
+export interface SpaceObject {
+  key: string;
+  bytes: number;
+  /** Raw ETag, quotes included -- `md5FromETag` strips them. */
+  etag: string;
+}
+
+/** Paginated `ListObjectsV2` over the whole bucket. */
+export async function* listAllObjects(client: S3Client, bucket: string): AsyncGenerator<SpaceObject> {
+  let continuationToken: string | undefined;
+  do {
+    const page = await client.send(new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: continuationToken }));
+    for (const obj of page.Contents ?? []) {
+      if (!obj.Key) continue;
+      yield { key: obj.Key, bytes: obj.Size ?? 0, etag: obj.ETag ?? '' };
+    }
+    continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (continuationToken);
+}
+
+/**
+ * MD5 from a single-part upload's ETag. A multipart upload's ETag has a
+ * trailing `-N` part-count suffix and is NOT the object's MD5 (issue body) --
+ * such an ETag is deliberately not even shaped like 32 hex chars, so the
+ * regex below rejects it by construction rather than needing a separate
+ * `-N` check.
+ */
+export const md5FromETag = (etag: string): string | null => {
+  const bare = etag.replace(/^"|"$/g, '');
+  return /^[a-f0-9]{32}$/i.test(bare) ? bare.toLowerCase() : null;
+};
+
+export const RANGE_BYTES = 256 * 1024;
+
+/** The ID3v2 fallback's only network call: a ranged GET of an object's leading `RANGE_BYTES`. */
+export const rangedGet = async (
+  client: S3Client,
+  bucket: string,
+  key: string,
+  byteLength: number = RANGE_BYTES
+): Promise<Buffer> => {
+  const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key, Range: `bytes=0-${byteLength - 1}` }));
+  const chunks: Buffer[] = [];
+  const body = res.Body as AsyncIterable<Uint8Array> | undefined;
+  if (body) {
+    for await (const chunk of body) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+};

--- a/jobs/digital-archive-bind/tags.ts
+++ b/jobs/digital-archive-bind/tags.ts
@@ -1,0 +1,76 @@
+/**
+ * Tag resolution (BS#2319 "Tags"): AzuraCast's media API when
+ * `AZURACAST_API_KEY` is set, else a per-file 256KB ranged-GET ID3v2
+ * fallback (`store.ts` + `id3.ts`).
+ *
+ * The AzuraCast response shape here is best-effort from the issue body's
+ * own description ("returns artist/title/album/length/path per file") --
+ * it has not been verified against a live `remote.wxyc.org` response. That
+ * uncertainty is safe to ship behind, not blocking: a field AzuraCast
+ * doesn't actually send just resolves to `null` here exactly like a file
+ * with no ID3 tag at all, which `group.ts` already handles by reporting the
+ * file ungroupable rather than misbinding it. Verify the mapping against a
+ * real response (`GET /api/station/main/files`) before the first prod run
+ * with `AZURACAST_API_KEY` set; see the README.
+ */
+
+import type { Id3Tags } from './id3.js';
+import { parseId3v2 } from './id3.js';
+import { RANGE_BYTES, rangedGet } from './store.js';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+interface AzuraCastFileEntry {
+  path?: string;
+  artist?: string;
+  title?: string;
+  album?: string;
+  album_artist?: string;
+  track?: string | number;
+  length?: number;
+}
+
+const toId3Tags = (entry: AzuraCastFileEntry): Id3Tags => ({
+  title: entry.title ?? null,
+  artist: entry.artist ?? null,
+  album: entry.album ?? null,
+  albumArtist: entry.album_artist ?? null,
+  track: entry.track !== undefined ? Number.parseInt(String(entry.track), 10) || null : null,
+  disc: null,
+  durationMs: entry.length !== undefined ? Math.round(entry.length * 1000) : null,
+});
+
+/** `path` -> resolved tags, for every file AzuraCast's media API knows about. */
+export const fetchAzuraCastTags = async (baseUrl: string, apiKey: string): Promise<Map<string, Id3Tags>> => {
+  const res = await fetch(new URL('/api/station/main/files', baseUrl), {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(`AzuraCast files API returned ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as AzuraCastFileEntry[];
+
+  const map = new Map<string, Id3Tags>();
+  for (const entry of body) {
+    if (!entry.path) continue;
+    map.set(entry.path, toId3Tags(entry));
+  }
+  return map;
+};
+
+/**
+ * Resolve one file's tags: an AzuraCast hit wins outright; otherwise fall
+ * back to the ranged-GET ID3v2 parse. `azuraCastTags === null` means the API
+ * key is unset -- every file goes through the fallback.
+ */
+export const resolveTagsForFile = async (
+  client: S3Client,
+  bucket: string,
+  objectKey: string,
+  azuraCastTags: ReadonlyMap<string, Id3Tags> | null
+): Promise<Id3Tags> => {
+  const fromApi = azuraCastTags?.get(objectKey);
+  if (fromApi) return fromApi;
+
+  const buf = await rangedGet(client, bucket, objectKey, RANGE_BYTES);
+  return parseId3v2(buf);
+};

--- a/jobs/digital-archive-bind/tsconfig.json
+++ b/jobs/digital-archive-bind/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/digital-archive-bind/tsup.config.ts
+++ b/jobs/digital-archive-bind/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  // `job.ts` is the ESM CLI entrypoint the Docker image runs (dist/job.js).
+  // `write.ts`/`match.ts`/`candidates.ts` also emit a CommonJS bundle each
+  // (dist/*.cjs) so the babel-jest integration spec can `require` and
+  // exercise the REAL write/match/candidate-load functions against Postgres
+  // rather than reimplementing them — same arrangement as
+  // `jobs/library-call-number-dedup`'s `merge.ts`.
+  entry: ['job.ts', 'write.ts', 'match.ts', 'candidates.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/digital-archive-bind/types.ts
+++ b/jobs/digital-archive-bind/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared shapes threaded through the digital-archive-bind pipeline:
+ * inventory (`store.ts` + `tags.ts`) -> grouping (`group.ts`) -> matching
+ * (`match.ts`) -> writing (`write.ts`). Centralized so each stage's tests
+ * can build fixtures against one contract instead of five ad-hoc ones.
+ */
+
+import type { ContentKind } from './classify.js';
+import type { Id3Tags } from './id3.js';
+
+/** One Space object the job decided is library content, tags resolved. */
+export interface InventoryFile {
+  objectKey: string;
+  contentKind: ContentKind;
+  codec: string;
+  bytes: number;
+  /** From the ETag, single-part uploads only (never set for a `-N` multipart ETag). */
+  md5: string | null;
+  tags: Id3Tags;
+}
+
+/**
+ * One candidate album: files grouped on normalized `(album_artist ?? artist,
+ * album)` (step 3) further split by `discNumber`, since `digital_asset`'s
+ * unique key is `(library_id, provenance, disc_number)` -- a multi-disc set
+ * is one candidate per disc, not one candidate for the whole set.
+ */
+export interface CandidateAlbum {
+  contentKind: ContentKind;
+  /** `foldArtistName(album_artist ?? artist)` -- the matcher's artist leg. */
+  artistFoldKey: string;
+  /** `normalizeAlbumTitle(album)` -- the matcher's exact-tier album leg. */
+  albumNormKey: string;
+  discNumber: number;
+  /** Raw display values (first file's tags) for the CSV / report. */
+  displayArtist: string;
+  displayAlbum: string;
+  files: InventoryFile[];
+}
+
+export type MatchTier = 'exact' | 'fuzzy';
+
+export type MatchResult =
+  | { kind: 'matched'; libraryId: number; tier: MatchTier; note: string }
+  | { kind: 'ambiguous'; libraryIds: number[] }
+  | { kind: 'unmatched' };
+
+/** A candidate album the matcher resolved to exactly one `library.id`. */
+export interface MatchedAlbum {
+  candidate: CandidateAlbum;
+  libraryId: number;
+  tier: MatchTier;
+  bindNote: string;
+}

--- a/jobs/digital-archive-bind/write.ts
+++ b/jobs/digital-archive-bind/write.ts
@@ -1,0 +1,335 @@
+/**
+ * Write phase (BS#2319 issue comments 1+2 -- the binding parts of this job):
+ * plan what to do with each matched candidate album against the slot it
+ * would occupy, then execute that plan in the smallest number of
+ * `digital_asset`-touching statements possible.
+ *
+ * The upsert key is `(library_id, provenance, disc_number)` (comment 1).
+ * `provenance` is always `'rotation_upload'` here -- the hand-uploaded
+ * auto-DJ MP3 population this job exists to inventory; `'cd_rip'` belongs to
+ * a later phase. `digital_asset_store.name` is `'azuracast'` (comment 1,
+ * correcting the `'azuracast-do-spaces'` example in the merged schema.ts
+ * JSDoc).
+ *
+ * Per-slot rule (comment 2), decided ahead of this job so a re-run's
+ * behaviour is settled, not improvised:
+ *   - no existing row               -> insert `needs_review`
+ *   - existing row, `needs_review`  -> untouched (idempotent re-run)
+ *   - existing row, `rejected`      -> skip, but ALWAYS report the object
+ *                                       keys + slot it wanted, so a blocked
+ *                                       candidate is never silently
+ *                                       indistinguishable from no candidate
+ *                                       at all. `--rebind-keys` overrides
+ *                                       this for exactly the named object
+ *                                       keys (the merge.ts collision-DELETE
+ *                                       recovery path).
+ *   - existing row, `bound`         -> NEVER written, under any flag --
+ *                                       compare the candidate's object keys
+ *                                       against the bound asset's files and
+ *                                       report DRIFT when they differ (a
+ *                                       live-playout file replaced or moved
+ *                                       under a binding that was correct
+ *                                       when it was made).
+ *
+ * **Watermark bound (comment 3, migration 0159): at most one
+ * `digital_asset`-touching statement per write phase per outcome class.**
+ * All new-slot inserts land in ONE multi-row `INSERT` (the trigger is
+ * `FOR EACH STATEMENT`, so one INSERT of 4,000 rows costs the same one
+ * advance as an INSERT of one row); all `--rebind-keys` reopens land in ONE
+ * multi-row `UPDATE`. A run that only inserts costs exactly one advance; a
+ * run that also reopens rejected slots costs at most two -- never one per
+ * album. `digital_asset_file` carries no trigger, so its writes are free to
+ * batch however is convenient.
+ */
+
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db, digital_asset, digital_asset_file, digital_asset_store } from '@wxyc/database';
+import type { MatchedAlbum } from './types.js';
+
+export const PROVENANCE = 'rotation_upload';
+export const STORE_NAME = 'azuracast';
+
+export interface ExistingSlot {
+  id: number;
+  libraryId: number;
+  discNumber: number;
+  status: string;
+}
+
+export interface RejectedBlocked {
+  libraryId: number;
+  discNumber: number;
+  objectKeys: string[];
+}
+
+export interface RejectedReopened {
+  assetId: number;
+  matched: MatchedAlbum;
+}
+
+export interface BoundDrift {
+  assetId: number;
+  libraryId: number;
+  discNumber: number;
+  candidateKeys: string[];
+  boundKeys: string[];
+}
+
+export interface SameRunCollision {
+  libraryId: number;
+  discNumber: number;
+  objectKeys: string[];
+}
+
+export interface WritePlan {
+  toInsert: MatchedAlbum[];
+  rejectedBlocked: RejectedBlocked[];
+  rejectedReopened: RejectedReopened[];
+  boundDrift: BoundDrift[];
+  /**
+   * Two DIFFERENT candidate groups in the SAME run resolved to the same
+   * `(library_id, disc_number)` slot -- e.g. a `freeform/` copy and a
+   * `rotation/Heavy/` copy of the same album, both present in the Space at
+   * once. `existingSlots` can't catch this (it's a snapshot taken before
+   * this run's own inserts), and a plain multi-row INSERT would hit the
+   * unique index and abort the WHOLE batch, not just the second row. The
+   * first-seen candidate is queued for insert; every later one targeting
+   * the same slot is reported here instead, unwritten.
+   */
+  sameRunCollision: SameRunCollision[];
+}
+
+const slotKey = (libraryId: number, discNumber: number): string => `${libraryId}::${discNumber}`;
+
+const sameKeySet = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every((k) => setB.has(k));
+};
+
+/**
+ * Pure planner -- no DB access, so the per-slot rule above is unit-testable
+ * against hand-built `ExistingSlot`/bound-file fixtures.
+ */
+export const planWrites = (
+  matched: readonly MatchedAlbum[],
+  existingSlots: readonly ExistingSlot[],
+  boundFileKeys: ReadonlyMap<number, readonly string[]>,
+  rebindKeys: ReadonlySet<string>
+): WritePlan => {
+  const slots = new Map<string, ExistingSlot>();
+  for (const slot of existingSlots) slots.set(slotKey(slot.libraryId, slot.discNumber), slot);
+
+  const plan: WritePlan = {
+    toInsert: [],
+    rejectedBlocked: [],
+    rejectedReopened: [],
+    boundDrift: [],
+    sameRunCollision: [],
+  };
+  const claimedThisRun = new Set<string>();
+
+  for (const candidate of matched) {
+    const discNumber = candidate.candidate.discNumber;
+    const key = slotKey(candidate.libraryId, discNumber);
+    const existing = slots.get(key);
+    const candidateKeys = candidate.candidate.files.map((f) => f.objectKey);
+
+    if (!existing) {
+      if (claimedThisRun.has(key)) {
+        plan.sameRunCollision.push({ libraryId: candidate.libraryId, discNumber, objectKeys: candidateKeys });
+        continue;
+      }
+      claimedThisRun.add(key);
+      plan.toInsert.push(candidate);
+      continue;
+    }
+
+    if (existing.status === 'bound') {
+      const boundKeys = [...(boundFileKeys.get(existing.id) ?? [])];
+      if (!sameKeySet(candidateKeys, boundKeys)) {
+        plan.boundDrift.push({
+          assetId: existing.id,
+          libraryId: candidate.libraryId,
+          discNumber,
+          candidateKeys,
+          boundKeys,
+        });
+      }
+      continue;
+    }
+
+    if (existing.status === 'rejected') {
+      if (candidateKeys.some((k) => rebindKeys.has(k))) {
+        plan.rejectedReopened.push({ assetId: existing.id, matched: candidate });
+      } else {
+        plan.rejectedBlocked.push({ libraryId: candidate.libraryId, discNumber, objectKeys: candidateKeys });
+      }
+      continue;
+    }
+
+    // 'needs_review' -- already awaiting a human decision. Untouched, so a
+    // re-run of the whole job is a no-op for this slot.
+  }
+
+  return plan;
+};
+
+/** Get-or-create the `azuracast` store row. No trigger on this table -- cheap regardless. */
+export const ensureStore = async (): Promise<number> => {
+  await db
+    .insert(digital_asset_store)
+    .values({ name: STORE_NAME })
+    .onConflictDoNothing({ target: digital_asset_store.name });
+  const [row] = await db
+    .select({ id: digital_asset_store.id })
+    .from(digital_asset_store)
+    .where(eq(digital_asset_store.name, STORE_NAME));
+  return row.id;
+};
+
+export const loadExistingSlots = async (libraryIds: readonly number[]): Promise<ExistingSlot[]> => {
+  if (libraryIds.length === 0) return [];
+  const rows = await db
+    .select({
+      id: digital_asset.id,
+      libraryId: digital_asset.library_id,
+      discNumber: digital_asset.disc_number,
+      status: digital_asset.status,
+    })
+    .from(digital_asset)
+    .where(and(eq(digital_asset.provenance, PROVENANCE), inArray(digital_asset.library_id, [...libraryIds])));
+  return rows;
+};
+
+export const loadBoundFileKeys = async (assetIds: readonly number[]): Promise<Map<number, string[]>> => {
+  const result = new Map<number, string[]>();
+  if (assetIds.length === 0) return result;
+  const rows = await db
+    .select({ assetId: digital_asset_file.asset_id, objectKey: digital_asset_file.object_key })
+    .from(digital_asset_file)
+    .where(inArray(digital_asset_file.asset_id, [...assetIds]));
+  for (const row of rows) {
+    const keys = result.get(row.assetId) ?? [];
+    keys.push(row.objectKey);
+    result.set(row.assetId, keys);
+  }
+  return result;
+};
+
+export interface WriteCounts {
+  inserted: number;
+  reopened: number;
+  filesWritten: number;
+}
+
+const fileRowOf = (assetId: number, storeId: number, file: MatchedAlbum['candidate']['files'][number]) => ({
+  asset_id: assetId,
+  store_id: storeId,
+  object_key: file.objectKey,
+  codec: file.codec,
+  bitrate_kbps: null,
+  track_number: file.tags.track,
+  title: file.tags.title ?? file.objectKey,
+  duration_secs: file.tags.durationMs !== null ? file.tags.durationMs / 1000 : null,
+  bytes: file.bytes,
+  md5: file.md5,
+  sha256: null,
+  flac_md5: null,
+  tag_artist: file.tags.artist,
+  tag_album: file.tags.album,
+  tag_track: file.tags.track !== null ? String(file.tags.track) : null,
+});
+
+/**
+ * Execute a plan: at most one `digital_asset` INSERT and one `digital_asset`
+ * UPDATE, per the watermark constraint in this file's header. Runs outside
+ * any long-lived transaction spanning the inventory/tag-read phases --
+ * everything needed is already in memory by the time this is called, so the
+ * DB round-trips here are the whole cost.
+ */
+export const executeWrites = async (plan: WritePlan, storeId: number): Promise<WriteCounts> => {
+  let inserted = 0;
+  let reopened = 0;
+  const fileRows: ReturnType<typeof fileRowOf>[] = [];
+
+  if (plan.toInsert.length > 0) {
+    const inserts = plan.toInsert.map((m) => ({
+      library_id: m.libraryId,
+      provenance: PROVENANCE,
+      disc_number: m.candidate.discNumber,
+      status: 'needs_review' as const,
+      bind_note: m.bindNote,
+    }));
+    const returned = await db.insert(digital_asset).values(inserts).returning({ id: digital_asset.id });
+    inserted = returned.length;
+    plan.toInsert.forEach((m, i) => {
+      for (const file of m.candidate.files) fileRows.push(fileRowOf(returned[i].id, storeId, file));
+    });
+  }
+
+  if (plan.rejectedReopened.length > 0) {
+    // Single VALUES-join UPDATE so every reopen advances the watermark
+    // together, not once per row (docs/bulk-update-playbook.md).
+    const values = sql.join(
+      plan.rejectedReopened.map((r) => sql`(${r.assetId}::int, ${r.matched.bindNote}::text)`),
+      sql`, `
+    );
+    await db.execute(sql`
+      UPDATE ${digital_asset} AS d
+         SET status = 'needs_review', bind_note = v.bind_note
+        FROM (VALUES ${values}) AS v(id, bind_note)
+       WHERE d.id = v.id
+    `);
+    reopened = plan.rejectedReopened.length;
+
+    const reopenedIds = plan.rejectedReopened.map((r) => r.assetId);
+    await db.delete(digital_asset_file).where(inArray(digital_asset_file.asset_id, reopenedIds));
+    for (const r of plan.rejectedReopened) {
+      for (const file of r.matched.candidate.files) fileRows.push(fileRowOf(r.assetId, storeId, file));
+    }
+  }
+
+  if (fileRows.length > 0) {
+    await db.insert(digital_asset_file).values(fileRows);
+  }
+
+  return { inserted, reopened, filesWritten: fileRows.length };
+};
+
+export interface ApplyDecisionsResult {
+  boundAttempted: number;
+  rejectedAttempted: number;
+  rowsUpdated: number;
+}
+
+/**
+ * `--import <path>` step 5: write back exactly the rows a reviewer decided.
+ * Guarded `WHERE status = 'needs_review'` -- "the review import only
+ * transitions `needs_review` -> `bound|rejected`" (issue constraints), so a
+ * CSV re-imported after a row was already decided (by this run or a
+ * concurrent one) can't flip it a second time. One VALUES-join UPDATE for
+ * the whole file, matching the watermark-bound shape above.
+ */
+export const applyReviewDecisions = async (
+  decisions: readonly { assetId: number; decision: 'bound' | 'rejected' }[]
+): Promise<ApplyDecisionsResult> => {
+  if (decisions.length === 0) return { boundAttempted: 0, rejectedAttempted: 0, rowsUpdated: 0 };
+
+  const values = sql.join(
+    decisions.map((d) => sql`(${d.assetId}::int, ${d.decision}::text)`),
+    sql`, `
+  );
+  const result = await db.execute(sql`
+    UPDATE ${digital_asset} AS d
+       SET status = v.decision
+      FROM (VALUES ${values}) AS v(id, decision)
+     WHERE d.id = v.id AND d.status = 'needs_review'
+  `);
+
+  return {
+    boundAttempted: decisions.filter((d) => d.decision === 'bound').length,
+    rejectedAttempted: decisions.filter((d) => d.decision === 'rejected').length,
+    rowsUpdated: Number((result as unknown as { count?: number }).count ?? 0),
+  };
+};

--- a/jobs/digital-archive-bind/write.ts
+++ b/jobs/digital-archive-bind/write.ts
@@ -31,15 +31,24 @@
  *                                       under a binding that was correct
  *                                       when it was made).
  *
- * **Watermark bound (comment 3, migration 0159): at most one
- * `digital_asset`-touching statement per write phase per outcome class.**
- * All new-slot inserts land in ONE multi-row `INSERT` (the trigger is
- * `FOR EACH STATEMENT`, so one INSERT of 4,000 rows costs the same one
- * advance as an INSERT of one row); all `--rebind-keys` reopens land in ONE
- * multi-row `UPDATE`. A run that only inserts costs exactly one advance; a
- * run that also reopens rejected slots costs at most two -- never one per
- * album. `digital_asset_file` carries no trigger, so its writes are free to
- * batch however is convenient.
+ * **Watermark bound (comment 3, migration 0159): one advance per write
+ * phase, enforced by the transaction rather than by statement counting.**
+ * `executeWrites` runs entirely inside `db.transaction`, and Postgres
+ * `now()` is transaction-start time, so every `FOR EACH STATEMENT` firing of
+ * `touch_library_watermark()` inside the phase writes the SAME instant --
+ * one advance however many statements touch `digital_asset`. That is what
+ * makes chunking safe: it decouples the watermark cost from the statement
+ * count, so the inserts below can be split to respect the bind-parameter
+ * ceiling without paying an advance per chunk. Every advance forces every
+ * iOS device to re-download the whole gzipped NDJSON catalog and rebuild its
+ * FTS5 index, so this is a real user-visible cost, not bookkeeping.
+ *
+ * The transaction is equally load-bearing for atomicity: the `digital_asset`
+ * INSERT and the `digital_asset_file` INSERT must commit together or not at
+ * all. Committed separately, a failure between them leaves `needs_review`
+ * assets holding zero files -- and `planWrites` deliberately leaves
+ * `needs_review` slots untouched, so no re-run would ever fill them. The
+ * only recovery would be hand-editing rows.
  */
 
 import { and, eq, inArray, sql } from 'drizzle-orm';
@@ -161,6 +170,17 @@ export const planWrites = (
 
     if (existing.status === 'rejected') {
       if (candidateKeys.some((k) => rebindKeys.has(k))) {
+        // The same-run collision guard covers reopens too, not just fresh
+        // slots: two candidates resolving to one rejected slot (a
+        // `freeform/` copy and a `rotation/Heavy/` copy, say) with a rebind
+        // file naming a key from each would otherwise both reopen the SAME
+        // asset id -- putting a duplicate id in the VALUES-join UPDATE and
+        // pushing both albums' files onto one asset.
+        if (claimedThisRun.has(key)) {
+          plan.sameRunCollision.push({ libraryId: candidate.libraryId, discNumber, objectKeys: candidateKeys });
+          continue;
+        }
+        claimedThisRun.add(key);
         plan.rejectedReopened.push({ assetId: existing.id, matched: candidate });
       } else {
         plan.rejectedBlocked.push({ libraryId: candidate.libraryId, discNumber, objectKeys: candidateKeys });
@@ -242,60 +262,109 @@ const fileRowOf = (assetId: number, storeId: number, file: MatchedAlbum['candida
 });
 
 /**
- * Execute a plan: at most one `digital_asset` INSERT and one `digital_asset`
- * UPDATE, per the watermark constraint in this file's header. Runs outside
- * any long-lived transaction spanning the inventory/tag-read phases --
- * everything needed is already in memory by the time this is called, so the
- * DB round-trips here are the whole cost.
+ * Largest number of rows to put in one multi-row INSERT.
+ *
+ * postgres.js writes the Bind message's parameter count as an int16, so a
+ * single statement can carry at most 65,535 bind parameters, and drizzle
+ * emits one parameter per explicitly-provided column value (nulls included;
+ * only `undefined` becomes DEFAULT). `fileRowOf` supplies 15 columns, so an
+ * unchunked `digital_asset_file` INSERT overflows at 4,369 rows -- against a
+ * Space holding ~23,500 files. 1,000 rows is 15,000 parameters at today's
+ * widest row, leaving room for several more columns before this constant
+ * needs revisiting. Chunking costs nothing on the watermark because the
+ * whole phase is one transaction (see this file's header).
  */
-export const executeWrites = async (plan: WritePlan, storeId: number): Promise<WriteCounts> => {
-  let inserted = 0;
-  let reopened = 0;
-  const fileRows: ReturnType<typeof fileRowOf>[] = [];
+const INSERT_CHUNK_ROWS = 1_000;
 
-  if (plan.toInsert.length > 0) {
-    const inserts = plan.toInsert.map((m) => ({
-      library_id: m.libraryId,
-      provenance: PROVENANCE,
-      disc_number: m.candidate.discNumber,
-      status: 'needs_review' as const,
-      bind_note: m.bindNote,
-    }));
-    const returned = await db.insert(digital_asset).values(inserts).returning({ id: digital_asset.id });
-    inserted = returned.length;
-    plan.toInsert.forEach((m, i) => {
-      for (const file of m.candidate.files) fileRows.push(fileRowOf(returned[i].id, storeId, file));
-    });
-  }
-
-  if (plan.rejectedReopened.length > 0) {
-    // Single VALUES-join UPDATE so every reopen advances the watermark
-    // together, not once per row (docs/bulk-update-playbook.md).
-    const values = sql.join(
-      plan.rejectedReopened.map((r) => sql`(${r.assetId}::int, ${r.matched.bindNote}::text)`),
-      sql`, `
-    );
-    await db.execute(sql`
-      UPDATE ${digital_asset} AS d
-         SET status = 'needs_review', bind_note = v.bind_note
-        FROM (VALUES ${values}) AS v(id, bind_note)
-       WHERE d.id = v.id
-    `);
-    reopened = plan.rejectedReopened.length;
-
-    const reopenedIds = plan.rejectedReopened.map((r) => r.assetId);
-    await db.delete(digital_asset_file).where(inArray(digital_asset_file.asset_id, reopenedIds));
-    for (const r of plan.rejectedReopened) {
-      for (const file of r.matched.candidate.files) fileRows.push(fileRowOf(r.assetId, storeId, file));
-    }
-  }
-
-  if (fileRows.length > 0) {
-    await db.insert(digital_asset_file).values(fileRows);
-  }
-
-  return { inserted, reopened, filesWritten: fileRows.length };
+const chunk = <T>(rows: readonly T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) out.push(rows.slice(i, i + size));
+  return out;
 };
+
+/**
+ * Execute a plan, atomically. Every statement runs in one transaction, which
+ * is what bounds the watermark to a single advance and what keeps assets and
+ * their files from committing separately (see this file's header for both).
+ * The inventory/tag-read phases stay outside it -- everything needed is
+ * already in memory by the time this is called.
+ */
+export const executeWrites = async (plan: WritePlan, storeId: number): Promise<WriteCounts> =>
+  db.transaction(async (tx) => {
+    let inserted = 0;
+    let reopened = 0;
+    const fileRows: ReturnType<typeof fileRowOf>[] = [];
+
+    if (plan.toInsert.length > 0) {
+      // Attach files to assets by SLOT, never by the position of the
+      // `RETURNING` rows. Postgres does not document row order for
+      // `INSERT ... VALUES ... RETURNING`, and chunking makes the old
+      // positional correspondence wrong across chunk boundaries as well.
+      // A divergence there would attach every album's files to a different
+      // album's asset -- silent mass mis-binding, no error, no failing test.
+      // `(library_id, disc_number)` is unique here because `provenance` is
+      // the constant PROVENANCE, matching the table's unique index.
+      const assetIdBySlot = new Map<string, number>();
+      for (const group of chunk(plan.toInsert, INSERT_CHUNK_ROWS)) {
+        const returned = await tx
+          .insert(digital_asset)
+          .values(
+            group.map((m) => ({
+              library_id: m.libraryId,
+              provenance: PROVENANCE,
+              disc_number: m.candidate.discNumber,
+              status: 'needs_review' as const,
+              bind_note: m.bindNote,
+            }))
+          )
+          .returning({
+            id: digital_asset.id,
+            library_id: digital_asset.library_id,
+            disc_number: digital_asset.disc_number,
+          });
+        for (const row of returned) assetIdBySlot.set(slotKey(row.library_id, row.disc_number), row.id);
+        inserted += returned.length;
+      }
+
+      for (const m of plan.toInsert) {
+        const key = slotKey(m.libraryId, m.candidate.discNumber);
+        const assetId = assetIdBySlot.get(key);
+        // Unreachable unless the INSERT silently dropped a row. Throwing
+        // rolls the whole transaction back, which is the point: a partial
+        // write here is the state no re-run can repair.
+        if (assetId === undefined) throw new Error(`digital_asset INSERT returned no row for slot ${key}`);
+        for (const file of m.candidate.files) fileRows.push(fileRowOf(assetId, storeId, file));
+      }
+    }
+
+    if (plan.rejectedReopened.length > 0) {
+      // Single VALUES-join UPDATE, matching the shape in
+      // docs/bulk-update-playbook.md.
+      const values = sql.join(
+        plan.rejectedReopened.map((r) => sql`(${r.assetId}::int, ${r.matched.bindNote}::text)`),
+        sql`, `
+      );
+      await tx.execute(sql`
+        UPDATE ${digital_asset} AS d
+           SET status = 'needs_review', bind_note = v.bind_note
+          FROM (VALUES ${values}) AS v(id, bind_note)
+         WHERE d.id = v.id
+      `);
+      reopened = plan.rejectedReopened.length;
+
+      const reopenedIds = plan.rejectedReopened.map((r) => r.assetId);
+      await tx.delete(digital_asset_file).where(inArray(digital_asset_file.asset_id, reopenedIds));
+      for (const r of plan.rejectedReopened) {
+        for (const file of r.matched.candidate.files) fileRows.push(fileRowOf(r.assetId, storeId, file));
+      }
+    }
+
+    for (const group of chunk(fileRows, INSERT_CHUNK_ROWS)) {
+      await tx.insert(digital_asset_file).values(group);
+    }
+
+    return { inserted, reopened, filesWritten: fileRows.length };
+  });
 
 export interface ApplyDecisionsResult {
   boundAttempted: number;
@@ -312,18 +381,27 @@ export interface ApplyDecisionsResult {
  * the whole file, matching the watermark-bound shape above.
  */
 export const applyReviewDecisions = async (
-  decisions: readonly { assetId: number; decision: 'bound' | 'rejected' }[]
+  decisions: readonly { assetId: number; decision: 'bound' | 'rejected'; note?: string | null }[]
 ): Promise<ApplyDecisionsResult> => {
   if (decisions.length === 0) return { boundAttempted: 0, rejectedAttempted: 0, rowsUpdated: 0 };
 
   const values = sql.join(
-    decisions.map((d) => sql`(${d.assetId}::int, ${d.decision}::text)`),
+    decisions.map((d) => sql`(${d.assetId}::int, ${d.decision}::text, ${d.note ?? null}::text)`),
     sql`, `
   );
+  // The reviewer's note is APPENDED to `bind_note`, not written over it: the
+  // existing value holds the matcher's own evidence (`exact`,
+  // `fuzzy:relaxed-key`), which is what a later reader needs in order to
+  // judge whether a rejection was the matcher's fault or the tags'. An empty
+  // note leaves the column untouched.
   const result = await db.execute(sql`
     UPDATE ${digital_asset} AS d
-       SET status = v.decision
-      FROM (VALUES ${values}) AS v(id, decision)
+       SET status = v.decision,
+           bind_note = CASE
+                         WHEN NULLIF(v.note, '') IS NULL THEN d.bind_note
+                         ELSE COALESCE(d.bind_note || ' | ', '') || 'review: ' || v.note
+                       END
+      FROM (VALUES ${values}) AS v(id, decision, note)
      WHERE d.id = v.id AND d.status = 'needs_review'
   `);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,6 +685,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/digital-archive-bind": {
+      "name": "@wxyc/digital-archive-bind",
+      "version": "1.0.0",
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1121.0",
+        "@sentry/node": "^10.70.0",
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-april-gap-import": {
       "name": "@wxyc/flowsheet-april-gap-import",
       "version": "1.0.0",
@@ -6724,6 +6740,10 @@
     },
     "node_modules/@wxyc/database": {
       "resolved": "shared/database",
+      "link": true
+    },
+    "node_modules/@wxyc/digital-archive-bind": {
+      "resolved": "jobs/digital-archive-bind",
       "link": true
     },
     "node_modules/@wxyc/enrichment-worker": {

--- a/tests/integration/digital-archive-bind-write.spec.js
+++ b/tests/integration/digital-archive-bind-write.spec.js
@@ -391,11 +391,7 @@ describe('digital-archive-bind — REAL write functions (real PG)', () => {
     });
 
     const plan = write.planWrites(
-      [
-        matchedFor(libNote, 'note-a.mp3'),
-        matchedFor(libEmpty, 'note-b.mp3'),
-        matchedFor(libNull, 'note-c.mp3'),
-      ],
+      [matchedFor(libNote, 'note-a.mp3'), matchedFor(libEmpty, 'note-b.mp3'), matchedFor(libNull, 'note-c.mp3')],
       [],
       new Map(),
       new Set()

--- a/tests/integration/digital-archive-bind-write.spec.js
+++ b/tests/integration/digital-archive-bind-write.spec.js
@@ -354,9 +354,82 @@ describe('digital-archive-bind — REAL write functions (real PG)', () => {
     );
     expect(plan.toInsert).toHaveLength(1);
 
-    await expect(write.executeWrites(plan, storeId)).rejects.toThrow();
+    // Pinned to the constraint this test's own setup forces, not a bare
+    // `toThrow()`: an unrelated failure earlier in `executeWrites` (the
+    // slot-map guard, a connection error) would otherwise satisfy the
+    // assertion while proving nothing about rollback.
+    await expect(write.executeWrites(plan, storeId)).rejects.toThrow(/duplicate key|unique/i);
 
     const orphans = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
     expect(orphans).toHaveLength(0); // the asset must not survive its files' failure
+  });
+
+  // BS#2319 review: `importReviewCsv` parses the reviewer's note and
+  // `applyReviewDecisions` used to discard it, so rejection reasons were lost
+  // on import. It is APPENDED rather than written over, because `bind_note`
+  // already holds the matcher's own evidence (`exact`, `fuzzy:relaxed-key`) —
+  // which is what tells a later reader whether a rejection was the matcher's
+  // fault or the tags'. The NULL case is the one worth pinning: naive
+  // concatenation against a NULL `bind_note` yields NULL and silently erases
+  // the note instead of storing it.
+  it('appends the reviewer note to bind_note, and leaves it alone when the note is empty', async () => {
+    const libNote = await seedLibrary('BS2319 Note Album');
+    const libEmpty = await seedLibrary('BS2319 Empty Note Album');
+    const libNull = await seedLibrary('BS2319 Null BindNote Album');
+    const storeId = await write.ensureStore();
+
+    const matchedFor = (libraryId, key) => ({
+      candidate: candidateAlbum({
+        contentKind: 'freeform',
+        artist: 'BS2319 Fixture Artist',
+        album: 'BS2319 Note Album',
+        objectKeys: [key],
+      }),
+      libraryId,
+      tier: 'exact',
+      bindNote: 'exact',
+    });
+
+    const plan = write.planWrites(
+      [
+        matchedFor(libNote, 'note-a.mp3'),
+        matchedFor(libEmpty, 'note-b.mp3'),
+        matchedFor(libNull, 'note-c.mp3'),
+      ],
+      [],
+      new Map(),
+      new Set()
+    );
+    await write.executeWrites(plan, storeId);
+
+    const seeded = await sql`
+      SELECT id, library_id FROM ${sql(SCHEMA)}.digital_asset
+       WHERE library_id = ANY(${[libNote, libEmpty, libNull]})
+    `;
+    seeded.forEach((r) => assetIds.push(r.id));
+    const idOf = (libraryId) => seeded.find((r) => r.library_id === libraryId).id;
+
+    // The third row starts with a NULL bind_note — the concatenation trap.
+    await sql`UPDATE ${sql(SCHEMA)}.digital_asset SET bind_note = NULL WHERE id = ${idOf(libNull)}`;
+
+    await write.applyReviewDecisions([
+      { assetId: idOf(libNote), decision: 'rejected', note: 'wrong album' },
+      { assetId: idOf(libEmpty), decision: 'bound', note: '' },
+      { assetId: idOf(libNull), decision: 'rejected', note: 'no such release' },
+    ]);
+
+    const after = await sql`
+      SELECT id, status, bind_note FROM ${sql(SCHEMA)}.digital_asset
+       WHERE id = ANY(${[idOf(libNote), idOf(libEmpty), idOf(libNull)]})
+    `;
+    const noteOf = (id) => after.find((r) => r.id === id).bind_note;
+
+    // Appended, with the matcher's evidence preserved ahead of it.
+    expect(noteOf(idOf(libNote))).toBe('exact | review: wrong album');
+    // Empty note leaves the column exactly as the matcher wrote it.
+    expect(noteOf(idOf(libEmpty))).toBe('exact');
+    // NULL prior note stores the review note alone — never NULL, and with no
+    // leading separator.
+    expect(noteOf(idOf(libNull))).toBe('review: no such release');
   });
 });

--- a/tests/integration/digital-archive-bind-write.spec.js
+++ b/tests/integration/digital-archive-bind-write.spec.js
@@ -358,7 +358,19 @@ describe('digital-archive-bind — REAL write functions (real PG)', () => {
     // `toThrow()`: an unrelated failure earlier in `executeWrites` (the
     // slot-map guard, a connection error) would otherwise satisfy the
     // assertion while proving nothing about rollback.
-    await expect(write.executeWrites(plan, storeId)).rejects.toThrow(/duplicate key|unique/i);
+    //
+    // Pinned on the SQLSTATE rather than the message, because drizzle wraps
+    // the driver error: `err.message` is only "Failed query: insert into
+    // digital_asset_file …", and the Postgres "duplicate key value violates
+    // unique constraint" text lives on `err.cause`. 23505 is unique_violation,
+    // and a code can't drift the way wording can.
+    const err = await write.executeWrites(plan, storeId).then(
+      () => {
+        throw new Error('executeWrites resolved; expected a unique violation on digital_asset_file');
+      },
+      (e) => e
+    );
+    expect(err.cause?.code ?? err.code).toBe('23505');
 
     const orphans = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
     expect(orphans).toHaveLength(0); // the asset must not survive its files' failure

--- a/tests/integration/digital-archive-bind-write.spec.js
+++ b/tests/integration/digital-archive-bind-write.spec.js
@@ -1,0 +1,275 @@
+/**
+ * Integration tests for the REAL shipped functions of
+ * `jobs/digital-archive-bind`, against a real Postgres (BS#2319 AC:
+ * "a fixture inventory against seeded rotation + library rows produces the
+ * expected needs_review set; re-running is a no-op; import flips exactly
+ * the listed rows").
+ *
+ * Exercises the pipeline root-to-write: `candidates.ts` loads the
+ * `rotation`/`library` match targets, `match.ts` resolves a hand-built
+ * `CandidateAlbum` (standing in for what `group.ts` would produce from a
+ * real S3 inventory -- the S3/tag-read legs are unit-tested elsewhere and
+ * don't need a database), and `write.ts` plans and executes the DB writes.
+ *
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker
+ * tier). When `write.ts`/`match.ts`/`candidates.ts` change, rebuild
+ * (`npm run build --workspace=@wxyc/digital-archive-bind`); CI's Build step
+ * produces `dist/*.cjs` before the integration tier runs.
+ */
+
+// The repo-wide `tests/__mocks__/drizzle-orm.ts` manual mock (written for
+// the ts-jest unit tier) is AUTOMATICALLY applied to every `drizzle-orm`
+// require. Our compiled `dist/*.cjs` modules require the REAL drizzle-orm,
+// so unmock it. Hoisted above the requires below by babel-plugin-jest-hoist.
+jest.unmock('drizzle-orm');
+
+const path = require('path');
+const { getTestDb } = require('../utils/db');
+
+const jobDist = (name) => path.join(__dirname, '..', '..', 'jobs', 'digital-archive-bind', 'dist', name);
+const candidates = require(jobDist('candidates.cjs'));
+const match = require(jobDist('match.cjs'));
+const write = require(jobDist('write.cjs'));
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const GENRE_ID = 11; // exists in the integration fixture
+const FORMAT_ID = 1;
+
+const emptyTags = {
+  title: null,
+  artist: null,
+  album: null,
+  albumArtist: null,
+  track: null,
+  disc: null,
+  durationMs: null,
+};
+
+const candidateAlbum = ({ contentKind, artist, album, objectKeys, discNumber = 1 }) => ({
+  contentKind,
+  artistFoldKey: artist.toLowerCase(),
+  albumNormKey: album.toLowerCase(),
+  discNumber,
+  displayArtist: artist,
+  displayAlbum: album,
+  files: objectKeys.map((objectKey, i) => ({
+    objectKey,
+    contentKind,
+    codec: 'mp3',
+    bytes: 1000 + i,
+    md5: null,
+    tags: { ...emptyTags, artist, album, track: i + 1 },
+  })),
+});
+
+describe('digital-archive-bind — REAL write functions (real PG)', () => {
+  let sql;
+  let artistId;
+  const libraryIds = [];
+  const assetIds = [];
+
+  beforeAll(async () => {
+    sql = getTestDb();
+  });
+
+  beforeEach(async () => {
+    const [a] = await sql`
+      INSERT INTO ${sql(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+      VALUES ('BS2319 Fixture Artist', 'BS2319 Fixture Artist', 'ZZ')
+      RETURNING id
+    `;
+    artistId = a.id;
+  });
+
+  afterEach(async () => {
+    try {
+      if (assetIds.length > 0) {
+        await sql`DELETE FROM ${sql(SCHEMA)}.digital_asset_file WHERE asset_id = ANY(${assetIds})`;
+        await sql`DELETE FROM ${sql(SCHEMA)}.digital_asset WHERE id = ANY(${assetIds})`;
+      }
+      if (libraryIds.length > 0) {
+        await sql`DELETE FROM ${sql(SCHEMA)}.rotation WHERE album_id = ANY(${libraryIds})`;
+        await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+      }
+      if (artistId) await sql`DELETE FROM ${sql(SCHEMA)}.artists WHERE id = ${artistId}`;
+    } finally {
+      assetIds.length = 0;
+      libraryIds.length = 0;
+      artistId = null;
+    }
+  });
+
+  const seedLibrary = async (albumTitle, extra = {}) => {
+    const [row] = await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+      VALUES (${artistId}, ${GENRE_ID}, ${FORMAT_ID}, ${albumTitle}, ${Math.floor(Math.random() * 30_000) + 1}, ${extra.artistName ?? 'BS2319 Fixture Artist'})
+      RETURNING id
+    `;
+    libraryIds.push(row.id);
+    return row.id;
+  };
+
+  it('a freeform candidate matched against a seeded library row inserts a needs_review asset + its files, and re-running is a no-op', async () => {
+    const libraryId = await seedLibrary('BS2319 Freeform Album');
+
+    const libraryCandidates = await candidates.loadLibraryCandidates();
+    const album = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Freeform Album',
+      objectKeys: [
+        'library/freeform/BS2319 Fixture Artist/BS2319 Freeform Album/01.mp3',
+        'library/freeform/BS2319 Fixture Artist/BS2319 Freeform Album/02.mp3',
+      ],
+    });
+    const result = match.matchLibrary(album, libraryCandidates);
+    expect(result.kind).toBe('matched');
+    expect(result.libraryId).toBe(libraryId);
+
+    const matched = { candidate: album, libraryId: result.libraryId, tier: result.tier, bindNote: result.note };
+
+    const storeId = await write.ensureStore();
+    const existingBefore = await write.loadExistingSlots([libraryId]);
+    const plan1 = write.planWrites([matched], existingBefore, new Map(), new Set());
+    expect(plan1.toInsert).toHaveLength(1);
+
+    const counts1 = await write.executeWrites(plan1, storeId);
+    expect(counts1.inserted).toBe(1);
+    expect(counts1.filesWritten).toBe(2);
+
+    const assetRows = await sql`
+      SELECT id, status, provenance, disc_number FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}
+    `;
+    expect(assetRows).toHaveLength(1);
+    expect(assetRows[0].status).toBe('needs_review');
+    expect(assetRows[0].provenance).toBe('rotation_upload');
+    assetIds.push(assetRows[0].id);
+
+    const fileRows = await sql`
+      SELECT object_key FROM ${sql(SCHEMA)}.digital_asset_file WHERE asset_id = ${assetRows[0].id} ORDER BY object_key
+    `;
+    expect(fileRows.map((r) => r.object_key)).toEqual(album.files.map((f) => f.objectKey).sort());
+
+    // Re-run: the slot now holds a needs_review row, so the plan must insert nothing more.
+    const existingAfter = await write.loadExistingSlots([libraryId]);
+    const plan2 = write.planWrites([matched], existingAfter, new Map(), new Set());
+    expect(plan2.toInsert).toHaveLength(0);
+    const counts2 = await write.executeWrites(plan2, storeId);
+    expect(counts2.inserted).toBe(0);
+    expect(counts2.filesWritten).toBe(0);
+
+    const assetRowsAfter = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
+    expect(assetRowsAfter).toHaveLength(1); // no duplicate
+  });
+
+  it('a rotation-derived candidate matches against a seeded rotation row, not library', async () => {
+    const libraryId = await seedLibrary('BS2319 Rotation Album');
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title)
+      VALUES (${libraryId}, 'H', 'BS2319 Fixture Artist', 'BS2319 Rotation Album')
+    `;
+
+    const rotationCandidates = await candidates.loadRotationCandidates();
+    const album = candidateAlbum({
+      contentKind: 'rotation_bin',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Rotation Album',
+      objectKeys: ['rotation/Heavy/01.mp3'],
+    });
+    const result = match.matchRotation(album, rotationCandidates);
+    expect(result).toEqual({ kind: 'matched', libraryId, tier: 'exact', note: 'exact' });
+  });
+
+  it('the review import flips exactly the rows a reviewer decided, and only from needs_review', async () => {
+    const libA = await seedLibrary('BS2319 Import A');
+    const libB = await seedLibrary('BS2319 Import B');
+    const storeId = await write.ensureStore();
+
+    const albumA = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Import A',
+      objectKeys: ['a.mp3'],
+    });
+    const albumB = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Import B',
+      objectKeys: ['b.mp3'],
+    });
+    const matchedA = { candidate: albumA, libraryId: libA, tier: 'exact', bindNote: 'exact' };
+    const matchedB = { candidate: albumB, libraryId: libB, tier: 'exact', bindNote: 'exact' };
+
+    const plan = write.planWrites([matchedA, matchedB], [], new Map(), new Set());
+    await write.executeWrites(plan, storeId);
+
+    const rows = await sql`
+      SELECT id, library_id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ANY(${[libA, libB]}) ORDER BY library_id
+    `;
+    rows.forEach((r) => assetIds.push(r.id));
+    const idA = rows.find((r) => r.library_id === libA).id;
+    const idB = rows.find((r) => r.library_id === libB).id;
+
+    const result = await write.applyReviewDecisions([
+      { assetId: idA, decision: 'bound' },
+      { assetId: idB, decision: 'rejected' },
+    ]);
+    expect(result.rowsUpdated).toBe(2);
+
+    const after = await sql`SELECT id, status FROM ${sql(SCHEMA)}.digital_asset WHERE id = ANY(${[idA, idB]})`;
+    expect(after.find((r) => r.id === idA).status).toBe('bound');
+    expect(after.find((r) => r.id === idB).status).toBe('rejected');
+
+    // Re-importing the SAME decisions again is a no-op: both rows are no longer needs_review.
+    const second = await write.applyReviewDecisions([
+      { assetId: idA, decision: 'rejected' },
+      { assetId: idB, decision: 'bound' },
+    ]);
+    expect(second.rowsUpdated).toBe(0);
+    const stillAfter = await sql`SELECT id, status FROM ${sql(SCHEMA)}.digital_asset WHERE id = ANY(${[idA, idB]})`;
+    expect(stillAfter.find((r) => r.id === idA).status).toBe('bound');
+    expect(stillAfter.find((r) => r.id === idB).status).toBe('rejected');
+  });
+
+  it('never writes into a bound slot and reports drift when the candidate keys differ', async () => {
+    const libraryId = await seedLibrary('BS2319 Drift Album');
+    const storeId = await write.ensureStore();
+
+    const original = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Drift Album',
+      objectKeys: ['original.mp3'],
+    });
+    const matchedOriginal = { candidate: original, libraryId, tier: 'exact', bindNote: 'exact' };
+    const plan0 = write.planWrites([matchedOriginal], [], new Map(), new Set());
+    await write.executeWrites(plan0, storeId);
+
+    const [assetRow] = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
+    assetIds.push(assetRow.id);
+    await sql`UPDATE ${sql(SCHEMA)}.digital_asset SET status = 'bound' WHERE id = ${assetRow.id}`;
+
+    const drifted = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Drift Album',
+      objectKeys: ['replaced.mp3'],
+    });
+    const matchedDrifted = { candidate: drifted, libraryId, tier: 'exact', bindNote: 'exact' };
+
+    const existing = await write.loadExistingSlots([libraryId]);
+    const boundFiles = await write.loadBoundFileKeys([assetRow.id]);
+    const plan = write.planWrites([matchedDrifted], existing, boundFiles, new Set());
+
+    expect(plan.toInsert).toHaveLength(0);
+    expect(plan.boundDrift).toEqual([
+      { assetId: assetRow.id, libraryId, discNumber: 1, candidateKeys: ['replaced.mp3'], boundKeys: ['original.mp3'] },
+    ]);
+
+    await write.executeWrites(plan, storeId);
+    const stillOriginal =
+      await sql`SELECT object_key FROM ${sql(SCHEMA)}.digital_asset_file WHERE asset_id = ${assetRow.id}`;
+    expect(stillOriginal.map((r) => r.object_key)).toEqual(['original.mp3']);
+  });
+});

--- a/tests/integration/digital-archive-bind-write.spec.js
+++ b/tests/integration/digital-archive-bind-write.spec.js
@@ -272,4 +272,91 @@ describe('digital-archive-bind — REAL write functions (real PG)', () => {
       await sql`SELECT object_key FROM ${sql(SCHEMA)}.digital_asset_file WHERE asset_id = ${assetRow.id}`;
     expect(stillOriginal.map((r) => r.object_key)).toEqual(['original.mp3']);
   });
+
+  // BS#2319 review F1: `fileRowOf` supplies 15 explicit columns and drizzle
+  // emits one bind parameter per provided value, while postgres.js writes the
+  // Bind message's parameter count as an int16 -- so a single unchunked
+  // `digital_asset_file` INSERT dies above 4,369 rows (65,535 / 15). The real
+  // Space holds ~23,500 files. This album alone exceeds the ceiling, so the
+  // test fails against an unchunked insert and passes only with the chunking
+  // in `executeWrites`. It sits just over the boundary rather than at full
+  // scale, to stay fast while still being a true regression test.
+  it('writes an album whose file count exceeds the single-statement bind-parameter ceiling', async () => {
+    const FILES = 4_400; // 4,400 * 15 params = 66,000 > 65,535
+    const libraryId = await seedLibrary('BS2319 Oversized Album');
+
+    const album = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Oversized Album',
+      objectKeys: Array.from(
+        { length: FILES },
+        (_, i) => `library/freeform/oversized/${String(i).padStart(5, '0')}.mp3`
+      ),
+    });
+    const matched = { candidate: album, libraryId, tier: 'exact', bindNote: 'exact' };
+
+    const storeId = await write.ensureStore();
+    const plan = write.planWrites([matched], await write.loadExistingSlots([libraryId]), new Map(), new Set());
+    const counts = await write.executeWrites(plan, storeId);
+
+    expect(counts.inserted).toBe(1);
+    expect(counts.filesWritten).toBe(FILES);
+
+    const [asset] = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
+    assetIds.push(asset.id);
+    const [{ count }] =
+      await sql`SELECT COUNT(*)::int AS count FROM ${sql(SCHEMA)}.digital_asset_file WHERE asset_id = ${asset.id}`;
+    expect(count).toBe(FILES);
+  });
+
+  // BS#2319 review F2: the asset INSERT and the file INSERT must commit
+  // together. Committed separately, a mid-sequence failure leaves
+  // `needs_review` assets holding zero files -- and `planWrites` deliberately
+  // leaves `needs_review` slots untouched, so no re-run would ever fill them.
+  // Here the file INSERT is forced to fail on `digital_asset_file`'s
+  // UNIQUE (store_id, object_key) by pre-planting one of the object keys.
+  it('rolls the asset rows back when the file insert fails, leaving no fileless asset behind', async () => {
+    const libraryId = await seedLibrary('BS2319 Rollback Album');
+    const storeId = await write.ensureStore();
+    const collidingKey = 'library/freeform/rollback/collide.mp3';
+
+    // A pre-existing file row owning the key, attached to an unrelated asset.
+    const squatterLibraryId = await seedLibrary('BS2319 Rollback Squatter');
+    const squatter = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Rollback Squatter',
+      objectKeys: [collidingKey],
+    });
+    const squatterPlan = write.planWrites(
+      [{ candidate: squatter, libraryId: squatterLibraryId, tier: 'exact', bindNote: 'exact' }],
+      await write.loadExistingSlots([squatterLibraryId]),
+      new Map(),
+      new Set()
+    );
+    await write.executeWrites(squatterPlan, storeId);
+    const [squatterAsset] =
+      await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${squatterLibraryId}`;
+    assetIds.push(squatterAsset.id);
+
+    const album = candidateAlbum({
+      contentKind: 'freeform',
+      artist: 'BS2319 Fixture Artist',
+      album: 'BS2319 Rollback Album',
+      objectKeys: [collidingKey],
+    });
+    const plan = write.planWrites(
+      [{ candidate: album, libraryId, tier: 'exact', bindNote: 'exact' }],
+      await write.loadExistingSlots([libraryId]),
+      new Map(),
+      new Set()
+    );
+    expect(plan.toInsert).toHaveLength(1);
+
+    await expect(write.executeWrites(plan, storeId)).rejects.toThrow();
+
+    const orphans = await sql`SELECT id FROM ${sql(SCHEMA)}.digital_asset WHERE library_id = ${libraryId}`;
+    expect(orphans).toHaveLength(0); // the asset must not survive its files' failure
+  });
 });

--- a/tests/unit/jobs/digital-archive-bind/classify.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/classify.test.ts
@@ -1,0 +1,93 @@
+import { classifyObjectKey, isRotationDerived } from '../../../../jobs/digital-archive-bind/classify';
+
+describe('digital-archive-bind classify', () => {
+  describe('directory markers', () => {
+    it('skips a key ending in / as a directory marker', () => {
+      expect(classifyObjectKey('library/freeform/Artist/Album/')).toEqual({
+        kind: 'skip',
+        reason: 'directory-marker',
+      });
+    });
+  });
+
+  describe('named skip prefixes', () => {
+    it.each([
+      '.albumart/Artist/Album.jpg',
+      '.covers/Artist/Album.jpg',
+      '.waveforms/Artist/Album.json',
+      'station IDs/legal-id-01.mp3',
+      'test/fixture.mp3',
+      'shows/2026-08-01.mp3',
+    ])('skips %s under a named skip prefix', (key) => {
+      expect(classifyObjectKey(key)).toEqual({ kind: 'skip', reason: 'skip-prefix' });
+    });
+  });
+
+  describe('non-audio extensions', () => {
+    it.each([
+      'library/freeform/Artist/Album/liner.pdf',
+      'library/freeform/Artist/Album/promo.mp4',
+      'library/freeform/station.ini',
+      'library/freeform/.DS_Store',
+      'rotation/Heavy/session.atf',
+    ])('skips %s as a non-audio extension', (key) => {
+      expect(classifyObjectKey(key)).toEqual({ kind: 'skip', reason: 'non-audio-extension' });
+    });
+  });
+
+  describe('objects outside the content prefixes', () => {
+    it.each(['random-top-level-folder/track.mp3', 'library/other-subdir/track.mp3', 'rotation/Unknown/track.mp3'])(
+      'skips %s as outside the content prefixes',
+      (key) => {
+        expect(classifyObjectKey(key)).toEqual({ kind: 'skip', reason: 'not-content-prefix' });
+      }
+    );
+  });
+
+  describe('library content, in scope', () => {
+    it('classifies a freeform mp3', () => {
+      expect(classifyObjectKey('library/freeform/Roméo Poirier/Living Room Session/03_track.mp3')).toEqual({
+        kind: 'content',
+        contentKind: 'freeform',
+        codec: 'mp3',
+      });
+    });
+
+    it('classifies a recently_rotated flat file', () => {
+      expect(classifyObjectKey('library/recently_rotated/artist_-_album_-_01_title.flac')).toEqual({
+        kind: 'content',
+        contentKind: 'recently_rotated',
+        codec: 'flac',
+      });
+    });
+
+    it.each(['Heavy', 'Medium', 'Light', 'Singles'])('classifies a rotation/%s file', (bin) => {
+      expect(classifyObjectKey(`rotation/${bin}/01_take_a_number.mp3`)).toEqual({
+        kind: 'content',
+        contentKind: 'rotation_bin',
+        codec: 'mp3',
+      });
+    });
+
+    // BS#2319 comment 4: m4a and wav are IN SCOPE, not skipped.
+    it.each([
+      ['library/freeform/Artist/Album/01.m4a', 'm4a'],
+      ['library/freeform/Artist/Album/01.wav', 'wav'],
+      ['library/freeform/Artist/Album/01.aac', 'aac'],
+      ['library/freeform/Artist/Album/01.MP3', 'mp3'],
+    ])('classifies %s as codec %s (case-insensitive extension)', (key, codec) => {
+      expect(classifyObjectKey(key)).toEqual({ kind: 'content', contentKind: 'freeform', codec });
+    });
+  });
+
+  describe('isRotationDerived', () => {
+    it('is true for recently_rotated and rotation_bin', () => {
+      expect(isRotationDerived('recently_rotated')).toBe(true);
+      expect(isRotationDerived('rotation_bin')).toBe(true);
+    });
+
+    it('is false for freeform', () => {
+      expect(isRotationDerived('freeform')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/csv.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/csv.test.ts
@@ -1,0 +1,80 @@
+import { exportReviewCsv, importReviewCsv, type ReviewRow } from '../../../../jobs/digital-archive-bind/csv';
+
+const row = (overrides: Partial<ReviewRow> & { assetId: number }): ReviewRow => ({
+  libraryId: 100,
+  discNumber: 1,
+  provenance: 'rotation_upload',
+  bindNote: 'exact',
+  contentKind: 'freeform',
+  proposedArtist: 'Jessica Pratt',
+  proposedAlbumTitle: 'On Your Own Love Again',
+  tagArtist: 'Jessica Pratt',
+  tagAlbum: 'On Your Own Love Again',
+  objectKeys: ['library/freeform/Jessica Pratt/On Your Own Love Again/01.mp3'],
+  ...overrides,
+});
+
+describe('digital-archive-bind csv', () => {
+  it('round-trips asset id, tags, proposed library id, bind_note, and prefix', () => {
+    const rows: ReviewRow[] = [row({ assetId: 1 }), row({ assetId: 2, libraryId: 200, bindNote: 'fuzzy:relaxed-key' })];
+    const csv = exportReviewCsv(rows);
+
+    expect(csv).toContain('asset_id');
+    expect(csv).toContain('library_id');
+    expect(csv).toContain('proposed_artist');
+    expect(csv).toContain('bind_note');
+    expect(csv).toContain('decision');
+
+    // Nobody has filled in a decision yet -- importing the untouched export flips nothing.
+    expect(importReviewCsv(csv)).toEqual([]);
+  });
+
+  it('quotes a field containing a comma', () => {
+    const csv = exportReviewCsv([row({ assetId: 1, proposedAlbumTitle: 'Nerve Bumps, A Queer Divine Satisfaction' })]);
+    expect(csv).toContain('"Nerve Bumps, A Queer Divine Satisfaction"');
+  });
+
+  it('joins multiple object keys with a semicolon', () => {
+    const csv = exportReviewCsv([row({ assetId: 1, objectKeys: ['a/01.mp3', 'a/02.mp3'] })]);
+    expect(csv).toContain('a/01.mp3; a/02.mp3');
+  });
+
+  it('flips exactly the rows a reviewer marked bound or rejected', () => {
+    const csv = exportReviewCsv([row({ assetId: 1 }), row({ assetId: 2 }), row({ assetId: 3 })]);
+    const lines = csv.split('\n');
+    const decisionIndex = lines[0].split(',').indexOf('decision');
+
+    const decided = lines.map((line, i) => {
+      if (i === 0 || line.trim() === '') return line;
+      const cells = line.split(',');
+      if (i === 1) cells[decisionIndex] = 'bound';
+      if (i === 2) cells[decisionIndex] = 'rejected';
+      return cells.join(',');
+    });
+
+    const decisions = importReviewCsv(decided.join('\n'));
+    expect(decisions).toEqual(
+      expect.arrayContaining([
+        { assetId: 1, decision: 'bound', note: '' },
+        { assetId: 2, decision: 'rejected', note: '' },
+      ])
+    );
+    expect(decisions.find((d) => d.assetId === 3)).toBeUndefined();
+  });
+
+  it('ignores an unrecognized decision value rather than treating it as a transition', () => {
+    const csv = [
+      'asset_id,library_id,disc_number,provenance,content_kind,bind_note,proposed_artist,proposed_album_title,tag_artist,tag_album,object_keys,decision,note',
+      '1,100,1,rotation_upload,freeform,exact,Artist,Album,Artist,Album,key.mp3,maybe,',
+    ].join('\n');
+    expect(importReviewCsv(csv)).toEqual([]);
+  });
+
+  it('carries a reviewer note through the round trip', () => {
+    const csv = [
+      'asset_id,library_id,disc_number,provenance,content_kind,bind_note,proposed_artist,proposed_album_title,tag_artist,tag_album,object_keys,decision,note',
+      '1,100,1,rotation_upload,freeform,exact,Artist,Album,Artist,Album,key.mp3,rejected,"wrong pressing, keep looking"',
+    ].join('\n');
+    expect(importReviewCsv(csv)).toEqual([{ assetId: 1, decision: 'rejected', note: 'wrong pressing, keep looking' }]);
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/group.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/group.test.ts
@@ -1,0 +1,123 @@
+import { groupIntoAlbums } from '../../../../jobs/digital-archive-bind/group';
+import type { InventoryFile } from '../../../../jobs/digital-archive-bind/types';
+
+const emptyTags = {
+  title: null,
+  artist: null,
+  album: null,
+  albumArtist: null,
+  track: null,
+  disc: null,
+  durationMs: null,
+};
+
+const file = (overrides: Partial<InventoryFile> & { objectKey: string }): InventoryFile => ({
+  contentKind: 'freeform',
+  codec: 'mp3',
+  bytes: 1000,
+  md5: null,
+  tags: { ...emptyTags },
+  ...overrides,
+});
+
+describe('digital-archive-bind group', () => {
+  it('groups files sharing normalized (album_artist ?? artist, album)', () => {
+    const files: InventoryFile[] = [
+      file({
+        objectKey: 'library/freeform/A/01.mp3',
+        tags: { ...emptyTags, artist: 'Jessica Pratt', album: 'On Your Own Love Again', track: 1 },
+      }),
+      file({
+        objectKey: 'library/freeform/A/02.mp3',
+        tags: { ...emptyTags, artist: 'jessica pratt', album: 'ON YOUR OWN LOVE AGAIN', track: 2 },
+      }),
+    ];
+
+    const { albums, ungroupable } = groupIntoAlbums(files);
+    expect(ungroupable).toHaveLength(0);
+    expect(albums).toHaveLength(1);
+    expect(albums[0].files.map((f) => f.objectKey).sort()).toEqual([
+      'library/freeform/A/01.mp3',
+      'library/freeform/A/02.mp3',
+    ]);
+  });
+
+  it('splits by discNumber -- a multi-disc set is one candidate per disc', () => {
+    const files: InventoryFile[] = [
+      file({
+        objectKey: 'library/freeform/B/d1-01.mp3',
+        tags: { ...emptyTags, artist: 'Artist', album: 'Double Album', disc: 1 },
+      }),
+      file({
+        objectKey: 'library/freeform/B/d2-01.mp3',
+        tags: { ...emptyTags, artist: 'Artist', album: 'Double Album', disc: 2 },
+      }),
+    ];
+
+    const { albums } = groupIntoAlbums(files);
+    expect(albums).toHaveLength(2);
+    expect(albums.map((a) => a.discNumber).sort()).toEqual([1, 2]);
+  });
+
+  it('defaults discNumber to 1 when TPOS is absent', () => {
+    const files: InventoryFile[] = [
+      file({ objectKey: 'library/freeform/C/01.mp3', tags: { ...emptyTags, artist: 'Artist', album: 'Album' } }),
+    ];
+    const { albums } = groupIntoAlbums(files);
+    expect(albums[0].discNumber).toBe(1);
+  });
+
+  it('keeps groups from different content kinds separate even with identical tags', () => {
+    const files: InventoryFile[] = [
+      file({
+        objectKey: 'library/freeform/D/01.mp3',
+        contentKind: 'freeform',
+        tags: { ...emptyTags, artist: 'Same Artist', album: 'Same Album' },
+      }),
+      file({
+        objectKey: 'rotation/Heavy/01.mp3',
+        contentKind: 'rotation_bin',
+        tags: { ...emptyTags, artist: 'Same Artist', album: 'Same Album' },
+      }),
+    ];
+    const { albums } = groupIntoAlbums(files);
+    expect(albums).toHaveLength(2);
+  });
+
+  it('reports files with no usable artist+album as ungroupable rather than dropping them', () => {
+    const files: InventoryFile[] = [file({ objectKey: 'library/freeform/E/untagged.mp3', tags: { ...emptyTags } })];
+    const { albums, ungroupable } = groupIntoAlbums(files);
+    expect(albums).toHaveLength(0);
+    expect(ungroupable.map((f) => f.objectKey)).toEqual(['library/freeform/E/untagged.mp3']);
+  });
+
+  it("sorts a group's files by track number for deterministic display", () => {
+    const files: InventoryFile[] = [
+      file({
+        objectKey: 'library/freeform/F/03.mp3',
+        tags: { ...emptyTags, artist: 'Artist', album: 'Album', track: 3 },
+      }),
+      file({
+        objectKey: 'library/freeform/F/01.mp3',
+        tags: { ...emptyTags, artist: 'Artist', album: 'Album', track: 1 },
+      }),
+      file({
+        objectKey: 'library/freeform/F/02.mp3',
+        tags: { ...emptyTags, artist: 'Artist', album: 'Album', track: 2 },
+      }),
+    ];
+    const { albums } = groupIntoAlbums(files);
+    expect(albums[0].files.map((f) => f.tags.track)).toEqual([1, 2, 3]);
+  });
+
+  it('uses TPE2 (album artist) over TPE1 (artist) for the display artist', () => {
+    const files: InventoryFile[] = [
+      file({
+        objectKey: 'library/freeform/G/01.mp3',
+        tags: { ...emptyTags, artist: 'Thom Yorke', albumArtist: 'The Smile', album: 'Wall of Eyes' },
+      }),
+    ];
+    const { albums } = groupIntoAlbums(files);
+    expect(albums[0].displayArtist).toBe('The Smile');
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/id3.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/id3.test.ts
@@ -1,0 +1,123 @@
+import { parseId3v2 } from '../../../../jobs/digital-archive-bind/id3';
+
+/**
+ * Checked-in ID3v2.3 fixture headers, hand-built as explicit byte sequences
+ * below rather than as binary blobs under `fixtures/` — a raw binary fixture
+ * reviews as an opaque diff on GitHub, where this builder's output is
+ * auditable byte-for-byte in the PR. `buildId3v2` is deliberately a
+ * minimal, independent encoder (not a call into `parseId3v2`'s own code) so
+ * the test can't pass by construction.
+ */
+const synchsafe = (size: number): Buffer => {
+  const out = Buffer.alloc(4);
+  out[0] = (size >>> 21) & 0x7f;
+  out[1] = (size >>> 14) & 0x7f;
+  out[2] = (size >>> 7) & 0x7f;
+  out[3] = size & 0x7f;
+  return out;
+};
+
+const textFrame = (id: string, text: string, encoding = 0x00): Buffer => {
+  const body = Buffer.concat([Buffer.from([encoding]), Buffer.from(text, 'latin1')]);
+  const header = Buffer.concat([Buffer.from(id, 'latin1'), Buffer.alloc(4), Buffer.alloc(2)]);
+  header.writeUInt32BE(body.length, 4); // v2.3 frame size is plain big-endian, not synchsafe
+  return Buffer.concat([header, body]);
+};
+
+const buildId3v2 = (frames: Buffer[]): Buffer => {
+  const frameBytes = Buffer.concat(frames);
+  const header = Buffer.concat([
+    Buffer.from('ID3', 'latin1'),
+    Buffer.from([0x03, 0x00, 0x00]),
+    synchsafe(frameBytes.length),
+  ]);
+  return Buffer.concat([header, frameBytes]);
+};
+
+describe('digital-archive-bind ID3v2 parser', () => {
+  it('parses a full-tag file (BS#2319 AC fixture 1)', () => {
+    const buf = buildId3v2([
+      textFrame('TIT2', 'Off the Record'),
+      textFrame('TPE1', 'Roméo Poirier'),
+      textFrame('TALB', 'Living Room Session'),
+      textFrame('TPE2', 'Roméo Poirier'),
+      textFrame('TRCK', '3/12'),
+      textFrame('TPOS', '1/1'),
+      textFrame('TLEN', '245000'),
+    ]);
+
+    expect(parseId3v2(buf)).toEqual({
+      title: 'Off the Record',
+      artist: 'Roméo Poirier',
+      album: 'Living Room Session',
+      albumArtist: 'Roméo Poirier',
+      track: 3,
+      disc: 1,
+      durationMs: 245000,
+    });
+  });
+
+  it('parses a no-track-number file (BS#2319 AC fixture 2)', () => {
+    const buf = buildId3v2([
+      textFrame('TIT2', 'Take a Number'),
+      textFrame('TPE1', 'Heavy Rotation Artist'),
+      textFrame('TALB', 'Heavy'),
+    ]);
+
+    const tags = parseId3v2(buf);
+    expect(tags.title).toBe('Take a Number');
+    expect(tags.artist).toBe('Heavy Rotation Artist');
+    expect(tags.album).toBe('Heavy');
+    expect(tags.track).toBeNull();
+    expect(tags.disc).toBeNull();
+  });
+
+  it('parses a TPOS disc file (BS#2319 AC fixture 3)', () => {
+    const buf = buildId3v2([
+      textFrame('TIT2', 'Side B, Track 1'),
+      textFrame('TPE1', 'Duke Ellington & John Coltrane'),
+      textFrame('TALB', 'Duke Ellington & John Coltrane'),
+      textFrame('TPOS', '2/2'),
+    ]);
+
+    expect(parseId3v2(buf).disc).toBe(2);
+  });
+
+  it('returns all-null tags for a buffer with no ID3 header', () => {
+    const buf = Buffer.from('not an id3 tag at all', 'latin1');
+    expect(parseId3v2(buf)).toEqual({
+      title: null,
+      artist: null,
+      album: null,
+      albumArtist: null,
+      track: null,
+      disc: null,
+      durationMs: null,
+    });
+  });
+
+  it('is total over a short/truncated buffer (the 256KB ranged-GET boundary)', () => {
+    const full = buildId3v2([textFrame('TIT2', 'Truncated'), textFrame('TPE1', 'Artist Whose Tag Overruns')]);
+    const truncated = full.subarray(0, 12); // header + a sliver of the first frame header
+    expect(() => parseId3v2(truncated)).not.toThrow();
+  });
+
+  it('decodes a UTF-16 (BOM) text frame', () => {
+    const text = 'Chuquimamani-Condori';
+    const utf16 = Buffer.from(text, 'utf16le');
+    const bom = Buffer.from([0xff, 0xfe]);
+    const body = Buffer.concat([Buffer.from([0x01]), bom, utf16]);
+    const header = Buffer.concat([Buffer.from('TPE1', 'latin1'), Buffer.alloc(4), Buffer.alloc(2)]);
+    header.writeUInt32BE(body.length, 4);
+    const buf = buildId3v2([Buffer.concat([header, body])]);
+    expect(parseId3v2(buf).artist).toBe(text);
+  });
+
+  it('strips trailing NUL padding from a text frame', () => {
+    const header = Buffer.concat([Buffer.from('TALB', 'latin1'), Buffer.alloc(4), Buffer.alloc(2)]);
+    const body = Buffer.concat([Buffer.from([0x00]), Buffer.from('Padded Album\0\0\0', 'latin1')]);
+    header.writeUInt32BE(body.length, 4);
+    const buf = buildId3v2([Buffer.concat([header, body])]);
+    expect(parseId3v2(buf).album).toBe('Padded Album');
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/id3.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/id3.test.ts
@@ -96,10 +96,27 @@ describe('digital-archive-bind ID3v2 parser', () => {
     });
   });
 
-  it('is total over a short/truncated buffer (the 256KB ranged-GET boundary)', () => {
+  it('is total over a buffer cut before any frame header is readable', () => {
     const full = buildId3v2([textFrame('TIT2', 'Truncated'), textFrame('TPE1', 'Artist Whose Tag Overruns')]);
     const truncated = full.subarray(0, 12); // header + a sliver of the first frame header
     expect(() => parseId3v2(truncated)).not.toThrow();
+    expect(parseId3v2(truncated).title).toBeNull();
+  });
+
+  it('recovers whole frames when the buffer is cut MID-BODY (the 256KB ranged-GET boundary)', () => {
+    // The case the ranged GET actually produces: a complete first frame, then
+    // a second whose header parses but whose body runs past the end of what
+    // we fetched. Cutting at 12 bytes (above) never enters the frame loop at
+    // all -- `offset + 10 <= tagEnd` is false on the first iteration -- so it
+    // exercises none of the truncation handling it appears to name.
+    const full = buildId3v2([textFrame('TIT2', 'Complete Title'), textFrame('TPE1', 'Artist Whose Tag Overruns')]);
+    const firstFrameEnd = 10 + 10 + Buffer.byteLength('Complete Title', 'latin1') + 1;
+    const midSecondBody = full.subarray(0, firstFrameEnd + 10 + 4);
+
+    expect(() => parseId3v2(midSecondBody)).not.toThrow();
+    const tags = parseId3v2(midSecondBody);
+    expect(tags.title).toBe('Complete Title'); // the frame that fully arrived survives
+    expect(tags.artist).toBeNull(); // the one cut mid-body is dropped, not half-decoded
   });
 
   it('decodes a UTF-16 (BOM) text frame', () => {

--- a/tests/unit/jobs/digital-archive-bind/match.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/match.test.ts
@@ -1,0 +1,131 @@
+import {
+  matchLibrary,
+  matchRotation,
+  type LibraryCandidateRow,
+  type RotationCandidateRow,
+} from '../../../../jobs/digital-archive-bind/match';
+import { artistFoldKey } from '../../../../jobs/digital-archive-bind/normalize';
+import { normalizeAlbumTitle } from '@wxyc/database';
+import type { CandidateAlbum } from '../../../../jobs/digital-archive-bind/types';
+
+const candidateOf = (
+  artist: string,
+  album: string,
+  contentKind: CandidateAlbum['contentKind'] = 'freeform'
+): CandidateAlbum => ({
+  contentKind,
+  artistFoldKey: artistFoldKey(artist),
+  albumNormKey: normalizeAlbumTitle(album),
+  discNumber: 1,
+  displayArtist: artist,
+  displayAlbum: album,
+  files: [],
+});
+
+describe('digital-archive-bind match', () => {
+  describe('matchRotation', () => {
+    const rows: RotationCandidateRow[] = [
+      { libraryId: 101, artistName: 'Chuquimamani-Condori', albumTitle: 'Edits' },
+      { libraryId: 202, artistName: 'Duke Ellington & John Coltrane', albumTitle: 'Duke Ellington & John Coltrane' },
+    ];
+
+    it('resolves an exact normalized match', () => {
+      const result = matchRotation(candidateOf('chuquimamani-condori', 'EDITS'), rows);
+      expect(result).toEqual({ kind: 'matched', libraryId: 101, tier: 'exact', note: 'exact' });
+    });
+
+    it('resolves a fuzzy match on punctuation the exact tier misses', () => {
+      const punctuated: RotationCandidateRow[] = [
+        { libraryId: 303, artistName: 'An Artist', albumTitle: 'Nerve Bumps (A Queer Divine Satisfaction)' },
+      ];
+      const result = matchRotation(candidateOf('An Artist', 'Nerve Bumps: A Queer Divine Satisfaction'), punctuated);
+      expect(result.kind).toBe('matched');
+      if (result.kind === 'matched') {
+        expect(result.libraryId).toBe(303);
+        expect(result.tier).toBe('fuzzy');
+      }
+    });
+
+    it('reports no match as unmatched', () => {
+      expect(matchRotation(candidateOf('Nobody', 'Nothing'), rows)).toEqual({ kind: 'unmatched' });
+    });
+
+    it('reports >1 distinct album at the exact tier as ambiguous, without falling through to fuzzy', () => {
+      const dup: RotationCandidateRow[] = [
+        { libraryId: 1, artistName: 'Same Artist', albumTitle: 'Same Album' },
+        { libraryId: 2, artistName: 'Same Artist', albumTitle: 'Same Album' },
+      ];
+      const result = matchRotation(candidateOf('Same Artist', 'Same Album'), dup);
+      expect(result.kind).toBe('ambiguous');
+      if (result.kind === 'ambiguous') expect(result.libraryIds.sort()).toEqual([1, 2]);
+    });
+
+    it('does not collapse a sequel title onto its base title at the fuzzy tier', () => {
+      const rowsWithSequel: RotationCandidateRow[] = [
+        { libraryId: 9, artistName: 'An Artist', albumTitle: 'Black Metal' },
+      ];
+      expect(matchRotation(candidateOf('An Artist', 'Black Metal 2'), rowsWithSequel)).toEqual({ kind: 'unmatched' });
+    });
+
+    it('collapses duplicate rotation rows pointing at the same album_id to a single exact match', () => {
+      const reAdded: RotationCandidateRow[] = [
+        { libraryId: 55, artistName: 'Repeat Artist', albumTitle: 'Repeat Album' },
+        { libraryId: 55, artistName: 'Repeat Artist', albumTitle: 'Repeat Album' },
+      ];
+      const result = matchRotation(candidateOf('Repeat Artist', 'Repeat Album'), reAdded);
+      expect(result).toEqual({ kind: 'matched', libraryId: 55, tier: 'exact', note: 'exact' });
+    });
+  });
+
+  describe('matchLibrary', () => {
+    it('matches on artist_name', () => {
+      const rows: LibraryCandidateRow[] = [
+        {
+          libraryId: 1,
+          artistName: 'Jessica Pratt',
+          albumArtist: null,
+          alternateArtistName: null,
+          albumTitle: 'On Your Own Love Again',
+        },
+      ];
+      const result = matchLibrary(candidateOf('Jessica Pratt', 'On Your Own Love Again'), rows);
+      expect(result).toEqual({ kind: 'matched', libraryId: 1, tier: 'exact', note: 'exact' });
+    });
+
+    it('matches on album_artist when artist_name differs (compilation filing convention)', () => {
+      const rows: LibraryCandidateRow[] = [
+        {
+          libraryId: 2,
+          artistName: 'Thom Yorke',
+          albumArtist: 'The Smile',
+          alternateArtistName: null,
+          albumTitle: 'Wall of Eyes',
+        },
+      ];
+      const result = matchLibrary(candidateOf('The Smile', 'Wall of Eyes'), rows);
+      expect(result).toEqual({ kind: 'matched', libraryId: 2, tier: 'exact', note: 'exact' });
+    });
+
+    it('widens to alternate_artist_name only at the fuzzy tier', () => {
+      const rows: LibraryCandidateRow[] = [
+        {
+          libraryId: 3,
+          artistName: 'Filed Under This Name',
+          albumArtist: null,
+          alternateArtistName: 'Also Known As',
+          albumTitle: 'Some Album',
+        },
+      ];
+      expect(matchLibrary(candidateOf('Also Known As', 'Some Album'), rows)).toEqual({
+        kind: 'matched',
+        libraryId: 3,
+        tier: 'fuzzy',
+        note: expect.stringContaining('fuzzy'),
+      });
+    });
+
+    it('reports zero matches as unmatched', () => {
+      expect(matchLibrary(candidateOf('Nobody', 'Nothing'), [])).toEqual({ kind: 'unmatched' });
+    });
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/normalize.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/normalize.test.ts
@@ -1,0 +1,49 @@
+import { albumGroupKey, relaxedAlbumKey } from '../../../../jobs/digital-archive-bind/normalize';
+
+describe('digital-archive-bind normalize', () => {
+  describe('albumGroupKey', () => {
+    it('prefers album_artist over artist when both are present and differ', () => {
+      // A compilation track credited to a guest artist, banded under the
+      // album's real band -- the group key must land on the band, not the
+      // per-track credit, or every track scatters into its own "album".
+      const trackCredit = albumGroupKey('The Smile', 'Thom Yorke', 'Wall of Eyes');
+      const bandOnly = albumGroupKey(null, 'The Smile', 'Wall of Eyes');
+      expect(trackCredit).toBe(bandOnly);
+      expect(trackCredit).not.toBe(albumGroupKey(null, 'Thom Yorke', 'Wall of Eyes'));
+    });
+
+    it('falls back to artist when album_artist is absent', () => {
+      expect(albumGroupKey(null, 'Roméo Poirier', 'Living Room Session')).toBe(
+        albumGroupKey(undefined, 'Roméo Poirier', 'Living Room Session')
+      );
+    });
+
+    it('is diacritic- and case-insensitive on the artist leg', () => {
+      expect(albumGroupKey(null, 'Roméo Poirier', 'Off the Record')).toBe(
+        albumGroupKey(null, 'ROMEO POIRIER', 'Off the Record')
+      );
+    });
+
+    it('collapses edition cruft on the album leg', () => {
+      expect(albumGroupKey(null, 'An Artist', 'Pet Sounds')).toBe(
+        albumGroupKey(null, 'An Artist', 'Pet Sounds (Remastered)')
+      );
+    });
+
+    it('produces different keys for different albums', () => {
+      expect(albumGroupKey(null, 'An Artist', 'Album One')).not.toBe(albumGroupKey(null, 'An Artist', 'Album Two'));
+    });
+  });
+
+  describe('relaxedAlbumKey', () => {
+    it('collapses punctuation differences that normalizeAlbumTitle alone does not', () => {
+      const a = relaxedAlbumKey('nerve bumps (a queer divine satisfaction)');
+      const b = relaxedAlbumKey('nerve bumps: a queer divine satisfaction');
+      expect(a).toBe(b);
+    });
+
+    it('does not collapse a sequel-numbered title onto its base title', () => {
+      expect(relaxedAlbumKey('black metal 2')).not.toBe(relaxedAlbumKey('black metal'));
+    });
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/plan-writes.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/plan-writes.test.ts
@@ -101,4 +101,44 @@ describe('digital-archive-bind planWrites', () => {
     expect(plan.toInsert[0].candidate.files[0].objectKey).toBe('freeform.mp3');
     expect(plan.sameRunCollision).toEqual([{ libraryId: 1, discNumber: 1, objectKeys: ['rotation.mp3'] }]);
   });
+
+  // The collision guard has to cover the reopen branch as well as the empty-slot
+  // one. Without it both candidates land in `rejectedReopened` carrying the SAME
+  // asset id, which puts a duplicate id in `executeWrites`'s VALUES-join UPDATE
+  // (Postgres then picks one `v` row arbitrarily) and pushes both albums' files
+  // onto that single asset — plus a unique-index abort if their keys overlap.
+  // Delete the `claimedThisRun` check in the `rejected` branch and this fails.
+  it('reports a same-run collision when two candidates reopen the same rejected slot', () => {
+    const existing: ExistingSlot[] = [{ id: 20, libraryId: 1, discNumber: 1, status: 'rejected' }];
+    const plan = planWrites(
+      [matchedOf(1, 1, ['freeform.mp3']), matchedOf(1, 1, ['rotation.mp3'])],
+      existing,
+      new Map(),
+      // A rebind file naming a key from each candidate — the case an operator
+      // reaches for when recovering an orphaned slot.
+      new Set(['freeform.mp3', 'rotation.mp3'])
+    );
+    expect(plan.rejectedReopened).toHaveLength(1);
+    expect(plan.rejectedReopened[0].assetId).toBe(20);
+    expect(plan.rejectedReopened[0].matched.candidate.files[0].objectKey).toBe('freeform.mp3');
+    expect(plan.sameRunCollision).toEqual([{ libraryId: 1, discNumber: 1, objectKeys: ['rotation.mp3'] }]);
+  });
+
+  // A candidate that doesn't win the rebind must not consume the slot claim:
+  // it was never queued, so a later candidate that DOES name a rebind key is
+  // still free to reopen. Guards against "fix" the collision by claiming the
+  // key on the blocked path too.
+  it('a rebind-less candidate leaves a later rebind-bearing one free to reopen the slot', () => {
+    const existing: ExistingSlot[] = [{ id: 20, libraryId: 1, discNumber: 1, status: 'rejected' }];
+    const plan = planWrites(
+      [matchedOf(1, 1, ['no-rebind.mp3']), matchedOf(1, 1, ['named.mp3'])],
+      existing,
+      new Map(),
+      new Set(['named.mp3'])
+    );
+    expect(plan.rejectedBlocked).toEqual([{ libraryId: 1, discNumber: 1, objectKeys: ['no-rebind.mp3'] }]);
+    expect(plan.rejectedReopened).toHaveLength(1);
+    expect(plan.rejectedReopened[0].matched.candidate.files[0].objectKey).toBe('named.mp3');
+    expect(plan.sameRunCollision).toHaveLength(0);
+  });
 });

--- a/tests/unit/jobs/digital-archive-bind/plan-writes.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/plan-writes.test.ts
@@ -1,0 +1,104 @@
+import { planWrites, type ExistingSlot } from '../../../../jobs/digital-archive-bind/write';
+import type { MatchedAlbum } from '../../../../jobs/digital-archive-bind/types';
+
+const matchedOf = (
+  libraryId: number,
+  discNumber: number,
+  objectKeys: string[],
+  tier: 'exact' | 'fuzzy' = 'exact'
+): MatchedAlbum => ({
+  candidate: {
+    contentKind: 'freeform',
+    artistFoldKey: 'artist',
+    albumNormKey: 'album',
+    discNumber,
+    displayArtist: 'Artist',
+    displayAlbum: 'Album',
+    files: objectKeys.map((objectKey) => ({
+      objectKey,
+      contentKind: 'freeform',
+      codec: 'mp3',
+      bytes: 1000,
+      md5: null,
+      tags: { title: null, artist: null, album: null, albumArtist: null, track: null, disc: null, durationMs: null },
+    })),
+  },
+  libraryId,
+  tier,
+  bindNote: tier,
+});
+
+describe('digital-archive-bind planWrites', () => {
+  it('plans an insert for a candidate with no existing slot', () => {
+    const plan = planWrites([matchedOf(1, 1, ['a.mp3'])], [], new Map(), new Set());
+    expect(plan.toInsert).toHaveLength(1);
+    expect(plan.rejectedBlocked).toHaveLength(0);
+    expect(plan.rejectedReopened).toHaveLength(0);
+    expect(plan.boundDrift).toHaveLength(0);
+  });
+
+  it('skips a slot already needs_review -- a re-run is a no-op', () => {
+    const existing: ExistingSlot[] = [{ id: 10, libraryId: 1, discNumber: 1, status: 'needs_review' }];
+    const plan = planWrites([matchedOf(1, 1, ['a.mp3'])], existing, new Map(), new Set());
+    expect(plan.toInsert).toHaveLength(0);
+    expect(plan.rejectedBlocked).toHaveLength(0);
+    expect(plan.rejectedReopened).toHaveLength(0);
+    expect(plan.boundDrift).toHaveLength(0);
+  });
+
+  it('skips and reports a slot held by a rejected row, with its object keys and slot', () => {
+    const existing: ExistingSlot[] = [{ id: 20, libraryId: 1, discNumber: 1, status: 'rejected' }];
+    const plan = planWrites([matchedOf(1, 1, ['a.mp3', 'b.mp3'])], existing, new Map(), new Set());
+    expect(plan.toInsert).toHaveLength(0);
+    expect(plan.rejectedReopened).toHaveLength(0);
+    expect(plan.rejectedBlocked).toEqual([{ libraryId: 1, discNumber: 1, objectKeys: ['a.mp3', 'b.mp3'] }]);
+  });
+
+  it('reopens a rejected slot when --rebind-keys names one of the candidate object keys', () => {
+    const existing: ExistingSlot[] = [{ id: 20, libraryId: 1, discNumber: 1, status: 'rejected' }];
+    const plan = planWrites([matchedOf(1, 1, ['a.mp3', 'b.mp3'])], existing, new Map(), new Set(['b.mp3']));
+    expect(plan.rejectedBlocked).toHaveLength(0);
+    expect(plan.rejectedReopened).toEqual([{ assetId: 20, matched: matchedOf(1, 1, ['a.mp3', 'b.mp3']) }]);
+  });
+
+  it('never writes into a bound slot, even under --rebind-keys', () => {
+    const existing: ExistingSlot[] = [{ id: 30, libraryId: 1, discNumber: 1, status: 'bound' }];
+    const boundFiles = new Map([[30, ['a.mp3']]]);
+    const plan = planWrites([matchedOf(1, 1, ['a.mp3'])], existing, boundFiles, new Set(['a.mp3']));
+    expect(plan.toInsert).toHaveLength(0);
+    expect(plan.rejectedReopened).toHaveLength(0);
+    expect(plan.boundDrift).toHaveLength(0); // keys match -- no drift
+  });
+
+  it("reports drift when a bound slot's files differ from the candidate's keys", () => {
+    const existing: ExistingSlot[] = [{ id: 30, libraryId: 1, discNumber: 1, status: 'bound' }];
+    const boundFiles = new Map([[30, ['old-key.mp3']]]);
+    const plan = planWrites([matchedOf(1, 1, ['new-key.mp3'])], existing, boundFiles, new Set());
+    expect(plan.toInsert).toHaveLength(0);
+    expect(plan.boundDrift).toEqual([
+      { assetId: 30, libraryId: 1, discNumber: 1, candidateKeys: ['new-key.mp3'], boundKeys: ['old-key.mp3'] },
+    ]);
+  });
+
+  it('treats disc_number as part of the slot key -- disc 2 of a bound album still inserts', () => {
+    const existing: ExistingSlot[] = [{ id: 30, libraryId: 1, discNumber: 1, status: 'bound' }];
+    const boundFiles = new Map([[30, ['disc1.mp3']]]);
+    const plan = planWrites([matchedOf(1, 2, ['disc2.mp3'])], existing, boundFiles, new Set());
+    expect(plan.toInsert).toHaveLength(1);
+    expect(plan.boundDrift).toHaveLength(0);
+  });
+
+  it('reports a same-run collision when two candidates target the same empty slot, and queues only the first', () => {
+    // e.g. a freeform/ copy and a rotation/Heavy/ copy of the same album,
+    // both present in the Space and both matching the same library_id.
+    const plan = planWrites(
+      [matchedOf(1, 1, ['freeform.mp3']), matchedOf(1, 1, ['rotation.mp3'])],
+      [],
+      new Map(),
+      new Set()
+    );
+    expect(plan.toInsert).toHaveLength(1);
+    expect(plan.toInsert[0].candidate.files[0].objectKey).toBe('freeform.mp3');
+    expect(plan.sameRunCollision).toEqual([{ libraryId: 1, discNumber: 1, objectKeys: ['rotation.mp3'] }]);
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/report.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/report.test.ts
@@ -1,0 +1,56 @@
+import { formatSummary, type RunSummary } from '../../../../jobs/digital-archive-bind/report';
+
+const baseSummary: RunSummary = {
+  mode: 'dry-run',
+  filesSeen: 100,
+  skippedByReason: { 'non-audio-extension': 3, 'not-content-prefix': 2 },
+  albumsGrouped: 10,
+  ungroupableFiles: 1,
+  matchedExact: 6,
+  matchedFuzzy: 1,
+  ambiguous: 1,
+  unmatched: 2,
+  inserted: 7,
+  reopened: 0,
+  rejectedBlocked: [],
+  boundDrift: [],
+  sameRunCollision: [],
+};
+
+describe('digital-archive-bind report', () => {
+  it('renders the counts a dry run promises', () => {
+    const text = formatSummary(baseSummary);
+    expect(text).toContain('DRY-RUN');
+    expect(text).toContain('files seen:        100');
+    expect(text).toContain('would insert (needs_review): 7');
+    expect(text).toContain('skipped (non-audio-extension): 3');
+  });
+
+  it('never reports a blocked or bound-drift row silently -- object keys and slot are always printed', () => {
+    const summary: RunSummary = {
+      ...baseSummary,
+      rejectedBlocked: [{ libraryId: 5, discNumber: 1, objectKeys: ['a.mp3', 'b.mp3'] }],
+      boundDrift: [{ assetId: 9, libraryId: 6, discNumber: 1, candidateKeys: ['new.mp3'], boundKeys: ['old.mp3'] }],
+    };
+    const text = formatSummary(summary);
+    expect(text).toContain('a.mp3, b.mp3');
+    expect(text).toContain('--rebind-keys');
+    expect(text).toContain('old.mp3');
+    expect(text).toContain('new.mp3');
+  });
+
+  it('reports a same-run collision with its slot and object keys', () => {
+    const summary: RunSummary = {
+      ...baseSummary,
+      sameRunCollision: [{ libraryId: 5, discNumber: 1, objectKeys: ['rotation.mp3'] }],
+    };
+    const text = formatSummary(summary);
+    expect(text).toContain('library_id=5 disc=1: rotation.mp3');
+  });
+
+  it("labels an apply run's counts as done, not projected", () => {
+    const text = formatSummary({ ...baseSummary, mode: 'apply' });
+    expect(text).toContain('inserted (needs_review): 7');
+    expect(text).not.toContain('would insert');
+  });
+});

--- a/tests/unit/jobs/digital-archive-bind/store.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/store.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
 import { md5FromETag } from '../../../../jobs/digital-archive-bind/store';
 
@@ -19,11 +19,27 @@ describe('digital-archive-bind store', () => {
 
   describe('read-only enforcement', () => {
     // BS#2319 constraint: "Read-only against the Space -- GET/LIST only; a
-    // write-capable code path must not exist." This greps the module's own
-    // source rather than trusting a docblock, so a future edit that adds a
-    // write command fails a test instead of failing silently.
-    it('imports no write-capable S3 command', () => {
-      const source = readFileSync(path.join(__dirname, '../../../../jobs/digital-archive-bind/store.ts'), 'utf8');
+    // write-capable code path must not exist." This greps source rather than
+    // trusting a docblock, so a future edit that adds a write command fails a
+    // test instead of failing silently.
+    //
+    // It scans EVERY .ts file in the job, not just store.ts: the claim the
+    // module header and the README both make is that no mutating command
+    // exists anywhere in this job, and a guard scoped to one file would pass
+    // while a sibling module imported DeleteObjectCommand.
+    const jobSources = (): string => {
+      const dir = path.join(__dirname, '../../../../jobs/digital-archive-bind');
+      const walk = (d: string): string[] =>
+        readdirSync(d, { withFileTypes: true }).flatMap((e) =>
+          e.isDirectory() ? walk(path.join(d, e.name)) : e.name.endsWith('.ts') ? [path.join(d, e.name)] : []
+        );
+      const files = walk(dir);
+      expect(files.length).toBeGreaterThan(1); // a walk that finds nothing must not pass vacuously
+      return files.map((f) => readFileSync(f, 'utf8')).join('\n');
+    };
+
+    it('imports no write-capable S3 command anywhere in the job', () => {
+      const source = jobSources();
       const forbidden = [
         'PutObjectCommand',
         'DeleteObjectCommand',

--- a/tests/unit/jobs/digital-archive-bind/store.test.ts
+++ b/tests/unit/jobs/digital-archive-bind/store.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { md5FromETag } from '../../../../jobs/digital-archive-bind/store';
+
+describe('digital-archive-bind store', () => {
+  describe('md5FromETag', () => {
+    it('extracts the MD5 from a single-part ETag', () => {
+      expect(md5FromETag('"9e107d9d372bb6826bd81d3542a419d6"')).toBe('9e107d9d372bb6826bd81d3542a419d6');
+    });
+
+    it('returns null for a multipart ETag (-N suffix)', () => {
+      expect(md5FromETag('"9e107d9d372bb6826bd81d3542a419d6-4"')).toBeNull();
+    });
+
+    it('returns null for a malformed ETag', () => {
+      expect(md5FromETag('not-an-etag')).toBeNull();
+    });
+  });
+
+  describe('read-only enforcement', () => {
+    // BS#2319 constraint: "Read-only against the Space -- GET/LIST only; a
+    // write-capable code path must not exist." This greps the module's own
+    // source rather than trusting a docblock, so a future edit that adds a
+    // write command fails a test instead of failing silently.
+    it('imports no write-capable S3 command', () => {
+      const source = readFileSync(path.join(__dirname, '../../../../jobs/digital-archive-bind/store.ts'), 'utf8');
+      const forbidden = [
+        'PutObjectCommand',
+        'DeleteObjectCommand',
+        'DeleteObjectsCommand',
+        'CopyObjectCommand',
+        'CreateMultipartUploadCommand',
+        'UploadPartCommand',
+        'CompleteMultipartUploadCommand',
+        'PutBucketCommand',
+        'DeleteBucketCommand',
+        'PutObjectAclCommand',
+      ];
+      for (const name of forbidden) {
+        expect(source).not.toContain(name);
+      }
+    });
+
+    it('imports only S3Client, ListObjectsV2Command, and GetObjectCommand from @aws-sdk/client-s3', () => {
+      const source = readFileSync(path.join(__dirname, '../../../../jobs/digital-archive-bind/store.ts'), 'utf8');
+      const importLine = source.split('\n').find((l) => l.includes("from '@aws-sdk/client-s3'"));
+      expect(importLine).toBeDefined();
+      expect(importLine).toContain('S3Client');
+      expect(importLine).toContain('ListObjectsV2Command');
+      expect(importLine).toContain('GetObjectCommand');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New one-shot `jobs/digital-archive-bind/`: paginated read-only inventory of the AzuraCast DigitalOcean Space, ID3v2 tag resolution (AzuraCast media API or a 256KB ranged-GET fallback), album grouping on normalized `(album_artist ?? artist, album)` split by disc number, and a two-tier exact/fuzzy matcher against `rotation` (rotation-derived prefixes) then `library` (`freeform/`).
- Matched albums land as `digital_asset(needs_review)` + `digital_asset_file` rows; a reviewer round-trips a CSV via `--export`/`--import` to flip rows to `bound`/`rejected`.
- Implements the issue's binding comments (which supersede the body): `digital_asset_store.name` is `azuracast`; a `rejected` slot is skipped but always reported, with `--rebind-keys` as the targeted recovery path for `merge.ts`'s collision-DELETE orphans; a `bound` slot is never written under any flag, with a files-differ comparison reported as drift.
- The write phase batches into the fewest possible `digital_asset`-touching statements (one `INSERT`, one `UPDATE`) so an `--apply` run costs at most one or two `library_watermark` advances, never one per album (migration 0159's `FOR EACH STATEMENT` trigger).
- Dry-run by default; `--apply` writes. Read-only against the Space by construction — `store.ts` imports only `S3Client`/`ListObjectsV2Command`/`GetObjectCommand`, enforced by a source-grep unit test.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 512 suites / 8968 tests passing (incl. 9 new suites / 81 tests: classify, ID3v2 parser fixtures, normalize/match precedence, album grouping, CSV round trip, the per-slot write planner, and the read-only-import guard)
- [x] `npm run ci:testmock` (targeted): `tests/integration/digital-archive-bind-write.spec.js` against a real Postgres — a fixture album matched against seeded `library`/`rotation` rows produces the expected `needs_review` row + files, a re-run is a no-op, `applyReviewDecisions` flips exactly the rows it's given (only from `needs_review`), and a bound slot reports drift without writing

Closes #2319