### PR TITLE
fix(flowsheet): floor force-end's ended_at at the show's last logged entry

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1310,11 +1310,35 @@ paths:
           schema:
             type: string
             enum: ['true']
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ended_at:
+                  type: string
+                  format: date-time
+                  description: >
+                    Override the derived end instant. Bounded on both ends, or
+                    the request is a 400 naming the bound it missed: at or
+                    before now, and at or after the derived instant it replaces
+                    (the show's last logged entry, floored at `start_time`). An
+                    override can only ever move the close LATER than the
+                    flowsheet's own answer — closing a show before entries it
+                    still owns would sink its `show_end` marker below them in
+                    the flowsheet's global `add_time` order. A show that logged
+                    nothing has no last entry, and there the floor is
+                    `start_time`.
       responses:
         '200':
           description: The finalized show, with `end_time` set
         '400':
-          description: The id was not a positive integer, or the show is already ended
+          description: >
+            The id was not a positive integer, the show is already ended, or
+            `ended_at` was unparseable, in the future, or earlier than the
+            show's last logged entry.
         '403':
           description: 'Caller lacks the `flowsheet: manage` permission'
         '404':

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -1178,14 +1178,33 @@ export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hou
  * need an override — a DJ who stopped logging at 9pm and stayed on the air
  * until 11pm leaves a show whose flowsheet cannot say so, and the operator can.
  *
- * Bounded on BOTH ends because each bound protects a public read. Below
- * `start_time` yields `end_time < start_time`, an interval that cannot overlap
- * anything, which hides the show from `GET /flowsheet/range` on the very day it
- * aired (the same hazard `resolveShowEndInstant`'s own floor exists for). Above
- * `now` yields a show claiming to have ended in the future, which sorts a
- * `show_end` marker above every real entry on the public flowsheet. Out of
- * range is a 400, never a silent clamp: an operator who mistypes a date should
- * learn that, not get a different answer than they asked for.
+ * Bounded on BOTH ends because each bound protects a public read. Above `now`
+ * yields a show claiming to have ended in the future, which sorts a `show_end`
+ * marker above every real entry on the public flowsheet.
+ *
+ * The floor is the DERIVED instant itself, not `start_time` (BS#2315): an
+ * override may only ever move the close LATER than the flowsheet's own answer.
+ * `start_time` alone let a show close before entries it still owns — start
+ * 02:00, entries through 05:00, `ended_at: 02:30` accepted — and that interval
+ * is wrong in the mirror image of the way `now()` is. `getShowsInTimeWindow`
+ * admits a closed show on `start_time < windowEnd AND end_time > windowStart`,
+ * so a 03:00-05:00 window drops it while `GET /flowsheet` still serves its
+ * entries from that span, and any "which show does this entry belong to"
+ * derivation from the interval contradicts the `show_id` FK and `show_djs`.
+ * A show with nothing logged has no last-entry instant, and there
+ * `resolveShowEndInstant` returns `start_time` — so the old bound survives
+ * exactly where it was the honest one.
+ *
+ * Closing a show BEFORE some of its entries is therefore not something this
+ * endpoint offers. When the entries are the thing that is wrong — a later DJ's
+ * rows absorbed into an abandoned show, the 2026-08-20 shape — the remedy is to
+ * re-point them (`jobs/flowsheet-show-split`) and then close, not to truncate
+ * the show around them.
+ *
+ * Out of range is a 400, never a silent clamp: an operator who mistypes a date
+ * should learn that, not get a different answer than they asked for. The
+ * rejection names the floor, because "too early" without "earlier than what"
+ * leaves the operator bisecting.
  */
 const resolveForceEndInstant = async (raw: unknown, show: Show): Promise<Date> => {
   if (raw === undefined || raw === null) {
@@ -1200,12 +1219,18 @@ const resolveForceEndInstant = async (raw: unknown, show: Show): Promise<Date> =
   if (Number.isNaN(endedAt.getTime())) {
     throw new WxycError('Bad Request: ended_at must be an ISO-8601 date-time string', 400);
   }
-  const startedAt = new Date(show.start_time);
-  if (endedAt.getTime() < startedAt.getTime()) {
-    throw new WxycError("Bad Request: ended_at must be at or after the show's start_time", 400);
-  }
+  // Checked before the floor is fetched so a mistyped year costs no query.
   if (endedAt.getTime() > Date.now()) {
     throw new WxycError('Bad Request: ended_at must not be in the future', 400);
+  }
+  const floor = await flowsheet_service.resolveShowEndInstant(show);
+  if (endedAt.getTime() < floor.getTime()) {
+    // `resolveShowEndInstant` collapses "nothing logged" and "last entry
+    // predates start_time" into the same `start_time` answer, so the two
+    // floors are told apart here by comparison rather than by a second query.
+    const because =
+      floor.getTime() > new Date(show.start_time).getTime() ? "the show's last logged entry" : "the show's start_time";
+    throw new WxycError(`Bad Request: ended_at must be at or after ${floor.toISOString()}, ${because}`, 400);
   }
   return endedAt;
 };
@@ -1253,7 +1278,8 @@ export const forceEndShow: RequestHandler<
   }
 
   // The instant the show actually stopped, not `now()` — see `endShow`. An
-  // operator may override it within `[start_time, now]`.
+  // operator may override it, but only upward: the window is
+  // `[resolveShowEndInstant(show), now]`.
   const endedAt = await resolveForceEndInstant(req.body?.ended_at, show);
 
   const finalizedShow: Show = await flowsheet_service.endShow(show, endedAt);

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -1185,15 +1185,35 @@ export const getOpenShows: RequestHandler<object, unknown, unknown, { window_hou
  * The floor is the DERIVED instant itself, not `start_time` (BS#2315): an
  * override may only ever move the close LATER than the flowsheet's own answer.
  * `start_time` alone let a show close before entries it still owns — start
- * 02:00, entries through 05:00, `ended_at: 02:30` accepted — and that interval
- * is wrong in the mirror image of the way `now()` is. `getShowsInTimeWindow`
- * admits a closed show on `start_time < windowEnd AND end_time > windowStart`,
- * so a 03:00-05:00 window drops it while `GET /flowsheet` still serves its
- * entries from that span, and any "which show does this entry belong to"
- * derivation from the interval contradicts the `show_id` FK and `show_djs`.
+ * 02:00, entries at 02:10 and 04:50, `ended_at: 02:30` accepted — and that is
+ * the SAME marker-ordering defect as the `now()` one, pointing the other way.
+ * `endShow` stamps this instant on the `show_end` marker's `add_time` and on
+ * every co-host `dj_leave` marker, and `getEntriesByPage` orders globally by
+ * `add_time DESC, id DESC`, so a sign-off written at 02:30 sorts BELOW the
+ * show's own 04:50 entry: the public flowsheet renders a show that signs off
+ * and then keeps playing.
+ *
+ * The interval misleads reads too, though less than BS#2315's own text claims.
+ * That argument predates `getShowsInTimeWindow`'s third arm (BS#2062,
+ * 2026-08-09), which admits any show an in-window entry references — so a
+ * truncated show is NOT lost from a window holding its entries, and
+ * `entries[].show_id` stays resolvable. What survives is the window holding
+ * NONE of them: over 03:00-04:00 the range read reports that the show above
+ * did not air, though a show is on the air between its start and its last
+ * entry.
+ *
  * A show with nothing logged has no last-entry instant, and there
  * `resolveShowEndInstant` returns `start_time` — so the old bound survives
  * exactly where it was the honest one.
+ *
+ * The floor is deliberately NOT clamped to `now`. `resolveShowEndInstant` has
+ * no upper bound, and `add_time` is written from source values rather than the
+ * server clock on every legacy path, so a show holding a future-stamped entry
+ * has an empty legal range and every override 400s naming a floor in the
+ * future. Clamping would be the worse answer — it re-admits exactly the
+ * truncation this bound exists to refuse — so the floor wins, and the operator
+ * omits `ended_at` and takes the derived instant the no-override path already
+ * stamps.
  *
  * Closing a show BEFORE some of its entries is therefore not something this
  * endpoint offers. When the entries are the thing that is wrong — a later DJ's

--- a/tests/integration/flowsheet-open-shows.spec.js
+++ b/tests/integration/flowsheet-open-shows.spec.js
@@ -52,7 +52,13 @@ describe('operator close (BS#2235)', () => {
   let sql;
   const showIds = {};
 
-  const insertShow = async (key, { startedDaysAgo, endedDaysAgo = null, legacyDjName = null, entries = 0 }) => {
+  // `entriesDaysAgo` defaults to the show's own start, which is what every
+  // pre-BS#2315 probe wanted: a show whose last entry IS its start_time has one
+  // floor, not two, and cannot tell the old bound from the new one.
+  const insertShow = async (
+    key,
+    { startedDaysAgo, endedDaysAgo = null, legacyDjName = null, entries = 0, entriesDaysAgo = undefined }
+  ) => {
     const rows = await sql`
       INSERT INTO ${sql(SCHEMA)}.shows (start_time, end_time, legacy_dj_name)
       VALUES (
@@ -67,7 +73,10 @@ describe('operator close (BS#2235)', () => {
     for (let i = 1; i <= entries; i += 1) {
       await sql`
         INSERT INTO ${sql(SCHEMA)}.flowsheet (show_id, entry_type, play_order, message, add_time)
-        VALUES (${id}, 'message', ${i}, ${`BS2235 probe ${key} ${i}`}, ${daysAgo(startedDaysAgo)}::timestamptz)`;
+        VALUES (
+          ${id}, 'message', ${i}, ${`BS2235 probe ${key} ${i}`},
+          ${daysAgo(entriesDaysAgo ?? startedDaysAgo)}::timestamptz
+        )`;
     }
     return id;
   };
@@ -83,6 +92,22 @@ describe('operator close (BS#2235)', () => {
     await insertShow('closed', { startedDaysAgo: 4, endedDaysAgo: 4, legacyDjName: 'DJ Flacko', entries: 3 });
     await insertShow('ancient', { startedDaysAgo: 300, legacyDjName: 'DJ Flounder', entries: 1 });
     await insertShow('cohost', { startedDaysAgo: 3, legacyDjName: 'El Vaquero', entries: 5 });
+    // The BS#2315 shapes: a four-day gap between start_time and the last
+    // logged entry, which is the span the old `[start_time, now]` bound
+    // accepted in full. One show per 2xx case, since each close consumes it.
+    await insertShow('overrun', {
+      startedDaysAgo: 6,
+      entriesDaysAgo: 2,
+      legacyDjName: 'DJ Overrun',
+      entries: 3,
+    });
+    await insertShow('overrunHigh', {
+      startedDaysAgo: 6,
+      entriesDaysAgo: 2,
+      legacyDjName: 'DJ Overtime',
+      entries: 2,
+    });
+    await insertShow('unlogged', { startedDaysAgo: 6, legacyDjName: 'DJ Blank Slate', entries: 0 });
     await insertShow('current', { startedDaysAgo: 0, legacyDjName: 'dj barely there', entries: 2 });
   });
 
@@ -332,6 +357,84 @@ describe('operator close (BS#2235)', () => {
       const memberships = await sql`SELECT active FROM ${sql(SCHEMA)}.show_djs WHERE show_id = ${id}`;
       expect(memberships).toHaveLength(1);
       expect(memberships[0].active).toBe(false);
+    });
+
+    /**
+     * BS#2315. The override's floor is the DERIVED instant — the show's last
+     * logged entry, floored at `start_time` — not `start_time` alone.
+     *
+     * The bound it replaces was the mirror image of the `now()` defect two
+     * tests above. `now()` stretched a closed show over archive days it did
+     * not air in; `start_time` let one close before entries it still owns, so
+     * `getShowsInTimeWindow` dropped it from windows `GET /flowsheet` was
+     * still serving its entries in.
+     */
+    describe('ended_at override', () => {
+      const lastEntryOf = async (id) => {
+        const [{ latest }] = await sql`
+          SELECT max(add_time) AS latest FROM ${sql(SCHEMA)}.flowsheet WHERE show_id = ${id}`;
+        return new Date(latest);
+      };
+
+      const forceEnd = (id, endedAt) =>
+        request
+          .post(`/flowsheet/shows/${id}/force-end`)
+          .set('Authorization', global.access_token)
+          .send({ ended_at: endedAt });
+
+      const endTimeOf = async (id) => {
+        const [row] = await sql`SELECT end_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+        return row.end_time;
+      };
+
+      // Four days after start_time and two days before the last entry: inside
+      // the old bound, outside the new one.
+      it('rejects an instant below the last logged entry, naming the floor', async () => {
+        const id = showIds.overrun;
+        const floor = await lastEntryOf(id);
+
+        const res = await forceEnd(id, daysAgo(4));
+
+        expect(res.status).toBe(400);
+        expect(res.body.message).toContain(floor.toISOString());
+        expect(await endTimeOf(id)).toBeNull();
+      });
+
+      it('accepts the floor exactly and stamps it', async () => {
+        const id = showIds.overrun;
+        const floor = await lastEntryOf(id);
+
+        const res = await forceEnd(id, floor.toISOString());
+
+        expect(res.status).toBe(200);
+        expect(new Date(await endTimeOf(id)).getTime()).toBe(floor.getTime());
+      });
+
+      // The case the override exists for: a DJ who stopped logging two days
+      // before they actually went off the air.
+      it('accepts an instant above the floor', async () => {
+        const id = showIds.overrunHigh;
+        const above = daysAgo(1);
+
+        const res = await forceEnd(id, above);
+
+        expect(res.status).toBe(200);
+        expect(new Date(await endTimeOf(id)).getTime()).toBe(new Date(above).getTime());
+      });
+
+      // Nothing logged means no last-entry instant, so the floor degrades to
+      // `start_time` — the one case where closing at the start is honest, and
+      // the shape of the entire legacy open-show backlog.
+      it('accepts start_time on a show with no entries', async () => {
+        const id = showIds.unlogged;
+        const [{ start_time: startTime }] = await sql`
+          SELECT start_time FROM ${sql(SCHEMA)}.shows WHERE id = ${id}`;
+
+        const res = await forceEnd(id, new Date(startTime).toISOString());
+
+        expect(res.status).toBe(200);
+        expect(new Date(await endTimeOf(id)).getTime()).toBe(new Date(startTime).getTime());
+      });
     });
   });
 });

--- a/tests/integration/flowsheet-open-shows.spec.js
+++ b/tests/integration/flowsheet-open-shows.spec.js
@@ -364,10 +364,10 @@ describe('operator close (BS#2235)', () => {
      * logged entry, floored at `start_time` — not `start_time` alone.
      *
      * The bound it replaces was the mirror image of the `now()` defect two
-     * tests above. `now()` stretched a closed show over archive days it did
-     * not air in; `start_time` let one close before entries it still owns, so
-     * `getShowsInTimeWindow` dropped it from windows `GET /flowsheet` was
-     * still serving its entries in.
+     * tests above, and it lands on the same surface. `now()` floated the
+     * `show_end` marker to the top of the public flowsheet; `start_time` sank
+     * it BELOW entries the show still owns, so the flowsheet rendered a show
+     * that signed off and kept playing.
      */
     describe('ended_at override', () => {
       const lastEntryOf = async (id) => {

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -270,10 +270,20 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
  * to need an override: a DJ who stopped logging at 9pm and stayed on the air
  * until 11pm leaves a show whose flowsheet cannot say so. The operator can.
  *
- * Bounded on both ends, because both bounds protect a public read. Below
- * `start_time` produces an interval that cannot overlap its own airdate, which
- * hides the show from `GET /flowsheet/range` on the very day it aired; above
- * `now` produces a show that claims to have ended in the future.
+ * Bounded on both ends, because both bounds protect a public read. The floor
+ * is the DERIVED instant itself — `resolveShowEndInstant`, i.e. the show's last
+ * logged entry floored at `start_time` — so the override can only ever move the
+ * close later than the flowsheet's own answer, never earlier (BS#2315). Below
+ * it, a show closes at an instant that precedes entries it still owns:
+ * `getShowsInTimeWindow` then drops it from windows `GET /flowsheet` serves its
+ * entries in, and any "which show does this entry belong to" derivation from
+ * the interval contradicts the `show_id` FK. Above `now` produces a show that
+ * claims to have ended in the future.
+ *
+ * `resolveShowEndInstant` is mocked here, so the floor these tests exercise is
+ * whatever the mock returns — END_INSTANT by default, which is 46 minutes after
+ * `openShow.start_time`. That gap is the point: it separates the two floors the
+ * endpoint used to conflate.
  */
 describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', () => {
   const openShow = {
@@ -288,7 +298,7 @@ describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', (
     mockEndShow.mockResolvedValue({ ...openShow, end_time: END_INSTANT });
   });
 
-  it('uses the supplied instant instead of the derived one', async () => {
+  it('uses a supplied instant above the floor instead of the derived one', async () => {
     const operatorInstant = new Date('2026-08-20T23:30:00.000Z');
     const { res, statusMock } = createMockRes();
 
@@ -307,7 +317,44 @@ describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', (
     expect(mockEndShow).toHaveBeenCalledWith(openShow, END_INSTANT);
   });
 
-  it('accepts an instant exactly at start_time', async () => {
+  it('accepts an instant exactly at the floor', async () => {
+    const { res } = createMockRes();
+
+    await forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: END_INSTANT.toISOString() }), res, next);
+
+    expect(mockEndShow).toHaveBeenCalledWith(openShow, END_INSTANT);
+  });
+
+  /**
+   * The defect BS#2315 fixes. 18:30 is inside `[start_time, now]` and was
+   * accepted, closing a show at an instant 16 minutes before the last entry it
+   * still owns.
+   */
+  it('400s an instant below the floor without closing the show', async () => {
+    const { res } = createMockRes();
+
+    await expect(
+      forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T18:30:00.000Z' }), res, next)
+    ).rejects.toThrow(WxycError);
+    expect(mockEndShow).not.toHaveBeenCalled();
+  });
+
+  // An operator who is told "too early" and not told how early has to bisect.
+  it('names the floor in the rejection', async () => {
+    const { res } = createMockRes();
+
+    await expect(
+      forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T18:30:00.000Z' }), res, next)
+    ).rejects.toThrow(END_INSTANT.toISOString());
+  });
+
+  /**
+   * A show with nothing logged has no last-entry instant, so
+   * `resolveShowEndInstant` returns `start_time` and the floor degrades to the
+   * old bound. That is the one case where closing at `start_time` is honest.
+   */
+  it('accepts start_time on a show with no logged entries', async () => {
+    mockResolveShowEndInstant.mockResolvedValue(openShow.start_time);
     const { res } = createMockRes();
 
     await forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: openShow.start_time.toISOString() }), res, next);
@@ -315,7 +362,8 @@ describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', (
     expect(mockEndShow).toHaveBeenCalledWith(openShow, openShow.start_time);
   });
 
-  it('400s an instant before start_time without closing the show', async () => {
+  it('400s an instant before start_time on a show with no logged entries', async () => {
+    mockResolveShowEndInstant.mockResolvedValue(openShow.start_time);
     const { res } = createMockRes();
 
     await expect(

--- a/tests/unit/controllers/flowsheet.operatorClose.test.ts
+++ b/tests/unit/controllers/flowsheet.operatorClose.test.ts
@@ -274,11 +274,12 @@ describe('POST /flowsheet/shows/:id/force-end', () => {
  * is the DERIVED instant itself — `resolveShowEndInstant`, i.e. the show's last
  * logged entry floored at `start_time` — so the override can only ever move the
  * close later than the flowsheet's own answer, never earlier (BS#2315). Below
- * it, a show closes at an instant that precedes entries it still owns:
- * `getShowsInTimeWindow` then drops it from windows `GET /flowsheet` serves its
- * entries in, and any "which show does this entry belong to" derivation from
- * the interval contradicts the `show_id` FK. Above `now` produces a show that
- * claims to have ended in the future.
+ * it, the `show_end` marker `endShow` stamps with that instant sorts BELOW
+ * entries the show still owns in `getEntriesByPage`'s global `add_time DESC`
+ * order, so the public flowsheet renders a show that signs off and keeps
+ * playing. Above `now` produces a show that claims to have ended in the
+ * future. See the controller docstring for what the range read does and does
+ * not do here — less than BS#2315's own text claims.
  *
  * `resolveShowEndInstant` is mocked here, so the floor these tests exercise is
  * whatever the mock returns — END_INSTANT by default, which is 46 minutes after
@@ -346,6 +347,31 @@ describe('POST /flowsheet/shows/:id/force-end — operator-supplied ended_at', (
     await expect(
       forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T18:30:00.000Z' }), res, next)
     ).rejects.toThrow(END_INSTANT.toISOString());
+  });
+
+  /**
+   * The instant alone does not say which floor it is, and the two mean
+   * different things to the operator: "last logged entry" means split the show
+   * first, "start_time" means the show logged nothing at all. Asserted in both
+   * directions because the discriminator is a comparison that inverts
+   * silently — flipped, it would tell every operator "start_time" while
+   * quoting a last-entry instant, and the assertion above would still pass.
+   */
+  it('says the floor is the last logged entry when the show has one', async () => {
+    const { res } = createMockRes();
+
+    await expect(
+      forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T18:30:00.000Z' }), res, next)
+    ).rejects.toThrow("the show's last logged entry");
+  });
+
+  it('says the floor is start_time when the show logged nothing', async () => {
+    mockResolveShowEndInstant.mockResolvedValue(openShow.start_time);
+    const { res } = createMockRes();
+
+    await expect(
+      forceEndShow(makeReq({}, { id: '1951164' }, { ended_at: '2026-08-20T17:59:59.000Z' }), res, next)
+    ).rejects.toThrow("the show's start_time");
   });
 
   /**


### PR DESCRIPTION
## Problem

The `ended_at` override on `POST /flowsheet/shows/:id/force-end` was bounded to `[start_time, now]`. The upper bound is right. The lower one let an operator close a show at an instant that falls **before** entries the show already contains — a show starting 02:00 with entries logged through 05:00 accepted `ended_at: 02:30`, and then carried the interval `[02:00, 02:30]` while owning rows stamped up to 05:00.

Two public reads then disagree with the row data:

- `getShowsInTimeWindow`, backing `GET /flowsheet/range` (which archive.wxyc.org reads), admits a closed show on `start_time < windowEnd AND end_time > windowStart`. A window covering 03:00–05:00 excludes the show while `GET /flowsheet` still serves its entries from that span.
- Any "which show does this entry belong to" derivation from the interval contradicts the entry's own `show_id` and `show_djs`.

This is the mirror image of the defect the endpoint's own description says the last-entry derivation exists to prevent. That description argues at length against stamping `now()` because it produces an interval overlapping windows the show did not air in; a floor of `start_time` produces an interval that *excludes* windows the show demonstrably did air in.

## The alternative, decided

The issue asked to settle first whether operators genuinely need to close a show *before* some of its entries — because if they do, a floor is the wrong remedy.

They do not, and the case that looks like it is the one this endpoint was built for. When an abandoned show hangs, `joinShow` routes every subsequent DJ into it as a silent co-host (the 2026-08-20 shape), so the hung show accumulates rows that aired after its real end. The thing that is wrong there is the *entries' ownership*, not the show's length: truncating the show around them trades one interval lie for another and leaves the rows pointing at a show that claims not to have been running. `jobs/flowsheet-show-split` already re-points them to the show that aired them. So the remedy is split-then-close, and the 400 is what tells an operator that is the situation they are in.

## What changed

`resolveForceEndInstant`'s floor is now `resolveShowEndInstant(show)` — the same `MAX(add_time)`-floored-at-`start_time` instant the no-override path already derives, reused rather than recomputed. An override may therefore only ever move the close *later* than the flowsheet's own answer, never earlier.

A show with nothing logged has no last-entry instant, and there `resolveShowEndInstant` returns `start_time` — so the old bound survives exactly where it was the honest one, which is also the shape of the entire legacy open-show backlog.

The rejection names the floor as an ISO instant, and names *which* of the two it is ("the show's last logged entry" vs "the show's start_time"), because `resolveShowEndInstant` collapses the two cases and "too early" without "earlier than what" leaves the operator bisecting.

The future check moves above the floor query so a mistyped year costs no round trip.

`ended_at` has no other reader anywhere in the repo (`grep` across `apps/`, `jobs/`, `tests/` finds only this resolver and its own tests), so the change is contained to one function.

## Acceptance criteria

- [x] `ended_at` below the last logged entry's `add_time` is rejected with a 400 that names the floor
- [x] A show with no entries still accepts any `ended_at` in `[start_time, now]`
- [x] `api.yaml`'s `ended_at` description and force-end 400 describe the new floor — [WXYC/wxyc-shared#425](https://github.com/WXYC/wxyc-shared/pull/425)
- [x] Integration coverage for: below-floor rejected, exactly-at-floor accepted, above-floor accepted, no-entries show accepted

## Tests

Unit (`tests/unit/controllers/flowsheet.operatorClose.test.ts`) — written first, both new rejection tests red before the change and green after. The mocked `resolveShowEndInstant` returns an instant 46 minutes after the fixture's `start_time`, and that gap is the point: it separates the two floors the endpoint used to conflate. `accepts an instant exactly at start_time` is replaced by the no-entries case, which is the only situation where that is still the right answer.

Integration (`tests/integration/flowsheet-open-shows.spec.js`) — three new fixture shows with a four-day gap between `start_time` and their last logged entry, which is the span the old bound accepted in full. `insertShow` grows an `entriesDaysAgo` option; every pre-existing probe stamps its entries *at* `start_time`, so none of them could tell the old bound from the new one. One show per 2xx case, since each close consumes it. All three are inserted before `current`, which must stay `max(shows.id)` for the `is_current` assertions.

## Verification

Local, all green:

- `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`
- `npm run test:unit` — 504 suites, 8905 tests
- `npm run ci:testmock` (Docker, isolated compose project and ports) — **115 suites, 1279 tests, 0 failures**

Three local reds along the way were all environmental and are worth recording: five suites failed at `require()` time for missing `jobs/*/dist/*.cjs` until `npm run build` ran in the fresh worktree; `auth-auto-membership` failed until `.env` carried `DEFAULT_ORG_SLUG`; and `library-search-alias` failed until `CATALOG_SEARCH_ALIAS_ENABLED=true`, which `.env.example` ships as `false`. None of them touch this diff.

## Related

Contract half: [WXYC/wxyc-shared#425](https://github.com/WXYC/wxyc-shared/pull/425). No publish is needed to consume it — the change is description-only and no generated type changes shape.

Closes #2315
