### PR TITLE
fix(flowsheet): synthesize streaming search URLs on the V2 flowsheet read path

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -395,6 +395,13 @@ export type FSEntryRaw = {
  * this is the single producer of every IFSEntry that reaches the `/flowsheet`
  * (top-level fields) and `/v2/flowsheet` (`transformToV2`, nested `metadata`)
  * read paths, so guarding the two hardwired streaming URLs here covers both.
+ *
+ * It is NOT, however, the single producer of every flowsheet-shaped payload:
+ * the mutation/peek echoes (`projectFlowsheetEntry`) and the SSE `liveFs:update`
+ * channel (`pickClientFacingColumns`) project straight off the DB/CDC row and
+ * never come through here. They therefore do not get #2339's search-URL fill —
+ * see the header of `utils/album-metadata-projection.ts` for why that asymmetry
+ * is safe.
  */
 export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
   // BS#1714 host guard, shared with the legacy recentEntries serializer
@@ -406,9 +413,14 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
   // #2339: request-time-only fill for whatever the host guard just left
   // absent, mirroring `GET /proxy/metadata/album`'s degradation so the same
   // album doesn't grey out its streaming buttons on this endpoint alone. Runs
-  // AFTER the host guard so a suppressed mislabeled URL degrades to a
-  // synthesized one, same as an outright-missing one. Never persisted — this
-  // only touches the values below, not `raw` or any DB write.
+  // AFTER the host guard so a suppressed mislabeled URL degrades the same way
+  // an outright-missing one does. GATED: the fill only fires for a row whose
+  // post-guard values already carry at least one real streaming URL — shipped
+  // iOS 3.2 skips its live `/proxy/metadata/album` fetch on
+  // `inline.streaming.hasAny`, so filling a zero-streaming row would suppress
+  // the fallback that is the only thing serving it any metadata at all. See
+  // `fillSynthesizedSearchUrls` for the full rationale. Never persisted —
+  // this only touches the values below, not `raw` or any DB write.
   const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
     {
       spotify_url: guardedSpotifyUrl,

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -28,7 +28,11 @@ import {
   lastLoggedShowEntryOrderBy,
   lastLoggedShowEntryOrderBySql,
 } from '@wxyc/database';
-import { ALBUM_METADATA_PROJECTION, suppressMislabeledStreamingUrls } from '../utils/album-metadata-projection.js';
+import {
+  ALBUM_METADATA_PROJECTION,
+  suppressMislabeledStreamingUrls,
+  fillSynthesizedSearchUrls,
+} from '../utils/album-metadata-projection.js';
 import { getUpcomingShowsMapsCached } from './concerts.service.js';
 import { lookupCriticReviewsByAlbumIds } from './album-metadata-lookup.service.js';
 import { getConfig as getCriticReviewsConfig } from '../config/criticReviews.js';
@@ -397,7 +401,24 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
   // (BS#2103) — see `suppressMislabeledStreamingUrls`. Applied once and
   // reused for both the top-level field and the nested `metadata` object
   // below.
-  const { spotify_url, apple_music_url } = suppressMislabeledStreamingUrls(raw);
+  const { spotify_url: guardedSpotifyUrl, apple_music_url: guardedAppleMusicUrl } =
+    suppressMislabeledStreamingUrls(raw);
+  // #2339: request-time-only fill for whatever the host guard just left
+  // absent, mirroring `GET /proxy/metadata/album`'s degradation so the same
+  // album doesn't grey out its streaming buttons on this endpoint alone. Runs
+  // AFTER the host guard so a suppressed mislabeled URL degrades to a
+  // synthesized one, same as an outright-missing one. Never persisted — this
+  // only touches the values below, not `raw` or any DB write.
+  const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
+    {
+      spotify_url: guardedSpotifyUrl,
+      apple_music_url: guardedAppleMusicUrl,
+      youtube_music_url: raw.youtube_music_url,
+      bandcamp_url: raw.bandcamp_url,
+      soundcloud_url: raw.soundcloud_url,
+    },
+    { artist_name: raw.artist_name, album_title: raw.album_title, track_title: raw.track_title }
+  );
   return {
     id: raw.id,
     show_id: raw.show_id,
@@ -429,9 +450,9 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
     release_year: raw.release_year,
     spotify_url,
     apple_music_url,
-    youtube_music_url: raw.youtube_music_url,
-    bandcamp_url: raw.bandcamp_url,
-    soundcloud_url: raw.soundcloud_url,
+    youtube_music_url,
+    bandcamp_url,
+    soundcloud_url,
     artist_bio: raw.artist_bio,
     artist_wikipedia_url: raw.artist_wikipedia_url,
     on_streaming: raw.on_streaming ?? null,
@@ -452,9 +473,9 @@ export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
       release_year: raw.release_year,
       spotify_url,
       apple_music_url,
-      youtube_music_url: raw.youtube_music_url,
-      bandcamp_url: raw.bandcamp_url,
-      soundcloud_url: raw.soundcloud_url,
+      youtube_music_url,
+      bandcamp_url,
+      soundcloud_url,
       artist_bio: raw.artist_bio,
       artist_wikipedia_url: raw.artist_wikipedia_url,
       genres: raw.genres,

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -86,6 +86,7 @@ import {
   ALBUM_METADATA_PROJECTION_WITHOUT_ARTWORK,
   suppressMislabeledStreamingUrls,
   fillSynthesizedSearchUrls,
+  type SynthesizableStreamingUrls,
 } from '../utils/album-metadata-projection.js';
 import type { ConcertDTO } from './concerts.service.js';
 import { attachUpcomingShows, attachCriticReviews, getOnAirDJName } from './flowsheet.service.js';
@@ -1207,17 +1208,29 @@ async function resolveCriticReviews(candidates: RecentRow[]): Promise<Map<number
  * deliberately excluded, mirroring their exclusion from the iOS predicate —
  * none of them is playcut-detail metadata, so none of them can prevent the
  * empty render this guard exists to stop.
+ *
+ * The five streaming fields come in as `preFillStreaming` — the post-host-guard
+ * values BEFORE #2339's search-URL fill — rather than being read back off
+ * `grouped`, because a synthesized search URL is not renderable metadata for
+ * this rule's purposes: it is the same request-time fallback the proxy already
+ * builds out of nothing, so a row whose only wire values are synthesized
+ * fallbacks is still terminal-but-empty and must keep the 3.2 fallback fetch.
+ * They run through the same {@link wireUrl} filter the wire keys themselves do,
+ * so "present" here means exactly "would have earned a key without the fill".
+ * (With the fill gated on an existing real streaming URL this can only differ
+ * from the post-fill reading for a value that is non-blank yet unwireable, but
+ * the pre-fill reading is the one that is correct by construction.)
  */
-function hasRenderableInlineMetadata(grouped: GroupedPlaycut): boolean {
+function hasRenderableInlineMetadata(grouped: GroupedPlaycut, preFillStreaming: SynthesizableStreamingUrls): boolean {
   return (
     grouped.artworkURL !== undefined ||
     grouped.discogsURL !== undefined ||
     grouped.releaseYear !== undefined ||
-    grouped.spotifyURL !== undefined ||
-    grouped.appleMusicURL !== undefined ||
-    grouped.youtubeMusicURL !== undefined ||
-    grouped.bandcampURL !== undefined ||
-    grouped.soundcloudURL !== undefined ||
+    wireUrl(preFillStreaming.spotify_url) !== undefined ||
+    wireUrl(preFillStreaming.apple_music_url) !== undefined ||
+    wireUrl(preFillStreaming.youtube_music_url) !== undefined ||
+    wireUrl(preFillStreaming.bandcamp_url) !== undefined ||
+    wireUrl(preFillStreaming.soundcloud_url) !== undefined ||
     grouped.artistBio !== undefined ||
     grouped.artistWikipediaURL !== undefined ||
     grouped.genres !== undefined ||
@@ -1230,18 +1243,45 @@ function applyPlaycutMetadata(grouped: GroupedPlaycut, meta: PlaycutMetadataRow)
   // Spotify/Apple was mislabeled at the LML boundary before #1712 shipped and
   // must not reach the hardwired iOS "Spotify"/"Apple Music" button. Same
   // guard, same helper, as the /flowsheet serve seam.
-  const { spotify_url: guardedSpotifyUrl, apple_music_url: guardedAppleMusicUrl } =
-    suppressMislabeledStreamingUrls(meta);
+  const guarded = suppressMislabeledStreamingUrls(meta);
+  // The post-guard, PRE-#2339-fill streaming snapshot. Two consumers: the fill
+  // below takes it as input, and `hasRenderableInlineMetadata` reads it instead
+  // of `grouped` so a synthesized fallback can never manufacture "renderable
+  // metadata" out of a row that has none (BS#2103's empty-card guard).
+  const preFillStreaming: SynthesizableStreamingUrls = {
+    spotify_url: guarded.spotify_url,
+    apple_music_url: guarded.apple_music_url,
+    youtube_music_url: meta.youtube_music_url,
+    bandcamp_url: meta.bandcamp_url,
+    soundcloud_url: meta.soundcloud_url,
+  };
+
+  // #2339: request-time-only fill of whatever the COALESCE + host guard left
+  // absent, same helper and same ordering (guard, THEN fill) as
+  // `transformToIFSEntry` — so a suppressed mislabeled URL degrades exactly as
+  // an outright-missing one does. GATED on the snapshot above already carrying
+  // at least one real streaming URL: shipped iOS 3.2 skips its live
+  // `/proxy/metadata/album` fetch on `inline.streaming.hasAny`, so filling a
+  // zero-streaming row would suppress the very fallback that gives that row any
+  // metadata at all. See `fillSynthesizedSearchUrls` for the full rationale.
+  // Never persisted: `meta` (the DB row) is untouched, only this local response
+  // shape is filled.
+  //
+  // Computed BEFORE any of the five keys is written, so each is set exactly
+  // once and the wire's JSON key order is byte-identical to the pre-#2339
+  // output (pre-PR review finding 5).
+  const streaming = fillSynthesizedSearchUrls(preFillStreaming, {
+    artist_name: meta.artist_name,
+    album_title: meta.album_title,
+    track_title: meta.track_title,
+  });
 
   setUrlField(grouped, 'discogsURL', meta.discogs_url);
-  // Pre-#2339 (guarded, not yet synthesized) values first, so the
-  // `hasRenderableInlineMetadata` snapshot below reads real persisted state —
-  // see the snapshot's own comment for why.
-  setUrlField(grouped, 'spotifyURL', guardedSpotifyUrl);
-  setUrlField(grouped, 'appleMusicURL', guardedAppleMusicUrl);
-  setUrlField(grouped, 'youtubeMusicURL', meta.youtube_music_url);
-  setUrlField(grouped, 'bandcampURL', meta.bandcamp_url);
-  setUrlField(grouped, 'soundcloudURL', meta.soundcloud_url);
+  setUrlField(grouped, 'spotifyURL', streaming.spotify_url);
+  setUrlField(grouped, 'appleMusicURL', streaming.apple_music_url);
+  setUrlField(grouped, 'youtubeMusicURL', streaming.youtube_music_url);
+  setUrlField(grouped, 'bandcampURL', streaming.bandcamp_url);
+  setUrlField(grouped, 'soundcloudURL', streaming.soundcloud_url);
   setUrlField(grouped, 'artistWikipediaURL', meta.artist_wikipedia_url);
 
   if (meta.release_year !== null) {
@@ -1269,44 +1309,13 @@ function applyPlaycutMetadata(grouped: GroupedPlaycut, meta: PlaycutMetadataRow)
   // Option-3 serve rule (BS#2103 review): the status accompanies renderable
   // metadata or stays home. Evaluated HERE — after every one of the 12
   // predicate fields above (and the caller's earlier artworkURL assignment)
-  // has run, but BEFORE the #2339 fill below overwrites the five streaming
-  // URL fields — so the check reads the post-guard, PRE-SYNTHESIS payload,
-  // not the DB row and not the filled-in search URLs. A synthesized search
-  // URL is not "renderable metadata" in the sense this predicate protects:
-  // it's the same request-time fallback the proxy already builds from
-  // nothing, so a row whose only wire values are synthesized fallbacks is
-  // still terminal-but-empty for this rule's purposes, and must still ride
-  // to the `!hasRenderableInlineMetadata` branch's 3.2 fallback fetch rather
-  // than short-circuiting to a card with five search buttons and nothing
-  // else (BS#2103's empty-card bug, reopened if this snapshot moved after
-  // the fill).
-  const hasRealRenderableMetadata = hasRenderableInlineMetadata(grouped);
-
-  // #2339: request-time-only fill for whatever the host guard just left
-  // absent, same helper and same ordering (guard, THEN fill) as
-  // `transformToIFSEntry` — a suppressed mislabeled URL degrades to a
-  // synthesized one exactly as an outright-missing one does. Never
-  // persisted: `meta` (the DB row) is untouched, only this local response
-  // shape is filled. Applied AFTER the `hasRenderableInlineMetadata`
-  // snapshot above so the fill can't manufacture "renderable metadata" out
-  // of a row that has none.
-  const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
-    {
-      spotify_url: guardedSpotifyUrl,
-      apple_music_url: guardedAppleMusicUrl,
-      youtube_music_url: meta.youtube_music_url,
-      bandcamp_url: meta.bandcamp_url,
-      soundcloud_url: meta.soundcloud_url,
-    },
-    { artist_name: meta.artist_name, album_title: meta.album_title, track_title: meta.track_title }
-  );
-  setUrlField(grouped, 'spotifyURL', spotify_url);
-  setUrlField(grouped, 'appleMusicURL', apple_music_url);
-  setUrlField(grouped, 'youtubeMusicURL', youtube_music_url);
-  setUrlField(grouped, 'bandcampURL', bandcamp_url);
-  setUrlField(grouped, 'soundcloudURL', soundcloud_url);
-
-  if (meta.metadata_status !== null && hasRealRenderableMetadata) {
+  // has run — and against `preFillStreaming` rather than the filled wire
+  // values, so a row whose only populated fields would be synthesized
+  // fallbacks still counts as terminal-but-EMPTY and keeps 3.2's live
+  // `/proxy/metadata/album` fetch instead of short-circuiting to a card with
+  // five search buttons and nothing else. Position in the key order is
+  // unchanged from the unconditional version; only presence is conditional.
+  if (meta.metadata_status !== null && hasRenderableInlineMetadata(grouped, preFillStreaming)) {
     grouped.metadataStatus = meta.metadata_status;
   }
   // BS#1908 present-or-absent: null means "no library row", which is not the

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -1232,29 +1232,16 @@ function applyPlaycutMetadata(grouped: GroupedPlaycut, meta: PlaycutMetadataRow)
   // guard, same helper, as the /flowsheet serve seam.
   const { spotify_url: guardedSpotifyUrl, apple_music_url: guardedAppleMusicUrl } =
     suppressMislabeledStreamingUrls(meta);
-  // #2339: request-time-only fill for whatever the host guard just left
-  // absent, same helper and same ordering (guard, THEN fill) as
-  // `transformToIFSEntry` — a suppressed mislabeled URL degrades to a
-  // synthesized one exactly as an outright-missing one does. Never
-  // persisted: `meta` (the DB row) is untouched, only this local response
-  // shape is filled.
-  const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
-    {
-      spotify_url: guardedSpotifyUrl,
-      apple_music_url: guardedAppleMusicUrl,
-      youtube_music_url: meta.youtube_music_url,
-      bandcamp_url: meta.bandcamp_url,
-      soundcloud_url: meta.soundcloud_url,
-    },
-    { artist_name: meta.artist_name, album_title: meta.album_title, track_title: meta.track_title }
-  );
 
   setUrlField(grouped, 'discogsURL', meta.discogs_url);
-  setUrlField(grouped, 'spotifyURL', spotify_url);
-  setUrlField(grouped, 'appleMusicURL', apple_music_url);
-  setUrlField(grouped, 'youtubeMusicURL', youtube_music_url);
-  setUrlField(grouped, 'bandcampURL', bandcamp_url);
-  setUrlField(grouped, 'soundcloudURL', soundcloud_url);
+  // Pre-#2339 (guarded, not yet synthesized) values first, so the
+  // `hasRenderableInlineMetadata` snapshot below reads real persisted state —
+  // see the snapshot's own comment for why.
+  setUrlField(grouped, 'spotifyURL', guardedSpotifyUrl);
+  setUrlField(grouped, 'appleMusicURL', guardedAppleMusicUrl);
+  setUrlField(grouped, 'youtubeMusicURL', meta.youtube_music_url);
+  setUrlField(grouped, 'bandcampURL', meta.bandcamp_url);
+  setUrlField(grouped, 'soundcloudURL', meta.soundcloud_url);
   setUrlField(grouped, 'artistWikipediaURL', meta.artist_wikipedia_url);
 
   if (meta.release_year !== null) {
@@ -1282,11 +1269,44 @@ function applyPlaycutMetadata(grouped: GroupedPlaycut, meta: PlaycutMetadataRow)
   // Option-3 serve rule (BS#2103 review): the status accompanies renderable
   // metadata or stays home. Evaluated HERE — after every one of the 12
   // predicate fields above (and the caller's earlier artworkURL assignment)
-  // has run — so the check reads the post-guard WIRE payload, not the DB row:
-  // a row whose only persisted values were guarded off the wire counts as
-  // empty. Position in the key order is unchanged from the unconditional
-  // version; only presence is conditional.
-  if (meta.metadata_status !== null && hasRenderableInlineMetadata(grouped)) {
+  // has run, but BEFORE the #2339 fill below overwrites the five streaming
+  // URL fields — so the check reads the post-guard, PRE-SYNTHESIS payload,
+  // not the DB row and not the filled-in search URLs. A synthesized search
+  // URL is not "renderable metadata" in the sense this predicate protects:
+  // it's the same request-time fallback the proxy already builds from
+  // nothing, so a row whose only wire values are synthesized fallbacks is
+  // still terminal-but-empty for this rule's purposes, and must still ride
+  // to the `!hasRenderableInlineMetadata` branch's 3.2 fallback fetch rather
+  // than short-circuiting to a card with five search buttons and nothing
+  // else (BS#2103's empty-card bug, reopened if this snapshot moved after
+  // the fill).
+  const hasRealRenderableMetadata = hasRenderableInlineMetadata(grouped);
+
+  // #2339: request-time-only fill for whatever the host guard just left
+  // absent, same helper and same ordering (guard, THEN fill) as
+  // `transformToIFSEntry` — a suppressed mislabeled URL degrades to a
+  // synthesized one exactly as an outright-missing one does. Never
+  // persisted: `meta` (the DB row) is untouched, only this local response
+  // shape is filled. Applied AFTER the `hasRenderableInlineMetadata`
+  // snapshot above so the fill can't manufacture "renderable metadata" out
+  // of a row that has none.
+  const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
+    {
+      spotify_url: guardedSpotifyUrl,
+      apple_music_url: guardedAppleMusicUrl,
+      youtube_music_url: meta.youtube_music_url,
+      bandcamp_url: meta.bandcamp_url,
+      soundcloud_url: meta.soundcloud_url,
+    },
+    { artist_name: meta.artist_name, album_title: meta.album_title, track_title: meta.track_title }
+  );
+  setUrlField(grouped, 'spotifyURL', spotify_url);
+  setUrlField(grouped, 'appleMusicURL', apple_music_url);
+  setUrlField(grouped, 'youtubeMusicURL', youtube_music_url);
+  setUrlField(grouped, 'bandcampURL', bandcamp_url);
+  setUrlField(grouped, 'soundcloudURL', soundcloud_url);
+
+  if (meta.metadata_status !== null && hasRealRenderableMetadata) {
     grouped.metadataStatus = meta.metadata_status;
   }
   // BS#1908 present-or-absent: null means "no library row", which is not the

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -85,6 +85,7 @@ import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import {
   ALBUM_METADATA_PROJECTION_WITHOUT_ARTWORK,
   suppressMislabeledStreamingUrls,
+  fillSynthesizedSearchUrls,
 } from '../utils/album-metadata-projection.js';
 import type { ConcertDTO } from './concerts.service.js';
 import { attachUpcomingShows, attachCriticReviews, getOnAirDJName } from './flowsheet.service.js';
@@ -951,6 +952,14 @@ type PlaycutMetadataRow = {
   discogs_unavailable: boolean | null;
   discogs_unavailable_note: string | null;
   metadata_status: string | null;
+  // #2339: search-URL-synthesis inputs. Pulled straight off `flowsheet`
+  // (not `GroupedPlaycut.artistName`/`releaseTitle`/`songTitle`, which come
+  // from the tubafrenzy mirror payload and can drift from these columns —
+  // mojibake era, name variants) so this surface synthesizes from the exact
+  // same text `/flowsheet`'s `transformToIFSEntry` does.
+  artist_name: string | null;
+  album_title: string | null;
+  track_title: string | null;
 };
 
 /**
@@ -1000,6 +1009,10 @@ async function enrichPlaycutMetadata(candidates: Array<{ id: number }>): Promise
         discogs_unavailable: library.discogs_unavailable,
         discogs_unavailable_note: library.discogs_unavailable_note,
         metadata_status: flowsheet.metadata_status,
+        // #2339 synthesis inputs — see PlaycutMetadataRow's doc comment.
+        artist_name: flowsheet.artist_name,
+        album_title: flowsheet.album_title,
+        track_title: flowsheet.track_title,
       })
       .from(flowsheet)
       .leftJoin(library, eq(library.id, flowsheet.album_id))
@@ -1217,14 +1230,31 @@ function applyPlaycutMetadata(grouped: GroupedPlaycut, meta: PlaycutMetadataRow)
   // Spotify/Apple was mislabeled at the LML boundary before #1712 shipped and
   // must not reach the hardwired iOS "Spotify"/"Apple Music" button. Same
   // guard, same helper, as the /flowsheet serve seam.
-  const { spotify_url, apple_music_url } = suppressMislabeledStreamingUrls(meta);
+  const { spotify_url: guardedSpotifyUrl, apple_music_url: guardedAppleMusicUrl } =
+    suppressMislabeledStreamingUrls(meta);
+  // #2339: request-time-only fill for whatever the host guard just left
+  // absent, same helper and same ordering (guard, THEN fill) as
+  // `transformToIFSEntry` — a suppressed mislabeled URL degrades to a
+  // synthesized one exactly as an outright-missing one does. Never
+  // persisted: `meta` (the DB row) is untouched, only this local response
+  // shape is filled.
+  const { spotify_url, apple_music_url, youtube_music_url, bandcamp_url, soundcloud_url } = fillSynthesizedSearchUrls(
+    {
+      spotify_url: guardedSpotifyUrl,
+      apple_music_url: guardedAppleMusicUrl,
+      youtube_music_url: meta.youtube_music_url,
+      bandcamp_url: meta.bandcamp_url,
+      soundcloud_url: meta.soundcloud_url,
+    },
+    { artist_name: meta.artist_name, album_title: meta.album_title, track_title: meta.track_title }
+  );
 
   setUrlField(grouped, 'discogsURL', meta.discogs_url);
   setUrlField(grouped, 'spotifyURL', spotify_url);
   setUrlField(grouped, 'appleMusicURL', apple_music_url);
-  setUrlField(grouped, 'youtubeMusicURL', meta.youtube_music_url);
-  setUrlField(grouped, 'bandcampURL', meta.bandcamp_url);
-  setUrlField(grouped, 'soundcloudURL', meta.soundcloud_url);
+  setUrlField(grouped, 'youtubeMusicURL', youtube_music_url);
+  setUrlField(grouped, 'bandcampURL', bandcamp_url);
+  setUrlField(grouped, 'soundcloudURL', soundcloud_url);
   setUrlField(grouped, 'artistWikipediaURL', meta.artist_wikipedia_url);
 
   if (meta.release_year !== null) {

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -86,6 +86,7 @@ import {
   ALBUM_METADATA_PROJECTION_WITHOUT_ARTWORK,
   suppressMislabeledStreamingUrls,
   fillSynthesizedSearchUrls,
+  wireUrl,
   type SynthesizableStreamingUrls,
 } from '../utils/album-metadata-projection.js';
 import type { ConcertDTO } from './concerts.service.js';
@@ -103,77 +104,15 @@ function lookupKey(artist: string, album: string): string {
 /** SQL expression that computes the same lookup key from flowsheet columns. */
 const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
 
-/**
- * True iff `value` contains a character that makes `new URL()`'s verdict a
- * statement about a DIFFERENT string than the one we are about to emit.
- *
- * `wireUrl` validates with the WHATWG parser but emits the original text, so
- * every place the two disagree is a parser differential the wire inherits:
- *
- *   - **Backslash.** For the http(s) special schemes WHATWG folds `\` to `/`,
- *     so `new URL('https://www.discogs.com\\@evil.example/release/1')` reports
- *     hostname `www.discogs.com`. Foundation/RFC 3986 do NOT fold it, so the
- *     same bytes resolve to host `evil.example` on iOS. This is the identical
- *     differential `shared/lml-client/src/streaming-url-guard.ts`'s
- *     `safeHostname` opens with `if (url.includes('\\')) return null` (BS#1710);
- *     same reasoning, same verdict, at this seam.
- *   - **ASCII whitespace and control characters.** WHATWG *strips* raw tab, LF
- *     and CR anywhere in the input and percent-encodes other C0 characters and
- *     the space before parsing, so `'https://e.com/a\tb'` validates as
- *     `https://e.com/ab` — a URL that is not what we would emit. `.trim()`
- *     only reaches the ends. Foundation rejects the raw form, which is the
- *     throwing decode this whole helper exists to avoid.
+/*
+ * `hasWireUrlParserDifferential` and `wireUrl` moved to
+ * `../utils/album-metadata-projection.js` (#2339). They are imported below, not
+ * reimplemented: `wireUrl` is simultaneously this endpoint's OUTPUT filter and
+ * the read path's shared "does this streaming URL exist for the client"
+ * predicate, and the two must be one function or the fill's gate and the wire's
+ * key set can drift apart. Same collapse-the-copies rule BS#889 applied to
+ * `synthesizeSearchUrls`.
  */
-function hasWireUrlParserDifferential(value: string): boolean {
-  for (const char of value) {
-    const code = char.codePointAt(0) ?? 0;
-    // C0 controls + space (<= 0x20), DEL (0x7f), backslash (0x5c).
-    if (code <= 0x20 || code === 0x7f || code === 0x5c) return true;
-  }
-  return false;
-}
-
-/**
- * Normalize a persisted URL for the wire, or `undefined` to omit the key.
- *
- * iOS decodes every URL-typed playcut field with
- * `try container.decodeIfPresent(URL.self, forKey:)`. That is *throwing*, not
- * tolerant: a present-but-unparseable value raises `DecodingError` and fails
- * the whole `Playcut` decode, which empties the playlist for that listener.
- * `/flowsheet` can pass these through raw because its consumer decodes them as
- * strings; this endpoint cannot.
- *
- * Only an absolute `http`/`https` URL survives. Everything else — `''`,
- * whitespace, a relative path, a bare hostname, a scheme-relative `//host/...`,
- * a non-web scheme — is dropped rather than risked. Dropping a field costs one
- * missing button; emitting a bad one costs the whole playlist.
- *
- * REJECT, don't normalize. The emitted value is the trimmed ORIGINAL, never
- * `parsed.href`, so anything `new URL()` silently rewrites while parsing is a
- * differential between what was validated and what ships — see
- * {@link hasWireUrlParserDifferential}, which rejects those inputs outright.
- * Emitting `parsed.href` instead would close the same differentials, but it
- * would also percent-encode the ~21 production values carrying raw non-ASCII in
- * the path (`https://en.wikipedia.org/wiki/Nilüfer_Yanya` -> `…/Nil%C3%BCfer_…`),
- * which ship verbatim today and decode fine on iOS. Rejecting touches only the
- * hazardous inputs, leaves every good byte alone, and matches the repo's
- * existing precedent at the LML boundary (BS#1710).
- */
-function wireUrl(value: string | null | undefined): string | undefined {
-  if (!value) return undefined;
-  const trimmed = value.trim();
-  if (trimmed === '') return undefined;
-  if (hasWireUrlParserDifferential(trimmed)) return undefined;
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    return undefined;
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
-  if (parsed.hostname === '') return undefined;
-  return trimmed;
-}
 
 /**
  * Normalize a free-text wire field: the trimmed value, or `undefined` to omit

--- a/apps/backend/utils/album-metadata-projection.ts
+++ b/apps/backend/utils/album-metadata-projection.ts
@@ -36,12 +36,34 @@
  * come off `library` directly.)
  *
  * A THIRD behavior lives one layer up, not here (#2339): when the COALESCE
- * above (plus the host guard) still leaves a streaming URL absent, the two
- * serializer seams — `transformToIFSEntry` in `flowsheet.service.ts` and
- * `applyPlaycutMetadata` in `playlist-proxy.service.ts` — fill it with a
- * synthesized search URL via {@link fillSynthesizedSearchUrls}, mirroring
- * `GET /proxy/metadata/album`'s degradation (BS#1184/#1185). It is
- * deliberately NOT folded into this SQL projection: URL-encoding
+ * above (plus the host guard) still leaves a streaming URL absent, two
+ * serializer seams fill it with a synthesized search URL via
+ * {@link fillSynthesizedSearchUrls}, mirroring `GET /proxy/metadata/album`'s
+ * degradation (BS#1184/#1185) — but only for a row that ALREADY carries at
+ * least one real streaming URL. See that function for the gate and why it
+ * exists.
+ *
+ * Exactly TWO seams fill, and both are read-GETs:
+ *   - `transformToIFSEntry` in `flowsheet.service.ts` — serves the V1
+ *     `GET /flowsheet` top-level fields AND `/v2/flowsheet`'s nested
+ *     `metadata` object (both come off the one IFSEntry it builds);
+ *   - `applyPlaycutMetadata` in `playlist-proxy.service.ts` — the legacy
+ *     `GET /playlists/recentEntries?v=2` grouped payload.
+ *
+ * The other two producers of flowsheet-shaped payloads deliberately do NOT
+ * fill, and neither routes through `transformToIFSEntry`:
+ *   - the mutation/peek echoes (`projectFlowsheetEntry` in
+ *     `utils/flowsheet-projection.ts`, an allow-list projection straight off
+ *     the DB row — BS#1513);
+ *   - the SSE `liveFs:update` channel (`pickClientFacingColumns`, same
+ *     allow-list over a CDC row).
+ * That asymmetry is safe precisely BECAUSE the fill is gated: the only bit
+ * shipped iOS 3.2 branches on is "does this payload carry any streaming URL
+ * at all" (`inline.streaming.hasAny`), and the gate can only fire on rows
+ * where that bit is already true. So the gate-relevant bit never differs
+ * between producers for the same row — only button decoration does.
+ *
+ * The fill is deliberately NOT folded into this SQL projection: URL-encoding
  * artist/album/track text is a TS concern (`SearchUrlProvider` /
  * `synthesizeSearchUrls`), and — more importantly — this projection is a
  * pure read of persisted state, while a synthesized URL must never be
@@ -132,44 +154,126 @@ export interface SynthesizableStreamingUrls {
 const searchUrlProvider = new SearchUrlProvider();
 
 /**
- * Request-time fallback fill (#2339): whatever is still `null` after the
- * COALESCE + BS#1714 host guard gets a synthesized search URL, the same
- * `SearchUrlProvider.getAllSearchUrls` degradation `GET /proxy/metadata/album`
- * already applies at request time (BS#1184/#1185). A populated value — verified
- * or already-suppressed-then-filled — always wins; this only fills absences.
- * Never persisted (#1192): callers must apply this to the *response* object,
- * never write the result back to `album_metadata` or `flowsheet`.
+ * A persisted string that actually carries information, or `null`.
  *
- * Requires a non-blank `artist_name` to have anything to search on — mirrors
- * `FSEntryFieldsRaw.rotation_bin`'s "looks like a real track" gate just above
- * it in `flowsheet.service.ts`. A marker/talkset/breakpoint row (or a track
- * row that somehow lost its artist name) degrades to nulls exactly as before.
+ * `''` and whitespace-only values are treated as ABSENT, matching the
+ * degradation `GET /proxy/metadata/album` already applies: its fallback arms
+ * are plain falsy checks (`if (!metadata.spotifyUrl) …`), not `??`-nullish
+ * ones, so a persisted `''` there earns a synthesized URL rather than
+ * surviving to the wire. A `??` check here would instead let the blank
+ * through, where the legacy seam's `wireUrl` drops it with no fallback
+ * left to run and the V1 `/flowsheet` seam emits it verbatim as `""`.
+ *
+ * A non-blank value that is nonetheless unusable (scheme-relative, `javascript:`,
+ * a raw-backslash parser differential) counts as PRESENT here, exactly as the
+ * proxy's falsy check counts it — this helper's job is proxy parity, and the
+ * legacy seam's `wireUrl` is the separate, later filter that decides whether
+ * such a value earns a wire key.
+ */
+function nonBlank(value: string | null): string | null {
+  if (value === null) return null;
+  return value.trim() === '' ? null : value;
+}
+
+/**
+ * Request-time fallback fill (#2339): fill a still-absent streaming URL with a
+ * synthesized search URL — the same `SearchUrlProvider.getAllSearchUrls`
+ * degradation `GET /proxy/metadata/album` applies at request time
+ * (BS#1184/#1185) — for rows that qualify. Never persisted (#1192): callers
+ * must apply this to the *response* object, never write the result back to
+ * `album_metadata` or `flowsheet`.
+ *
+ * Inputs are the POST-host-guard values: `spotify_url` / `apple_music_url`
+ * must already have been through {@link suppressMislabeledStreamingUrls}, so a
+ * mislabeled URL degrades exactly as an outright-missing one does (#1714).
+ *
+ * TWO gates, both load-bearing:
+ *
+ *   1. **At least one real streaming URL already present** (owner decision,
+ *      2026-08-31, on #2339). Shipped iOS 3.2's `PlaycutMetadataService`
+ *      skips the live `/proxy/metadata/album` fetch when
+ *      `metadataStatus?.isTerminal == true || inline.streaming.hasAny`. A row
+ *      that already carries a real streaming URL short-circuits inline
+ *      REGARDLESS of what we do, so filling it only upgrades grey
+ *      Spotify/Apple buttons and can never suppress a fetch. A row with zero
+ *      real streaming URLs must keep serving NULLs: filling it would satisfy
+ *      `streaming.hasAny` and suppress the live proxy fallback — which
+ *      returns full metadata AND synthesizes its own links — leaving the user
+ *      a card with five search buttons and nothing else, permanently. That is
+ *      BS#2103's empty-card bug, reopened. The post-#2295-drain cohort (the
+ *      population this ticket exists for) qualifies: the drain persisted
+ *      synthesized YouTube Music / Bandcamp / SoundCloud URLs on every matched
+ *      row.
+ *
+ *      A row whose ONLY streaming URL was suppressed by the host guard counts
+ *      as zero-streaming and serves NULLs — the proxy fallback then both
+ *      fetches and synthesizes, consistent with #1714's degradation.
+ *
+ *      "Real" is non-null and non-blank, deliberately NOT "parses to a usable
+ *      URL". That leaves one residual gap: a row whose only streaming value is
+ *      non-blank yet unusable (scheme-relative, a raw-backslash parser
+ *      differential) passes the gate here while the legacy seam's `wireUrl`
+ *      drops it from the wire, so that row's `streaming.hasAny` does flip
+ *      false -> true. The known population is nil — the enrichment write path
+ *      only ever persists absolute URLs, and the two shapes in the wire golden
+ *      (rows 9011 / 9013) are constructed hazards, not audit findings — and a
+ *      URL-validity gate would have to differ per seam (the `/flowsheet` seam
+ *      applies no such filter), which is exactly the fork BS#2103 exists to
+ *      prevent. Revisit if such rows ever appear in the corpus.
+ *
+ *   2. **A non-blank `artist_name`** — there is nothing to search on without
+ *      one, and a whitespace-only name would synthesize five buttons opening
+ *      `%20%20%20` searches. A marker/talkset/breakpoint row (or a track row
+ *      that somehow lost its artist name) degrades to nulls exactly as before.
+ *
+ * Blank (`''` / whitespace-only) persisted values are normalized to `null`
+ * unconditionally — see {@link nonBlank} — whether or not the row qualifies
+ * for the fill, so a blank never reaches a wire as `""`.
  */
 export function fillSynthesizedSearchUrls(
   urls: SynthesizableStreamingUrls,
   text: { artist_name: string | null; album_title: string | null; track_title: string | null }
 ): SynthesizableStreamingUrls {
-  if (!text.artist_name) return urls;
-  if (
-    urls.spotify_url !== null &&
-    urls.apple_music_url !== null &&
-    urls.youtube_music_url !== null &&
-    urls.bandcamp_url !== null &&
-    urls.soundcloud_url !== null
-  ) {
-    return urls;
-  }
+  const present: SynthesizableStreamingUrls = {
+    spotify_url: nonBlank(urls.spotify_url),
+    apple_music_url: nonBlank(urls.apple_music_url),
+    youtube_music_url: nonBlank(urls.youtube_music_url),
+    bandcamp_url: nonBlank(urls.bandcamp_url),
+    soundcloud_url: nonBlank(urls.soundcloud_url),
+  };
+
+  // Gate 1: zero real streaming URLs -> serve NULLs, keep the 3.2 proxy fallback.
+  const carriesRealStreamingUrl =
+    present.spotify_url !== null ||
+    present.apple_music_url !== null ||
+    present.youtube_music_url !== null ||
+    present.bandcamp_url !== null ||
+    present.soundcloud_url !== null;
+  if (!carriesRealStreamingUrl) return present;
+
+  // Gate 2: nothing to search on.
+  const artistName = text.artist_name?.trim() ?? '';
+  if (artistName === '') return present;
+
+  // Nothing absent -> nothing to build. O(rows) string work, so skip it.
+  const hasAbsent =
+    present.spotify_url === null ||
+    present.apple_music_url === null ||
+    present.youtube_music_url === null ||
+    present.bandcamp_url === null ||
+    present.soundcloud_url === null;
+  if (!hasAbsent) return present;
 
   const fallback = searchUrlProvider.getAllSearchUrls(
-    text.artist_name,
-    text.album_title ?? undefined,
-    text.track_title ?? undefined
+    artistName,
+    nonBlank(text.album_title)?.trim(),
+    nonBlank(text.track_title)?.trim()
   );
   return {
-    spotify_url: urls.spotify_url ?? fallback.spotifyUrl,
-    apple_music_url: urls.apple_music_url ?? fallback.appleMusicUrl,
-    youtube_music_url: urls.youtube_music_url ?? fallback.youtubeMusicUrl,
-    bandcamp_url: urls.bandcamp_url ?? fallback.bandcampUrl,
-    soundcloud_url: urls.soundcloud_url ?? fallback.soundcloudUrl,
+    spotify_url: present.spotify_url ?? fallback.spotifyUrl,
+    apple_music_url: present.apple_music_url ?? fallback.appleMusicUrl,
+    youtube_music_url: present.youtube_music_url ?? fallback.youtubeMusicUrl,
+    bandcamp_url: present.bandcamp_url ?? fallback.bandcampUrl,
+    soundcloud_url: present.soundcloud_url ?? fallback.soundcloudUrl,
   };
 }

--- a/apps/backend/utils/album-metadata-projection.ts
+++ b/apps/backend/utils/album-metadata-projection.ts
@@ -40,8 +40,10 @@
  * serializer seams fill it with a synthesized search URL via
  * {@link fillSynthesizedSearchUrls}, mirroring `GET /proxy/metadata/album`'s
  * degradation (BS#1184/#1185) — but only for a row that ALREADY carries at
- * least one real streaming URL. See that function for the gate and why it
- * exists.
+ * least one streaming URL the client would actually see. The gate uses
+ * {@link wireUrl}, the wire's own presence predicate, so the gate bit and iOS
+ * 3.2's `inline.streaming.hasAny` are the same bit by construction. See that
+ * function for why the gate exists.
  *
  * Exactly TWO seams fill, and both are read-GETs:
  *   - `transformToIFSEntry` in `flowsheet.service.ts` — serves the V1
@@ -151,28 +153,104 @@ export interface SynthesizableStreamingUrls {
   soundcloud_url: string | null;
 }
 
+/**
+ * True iff `value` contains a character that makes `new URL()`'s verdict a
+ * statement about a DIFFERENT string than the one we are about to emit.
+ *
+ * `wireUrl` validates with the WHATWG parser but emits the original text, so
+ * every place the two disagree is a parser differential the wire inherits:
+ *
+ *   - **Backslash.** For the http(s) special schemes WHATWG folds `\` to `/`,
+ *     so `new URL('https://www.discogs.com\\@evil.example/release/1')` reports
+ *     hostname `www.discogs.com`. Foundation/RFC 3986 do NOT fold it, so the
+ *     same bytes resolve to host `evil.example` on iOS. This is the identical
+ *     differential `shared/lml-client/src/streaming-url-guard.ts`'s
+ *     `safeHostname` opens with `if (url.includes('\\')) return null` (BS#1710);
+ *     same reasoning, same verdict, at this seam.
+ *   - **ASCII whitespace and control characters.** WHATWG *strips* raw tab, LF
+ *     and CR anywhere in the input and percent-encodes other C0 characters and
+ *     the space before parsing, so `'https://e.com/a\tb'` validates as
+ *     `https://e.com/ab` — a URL that is not what we would emit. `.trim()`
+ *     only reaches the ends. Foundation rejects the raw form, which is the
+ *     throwing decode this whole helper exists to avoid.
+ */
+export function hasWireUrlParserDifferential(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    // C0 controls + space (<= 0x20), DEL (0x7f), backslash (0x5c).
+    if (code <= 0x20 || code === 0x7f || code === 0x5c) return true;
+  }
+  return false;
+}
+
+/**
+ * Normalize a persisted URL for the wire, or `undefined` to omit the key.
+ *
+ * iOS decodes every URL-typed playcut field with
+ * `try container.decodeIfPresent(URL.self, forKey:)`. That is *throwing*, not
+ * tolerant: a present-but-unparseable value raises `DecodingError` and fails
+ * the whole `Playcut` decode, which empties the playlist for that listener.
+ * `/flowsheet` passes these through raw because its consumer decodes them as
+ * strings, so only the legacy `?v=2` seam uses this as an OUTPUT filter. Both
+ * seams use it as a PREDICATE, though — `fillSynthesizedSearchUrls` asks it
+ * whether a persisted streaming URL exists for the client at all (#2339).
+ *
+ * Only an absolute `http`/`https` URL survives. Everything else — `''`,
+ * whitespace, a relative path, a bare hostname, a scheme-relative `//host/...`,
+ * a non-web scheme — is dropped rather than risked. Dropping a field costs one
+ * missing button; emitting a bad one costs the whole playlist.
+ *
+ * REJECT, don't normalize. The emitted value is the trimmed ORIGINAL, never
+ * `parsed.href`, so anything `new URL()` silently rewrites while parsing is a
+ * differential between what was validated and what ships — see
+ * {@link hasWireUrlParserDifferential}, which rejects those inputs outright.
+ * Emitting `parsed.href` instead would close the same differentials, but it
+ * would also percent-encode the ~21 production values carrying raw non-ASCII in
+ * the path (`https://en.wikipedia.org/wiki/Nilüfer_Yanya` -> `…/Nil%C3%BCfer_…`),
+ * which ship verbatim today and decode fine on iOS. Rejecting touches only the
+ * hazardous inputs, leaves every good byte alone, and matches the repo's
+ * existing precedent at the LML boundary (BS#1710).
+ */
+export function wireUrl(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+  if (hasWireUrlParserDifferential(trimmed)) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+  if (parsed.hostname === '') return undefined;
+  return trimmed;
+}
+
 const searchUrlProvider = new SearchUrlProvider();
 
 /**
- * A persisted string that actually carries information, or `null`.
+ * A persisted streaming URL that will actually reach a client, or `null`.
  *
- * `''` and whitespace-only values are treated as ABSENT, matching the
- * degradation `GET /proxy/metadata/album` already applies: its fallback arms
- * are plain falsy checks (`if (!metadata.spotifyUrl) …`), not `??`-nullish
- * ones, so a persisted `''` there earns a synthesized URL rather than
- * surviving to the wire. A `??` check here would instead let the blank
- * through, where the legacy seam's `wireUrl` drops it with no fallback
- * left to run and the V1 `/flowsheet` seam emits it verbatim as `""`.
+ * The test is {@link wireUrl}'s — absolute http(s), no parser differential —
+ * NOT merely "non-blank". Anything else (`''`, whitespace, a bare hostname, a
+ * scheme-relative `//host/…`, `javascript:`, a raw-tab/LF/backslash
+ * differential) is ABSENT for both of {@link fillSynthesizedSearchUrls}'s
+ * purposes: it does not qualify a row for the fill, and on a row that does
+ * qualify it degrades to a synthesized URL instead of surviving to be dropped
+ * downstream with no fallback left to run.
  *
- * A non-blank value that is nonetheless unusable (scheme-relative, `javascript:`,
- * a raw-backslash parser differential) counts as PRESENT here, exactly as the
- * proxy's falsy check counts it — this helper's job is proxy parity, and the
- * legacy seam's `wireUrl` is the separate, later filter that decides whether
- * such a value earns a wire key.
+ * Using the wire's own predicate is what makes the gate sound. The proxy's
+ * fallback arms are falsy checks (`if (!metadata.spotifyUrl) …`) rather than
+ * `??`-nullish ones, so this is the same degradation shape, evaluated against
+ * the same question the client asks: is there a link here or not.
+ *
+ * The original value is returned, not `wireUrl`'s trimmed copy — trimming is
+ * the legacy seam's output concern, and the `/flowsheet` seam has always
+ * emitted persisted text verbatim.
  */
-function nonBlank(value: string | null): string | null {
-  if (value === null) return null;
-  return value.trim() === '' ? null : value;
+function wireablePersistedUrl(value: string | null): string | null {
+  return wireUrl(value) === undefined ? null : value;
 }
 
 /**
@@ -189,67 +267,64 @@ function nonBlank(value: string | null): string | null {
  *
  * TWO gates, both load-bearing:
  *
- *   1. **At least one real streaming URL already present** (owner decision,
- *      2026-08-31, on #2339). Shipped iOS 3.2's `PlaycutMetadataService`
- *      skips the live `/proxy/metadata/album` fetch when
- *      `metadataStatus?.isTerminal == true || inline.streaming.hasAny`. A row
- *      that already carries a real streaming URL short-circuits inline
+ *   1. **At least one streaming URL that would reach the client** (owner
+ *      decision, 2026-08-31, on #2339). Shipped iOS 3.2's
+ *      `PlaycutMetadataService` skips the live `/proxy/metadata/album` fetch
+ *      when `metadataStatus?.isTerminal == true || inline.streaming.hasAny`. A
+ *      row that already carries a real streaming URL short-circuits inline
  *      REGARDLESS of what we do, so filling it only upgrades grey
- *      Spotify/Apple buttons and can never suppress a fetch. A row with zero
- *      real streaming URLs must keep serving NULLs: filling it would satisfy
- *      `streaming.hasAny` and suppress the live proxy fallback — which
- *      returns full metadata AND synthesizes its own links — leaving the user
- *      a card with five search buttons and nothing else, permanently. That is
+ *      Spotify/Apple buttons and can never suppress a fetch. A row with no such
+ *      URL must keep serving NULLs: filling it would satisfy
+ *      `streaming.hasAny` and suppress the live proxy fallback — which returns
+ *      full metadata AND synthesizes its own links — leaving the user a card
+ *      with five search buttons and nothing else, permanently. That is
  *      BS#2103's empty-card bug, reopened. The post-#2295-drain cohort (the
  *      population this ticket exists for) qualifies: the drain persisted
  *      synthesized YouTube Music / Bandcamp / SoundCloud URLs on every matched
  *      row.
  *
+ *      "Would reach the client" is {@link wireablePersistedUrl}, i.e.
+ *      {@link wireUrl}'s own predicate — so `carriesWireableStreamingUrl` and
+ *      the client's `streaming.hasAny` are the same bit by construction, and
+ *      the gate cannot be flipped by a value the wire is about to drop. The
+ *      gate is this one shared function at both seams; only the OUTPUT filters
+ *      differ per seam (the legacy `?v=2` payload runs `wireUrl` again on the
+ *      way out; `/flowsheet` emits verbatim).
+ *
  *      A row whose ONLY streaming URL was suppressed by the host guard counts
  *      as zero-streaming and serves NULLs — the proxy fallback then both
  *      fetches and synthesizes, consistent with #1714's degradation.
- *
- *      "Real" is non-null and non-blank, deliberately NOT "parses to a usable
- *      URL". That leaves one residual gap: a row whose only streaming value is
- *      non-blank yet unusable (scheme-relative, a raw-backslash parser
- *      differential) passes the gate here while the legacy seam's `wireUrl`
- *      drops it from the wire, so that row's `streaming.hasAny` does flip
- *      false -> true. The known population is nil — the enrichment write path
- *      only ever persists absolute URLs, and the two shapes in the wire golden
- *      (rows 9011 / 9013) are constructed hazards, not audit findings — and a
- *      URL-validity gate would have to differ per seam (the `/flowsheet` seam
- *      applies no such filter), which is exactly the fork BS#2103 exists to
- *      prevent. Revisit if such rows ever appear in the corpus.
  *
  *   2. **A non-blank `artist_name`** — there is nothing to search on without
  *      one, and a whitespace-only name would synthesize five buttons opening
  *      `%20%20%20` searches. A marker/talkset/breakpoint row (or a track row
  *      that somehow lost its artist name) degrades to nulls exactly as before.
  *
- * Blank (`''` / whitespace-only) persisted values are normalized to `null`
- * unconditionally — see {@link nonBlank} — whether or not the row qualifies
- * for the fill, so a blank never reaches a wire as `""`.
+ * A persisted value that fails the wire predicate is normalized to `null`
+ * unconditionally, whether or not the row qualifies for the fill, so a blank
+ * can never reach a wire as `""` and an unusable one can never reach a
+ * hardwired iOS button.
  */
 export function fillSynthesizedSearchUrls(
   urls: SynthesizableStreamingUrls,
   text: { artist_name: string | null; album_title: string | null; track_title: string | null }
 ): SynthesizableStreamingUrls {
   const present: SynthesizableStreamingUrls = {
-    spotify_url: nonBlank(urls.spotify_url),
-    apple_music_url: nonBlank(urls.apple_music_url),
-    youtube_music_url: nonBlank(urls.youtube_music_url),
-    bandcamp_url: nonBlank(urls.bandcamp_url),
-    soundcloud_url: nonBlank(urls.soundcloud_url),
+    spotify_url: wireablePersistedUrl(urls.spotify_url),
+    apple_music_url: wireablePersistedUrl(urls.apple_music_url),
+    youtube_music_url: wireablePersistedUrl(urls.youtube_music_url),
+    bandcamp_url: wireablePersistedUrl(urls.bandcamp_url),
+    soundcloud_url: wireablePersistedUrl(urls.soundcloud_url),
   };
 
-  // Gate 1: zero real streaming URLs -> serve NULLs, keep the 3.2 proxy fallback.
-  const carriesRealStreamingUrl =
+  // Gate 1: nothing the client would see -> serve NULLs, keep the 3.2 proxy fallback.
+  const carriesWireableStreamingUrl =
     present.spotify_url !== null ||
     present.apple_music_url !== null ||
     present.youtube_music_url !== null ||
     present.bandcamp_url !== null ||
     present.soundcloud_url !== null;
-  if (!carriesRealStreamingUrl) return present;
+  if (!carriesWireableStreamingUrl) return present;
 
   // Gate 2: nothing to search on.
   const artistName = text.artist_name?.trim() ?? '';
@@ -264,11 +339,9 @@ export function fillSynthesizedSearchUrls(
     present.soundcloud_url === null;
   if (!hasAbsent) return present;
 
-  const fallback = searchUrlProvider.getAllSearchUrls(
-    artistName,
-    nonBlank(text.album_title)?.trim(),
-    nonBlank(text.track_title)?.trim()
-  );
+  const albumTitle = text.album_title?.trim();
+  const trackTitle = text.track_title?.trim();
+  const fallback = searchUrlProvider.getAllSearchUrls(artistName, albumTitle || undefined, trackTitle || undefined);
   return {
     spotify_url: present.spotify_url ?? fallback.spotifyUrl,
     apple_music_url: present.apple_music_url ?? fallback.appleMusicUrl,

--- a/apps/backend/utils/album-metadata-projection.ts
+++ b/apps/backend/utils/album-metadata-projection.ts
@@ -34,10 +34,26 @@
  * (`library` is only needed for the sibling `artist_id` / `on_streaming` /
  * `discogs_unavailable` reads, which are NOT part of this projection — they
  * come off `library` directly.)
+ *
+ * A THIRD behavior lives one layer up, not here (#2339): when the COALESCE
+ * above (plus the host guard) still leaves a streaming URL absent, the two
+ * serializer seams — `transformToIFSEntry` in `flowsheet.service.ts` and
+ * `applyPlaycutMetadata` in `playlist-proxy.service.ts` — fill it with a
+ * synthesized search URL via {@link fillSynthesizedSearchUrls}, mirroring
+ * `GET /proxy/metadata/album`'s degradation (BS#1184/#1185). It is
+ * deliberately NOT folded into this SQL projection: URL-encoding
+ * artist/album/track text is a TS concern (`SearchUrlProvider` /
+ * `synthesizeSearchUrls`), and — more importantly — this projection is a
+ * pure read of persisted state, while a synthesized URL must never be
+ * persisted (#1192 — a synthesized Spotify/Apple link would launder a
+ * "couldn't verify" signal into a clickable button on disk). Keeping
+ * synthesis in TS, downstream of this SELECT, keeps that boundary visible:
+ * nothing this projection returns is ever fabricated, only coalesced.
  */
 import { album_metadata, flowsheet } from '@wxyc/database';
 import { sql } from 'drizzle-orm';
 import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
+import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 
 /**
  * Every coalesced album-metadata field EXCEPT `artwork_url`.
@@ -101,5 +117,59 @@ export function suppressMislabeledStreamingUrls(raw: StreamingUrlPair): Streamin
   return {
     spotify_url: isSpotifyUrl(raw.spotify_url) ? raw.spotify_url : null,
     apple_music_url: isAppleMusicUrl(raw.apple_music_url) ? raw.apple_music_url : null,
+  };
+}
+
+/** The five request-time-synthesizable streaming URL fields (#2339). */
+export interface SynthesizableStreamingUrls {
+  spotify_url: string | null;
+  apple_music_url: string | null;
+  youtube_music_url: string | null;
+  bandcamp_url: string | null;
+  soundcloud_url: string | null;
+}
+
+const searchUrlProvider = new SearchUrlProvider();
+
+/**
+ * Request-time fallback fill (#2339): whatever is still `null` after the
+ * COALESCE + BS#1714 host guard gets a synthesized search URL, the same
+ * `SearchUrlProvider.getAllSearchUrls` degradation `GET /proxy/metadata/album`
+ * already applies at request time (BS#1184/#1185). A populated value — verified
+ * or already-suppressed-then-filled — always wins; this only fills absences.
+ * Never persisted (#1192): callers must apply this to the *response* object,
+ * never write the result back to `album_metadata` or `flowsheet`.
+ *
+ * Requires a non-blank `artist_name` to have anything to search on — mirrors
+ * `FSEntryFieldsRaw.rotation_bin`'s "looks like a real track" gate just above
+ * it in `flowsheet.service.ts`. A marker/talkset/breakpoint row (or a track
+ * row that somehow lost its artist name) degrades to nulls exactly as before.
+ */
+export function fillSynthesizedSearchUrls(
+  urls: SynthesizableStreamingUrls,
+  text: { artist_name: string | null; album_title: string | null; track_title: string | null }
+): SynthesizableStreamingUrls {
+  if (!text.artist_name) return urls;
+  if (
+    urls.spotify_url !== null &&
+    urls.apple_music_url !== null &&
+    urls.youtube_music_url !== null &&
+    urls.bandcamp_url !== null &&
+    urls.soundcloud_url !== null
+  ) {
+    return urls;
+  }
+
+  const fallback = searchUrlProvider.getAllSearchUrls(
+    text.artist_name,
+    text.album_title ?? undefined,
+    text.track_title ?? undefined
+  );
+  return {
+    spotify_url: urls.spotify_url ?? fallback.spotifyUrl,
+    apple_music_url: urls.apple_music_url ?? fallback.appleMusicUrl,
+    youtube_music_url: urls.youtube_music_url ?? fallback.youtubeMusicUrl,
+    bandcamp_url: urls.bandcamp_url ?? fallback.bandcampUrl,
+    soundcloud_url: urls.soundcloud_url ?? fallback.soundcloudUrl,
   };
 }

--- a/tests/fixtures/recent-entries-v2-wire-golden.json
+++ b/tests/fixtures/recent-entries-v2-wire-golden.json
@@ -91,11 +91,6 @@
         "Jazz"
       ],
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Jo%C3%A3o%20Gilberto%20Bim%20Bom",
-      "appleMusicURL": "https://music.apple.com/search?term=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
-      "bandcampURL": "https://bandcamp.com/search?q=Jo%C3%A3o%20Gilberto%20Chega%20de%20Saudade",
-      "soundcloudURL": "https://soundcloud.com/search?q=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -112,11 +107,6 @@
       "request": "false",
       "artistWikipediaURL": "https://en.wikipedia.org/wiki/İbrahim_Tatlıses",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
-      "appleMusicURL": "https://music.apple.com/search?term=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
-      "bandcampURL": "https://bandcamp.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Selam%20Olsun",
-      "soundcloudURL": "https://soundcloud.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -133,11 +123,6 @@
       "request": "false",
       "artistWikipediaURL": "https://en.wikipedia.org/wiki/Konono_Nº1",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Konono%20N%C2%BA1%20Lufuala%20Ndonga",
-      "appleMusicURL": "https://music.apple.com/search?term=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
-      "bandcampURL": "https://bandcamp.com/search?q=Konono%20N%C2%BA1%20Congotronics",
-      "soundcloudURL": "https://soundcloud.com/search?q=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -153,11 +138,11 @@
       "rotation": "false",
       "request": "false",
       "spotifyURL": "https://open.spotify.com/search/Eiko%20Ishibashi%20%26%20Jim%20O'Rourke%20Ei",
+      "appleMusicURL": "https://music.apple.com/search?term=Eiko%20Ishibashi%20%26%20Jim%20O'Rourke%20Ei",
       "youtubeMusicURL": "https://music.youtube.com/search?q=Agriculture%20Dan's%20Love%20Song",
       "bandcampURL": "https://bandcamp.com/search?q=Ash%20Wednesday%20Can't%20Stop%20It!%20Australian%20Post-Punk%201978-82%20(2025%20Deluxe%20Edition)",
       "soundcloudURL": "https://soundcloud.com/search?q=Agriculture%20Dan's%20Love%20Song",
       "artistId": 7000,
-      "appleMusicURL": "https://music.apple.com/search?term=Eiko%20Ishibashi%20%26%20Jim%20O'Rourke%20Ei",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -173,11 +158,6 @@
       "rotation": "false",
       "request": "false",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Hole%20Violet",
-      "appleMusicURL": "https://music.apple.com/search?term=Hole%20Violet",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Hole%20Violet",
-      "bandcampURL": "https://bandcamp.com/search?q=Hole%20Live%20Through%20This",
-      "soundcloudURL": "https://soundcloud.com/search?q=Hole%20Violet",
       "discogsUnavailable": false
     },
     {
@@ -192,11 +172,6 @@
       "rotation": "false",
       "request": "false",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Art%20Garfunkel%20All%20I%20Know",
-      "appleMusicURL": "https://music.apple.com/search?term=Art%20Garfunkel%20All%20I%20Know",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Art%20Garfunkel%20All%20I%20Know",
-      "bandcampURL": "https://bandcamp.com/search?q=Art%20Garfunkel%20Angel%20Clare",
-      "soundcloudURL": "https://soundcloud.com/search?q=Art%20Garfunkel%20All%20I%20Know",
       "discogsUnavailable": false
     },
     {
@@ -212,11 +187,6 @@
       "request": "false",
       "artworkURL": "https://i.discogs.com/bs2103-pratt.jpg",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby",
-      "appleMusicURL": "https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby",
-      "bandcampURL": "https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again",
-      "soundcloudURL": "https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -231,12 +201,12 @@
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
       "request": "false",
-      "bandcampURL": "https://chuquimamanicondori.bandcamp.com/album/dj-e",
-      "artistId": 7000,
       "spotifyURL": "https://open.spotify.com/search/Chuquimamani-Condori%20Call%20Your%20Name",
       "appleMusicURL": "https://music.apple.com/search?term=Chuquimamani-Condori%20Call%20Your%20Name",
       "youtubeMusicURL": "https://music.youtube.com/search?q=Chuquimamani-Condori%20Call%20Your%20Name",
+      "bandcampURL": "https://chuquimamanicondori.bandcamp.com/album/dj-e",
       "soundcloudURL": "https://soundcloud.com/search?q=Chuquimamani-Condori%20Call%20Your%20Name",
+      "artistId": 7000,
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -253,11 +223,6 @@
       "request": "false",
       "discogsURL": "https://www.discogs.com/release/999",
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Juana%20Molina%20la%20paradoja",
-      "appleMusicURL": "https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja",
-      "bandcampURL": "https://bandcamp.com/search?q=Juana%20Molina%20DOGA",
-      "soundcloudURL": "https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -272,11 +237,11 @@
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
       "request": "false",
-      "artistId": 7000,
       "spotifyURL": "https://open.spotify.com/search/Stereolab%20Brakhage",
       "appleMusicURL": "https://music.apple.com/search?term=Stereolab%20Brakhage",
       "youtubeMusicURL": "https://music.youtube.com/search?q=Stereolab%20Brakhage",
       "soundcloudURL": "https://soundcloud.com/search?q=Stereolab%20Brakhage",
+      "artistId": 7000,
       "discogsUnavailable": false
     },
     {
@@ -289,12 +254,7 @@
       "releaseTitle": "BS2103 Unenriched Album",
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
-      "request": "false",
-      "spotifyURL": "https://open.spotify.com/search/BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
-      "appleMusicURL": "https://music.apple.com/search?term=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
-      "bandcampURL": "https://bandcamp.com/search?q=BS2103%20Unenriched%20Artist%20BS2103%20Unenriched%20Album",
-      "soundcloudURL": "https://soundcloud.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)"
+      "request": "false"
     },
     {
       "id": 9013,
@@ -307,12 +267,12 @@
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
       "request": "false",
+      "spotifyURL": "https://open.spotify.com/search/Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
+      "appleMusicURL": "https://music.apple.com/search?term=Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
       "genres": [
         "Rock"
       ],
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
-      "appleMusicURL": "https://music.apple.com/search?term=Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -332,11 +292,6 @@
         "Folk Rock"
       ],
       "artistId": 7000,
-      "spotifyURL": "https://open.spotify.com/search/Cat%20Power%20Cross%20Bones%20Style",
-      "appleMusicURL": "https://music.apple.com/search?term=Cat%20Power%20Cross%20Bones%20Style",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Cat%20Power%20Cross%20Bones%20Style",
-      "bandcampURL": "https://bandcamp.com/search?q=Cat%20Power%20Moon%20Pix",
-      "soundcloudURL": "https://soundcloud.com/search?q=Cat%20Power%20Cross%20Bones%20Style",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": true
     }

--- a/tests/fixtures/recent-entries-v2-wire-golden.json
+++ b/tests/fixtures/recent-entries-v2-wire-golden.json
@@ -237,10 +237,6 @@
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
       "request": "false",
-      "spotifyURL": "https://open.spotify.com/search/Stereolab%20Brakhage",
-      "appleMusicURL": "https://music.apple.com/search?term=Stereolab%20Brakhage",
-      "youtubeMusicURL": "https://music.youtube.com/search?q=Stereolab%20Brakhage",
-      "soundcloudURL": "https://soundcloud.com/search?q=Stereolab%20Brakhage",
       "artistId": 7000,
       "discogsUnavailable": false
     },
@@ -267,8 +263,6 @@
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
       "request": "false",
-      "spotifyURL": "https://open.spotify.com/search/Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
-      "appleMusicURL": "https://music.apple.com/search?term=Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
       "genres": [
         "Rock"
       ],

--- a/tests/fixtures/recent-entries-v2-wire-golden.json
+++ b/tests/fixtures/recent-entries-v2-wire-golden.json
@@ -91,6 +91,11 @@
         "Jazz"
       ],
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Jo%C3%A3o%20Gilberto%20Bim%20Bom",
+      "appleMusicURL": "https://music.apple.com/search?term=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
+      "bandcampURL": "https://bandcamp.com/search?q=Jo%C3%A3o%20Gilberto%20Chega%20de%20Saudade",
+      "soundcloudURL": "https://soundcloud.com/search?q=Jo%C3%A3o%20Gilberto%20Bim%20Bom",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -107,6 +112,11 @@
       "request": "false",
       "artistWikipediaURL": "https://en.wikipedia.org/wiki/İbrahim_Tatlıses",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
+      "appleMusicURL": "https://music.apple.com/search?term=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
+      "bandcampURL": "https://bandcamp.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Selam%20Olsun",
+      "soundcloudURL": "https://soundcloud.com/search?q=%C4%B0brahim%20Tatl%C4%B1ses%20Mavi%20Mavi",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -123,6 +133,11 @@
       "request": "false",
       "artistWikipediaURL": "https://en.wikipedia.org/wiki/Konono_Nº1",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Konono%20N%C2%BA1%20Lufuala%20Ndonga",
+      "appleMusicURL": "https://music.apple.com/search?term=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
+      "bandcampURL": "https://bandcamp.com/search?q=Konono%20N%C2%BA1%20Congotronics",
+      "soundcloudURL": "https://soundcloud.com/search?q=Konono%20N%C2%BA1%20Lufuala%20Ndonga",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -142,6 +157,7 @@
       "bandcampURL": "https://bandcamp.com/search?q=Ash%20Wednesday%20Can't%20Stop%20It!%20Australian%20Post-Punk%201978-82%20(2025%20Deluxe%20Edition)",
       "soundcloudURL": "https://soundcloud.com/search?q=Agriculture%20Dan's%20Love%20Song",
       "artistId": 7000,
+      "appleMusicURL": "https://music.apple.com/search?term=Eiko%20Ishibashi%20%26%20Jim%20O'Rourke%20Ei",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -157,6 +173,11 @@
       "rotation": "false",
       "request": "false",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Hole%20Violet",
+      "appleMusicURL": "https://music.apple.com/search?term=Hole%20Violet",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Hole%20Violet",
+      "bandcampURL": "https://bandcamp.com/search?q=Hole%20Live%20Through%20This",
+      "soundcloudURL": "https://soundcloud.com/search?q=Hole%20Violet",
       "discogsUnavailable": false
     },
     {
@@ -171,6 +192,11 @@
       "rotation": "false",
       "request": "false",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Art%20Garfunkel%20All%20I%20Know",
+      "appleMusicURL": "https://music.apple.com/search?term=Art%20Garfunkel%20All%20I%20Know",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Art%20Garfunkel%20All%20I%20Know",
+      "bandcampURL": "https://bandcamp.com/search?q=Art%20Garfunkel%20Angel%20Clare",
+      "soundcloudURL": "https://soundcloud.com/search?q=Art%20Garfunkel%20All%20I%20Know",
       "discogsUnavailable": false
     },
     {
@@ -186,6 +212,11 @@
       "request": "false",
       "artworkURL": "https://i.discogs.com/bs2103-pratt.jpg",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby",
+      "appleMusicURL": "https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby",
+      "bandcampURL": "https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again",
+      "soundcloudURL": "https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -202,6 +233,10 @@
       "request": "false",
       "bandcampURL": "https://chuquimamanicondori.bandcamp.com/album/dj-e",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Chuquimamani-Condori%20Call%20Your%20Name",
+      "appleMusicURL": "https://music.apple.com/search?term=Chuquimamani-Condori%20Call%20Your%20Name",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Chuquimamani-Condori%20Call%20Your%20Name",
+      "soundcloudURL": "https://soundcloud.com/search?q=Chuquimamani-Condori%20Call%20Your%20Name",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -218,6 +253,11 @@
       "request": "false",
       "discogsURL": "https://www.discogs.com/release/999",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Juana%20Molina%20la%20paradoja",
+      "appleMusicURL": "https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja",
+      "bandcampURL": "https://bandcamp.com/search?q=Juana%20Molina%20DOGA",
+      "soundcloudURL": "https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -233,6 +273,10 @@
       "rotation": "false",
       "request": "false",
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Stereolab%20Brakhage",
+      "appleMusicURL": "https://music.apple.com/search?term=Stereolab%20Brakhage",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Stereolab%20Brakhage",
+      "soundcloudURL": "https://soundcloud.com/search?q=Stereolab%20Brakhage",
       "discogsUnavailable": false
     },
     {
@@ -245,7 +289,12 @@
       "releaseTitle": "BS2103 Unenriched Album",
       "labelName": "BS2103 Probe Records",
       "rotation": "false",
-      "request": "false"
+      "request": "false",
+      "spotifyURL": "https://open.spotify.com/search/BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
+      "appleMusicURL": "https://music.apple.com/search?term=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)",
+      "bandcampURL": "https://bandcamp.com/search?q=BS2103%20Unenriched%20Artist%20BS2103%20Unenriched%20Album",
+      "soundcloudURL": "https://soundcloud.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)"
     },
     {
       "id": 9013,
@@ -262,6 +311,8 @@
         "Rock"
       ],
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
+      "appleMusicURL": "https://music.apple.com/search?term=Hermanos%20Guti%C3%A9rrez%20Tres%20Hermanos",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": false
     },
@@ -281,6 +332,11 @@
         "Folk Rock"
       ],
       "artistId": 7000,
+      "spotifyURL": "https://open.spotify.com/search/Cat%20Power%20Cross%20Bones%20Style",
+      "appleMusicURL": "https://music.apple.com/search?term=Cat%20Power%20Cross%20Bones%20Style",
+      "youtubeMusicURL": "https://music.youtube.com/search?q=Cat%20Power%20Cross%20Bones%20Style",
+      "bandcampURL": "https://bandcamp.com/search?q=Cat%20Power%20Moon%20Pix",
+      "soundcloudURL": "https://soundcloud.com/search?q=Cat%20Power%20Cross%20Bones%20Style",
       "metadataStatus": "enriched_match",
       "discogsUnavailable": true
     }

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -1712,33 +1712,54 @@ describe('discogsUnavailable on the flowsheet mutation echo (BS#1962)', () => {
 });
 
 /*
- * #2339: V2 flowsheet read-path streaming-URL search-url fill.
+ * #2339: V2 flowsheet read-path streaming-URL search-url fill, end to end.
  *
- * A library-linked track whose album carries no `album_metadata` row (fresh
- * library insert, no LML lookup has ever run) must serve synthesized search
- * URLs on every streaming field instead of `null` — matching `GET
- * /proxy/metadata/album`'s degradation (BS#1184/#1185) instead of the V2
- * flowsheet feed alone greying out those buttons.
+ * The fill is GATED on the row already carrying at least one real streaming
+ * URL: shipped iOS 3.2 skips its live `/proxy/metadata/album` fetch on
+ * `inline.streaming.hasAny`, so filling a zero-streaming row would suppress
+ * the only thing serving that row any metadata. Both arms are pinned here —
+ * a qualifying album (one persisted YouTube Music link, the post-#2295-drain
+ * shape) whose Spotify/Apple buttons upgrade from grey, and a zero-streaming
+ * album that must keep serving NULLs.
  */
 describe('streaming-URL search-url fill on GET /flowsheet (#2339)', () => {
+  const VERIFIED_YOUTUBE = 'https://music.youtube.com/playlist?list=OLAK5uy_bs2339';
   let sql;
-  let albumId;
+  let qualifyingAlbumId;
+  let zeroStreamingAlbumId;
 
   beforeAll(async () => {
     sql = makeSql();
-    const rows = await sql`
+    // artist_id 1 / genre_id 11 / format_id 1 reuse the existing
+    // genre_artist_crossreference row, same as the BS#1962 block above.
+    const qualifying = await sql`
       INSERT INTO ${sql(SCHEMA)}.library
         (artist_id, genre_id, format_id, album_title, code_number)
       VALUES
-        (1, 11, 1, 'BS2339 Test No Streaming Links', 9002)
+        (1, 11, 1, 'BS2339 Test Partial Streaming', 9002)
       RETURNING id
     `;
-    albumId = rows[0].id;
+    qualifyingAlbumId = qualifying[0].id;
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, youtube_music_url)
+      VALUES (${qualifyingAlbumId}, ${VERIFIED_YOUTUBE})
+    `;
+
+    const zero = await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (artist_id, genre_id, format_id, album_title, code_number)
+      VALUES
+        (1, 11, 1, 'BS2339 Test No Streaming Links', 9003)
+      RETURNING id
+    `;
+    zeroStreamingAlbumId = zero[0].id;
   });
 
   afterAll(async () => {
-    if (albumId) {
-      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ${albumId}`;
+    const ids = [qualifyingAlbumId, zeroStreamingAlbumId].filter(Boolean);
+    if (ids.length) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${ids})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${ids})`;
     }
     if (sql) await sql.end({ timeout: 5 });
   });
@@ -1751,30 +1772,48 @@ describe('streaming-URL search-url fill on GET /flowsheet (#2339)', () => {
     await fls_util.leave_show(global.primary_dj_id, global.access_token);
   });
 
-  test('a track whose album has no persisted streaming links serves synthesized search URLs, not null', async () => {
-    await request.post('/flowsheet').set('Authorization', global.access_token).send({
-      album_id: albumId,
-      track_title: 'BS2339 Test Track',
-    });
+  test('an album with one persisted streaming link serves synthesized search URLs for the rest', async () => {
+    const post = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({ album_id: qualifyingAlbumId, track_title: 'BS2339 Test Track' })
+      .expect(201);
+
+    // Read the text back off the echo rather than hardcoding the seeded
+    // artist name, so this pins the fill and not the seed fixture.
+    const artist = post.body.artist_name;
+    const album = post.body.album_title;
+    const track = post.body.track_title;
 
     const res = await request.get('/flowsheet').query({ limit: 30 }).send().expect(200);
-    const entry = res.body.entries.find((e) => e.album_id === albumId);
+    const entry = res.body.entries.find((e) => e.album_id === qualifyingAlbumId);
 
     expect(entry).toBeDefined();
-    expect(entry.spotify_url).toBe(
-      'https://open.spotify.com/search/' + encodeURIComponent('Built to Spill BS2339 Test Track')
-    );
+    expect(entry.spotify_url).toBe('https://open.spotify.com/search/' + encodeURIComponent(`${artist} ${track}`));
     expect(entry.apple_music_url).toBe(
-      'https://music.apple.com/search?term=' + encodeURIComponent('Built to Spill BS2339 Test Track')
+      'https://music.apple.com/search?term=' + encodeURIComponent(`${artist} ${track}`)
     );
-    expect(entry.youtube_music_url).toBe(
-      'https://music.youtube.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test Track')
-    );
-    expect(entry.bandcamp_url).toBe(
-      'https://bandcamp.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test No Streaming Links')
-    );
-    expect(entry.soundcloud_url).toBe(
-      'https://soundcloud.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test Track')
-    );
+    expect(entry.bandcamp_url).toBe('https://bandcamp.com/search?q=' + encodeURIComponent(`${artist} ${album}`));
+    expect(entry.soundcloud_url).toBe('https://soundcloud.com/search?q=' + encodeURIComponent(`${artist} ${track}`));
+    // The verified link wins untouched.
+    expect(entry.youtube_music_url).toBe(VERIFIED_YOUTUBE);
+  });
+
+  test('an album with zero persisted streaming links keeps serving NULLs (the 3.2 proxy fallback must still fire)', async () => {
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({ album_id: zeroStreamingAlbumId, track_title: 'BS2339 Zero Streaming Track' })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 30 }).send().expect(200);
+    const entry = res.body.entries.find((e) => e.album_id === zeroStreamingAlbumId);
+
+    expect(entry).toBeDefined();
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.youtube_music_url).toBeNull();
+    expect(entry.bandcamp_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
   });
 });

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -1710,3 +1710,71 @@ describe('discogsUnavailable on the flowsheet mutation echo (BS#1962)', () => {
     expect(res.body).not.toHaveProperty('discogsUnavailableNote');
   });
 });
+
+/*
+ * #2339: V2 flowsheet read-path streaming-URL search-url fill.
+ *
+ * A library-linked track whose album carries no `album_metadata` row (fresh
+ * library insert, no LML lookup has ever run) must serve synthesized search
+ * URLs on every streaming field instead of `null` — matching `GET
+ * /proxy/metadata/album`'s degradation (BS#1184/#1185) instead of the V2
+ * flowsheet feed alone greying out those buttons.
+ */
+describe('streaming-URL search-url fill on GET /flowsheet (#2339)', () => {
+  let sql;
+  let albumId;
+
+  beforeAll(async () => {
+    sql = makeSql();
+    const rows = await sql`
+      INSERT INTO ${sql(SCHEMA)}.library
+        (artist_id, genre_id, format_id, album_title, code_number)
+      VALUES
+        (1, 11, 1, 'BS2339 Test No Streaming Links', 9002)
+      RETURNING id
+    `;
+    albumId = rows[0].id;
+  });
+
+  afterAll(async () => {
+    if (albumId) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ${albumId}`;
+    }
+    if (sql) await sql.end({ timeout: 5 });
+  });
+
+  beforeEach(async () => {
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('a track whose album has no persisted streaming links serves synthesized search URLs, not null', async () => {
+    await request.post('/flowsheet').set('Authorization', global.access_token).send({
+      album_id: albumId,
+      track_title: 'BS2339 Test Track',
+    });
+
+    const res = await request.get('/flowsheet').query({ limit: 30 }).send().expect(200);
+    const entry = res.body.entries.find((e) => e.album_id === albumId);
+
+    expect(entry).toBeDefined();
+    expect(entry.spotify_url).toBe(
+      'https://open.spotify.com/search/' + encodeURIComponent('Built to Spill BS2339 Test Track')
+    );
+    expect(entry.apple_music_url).toBe(
+      'https://music.apple.com/search?term=' + encodeURIComponent('Built to Spill BS2339 Test Track')
+    );
+    expect(entry.youtube_music_url).toBe(
+      'https://music.youtube.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test Track')
+    );
+    expect(entry.bandcamp_url).toBe(
+      'https://bandcamp.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test No Streaming Links')
+    );
+    expect(entry.soundcloud_url).toBe(
+      'https://soundcloud.com/search?q=' + encodeURIComponent('Built to Spill BS2339 Test Track')
+    );
+  });
+});

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -565,9 +565,10 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
 
     const entry = res.body.playcuts.find((p) => p.id === flowsheetIds[11]);
     // The persisted value is a Bandcamp URL mislabeled as Spotify; it must not
-    // reach the hardwired iOS "Spotify" button — and since #2339, it degrades
+    // reach the hardwired iOS "Spotify" button — and since #2339 it degrades
     // to the same synthesized search URL an outright-missing value would get,
-    // rather than staying undefined.
+    // because this row's other four streaming links keep it past the fill's
+    // "already carries a real streaming URL" gate.
     expect(entry.spotifyURL).toBe(
       'https://open.spotify.com/search/' + encodeURIComponent(`${ENRICHED_ARTIST} stabilise`)
     );
@@ -584,46 +585,41 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     expect(Object.prototype.hasOwnProperty.call(entry, 'discogsURL')).toBe(false);
   });
 
-  test('a play with no persisted metadata still has an artist_name, so its five streaming URLs are synthesized (#2339) — everything else stays absent, never ""', async () => {
+  test('a play with no metadata emits no URL keys at all — never "" and, since #2339, no synthesized search URL either', async () => {
     const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const entry = res.body.playcuts.find((p) => p.id === flowsheetIds[12]);
     expect(entry).toBeDefined();
-    // These have nothing to synthesize from (no lookup-key text / no library
-    // row) and stay absent exactly as before.
-    for (const key of ['artworkURL', 'discogsURL', 'artistWikipediaURL']) {
+    // #2339's fill is GATED on the row already carrying at least one real
+    // streaming URL. This row carries none, so it fills nothing: shipped iOS
+    // 3.2 skips its live `/proxy/metadata/album` fetch on
+    // `inline.streaming.hasAny`, and filling here would suppress the only
+    // thing that serves this row any metadata — leaving a card with five
+    // search buttons and nothing else (BS#2103's empty-card bug).
+    for (const key of [
+      'artworkURL',
+      'discogsURL',
+      'spotifyURL',
+      'appleMusicURL',
+      'youtubeMusicURL',
+      'bandcampURL',
+      'soundcloudURL',
+      'artistWikipediaURL',
+    ]) {
       expect(Object.prototype.hasOwnProperty.call(entry, key)).toBe(false);
     }
-    // #2339: artist_name/album_title/track_title ARE present on this
-    // free-text row, so the five search-URL-synthesizable fields fill
-    // instead of staying absent — matching /proxy/metadata/album's
-    // degradation for the exact same unenriched-play shape.
-    const query = encodeURIComponent('BS2103 Unenriched Artist Probe Track (no metadata)');
-    expect(entry.spotifyURL).toBe('https://open.spotify.com/search/' + query);
-    expect(entry.appleMusicURL).toBe('https://music.apple.com/search?term=' + query);
-    expect(entry.youtubeMusicURL).toBe('https://music.youtube.com/search?q=' + query);
-    expect(entry.bandcampURL).toBe(
-      'https://bandcamp.com/search?q=' + encodeURIComponent('BS2103 Unenriched Artist BS2103 Unenriched Album')
-    );
-    expect(entry.soundcloudURL).toBe('https://soundcloud.com/search?q=' + query);
     expect(entry.releaseYear).toBeUndefined();
     expect(entry.artistBio).toBeUndefined();
     expect(entry.genres).toBeUndefined();
     expect(entry.artistId).toBeUndefined();
     // No library row -> the discogs-unavailable flag is omitted, not `false`.
     expect(Object.prototype.hasOwnProperty.call(entry, 'discogsUnavailable')).toBe(false);
-    // `metadata_status` is NOT NULL on the table (default 'pending'), but the
-    // wire key is conditional (option-3 serve rule) and evaluated against the
-    // PRE-#2339-fill payload (pre-PR review finding 1): a synthesized search
-    // URL is the same request-time fallback the proxy already builds from
-    // nothing, so it does not count as renderable inline metadata. This row
-    // has no persisted field at all, so the predicate stays false and the key
-    // stays home — harmless here either way, since 'pending' is non-terminal
-    // and 3.2 takes the same fetch arm whether the key rides or not. The row
-    // that actually matters (a terminal `enriched_no_match` row with an
-    // otherwise-empty payload) is pinned in the unit suite:
-    // playlist-proxy.service.test.ts's "conditional metadataStatus
-    // (terminal-but-empty guard)" describe block.
+    // `metadata_status` is NOT NULL on the table, but the wire key is
+    // conditional (option-3 serve rule): with zero renderable inline fields it
+    // is withheld, so shipped 3.2 keeps its live `/proxy/metadata/album`
+    // fallback instead of short-circuiting a terminal status to an empty card.
+    // Evaluated against the PRE-#2339-fill values, so a synthesized fallback
+    // could never flip it either.
     expect(Object.prototype.hasOwnProperty.call(entry, 'metadataStatus')).toBe(false);
   });
 
@@ -637,12 +633,10 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // deliberately independent: artwork keeps its historical semantics,
     // everything else uses /flowsheet's own-album_id projection.
     expect(lpEntry.artworkURL).toBe(CD_ARTWORK);
-    // #2339: no persisted spotify_url on either side of the COALESCE, but the
-    // play has an artist_name/album_title/track_title, so it synthesizes a
-    // search URL — unlike discogsURL, which the fill never touches.
-    expect(lpEntry.spotifyURL).toBe(
-      'https://open.spotify.com/search/' + encodeURIComponent(`${ARTIST_NAME} Probe Track (LP press)`)
-    );
+    // #2339's fill does not fire here: this album_metadata row holds artwork
+    // only, so the play carries zero real streaming URLs and stays past the
+    // fill's gate — no spotifyURL key, exactly as before the ticket.
+    expect(Object.prototype.hasOwnProperty.call(lpEntry, 'spotifyURL')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(lpEntry, 'discogsURL')).toBe(false);
   });
 

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -612,12 +612,19 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     expect(entry.artistId).toBeUndefined();
     // No library row -> the discogs-unavailable flag is omitted, not `false`.
     expect(Object.prototype.hasOwnProperty.call(entry, 'discogsUnavailable')).toBe(false);
-    // `metadata_status` is NOT NULL on the table, but the wire key is
-    // conditional (option-3 serve rule): the five synthesized fields above
-    // now count as renderable inline metadata, so this predicate has flipped
-    // to riding the status alongside them — an intentional #2339 side effect
-    // of the fill counting toward `hasRenderableInlineMetadata`.
-    expect(entry.metadataStatus).toBe('pending');
+    // `metadata_status` is NOT NULL on the table (default 'pending'), but the
+    // wire key is conditional (option-3 serve rule) and evaluated against the
+    // PRE-#2339-fill payload (pre-PR review finding 1): a synthesized search
+    // URL is the same request-time fallback the proxy already builds from
+    // nothing, so it does not count as renderable inline metadata. This row
+    // has no persisted field at all, so the predicate stays false and the key
+    // stays home — harmless here either way, since 'pending' is non-terminal
+    // and 3.2 takes the same fetch arm whether the key rides or not. The row
+    // that actually matters (a terminal `enriched_no_match` row with an
+    // otherwise-empty payload) is pinned in the unit suite:
+    // playlist-proxy.service.test.ts's "conditional metadataStatus
+    // (terminal-but-empty guard)" describe block.
+    expect(Object.prototype.hasOwnProperty.call(entry, 'metadataStatus')).toBe(false);
   });
 
   test('metadata keys off the play’s own album_id, matching /flowsheet (artwork keeps its own lookup-key tie-break)', async () => {

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -634,7 +634,7 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // everything else uses /flowsheet's own-album_id projection.
     expect(lpEntry.artworkURL).toBe(CD_ARTWORK);
     // #2339's fill does not fire here: this album_metadata row holds artwork
-    // only, so the play carries zero real streaming URLs and stays past the
+    // only, so the play carries no wireable streaming URL and stops at the
     // fill's gate — no spotifyURL key, exactly as before the ticket.
     expect(Object.prototype.hasOwnProperty.call(lpEntry, 'spotifyURL')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(lpEntry, 'discogsURL')).toBe(false);

--- a/tests/integration/playlist-recent-entries.spec.js
+++ b/tests/integration/playlist-recent-entries.spec.js
@@ -560,13 +560,17 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     expect(entry.discogsUnavailable).toBe(false);
   });
 
-  test("suppresses a spotify_url whose host isn't Spotify (BS#1714, end to end)", async () => {
+  test("suppresses a spotify_url whose host isn't Spotify, degrading to a synthesized search URL (BS#1714 + #2339, end to end)", async () => {
     const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const entry = res.body.playcuts.find((p) => p.id === flowsheetIds[11]);
     // The persisted value is a Bandcamp URL mislabeled as Spotify; it must not
-    // reach the hardwired iOS "Spotify" button.
-    expect(entry.spotifyURL).toBeUndefined();
+    // reach the hardwired iOS "Spotify" button — and since #2339, it degrades
+    // to the same synthesized search URL an outright-missing value would get,
+    // rather than staying undefined.
+    expect(entry.spotifyURL).toBe(
+      'https://open.spotify.com/search/' + encodeURIComponent(`${ENRICHED_ARTIST} stabilise`)
+    );
     // The correctly-hosted Bandcamp sibling is unaffected.
     expect(entry.bandcampURL).toBe(ENRICHED_BANDCAMP);
   });
@@ -580,23 +584,28 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     expect(Object.prototype.hasOwnProperty.call(entry, 'discogsURL')).toBe(false);
   });
 
-  test('a play with no metadata emits no URL keys at all — never ""', async () => {
+  test('a play with no persisted metadata still has an artist_name, so its five streaming URLs are synthesized (#2339) — everything else stays absent, never ""', async () => {
     const res = await request.get('/playlists/recentEntries').query({ v: 2, n: 100 }).expect(200);
 
     const entry = res.body.playcuts.find((p) => p.id === flowsheetIds[12]);
     expect(entry).toBeDefined();
-    for (const key of [
-      'artworkURL',
-      'discogsURL',
-      'spotifyURL',
-      'appleMusicURL',
-      'youtubeMusicURL',
-      'bandcampURL',
-      'soundcloudURL',
-      'artistWikipediaURL',
-    ]) {
+    // These have nothing to synthesize from (no lookup-key text / no library
+    // row) and stay absent exactly as before.
+    for (const key of ['artworkURL', 'discogsURL', 'artistWikipediaURL']) {
       expect(Object.prototype.hasOwnProperty.call(entry, key)).toBe(false);
     }
+    // #2339: artist_name/album_title/track_title ARE present on this
+    // free-text row, so the five search-URL-synthesizable fields fill
+    // instead of staying absent — matching /proxy/metadata/album's
+    // degradation for the exact same unenriched-play shape.
+    const query = encodeURIComponent('BS2103 Unenriched Artist Probe Track (no metadata)');
+    expect(entry.spotifyURL).toBe('https://open.spotify.com/search/' + query);
+    expect(entry.appleMusicURL).toBe('https://music.apple.com/search?term=' + query);
+    expect(entry.youtubeMusicURL).toBe('https://music.youtube.com/search?q=' + query);
+    expect(entry.bandcampURL).toBe(
+      'https://bandcamp.com/search?q=' + encodeURIComponent('BS2103 Unenriched Artist BS2103 Unenriched Album')
+    );
+    expect(entry.soundcloudURL).toBe('https://soundcloud.com/search?q=' + query);
     expect(entry.releaseYear).toBeUndefined();
     expect(entry.artistBio).toBeUndefined();
     expect(entry.genres).toBeUndefined();
@@ -604,10 +613,11 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // No library row -> the discogs-unavailable flag is omitted, not `false`.
     expect(Object.prototype.hasOwnProperty.call(entry, 'discogsUnavailable')).toBe(false);
     // `metadata_status` is NOT NULL on the table, but the wire key is
-    // conditional (option-3 serve rule): with zero renderable inline fields it
-    // is withheld, so shipped 3.2 keeps its live `/proxy/metadata/album`
-    // fallback instead of short-circuiting a terminal status to an empty card.
-    expect(Object.prototype.hasOwnProperty.call(entry, 'metadataStatus')).toBe(false);
+    // conditional (option-3 serve rule): the five synthesized fields above
+    // now count as renderable inline metadata, so this predicate has flipped
+    // to riding the status alongside them — an intentional #2339 side effect
+    // of the fill counting toward `hasRenderableInlineMetadata`.
+    expect(entry.metadataStatus).toBe('pending');
   });
 
   test('metadata keys off the play’s own album_id, matching /flowsheet (artwork keeps its own lookup-key tie-break)', async () => {
@@ -620,7 +630,12 @@ describe('GET /playlists/recentEntries (Phase 3 — Postgres-backed, WXYC/wiki#8
     // deliberately independent: artwork keeps its historical semantics,
     // everything else uses /flowsheet's own-album_id projection.
     expect(lpEntry.artworkURL).toBe(CD_ARTWORK);
-    expect(Object.prototype.hasOwnProperty.call(lpEntry, 'spotifyURL')).toBe(false);
+    // #2339: no persisted spotify_url on either side of the COALESCE, but the
+    // play has an artist_name/album_title/track_title, so it synthesizes a
+    // search URL — unlike discogsURL, which the fill never touches.
+    expect(lpEntry.spotifyURL).toBe(
+      'https://open.spotify.com/search/' + encodeURIComponent(`${ARTIST_NAME} Probe Track (LP press)`)
+    );
     expect(Object.prototype.hasOwnProperty.call(lpEntry, 'discogsURL')).toBe(false);
   });
 

--- a/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
+++ b/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
@@ -8,6 +8,13 @@ import { transformToIFSEntry, type FSEntryRaw } from '../../../apps/backend/serv
  * #1712's ingestion guard shipped; this seam host-guards them so a mislabeled
  * value never reaches the hardwired iOS "Spotify"/"Apple Music" button. Both the
  * top-level field and the nested `metadata` copy must be suppressed together.
+ *
+ * Since #2339, a value the guard just suppressed degrades to a synthesized
+ * search URL rather than staying `null` (the same fill every other absent
+ * streaming URL gets) — see `flowsheet.transformToIFSEntry.search-url-fill.test.ts`
+ * for the fill itself. The suppression assertions below were updated in that
+ * ticket to expect the synthesized fallback instead of `null`, since a raw
+ * makeRaw() fixture always carries a non-blank `artist_name`.
  */
 
 const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
@@ -55,22 +62,25 @@ const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
 });
 
 describe('transformToIFSEntry streaming-URL host guard (BS#1714)', () => {
-  it('suppresses a mislabeled spotify_url on both the top-level field and nested metadata', () => {
+  it('suppresses a mislabeled spotify_url on both the top-level field and nested metadata, degrading to a synthesized search URL (#2339)', () => {
     const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://www.deezer.com/album/254381182' }));
-    expect(entry.spotify_url).toBeNull();
-    expect(entry.metadata.spotify_url).toBeNull();
+    const expected = 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja';
+    expect(entry.spotify_url).toBe(expected);
+    expect(entry.metadata.spotify_url).toBe(expected);
   });
 
-  it('suppresses a mislabeled apple_music_url on both the top-level field and nested metadata', () => {
+  it('suppresses a mislabeled apple_music_url on both the top-level field and nested metadata, degrading to a synthesized search URL (#2339)', () => {
     const entry = transformToIFSEntry(makeRaw({ apple_music_url: 'https://tidal.com/browse/album/254381182' }));
-    expect(entry.apple_music_url).toBeNull();
-    expect(entry.metadata.apple_music_url).toBeNull();
+    const expected = 'https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja';
+    expect(entry.apple_music_url).toBe(expected);
+    expect(entry.metadata.apple_music_url).toBe(expected);
   });
 
-  it('drops a suffix-spoof host to null', () => {
+  it('drops a suffix-spoof host and degrades to a synthesized search URL (#2339)', () => {
     const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://open.spotify.com.evil.example/album/1' }));
-    expect(entry.spotify_url).toBeNull();
-    expect(entry.metadata.spotify_url).toBeNull();
+    const expected = 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja';
+    expect(entry.spotify_url).toBe(expected);
+    expect(entry.metadata.spotify_url).toBe(expected);
   });
 
   it('passes a genuine Spotify/Apple URL through on both positions', () => {

--- a/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
+++ b/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
@@ -9,12 +9,14 @@ import { transformToIFSEntry, type FSEntryRaw } from '../../../apps/backend/serv
  * value never reaches the hardwired iOS "Spotify"/"Apple Music" button. Both the
  * top-level field and the nested `metadata` copy must be suppressed together.
  *
- * Since #2339, a value the guard just suppressed degrades to a synthesized
- * search URL rather than staying `null` (the same fill every other absent
- * streaming URL gets) — see `flowsheet.transformToIFSEntry.search-url-fill.test.ts`
- * for the fill itself. The suppression assertions below were updated in that
- * ticket to expect the synthesized fallback instead of `null`, since a raw
- * makeRaw() fixture always carries a non-blank `artist_name`.
+ * #2339's search-URL fill does NOT change these expectations. It is gated on
+ * the post-guard values already carrying at least one real streaming URL, and
+ * the fixtures below suppress the row's ONLY streaming URL — leaving zero, so
+ * the row serves nulls and shipped iOS 3.2 keeps its live
+ * `/proxy/metadata/album` fallback (which both fetches and synthesizes). The
+ * case where a suppressed URL DOES degrade to a synthesized one — a row with
+ * another real streaming URL alongside it — is pinned in
+ * `flowsheet.transformToIFSEntry.search-url-fill.test.ts`.
  */
 
 const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
@@ -62,25 +64,22 @@ const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
 });
 
 describe('transformToIFSEntry streaming-URL host guard (BS#1714)', () => {
-  it('suppresses a mislabeled spotify_url on both the top-level field and nested metadata, degrading to a synthesized search URL (#2339)', () => {
+  it('suppresses a mislabeled spotify_url on both the top-level field and nested metadata', () => {
     const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://www.deezer.com/album/254381182' }));
-    const expected = 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja';
-    expect(entry.spotify_url).toBe(expected);
-    expect(entry.metadata.spotify_url).toBe(expected);
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
   });
 
-  it('suppresses a mislabeled apple_music_url on both the top-level field and nested metadata, degrading to a synthesized search URL (#2339)', () => {
+  it('suppresses a mislabeled apple_music_url on both the top-level field and nested metadata', () => {
     const entry = transformToIFSEntry(makeRaw({ apple_music_url: 'https://tidal.com/browse/album/254381182' }));
-    const expected = 'https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja';
-    expect(entry.apple_music_url).toBe(expected);
-    expect(entry.metadata.apple_music_url).toBe(expected);
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.metadata.apple_music_url).toBeNull();
   });
 
-  it('drops a suffix-spoof host and degrades to a synthesized search URL (#2339)', () => {
+  it('drops a suffix-spoof host to null', () => {
     const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://open.spotify.com.evil.example/album/1' }));
-    const expected = 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja';
-    expect(entry.spotify_url).toBe(expected);
-    expect(entry.metadata.spotify_url).toBe(expected);
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
   });
 
   it('passes a genuine Spotify/Apple URL through on both positions', () => {
@@ -96,6 +95,10 @@ describe('transformToIFSEntry streaming-URL host guard (BS#1714)', () => {
     expect(entry.metadata.apple_music_url).toBe('https://music.apple.com/us/album/genuine');
   });
 
+  // The three verified siblings make this row qualify for #2339's fill, so
+  // `spotify_url` degrades to a synthesized search URL here — pinned in the
+  // search-url-fill suite. What this test guards is that the guard does not
+  // touch the three values that were fine.
   it('leaves the other three streaming fields untouched when spotify_url is mislabeled', () => {
     const entry = transformToIFSEntry(
       makeRaw({

--- a/tests/unit/services/flowsheet.transformToIFSEntry.search-url-fill.test.ts
+++ b/tests/unit/services/flowsheet.transformToIFSEntry.search-url-fill.test.ts
@@ -1,15 +1,25 @@
 import { transformToIFSEntry, type FSEntryRaw } from '../../../apps/backend/services/flowsheet.service';
 
 /**
- * #2339. `transformToIFSEntry` is the single producer of every IFSEntry that
- * reaches `/flowsheet` (top-level fields), `/v2/flowsheet` (`transformToV2`,
- * nested `metadata`), and the mutation/peek echoes (BS#1513's
- * `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list projects off the same
- * IFSEntry). This pins the request-time streaming-URL fallback fill —
- * `fillSynthesizedSearchUrls` — at that one seam, so a still-absent value
- * degrades to a synthesized search URL identically to `GET
- * /proxy/metadata/album` (BS#1184/#1185) instead of reaching the wire as
- * `null`.
+ * #2339. `transformToIFSEntry` is one of the TWO read-GET seams that fill an
+ * absent streaming URL with a synthesized search URL — it builds the IFSEntry
+ * behind both `GET /flowsheet` (top-level fields) and `/v2/flowsheet`
+ * (`transformToV2`, nested `metadata`), so a single fill covers both. The other
+ * seam is `applyPlaycutMetadata` in `playlist-proxy.service.ts` (legacy `?v=2`).
+ *
+ * It is NOT the single producer of every flowsheet-shaped payload, and the two
+ * other producers deliberately do not fill: the mutation/peek echoes go through
+ * `projectFlowsheetEntry` and the SSE `liveFs:update` channel through
+ * `pickClientFacingColumns` (both in `utils/flowsheet-projection.ts`, both
+ * allow-list projections straight off the DB/CDC row, neither routing through
+ * `transformToIFSEntry`). That is safe because the fill is GATED: it only fires
+ * on rows that already carry a real streaming URL, so the only bit shipped iOS
+ * 3.2 branches on (`inline.streaming.hasAny`) is identical across producers for
+ * the same row — only button decoration differs.
+ *
+ * The fill mirrors `GET /proxy/metadata/album`'s degradation (BS#1184/#1185)
+ * for rows that qualify, and preserves NULLs (and the client's live proxy
+ * fallback) for rows that don't.
  */
 
 const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
@@ -59,28 +69,55 @@ const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
 });
 
 describe('transformToIFSEntry streaming-URL search-url fill (#2339)', () => {
-  it('fills all five absent streaming URLs with synthesized search URLs, on both the top-level fields and nested metadata', () => {
-    const entry = transformToIFSEntry(makeRaw());
+  // A row that already carries a real streaming URL short-circuits iOS 3.2's
+  // inline gate regardless of what we do, so filling it only upgrades grey
+  // buttons. `youtube_music_url` here stands in for the post-#2295-drain
+  // cohort, which carries exactly these synthesized YT/Bandcamp/SoundCloud
+  // URLs and NULL Spotify/Apple.
+  it('fills the absent streaming URLs on a row that already carries one, on both the top-level fields and nested metadata', () => {
+    const verifiedYoutube = 'https://music.youtube.com/playlist?list=OLAK5uy_verified';
+    const entry = transformToIFSEntry(makeRaw({ youtube_music_url: verifiedYoutube }));
 
     const expected = {
       spotify_url: 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja',
       apple_music_url: 'https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja',
-      youtube_music_url: 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja',
       bandcamp_url: 'https://bandcamp.com/search?q=Juana%20Molina%20DOGA',
       soundcloud_url: 'https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja',
     };
 
     expect(entry.spotify_url).toBe(expected.spotify_url);
     expect(entry.apple_music_url).toBe(expected.apple_music_url);
-    expect(entry.youtube_music_url).toBe(expected.youtube_music_url);
     expect(entry.bandcamp_url).toBe(expected.bandcamp_url);
     expect(entry.soundcloud_url).toBe(expected.soundcloud_url);
+    // The verified value wins untouched — the fill only fills absences.
+    expect(entry.youtube_music_url).toBe(verifiedYoutube);
 
     expect(entry.metadata.spotify_url).toBe(expected.spotify_url);
     expect(entry.metadata.apple_music_url).toBe(expected.apple_music_url);
-    expect(entry.metadata.youtube_music_url).toBe(expected.youtube_music_url);
     expect(entry.metadata.bandcamp_url).toBe(expected.bandcamp_url);
     expect(entry.metadata.soundcloud_url).toBe(expected.soundcloud_url);
+    expect(entry.metadata.youtube_music_url).toBe(verifiedYoutube);
+  });
+
+  // THE GATE. Shipped iOS 3.2's `PlaycutMetadataService` skips the live
+  // `/proxy/metadata/album` fetch when `metadataStatus?.isTerminal == true ||
+  // inline.streaming.hasAny`. A payload whose only populated fields would be
+  // synthesized fallbacks must not satisfy the client's inline-metadata gate —
+  // zero-streaming rows serve no streaming keys at all, so the proxy fallback
+  // (which returns full metadata AND synthesizes its own links) still fires.
+  it('does not fill a row with zero real streaming URLs — the terminal-but-empty case that must keep the 3.2 proxy fallback', () => {
+    const entry = transformToIFSEntry(makeRaw({ metadata_status: 'enriched_no_match' }));
+
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.youtube_music_url).toBeNull();
+    expect(entry.bandcamp_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
+    expect(entry.metadata.apple_music_url).toBeNull();
+    expect(entry.metadata.youtube_music_url).toBeNull();
+    expect(entry.metadata.bandcamp_url).toBeNull();
+    expect(entry.metadata.soundcloud_url).toBeNull();
   });
 
   it('a verified persisted URL still wins — fill only touches absent fields', () => {
@@ -93,21 +130,84 @@ describe('transformToIFSEntry streaming-URL search-url fill (#2339)', () => {
 
     expect(entry.spotify_url).toBe('https://open.spotify.com/album/genuine');
     expect(entry.youtube_music_url).toBe('https://music.youtube.com/playlist?list=verified');
-    // The other three were still absent, so they're filled.
+    // The other three were still absent on a qualifying row, so they're filled.
     expect(entry.apple_music_url).not.toBeNull();
     expect(entry.bandcamp_url).not.toBeNull();
     expect(entry.soundcloud_url).not.toBeNull();
   });
 
-  it('leaves every streaming URL null for a marker row with no artist_name (nothing to search on)', () => {
-    const entry = transformToIFSEntry(
-      makeRaw({ entry_type: 'talkset', artist_name: null, album_title: null, track_title: null })
-    );
+  // A suppressed URL is not a real streaming URL: the row it leaves behind has
+  // zero, so it serves NULLs and the proxy fallback both fetches and
+  // synthesizes — consistent with BS#1714's degradation.
+  it('treats a row whose ONLY streaming URL was host-guard-suppressed as zero-streaming', () => {
+    const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://www.deezer.com/album/254381182' }));
 
     expect(entry.spotify_url).toBeNull();
     expect(entry.apple_music_url).toBeNull();
     expect(entry.youtube_music_url).toBeNull();
     expect(entry.bandcamp_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
+  });
+
+  it('degrades a host-guard-suppressed URL to a synthesized one when a sibling keeps the row qualifying', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({
+        spotify_url: 'https://www.deezer.com/album/254381182',
+        bandcamp_url: 'https://juanamolina.bandcamp.com/album/doga',
+      })
+    );
+
+    expect(entry.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+    expect(entry.bandcamp_url).toBe('https://juanamolina.bandcamp.com/album/doga');
+  });
+
+  // Blank-aware, matching the proxy's `if (!metadata.spotifyUrl)` falsy branch:
+  // a persisted '' degrades to a synthesized URL on a qualifying row, rather
+  // than surviving a `??`-nullish check and reaching the V1 wire as `""`.
+  it("degrades a persisted '' to a synthesized URL on a qualifying row", () => {
+    const entry = transformToIFSEntry(
+      makeRaw({ spotify_url: '', bandcamp_url: 'https://juanamolina.bandcamp.com/album/doga' })
+    );
+
+    expect(entry.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+    expect(entry.metadata.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+  });
+
+  it('never emits a blank on the V1 wire — a whitespace-only value on a non-qualifying row becomes null, not ""', () => {
+    const entry = transformToIFSEntry(makeRaw({ spotify_url: '   ', soundcloud_url: '' }));
+
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
+    expect(entry.metadata.soundcloud_url).toBeNull();
+  });
+
+  it('synthesizes nothing for a whitespace-only artist_name (five buttons opening "%20%20%20" searches is not a degradation)', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({ artist_name: '   ', bandcamp_url: 'https://juanamolina.bandcamp.com/album/doga' })
+    );
+
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
+    // The one real value is untouched.
+    expect(entry.bandcamp_url).toBe('https://juanamolina.bandcamp.com/album/doga');
+  });
+
+  it('leaves every streaming URL null for a marker row with no artist_name (nothing to search on)', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({
+        entry_type: 'talkset',
+        artist_name: null,
+        album_title: null,
+        track_title: null,
+        bandcamp_url: 'https://example.bandcamp.com/album/x',
+      })
+    );
+
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.youtube_music_url).toBeNull();
     expect(entry.soundcloud_url).toBeNull();
   });
 });

--- a/tests/unit/services/flowsheet.transformToIFSEntry.search-url-fill.test.ts
+++ b/tests/unit/services/flowsheet.transformToIFSEntry.search-url-fill.test.ts
@@ -1,0 +1,113 @@
+import { transformToIFSEntry, type FSEntryRaw } from '../../../apps/backend/services/flowsheet.service';
+
+/**
+ * #2339. `transformToIFSEntry` is the single producer of every IFSEntry that
+ * reaches `/flowsheet` (top-level fields), `/v2/flowsheet` (`transformToV2`,
+ * nested `metadata`), and the mutation/peek echoes (BS#1513's
+ * `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list projects off the same
+ * IFSEntry). This pins the request-time streaming-URL fallback fill —
+ * `fillSynthesizedSearchUrls` — at that one seam, so a still-absent value
+ * degrades to a synthesized search URL identically to `GET
+ * /proxy/metadata/album` (BS#1184/#1185) instead of reaching the wire as
+ * `null`.
+ */
+
+const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
+  id: 1,
+  show_id: 100,
+  album_id: null,
+  entry_type: 'track',
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  track_position: null,
+  record_label: 'Sonamos',
+  label_id: null,
+  rotation_id: null,
+  rotation_bin: null,
+  artist_id: null,
+  request_flag: false,
+  segue: false,
+  message: null,
+  play_order: 1,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+  on_streaming: null,
+  discogs_unavailable: null,
+  discogs_unavailable_note: null,
+  metadata_status: 'enriched_no_match',
+  enriching_since: null,
+  radio_hour: null,
+  ...overrides,
+});
+
+describe('transformToIFSEntry streaming-URL search-url fill (#2339)', () => {
+  it('fills all five absent streaming URLs with synthesized search URLs, on both the top-level fields and nested metadata', () => {
+    const entry = transformToIFSEntry(makeRaw());
+
+    const expected = {
+      spotify_url: 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja',
+      apple_music_url: 'https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja',
+      youtube_music_url: 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja',
+      bandcamp_url: 'https://bandcamp.com/search?q=Juana%20Molina%20DOGA',
+      soundcloud_url: 'https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja',
+    };
+
+    expect(entry.spotify_url).toBe(expected.spotify_url);
+    expect(entry.apple_music_url).toBe(expected.apple_music_url);
+    expect(entry.youtube_music_url).toBe(expected.youtube_music_url);
+    expect(entry.bandcamp_url).toBe(expected.bandcamp_url);
+    expect(entry.soundcloud_url).toBe(expected.soundcloud_url);
+
+    expect(entry.metadata.spotify_url).toBe(expected.spotify_url);
+    expect(entry.metadata.apple_music_url).toBe(expected.apple_music_url);
+    expect(entry.metadata.youtube_music_url).toBe(expected.youtube_music_url);
+    expect(entry.metadata.bandcamp_url).toBe(expected.bandcamp_url);
+    expect(entry.metadata.soundcloud_url).toBe(expected.soundcloud_url);
+  });
+
+  it('a verified persisted URL still wins — fill only touches absent fields', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({
+        spotify_url: 'https://open.spotify.com/album/genuine',
+        youtube_music_url: 'https://music.youtube.com/playlist?list=verified',
+      })
+    );
+
+    expect(entry.spotify_url).toBe('https://open.spotify.com/album/genuine');
+    expect(entry.youtube_music_url).toBe('https://music.youtube.com/playlist?list=verified');
+    // The other three were still absent, so they're filled.
+    expect(entry.apple_music_url).not.toBeNull();
+    expect(entry.bandcamp_url).not.toBeNull();
+    expect(entry.soundcloud_url).not.toBeNull();
+  });
+
+  it('leaves every streaming URL null for a marker row with no artist_name (nothing to search on)', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({ entry_type: 'talkset', artist_name: null, album_title: null, track_title: null })
+    );
+
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.youtube_music_url).toBeNull();
+    expect(entry.bandcamp_url).toBeNull();
+    expect(entry.soundcloud_url).toBeNull();
+  });
+});

--- a/tests/unit/services/playlist-proxy-wire-golden.test.ts
+++ b/tests/unit/services/playlist-proxy-wire-golden.test.ts
@@ -172,7 +172,7 @@ const GOLDEN_PATH = join(__dirname, '../../fixtures/recent-entries-v2-wire-golde
  * file from the fixture, so regenerating one without acknowledging the other is
  * a red test rather than a silent change.
  */
-const GOLDEN_SHA256 = '1e4ed064c31619303db81e263ec1b039867dc65b1ed685b6da121dcf49cf0d72';
+const GOLDEN_SHA256 = '775de938c03fe6aa3e5ba2dfe63eba6cc5093f2dcb1f1948e5554a917439322f';
 
 /** Fixed ids and add_times — the payload must be byte-reproducible. */
 function row(id: number, albumId: number | null, artist: string, album: string, track: string, seconds: number) {
@@ -496,9 +496,10 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     // '' discogs sentinel (BS#1628).
     expect(byArtist('Jessica Pratt')).not.toHaveProperty('discogsURL');
     // Mislabeled streaming host (BS#1714) — the correct sibling survives, and
-    // (#2339) the suppressed spotify_url now degrades to the same synthesized
-    // search URL an outright-missing value would get, rather than staying
-    // omitted.
+    // (#2339) the suppressed spotify_url degrades to the same synthesized
+    // search URL an outright-missing value would get, because the surviving
+    // bandcamp_url keeps this row past the fill's "already carries a real
+    // streaming URL" gate.
     expect(byArtist('Chuquimamani-Condori').spotifyURL).toBe(
       'https://open.spotify.com/search/Chuquimamani-Condori%20Call%20Your%20Name'
     );
@@ -506,12 +507,22 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     // Whitespace: padded is trimmed, blank is dropped.
     expect(byArtist('Juana Molina').discogsURL).toBe('https://www.discogs.com/release/999');
     expect(byArtist('Juana Molina')).not.toHaveProperty('artistWikipediaURL');
-    // Non-web scheme, scheme-relative, bare host. discogsURL/bandcampURL have
-    // no synthesized fallback (discogs isn't one of the five #2339-synthesizable
-    // fields; the scheme-less bandcamp_url is a non-null string, so the fill's
-    // `?? fallback` never runs for it) and stay dropped. spotifyURL's
-    // scheme-relative value fails the same `isSpotifyUrl` host check the
-    // mislabeled-host case above does, so it degrades the same way (#2339).
+    // Non-web scheme, scheme-relative, bare host. discogsURL/bandcampURL stay
+    // dropped: discogs isn't one of the five #2339-synthesizable fields, and
+    // the scheme-less bandcamp_url is a non-blank string, so the fill's
+    // `?? fallback` never runs for it (it is then dropped by `wireUrl`).
+    // spotifyURL's scheme-relative value fails the same `isSpotifyUrl` host
+    // check the mislabeled-host case above does, so it degrades to a
+    // synthesized search URL (#2339).
+    //
+    // This row is also where the fill's gate shows its edge: "real streaming
+    // URL" means non-null and non-blank, NOT "survives `wireUrl`", so the
+    // unwireable bandcamp_url is what carries this row past the gate even
+    // though it earns no wire key. That matches the proxy's own
+    // `if (!metadata.spotifyUrl)` falsy check, which likewise treats a
+    // non-empty garbage string as present. Production `bandcamp_url` values
+    // are written absolute by the enrichment path, so this shape is a
+    // constructed hazard rather than a live population.
     expect(byArtist('Stereolab')).not.toHaveProperty('discogsURL');
     expect(byArtist('Stereolab').spotifyURL).toBe('https://open.spotify.com/search/Stereolab%20Brakhage');
     expect(byArtist('Stereolab')).not.toHaveProperty('bandcampURL');
@@ -540,34 +551,26 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     expect(degenerate).not.toHaveProperty('artistBio');
     expect(degenerate).not.toHaveProperty('discogsUnavailableNote');
     expect(degenerate.discogsUnavailable).toBe(true);
-    // A free-text play has nothing persisted, so the fields with no
-    // synthesized fallback carry no URL key at all…
+    // A free-text play carries no URL key at all — including the five
+    // streaming fields, which #2339's fill deliberately leaves alone: with
+    // zero real streaming URLs this row does not pass the fill's gate, so
+    // shipped iOS 3.2 keeps its live `/proxy/metadata/album` fallback (which
+    // returns full metadata AND synthesizes its own links) instead of
+    // short-circuiting on `inline.streaming.hasAny` to a card with five search
+    // buttons and nothing else.
     const bare = byArtist('BS2103 Unenriched Artist');
-    for (const key of ['artworkURL', 'discogsURL', 'artistWikipediaURL']) {
+    for (const key of [
+      'artworkURL',
+      'discogsURL',
+      'spotifyURL',
+      'appleMusicURL',
+      'youtubeMusicURL',
+      'bandcampURL',
+      'soundcloudURL',
+      'artistWikipediaURL',
+    ]) {
       expect(bare).not.toHaveProperty(key);
     }
-    // …but (#2339) it DOES have an artist_name, so the five synthesizable
-    // streaming fields fill with search URLs — matching /proxy/metadata/album's
-    // degradation for the exact same unenriched-play shape.
-    expect(bare.spotifyURL).toBe(
-      'https://open.spotify.com/search/BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
-    );
-    expect(bare.appleMusicURL).toBe(
-      'https://music.apple.com/search?term=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
-    );
-    expect(bare.youtubeMusicURL).toBe(
-      'https://music.youtube.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
-    );
-    expect(bare.bandcampURL).toBe(
-      'https://bandcamp.com/search?q=' + encodeURIComponent('BS2103 Unenriched Artist BS2103 Unenriched Album')
-    );
-    expect(bare.soundcloudURL).toBe(
-      'https://soundcloud.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
-    );
-    // No persisted field is renderable inline metadata (the fill doesn't
-    // count — pre-PR review finding 1), so the terminal-vs-empty predicate
-    // stays false and the control field stays home; this row's status is
-    // 'pending' (non-terminal) regardless, so this is harmless either way.
     expect(bare).not.toHaveProperty('metadataStatus');
   });
 

--- a/tests/unit/services/playlist-proxy-wire-golden.test.ts
+++ b/tests/unit/services/playlist-proxy-wire-golden.test.ts
@@ -172,7 +172,7 @@ const GOLDEN_PATH = join(__dirname, '../../fixtures/recent-entries-v2-wire-golde
  * file from the fixture, so regenerating one without acknowledging the other is
  * a red test rather than a silent change.
  */
-const GOLDEN_SHA256 = '775de938c03fe6aa3e5ba2dfe63eba6cc5093f2dcb1f1948e5554a917439322f';
+const GOLDEN_SHA256 = 'd8cc07bd3d720442cf6ea39f71d12ca641e9330e4145ac7ad6737b3708acfbb8';
 
 /** Fixed ids and add_times — the payload must be byte-reproducible. */
 function row(id: number, albumId: number | null, artist: string, album: string, track: string, seconds: number) {
@@ -507,25 +507,24 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     // Whitespace: padded is trimmed, blank is dropped.
     expect(byArtist('Juana Molina').discogsURL).toBe('https://www.discogs.com/release/999');
     expect(byArtist('Juana Molina')).not.toHaveProperty('artistWikipediaURL');
-    // Non-web scheme, scheme-relative, bare host. discogsURL/bandcampURL stay
-    // dropped: discogs isn't one of the five #2339-synthesizable fields, and
-    // the scheme-less bandcamp_url is a non-blank string, so the fill's
-    // `?? fallback` never runs for it (it is then dropped by `wireUrl`).
-    // spotifyURL's scheme-relative value fails the same `isSpotifyUrl` host
-    // check the mislabeled-host case above does, so it degrades to a
-    // synthesized search URL (#2339).
-    //
-    // This row is also where the fill's gate shows its edge: "real streaming
-    // URL" means non-null and non-blank, NOT "survives `wireUrl`", so the
-    // unwireable bandcamp_url is what carries this row past the gate even
-    // though it earns no wire key. That matches the proxy's own
-    // `if (!metadata.spotifyUrl)` falsy check, which likewise treats a
-    // non-empty garbage string as present. Production `bandcamp_url` values
-    // are written absolute by the enrichment path, so this shape is a
-    // constructed hazard rather than a live population.
-    expect(byArtist('Stereolab')).not.toHaveProperty('discogsURL');
-    expect(byArtist('Stereolab').spotifyURL).toBe('https://open.spotify.com/search/Stereolab%20Brakhage');
-    expect(byArtist('Stereolab')).not.toHaveProperty('bandcampURL');
+    // Non-web scheme, scheme-relative, bare host — every persisted value on
+    // this row is unwireable, so the row emits no URL key at all. It is also
+    // the row that proves #2339's gate uses WIRE semantics: the scheme-less
+    // `bandcamp_url` and scheme-relative `spotify_url` are non-blank strings,
+    // but neither would reach the client, so neither qualifies the row for the
+    // fill. Gating on non-blankness instead would have flipped this row's
+    // `inline.streaming.hasAny` from false to true purely by synthesizing —
+    // precisely the 3.2 fallback suppression the gate exists to prevent.
+    for (const key of [
+      'discogsURL',
+      'spotifyURL',
+      'appleMusicURL',
+      'youtubeMusicURL',
+      'bandcampURL',
+      'soundcloudURL',
+    ]) {
+      expect(byArtist('Stereolab')).not.toHaveProperty(key);
+    }
     // Raw non-ASCII is NOT a hazard and must survive untouched. This is also
     // why the serializer rejects rather than emitting `parsed.href`: href would
     // percent-encode these ~21 real production values for no gain.

--- a/tests/unit/services/playlist-proxy-wire-golden.test.ts
+++ b/tests/unit/services/playlist-proxy-wire-golden.test.ts
@@ -172,7 +172,7 @@ const GOLDEN_PATH = join(__dirname, '../../fixtures/recent-entries-v2-wire-golde
  * file from the fixture, so regenerating one without acknowledging the other is
  * a red test rather than a silent change.
  */
-const GOLDEN_SHA256 = '46a1064409f65356e076390bd209c198d0a8748ccb23bd51b5fb7ae1409c8f70';
+const GOLDEN_SHA256 = '1e4ed064c31619303db81e263ec1b039867dc65b1ed685b6da121dcf49cf0d72';
 
 /** Fixed ids and add_times — the payload must be byte-reproducible. */
 function row(id: number, albumId: number | null, artist: string, album: string, track: string, seconds: number) {
@@ -194,8 +194,22 @@ function row(id: number, albumId: number | null, artist: string, album: string, 
   };
 }
 
-/** Every metadata column, so each probe states its whole row explicitly. */
+/**
+ * Every metadata column, so each probe states its whole row explicitly.
+ *
+ * #2339 (pre-PR review finding 2): `artist_name` / `album_title` /
+ * `track_title` are three columns this ticket added to `enrichPlaycutMetadata`'s
+ * select — see `PlaycutMetadataRow`'s doc comment in
+ * `playlist-proxy.service.ts` — and in production they come off the SAME
+ * `flowsheet` row {@link row} builds, never a separate source. Defaulting them
+ * here from {@link ROWS_BY_ID} (rather than leaving them undefined, which
+ * silently short-circuits `fillSynthesizedSearchUrls`'s `if (!text.artist_name)
+ * return urls` guard and lets the golden pass without ever exercising the
+ * fill) keeps that invariant instead of hand-duplicating the strings and
+ * risking drift between the two.
+ */
 function meta(id: number, overrides: Record<string, unknown> = {}) {
+  const sourceRow = ROWS_BY_ID.get(id);
   return {
     id,
     discogs_url: null,
@@ -213,6 +227,9 @@ function meta(id: number, overrides: Record<string, unknown> = {}) {
     discogs_unavailable: false,
     discogs_unavailable_note: null,
     metadata_status: 'enriched_match',
+    artist_name: sourceRow?.artist_name ?? null,
+    album_title: sourceRow?.album_title ?? null,
+    track_title: sourceRow?.track_title ?? null,
     ...overrides,
   };
 }
@@ -233,6 +250,9 @@ const ROWS = [
   row(9013, 990013, 'Hermanos Gutiérrez', 'El Bueno Y El Malo', 'Tres Hermanos', 13),
   row(9014, 990014, 'Cat Power', 'Moon Pix', 'Cross Bones Style', 14),
 ];
+
+/** Row-id -> row lookup, so {@link meta} can default its #2339 text fields off the matching {@link row}. */
+const ROWS_BY_ID = new Map(ROWS.map((r) => [r.id, r]));
 
 const METADATA = [
   // Fully enriched. `artist_wikipedia_url` carries RAW un-percent-encoded UTF-8,
@@ -475,15 +495,25 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     expect(byArtist('Art Garfunkel')).not.toHaveProperty('artistWikipediaURL');
     // '' discogs sentinel (BS#1628).
     expect(byArtist('Jessica Pratt')).not.toHaveProperty('discogsURL');
-    // Mislabeled streaming host (BS#1714) — the correct sibling survives.
-    expect(byArtist('Chuquimamani-Condori')).not.toHaveProperty('spotifyURL');
+    // Mislabeled streaming host (BS#1714) — the correct sibling survives, and
+    // (#2339) the suppressed spotify_url now degrades to the same synthesized
+    // search URL an outright-missing value would get, rather than staying
+    // omitted.
+    expect(byArtist('Chuquimamani-Condori').spotifyURL).toBe(
+      'https://open.spotify.com/search/Chuquimamani-Condori%20Call%20Your%20Name'
+    );
     expect(byArtist('Chuquimamani-Condori').bandcampURL).toBe('https://chuquimamanicondori.bandcamp.com/album/dj-e');
     // Whitespace: padded is trimmed, blank is dropped.
     expect(byArtist('Juana Molina').discogsURL).toBe('https://www.discogs.com/release/999');
     expect(byArtist('Juana Molina')).not.toHaveProperty('artistWikipediaURL');
-    // Non-web scheme, scheme-relative, bare host.
+    // Non-web scheme, scheme-relative, bare host. discogsURL/bandcampURL have
+    // no synthesized fallback (discogs isn't one of the five #2339-synthesizable
+    // fields; the scheme-less bandcamp_url is a non-null string, so the fill's
+    // `?? fallback` never runs for it) and stay dropped. spotifyURL's
+    // scheme-relative value fails the same `isSpotifyUrl` host check the
+    // mislabeled-host case above does, so it degrades the same way (#2339).
     expect(byArtist('Stereolab')).not.toHaveProperty('discogsURL');
-    expect(byArtist('Stereolab')).not.toHaveProperty('spotifyURL');
+    expect(byArtist('Stereolab').spotifyURL).toBe('https://open.spotify.com/search/Stereolab%20Brakhage');
     expect(byArtist('Stereolab')).not.toHaveProperty('bandcampURL');
     // Raw non-ASCII is NOT a hazard and must survive untouched. This is also
     // why the serializer rejects rather than emitting `parsed.href`: href would
@@ -510,11 +540,34 @@ describe('BS#2103 v=2 wire golden (cross-repo contract with iOS 3.2)', () => {
     expect(degenerate).not.toHaveProperty('artistBio');
     expect(degenerate).not.toHaveProperty('discogsUnavailableNote');
     expect(degenerate.discogsUnavailable).toBe(true);
-    // A free-text play carries no URL key at all.
+    // A free-text play has nothing persisted, so the fields with no
+    // synthesized fallback carry no URL key at all…
     const bare = byArtist('BS2103 Unenriched Artist');
-    for (const key of ['artworkURL', 'discogsURL', 'spotifyURL', 'artistWikipediaURL']) {
+    for (const key of ['artworkURL', 'discogsURL', 'artistWikipediaURL']) {
       expect(bare).not.toHaveProperty(key);
     }
+    // …but (#2339) it DOES have an artist_name, so the five synthesizable
+    // streaming fields fill with search URLs — matching /proxy/metadata/album's
+    // degradation for the exact same unenriched-play shape.
+    expect(bare.spotifyURL).toBe(
+      'https://open.spotify.com/search/BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
+    );
+    expect(bare.appleMusicURL).toBe(
+      'https://music.apple.com/search?term=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
+    );
+    expect(bare.youtubeMusicURL).toBe(
+      'https://music.youtube.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
+    );
+    expect(bare.bandcampURL).toBe(
+      'https://bandcamp.com/search?q=' + encodeURIComponent('BS2103 Unenriched Artist BS2103 Unenriched Album')
+    );
+    expect(bare.soundcloudURL).toBe(
+      'https://soundcloud.com/search?q=BS2103%20Unenriched%20Artist%20Probe%20Track%20(no%20metadata)'
+    );
+    // No persisted field is renderable inline metadata (the fill doesn't
+    // count — pre-PR review finding 1), so the terminal-vs-empty predicate
+    // stays false and the control field stays home; this row's status is
+    // 'pending' (non-terminal) regardless, so this is harmless either way.
     expect(bare).not.toHaveProperty('metadataStatus');
   });
 

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -874,6 +874,12 @@ describe('playlist-proxy.service', () => {
       discogs_unavailable: false,
       discogs_unavailable_note: null,
       metadata_status: 'enriched_match',
+      // #2339 synthesis inputs. `enrichPlaycutMetadata` selects these off the
+      // SAME `flowsheet` row it selects the metadata projection from, so they
+      // are sourced here from `jessicaPrattRow` rather than hand-duplicated.
+      artist_name: jessicaPrattRow.artist_name,
+      album_title: jessicaPrattRow.album_title,
+      track_title: jessicaPrattRow.track_title,
     };
 
     /** An unenriched row: every metadata column NULL (no album_metadata, no inline value). */
@@ -894,6 +900,10 @@ describe('playlist-proxy.service', () => {
       discogs_unavailable: null,
       discogs_unavailable_note: null,
       metadata_status: 'pending',
+      // See fullMetadata: the #2339 text columns come off the same flowsheet row.
+      artist_name: jessicaPrattRow.artist_name,
+      album_title: jessicaPrattRow.album_title,
+      track_title: jessicaPrattRow.track_title,
     };
 
     it('emits every enrichment field under the exact iOS 3.2 camelCase key', async () => {
@@ -1004,68 +1014,122 @@ describe('playlist-proxy.service', () => {
     });
 
     // #2339: the legacy `?v=2` grouped payload must degrade the same way the
-    // V2 flowsheet feed does — a still-absent streaming URL after the
-    // COALESCE/host-guard gets a synthesized search URL rather than reaching
-    // the wire as omitted, exactly mirroring `GET /proxy/metadata/album`
-    // (BS#1184/#1185). Synthesized from `flowsheet.artist_name`/
-    // `album_title`/`track_title` (added to `enrichPlaycutMetadata`'s select
-    // by this ticket), never from `GroupedPlaycut.artistName`/`releaseTitle`/
-    // `songTitle` (the tubafrenzy-mirror-derived legacy fields).
+    // V2 flowsheet feed does — an absent streaming URL after the COALESCE /
+    // host guard gets a synthesized search URL instead of no key at all,
+    // mirroring `GET /proxy/metadata/album` (BS#1184/#1185). Synthesized from
+    // `flowsheet.artist_name`/`album_title`/`track_title` (added to
+    // `enrichPlaycutMetadata`'s select by this ticket), never from
+    // `GroupedPlaycut.artistName`/`releaseTitle`/`songTitle` (the
+    // tubafrenzy-mirror-derived legacy fields, which can drift).
+    //
+    // GATED on the row already carrying at least one real streaming URL —
+    // see `fillSynthesizedSearchUrls` and the zero-streaming test below.
     describe('streaming-URL search-url fill (#2339)', () => {
-      it('fills all five absent streaming URLs with synthesized search URLs', async () => {
+      /** The post-#2295-drain shape: synthesized YT/Bandcamp/SoundCloud, NULL Spotify/Apple. */
+      const drainedYoutube = 'https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby';
+
+      it('fills the absent streaming URLs on a row that already carries one, leaving the verified value untouched', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
-        mockMetadataWhere.mockResolvedValue([
-          {
-            ...emptyMetadata,
-            artist_name: jessicaPrattRow.artist_name,
-            album_title: jessicaPrattRow.album_title,
-            track_title: jessicaPrattRow.track_title,
-          },
-        ]);
+        mockMetadataWhere.mockResolvedValue([{ ...emptyMetadata, youtube_music_url: drainedYoutube }]);
 
         const [pc] = (await getRecentEntries(50)).playcuts;
 
         expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
         expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
-        expect(pc.youtubeMusicURL).toBe('https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
         expect(pc.bandcampURL).toBe('https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again');
         expect(pc.soundcloudURL).toBe('https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.youtubeMusicURL).toBe(drainedYoutube);
+      });
+
+      // THE GATE. Shipped iOS 3.2's `PlaycutMetadataService` skips the live
+      // `/proxy/metadata/album` fetch when `metadataStatus?.isTerminal == true
+      // || inline.streaming.hasAny`. A payload whose only populated fields
+      // would be synthesized fallbacks must not satisfy the client's
+      // inline-metadata gate — zero-streaming rows serve no streaming keys at
+      // all, so the proxy fallback (which returns full metadata AND
+      // synthesizes its own links) still fires. Filling here would leave the
+      // user a card with five search buttons and nothing else, permanently:
+      // BS#2103's empty-card bug, reopened.
+      it('fills nothing on a zero-streaming row — no streaming key rides at all', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([emptyMetadata]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        for (const key of ['spotifyURL', 'appleMusicURL', 'youtubeMusicURL', 'bandcampURL', 'soundcloudURL']) {
+          expect(Object.prototype.hasOwnProperty.call(pc, key)).toBe(false);
+        }
       });
 
       it('a verified persisted URL still wins over the fill', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         mockMetadataWhere.mockResolvedValue([
-          {
-            ...emptyMetadata,
-            artist_name: jessicaPrattRow.artist_name,
-            album_title: jessicaPrattRow.album_title,
-            track_title: jessicaPrattRow.track_title,
-            spotify_url: 'https://open.spotify.com/album/genuine',
-          },
+          { ...emptyMetadata, spotify_url: 'https://open.spotify.com/album/genuine' },
         ]);
 
         const [pc] = (await getRecentEntries(50)).playcuts;
 
         expect(pc.spotifyURL).toBe('https://open.spotify.com/album/genuine');
-        expect(pc.appleMusicURL).not.toBeUndefined();
+        expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
       });
 
-      it('a suppressed mislabeled host degrades to a synthesized URL rather than staying omitted', async () => {
+      it('a suppressed mislabeled host degrades to a synthesized URL when a sibling keeps the row qualifying', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         mockMetadataWhere.mockResolvedValue([
           {
             ...emptyMetadata,
-            artist_name: jessicaPrattRow.artist_name,
-            album_title: jessicaPrattRow.album_title,
-            track_title: jessicaPrattRow.track_title,
             // Mislabeled at the LML boundary (BS#1714) — a Deezer URL under spotify_url.
             spotify_url: 'https://www.deezer.com/album/254381182',
+            bandcamp_url: 'https://jessicapratt.bandcamp.com/album/on-your-own-love-again',
           },
         ]);
 
         const [pc] = (await getRecentEntries(50)).playcuts;
 
         expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.bandcampURL).toBe('https://jessicapratt.bandcamp.com/album/on-your-own-love-again');
+      });
+
+      // A suppressed URL is not a real streaming URL: the row it leaves behind
+      // has zero, so it serves nothing and the proxy fallback both fetches and
+      // synthesizes — consistent with BS#1714's degradation.
+      it('treats a row whose ONLY streaming URL was host-guard-suppressed as zero-streaming', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          { ...emptyMetadata, spotify_url: 'https://www.deezer.com/album/254381182' },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        for (const key of ['spotifyURL', 'appleMusicURL', 'youtubeMusicURL', 'bandcampURL', 'soundcloudURL']) {
+          expect(Object.prototype.hasOwnProperty.call(pc, key)).toBe(false);
+        }
+      });
+
+      // Blank-aware, matching the proxy's `if (!metadata.spotifyUrl)` falsy
+      // branch: a `??`-nullish check would let the '' survive the fill and then
+      // be dropped by `wireUrl` with no fallback left to run.
+      it("degrades a persisted '' to a synthesized URL on a qualifying row", async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([{ ...emptyMetadata, spotify_url: '', youtube_music_url: drainedYoutube }]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+      });
+
+      it('synthesizes nothing for a whitespace-only artist_name', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          { ...emptyMetadata, artist_name: '   ', youtube_music_url: drainedYoutube },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        expect(pc.youtubeMusicURL).toBe(drainedYoutube);
+        for (const key of ['spotifyURL', 'appleMusicURL', 'bandcampURL', 'soundcloudURL']) {
+          expect(Object.prototype.hasOwnProperty.call(pc, key)).toBe(false);
+        }
       });
     });
 
@@ -1098,44 +1162,49 @@ describe('playlist-proxy.service', () => {
         expect(pc.artistId).toBe(44321);
       });
 
-      // #2339 regression (pre-PR review finding 1): the fill in
-      // `applyPlaycutMetadata` used to run BEFORE this predicate was read, so
-      // a terminal-but-empty row's five freshly-synthesized search URLs made
-      // `hasRenderableInlineMetadata` true and let `metadataStatus` ride —
-      // exactly the empty-card regression this guard exists to prevent
-      // (measured 579 of 37,054 production playcuts, all `enriched_no_match`
-      // with no artwork/bio/discogs/year/genres). A synthesized search URL is
-      // the same request-time fallback the proxy already builds from
-      // nothing, so it must not count as "renderable metadata" for this
-      // predicate. `artist_name` is present here (unlike the sibling test
-      // above), so the fill DOES fire — the assertions below prove that
-      // directly, so this test cannot pass merely because the fill
-      // short-circuited on a blank artist_name.
-      it('withholds a terminal status even though the #2339 fill populates all five streaming URLs (enriched_no_match, no other renderable field)', async () => {
+      // #2339 + BS#2103 together. A terminal-but-empty row (measured 579 of
+      // 37,054 production playcuts, all `enriched_no_match` with no
+      // artwork/bio/discogs/year/genres) has ZERO real streaming URLs, so the
+      // gated fill does not fire at all: the contract is that a payload whose
+      // only populated fields would be synthesized fallbacks must not satisfy
+      // the client's inline-metadata gate — zero-streaming rows serve no
+      // streaming keys at all, and 3.2 keeps its live `/proxy/metadata/album`
+      // fetch rather than short-circuiting to a card with five search buttons
+      // and nothing else.
+      //
+      // Belt and braces: `hasRenderableInlineMetadata` reads the PRE-fill
+      // streaming snapshot, not the emitted wire values, so even a row that
+      // does qualify for the fill cannot manufacture a renderable-metadata
+      // verdict out of synthesized fallbacks.
+      it('withholds a terminal status on a zero-streaming enriched_no_match row, and emits no streaming key (#2339 gate)', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([{ ...emptyMetadata, metadata_status: 'enriched_no_match' }]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        for (const key of ['spotifyURL', 'appleMusicURL', 'youtubeMusicURL', 'bandcampURL', 'soundcloudURL']) {
+          expect(Object.prototype.hasOwnProperty.call(pc, key)).toBe(false);
+        }
+        expect(Object.prototype.hasOwnProperty.call(pc, 'metadataStatus')).toBe(false);
+      });
+
+      // The row that DOES fill still gets its status, because the pre-fill
+      // snapshot already had a renderable streaming URL — the fill changed
+      // decoration, not the verdict.
+      it('still emits a terminal status for a row whose real streaming URL made it renderable before the fill', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         mockMetadataWhere.mockResolvedValue([
           {
             ...emptyMetadata,
             metadata_status: 'enriched_no_match',
-            artist_name: jessicaPrattRow.artist_name,
-            album_title: jessicaPrattRow.album_title,
-            track_title: jessicaPrattRow.track_title,
+            youtube_music_url: 'https://music.youtube.com/playlist?list=OLAK5uy_real',
           },
         ]);
 
         const [pc] = (await getRecentEntries(50)).playcuts;
 
-        // The fill fired — proves the withheld status below isn't just the
-        // fill being a no-op.
         expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
-        expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
-        expect(pc.youtubeMusicURL).toBe('https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
-        expect(pc.bandcampURL).toBe('https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again');
-        expect(pc.soundcloudURL).toBe('https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
-        // …but the control field stays home: 3.2 must keep its live fallback
-        // fetch rather than short-circuit to a card with five search buttons
-        // and nothing else.
-        expect(Object.prototype.hasOwnProperty.call(pc, 'metadataStatus')).toBe(false);
+        expect(pc.metadataStatus).toBe('enriched_no_match');
       });
 
       it('withholds a terminal status when the only persisted values were guarded off the wire', async () => {
@@ -1237,8 +1306,13 @@ describe('playlist-proxy.service', () => {
 
       const [pc] = (await getRecentEntries(50)).playcuts;
 
-      expect(pc.spotifyURL).toBeUndefined();
-      expect(pc.appleMusicURL).toBeUndefined();
+      // Neither mislabeled value reaches its hardwired button. Since #2339
+      // they degrade to synthesized search URLs rather than to no key at all,
+      // because the three un-mislabeled siblings keep this row past the fill's
+      // "already carries a real streaming URL" gate — the identical-degradation
+      // rule from BS#1185.
+      expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+      expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
       // The un-mislabeled siblings are untouched.
       expect(pc.bandcampURL).toBe(fullMetadata.bandcamp_url);
       expect(pc.youtubeMusicURL).toBe(fullMetadata.youtube_music_url);

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -1003,6 +1003,72 @@ describe('playlist-proxy.service', () => {
       expect(Object.prototype.hasOwnProperty.call(pc, 'metadataStatus')).toBe(false);
     });
 
+    // #2339: the legacy `?v=2` grouped payload must degrade the same way the
+    // V2 flowsheet feed does — a still-absent streaming URL after the
+    // COALESCE/host-guard gets a synthesized search URL rather than reaching
+    // the wire as omitted, exactly mirroring `GET /proxy/metadata/album`
+    // (BS#1184/#1185). Synthesized from `flowsheet.artist_name`/
+    // `album_title`/`track_title` (added to `enrichPlaycutMetadata`'s select
+    // by this ticket), never from `GroupedPlaycut.artistName`/`releaseTitle`/
+    // `songTitle` (the tubafrenzy-mirror-derived legacy fields).
+    describe('streaming-URL search-url fill (#2339)', () => {
+      it('fills all five absent streaming URLs with synthesized search URLs', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          {
+            ...emptyMetadata,
+            artist_name: jessicaPrattRow.artist_name,
+            album_title: jessicaPrattRow.album_title,
+            track_title: jessicaPrattRow.track_title,
+          },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.youtubeMusicURL).toBe('https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.bandcampURL).toBe('https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again');
+        expect(pc.soundcloudURL).toBe('https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
+      });
+
+      it('a verified persisted URL still wins over the fill', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          {
+            ...emptyMetadata,
+            artist_name: jessicaPrattRow.artist_name,
+            album_title: jessicaPrattRow.album_title,
+            track_title: jessicaPrattRow.track_title,
+            spotify_url: 'https://open.spotify.com/album/genuine',
+          },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        expect(pc.spotifyURL).toBe('https://open.spotify.com/album/genuine');
+        expect(pc.appleMusicURL).not.toBeUndefined();
+      });
+
+      it('a suppressed mislabeled host degrades to a synthesized URL rather than staying omitted', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          {
+            ...emptyMetadata,
+            artist_name: jessicaPrattRow.artist_name,
+            album_title: jessicaPrattRow.album_title,
+            track_title: jessicaPrattRow.track_title,
+            // Mislabeled at the LML boundary (BS#1714) — a Deezer URL under spotify_url.
+            spotify_url: 'https://www.deezer.com/album/254381182',
+          },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+      });
+    });
+
     // On shipped iOS 3.2, `metadataStatus` is a CONTROL field, not data: a
     // terminal value makes `PlaycutDetailView.loadMetadata()` render straight
     // from the inline fields and never call `/proxy/metadata/album`

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -1231,6 +1231,44 @@ describe('playlist-proxy.service', () => {
         expect(pc.genres).toBeUndefined();
       });
 
+      // #2339's gate uses the WIRE's presence predicate (`wireUrl`), not
+      // "non-blank" — so a persisted streaming value that would never reach the
+      // client cannot qualify its row for the fill. Without this, a row like
+      // this one emits ZERO streaming keys before the ticket and FOUR
+      // synthesized ones after, flipping shipped 3.2's
+      // `inline.streaming.hasAny` from false to true purely by synthesizing,
+      // and suppressing the live `/proxy/metadata/album` fallback that is the
+      // only thing serving it any metadata. Every hazard shape below is one the
+      // columns permit and no write path validates: `youtube_music_url` /
+      // `bandcamp_url` / `soundcloud_url` are written verbatim from LML
+      // (`normalize-lookup.ts`, `enrich.ts`, `flowsheet-no-match-recheck`),
+      // and `sanitizeLookupStreamingUrls` guards only spotify/apple (BS#1710).
+      it('emits no streaming key for a row whose only persisted streaming URLs are unwireable (#2339 gate uses wire semantics)', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          {
+            ...emptyMetadata,
+            metadata_status: 'enriched_match',
+            // Scheme-relative: `new URL()` rejects it, iOS would too.
+            spotify_url: '//open.spotify.com/album/xyz',
+            // Bare hostname, no scheme.
+            bandcamp_url: 'jessicapratt.bandcamp.com/album/on-your-own-love-again',
+            // Raw tab — a WHATWG-vs-Foundation parser differential.
+            youtube_music_url: 'https://music.youtube.com/playlist?list=OLAK5uy_\tabc',
+            // Non-web scheme.
+            soundcloud_url: 'javascript:alert(1)',
+          },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        for (const key of ['spotifyURL', 'appleMusicURL', 'youtubeMusicURL', 'bandcampURL', 'soundcloudURL']) {
+          expect(Object.prototype.hasOwnProperty.call(pc, key)).toBe(false);
+        }
+        // Nothing renderable shipped, so the control field stays home too.
+        expect(Object.prototype.hasOwnProperty.call(pc, 'metadataStatus')).toBe(false);
+      });
+
       it('emits a terminal status when artwork alone survives (set before applyPlaycutMetadata)', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         mockArtworkOrderBy.mockResolvedValue([

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -1098,6 +1098,46 @@ describe('playlist-proxy.service', () => {
         expect(pc.artistId).toBe(44321);
       });
 
+      // #2339 regression (pre-PR review finding 1): the fill in
+      // `applyPlaycutMetadata` used to run BEFORE this predicate was read, so
+      // a terminal-but-empty row's five freshly-synthesized search URLs made
+      // `hasRenderableInlineMetadata` true and let `metadataStatus` ride —
+      // exactly the empty-card regression this guard exists to prevent
+      // (measured 579 of 37,054 production playcuts, all `enriched_no_match`
+      // with no artwork/bio/discogs/year/genres). A synthesized search URL is
+      // the same request-time fallback the proxy already builds from
+      // nothing, so it must not count as "renderable metadata" for this
+      // predicate. `artist_name` is present here (unlike the sibling test
+      // above), so the fill DOES fire — the assertions below prove that
+      // directly, so this test cannot pass merely because the fill
+      // short-circuited on a blank artist_name.
+      it('withholds a terminal status even though the #2339 fill populates all five streaming URLs (enriched_no_match, no other renderable field)', async () => {
+        mockLimit.mockResolvedValue([jessicaPrattRow]);
+        mockMetadataWhere.mockResolvedValue([
+          {
+            ...emptyMetadata,
+            metadata_status: 'enriched_no_match',
+            artist_name: jessicaPrattRow.artist_name,
+            album_title: jessicaPrattRow.album_title,
+            track_title: jessicaPrattRow.track_title,
+          },
+        ]);
+
+        const [pc] = (await getRecentEntries(50)).playcuts;
+
+        // The fill fired — proves the withheld status below isn't just the
+        // fill being a no-op.
+        expect(pc.spotifyURL).toBe('https://open.spotify.com/search/Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.appleMusicURL).toBe('https://music.apple.com/search?term=Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.youtubeMusicURL).toBe('https://music.youtube.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
+        expect(pc.bandcampURL).toBe('https://bandcamp.com/search?q=Jessica%20Pratt%20On%20Your%20Own%20Love%20Again');
+        expect(pc.soundcloudURL).toBe('https://soundcloud.com/search?q=Jessica%20Pratt%20Back%2C%20Baby');
+        // …but the control field stays home: 3.2 must keep its live fallback
+        // fetch rather than short-circuit to a card with five search buttons
+        // and nothing else.
+        expect(Object.prototype.hasOwnProperty.call(pc, 'metadataStatus')).toBe(false);
+      });
+
       it('withholds a terminal status when the only persisted values were guarded off the wire', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         // Every field is present in the DB but hazardous: the URL guard drops

--- a/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
+++ b/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
@@ -2,6 +2,15 @@
  * Unit tests for `fillSynthesizedSearchUrls` (#2339) — the request-time-only
  * fallback that fills a still-absent streaming URL with a synthesized search
  * URL, mirroring `GET /proxy/metadata/album`'s degradation (BS#1184/#1185).
+ *
+ * The fill is GATED (owner decision, 2026-08-31): it only fires for a row whose
+ * post-host-guard values already carry at least one REAL streaming URL —
+ * non-null and non-blank. Shipped iOS 3.2 skips its live
+ * `/proxy/metadata/album` fetch on `inline.streaming.hasAny`, so such a row
+ * short-circuits inline regardless and the fill can only upgrade grey
+ * Spotify/Apple buttons; a zero-streaming row must keep serving NULLs so the
+ * live proxy fallback (full metadata plus its own synthesized links) still
+ * fires.
  */
 
 import {
@@ -17,25 +26,121 @@ const allNull: SynthesizableStreamingUrls = {
   soundcloud_url: null,
 };
 
+const JUANA = { artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' };
+
+/** The post-#2295-drain shape: synthesized YT/Bandcamp/SoundCloud, NULL Spotify/Apple. */
+const DRAINED_YOUTUBE = 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja';
+
 describe('fillSynthesizedSearchUrls', () => {
-  it('fills all five absent URLs from artist/album/track text', () => {
-    const filled = fillSynthesizedSearchUrls(allNull, {
-      artist_name: 'Juana Molina',
-      album_title: 'DOGA',
-      track_title: 'la paradoja',
+  describe('the gate: at least one real streaming URL', () => {
+    it('fills the absent fields on a row that already carries one', () => {
+      const filled = fillSynthesizedSearchUrls({ ...allNull, youtube_music_url: DRAINED_YOUTUBE }, JUANA);
+
+      expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+      expect(filled.apple_music_url).toBe('https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja');
+      expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina%20DOGA');
+      expect(filled.soundcloud_url).toBe('https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja');
+      expect(filled.youtube_music_url).toBe(DRAINED_YOUTUBE);
     });
 
-    expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
-    expect(filled.apple_music_url).toBe('https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja');
-    expect(filled.youtube_music_url).toBe('https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja');
-    expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina%20DOGA');
-    expect(filled.soundcloud_url).toBe('https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja');
+    it('fills nothing when every field is absent — the row must keep serving NULLs', () => {
+      expect(fillSynthesizedSearchUrls(allNull, JUANA)).toEqual(allNull);
+    });
+
+    it("does not count a blank as real: '' / whitespace-only leave the row zero-streaming", () => {
+      const filled = fillSynthesizedSearchUrls({ ...allNull, spotify_url: '', bandcamp_url: '   ' }, JUANA);
+
+      // …and the blanks are normalized to null, so neither can reach the V1
+      // `/flowsheet` wire as `""`.
+      expect(filled).toEqual(allNull);
+    });
+
+    it('counts a caller-supplied post-guard null as absent (a suppressed URL never re-qualifies its own row)', () => {
+      // `suppressMislabeledStreamingUrls` has already nulled the mislabeled
+      // spotify_url before this helper sees it, so the row reads as
+      // zero-streaming — BS#1714 degradation, unchanged.
+      expect(fillSynthesizedSearchUrls(allNull, JUANA)).toEqual(allNull);
+    });
+  });
+
+  describe('blank-aware degradation (matching the proxy falsy branch)', () => {
+    it("degrades a persisted '' to a synthesized URL on a qualifying row", () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, spotify_url: '', youtube_music_url: DRAINED_YOUTUBE },
+        JUANA
+      );
+
+      expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+    });
+
+    it('degrades a whitespace-only persisted value the same way', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, soundcloud_url: ' \t ', youtube_music_url: DRAINED_YOUTUBE },
+        JUANA
+      );
+
+      expect(filled.soundcloud_url).toBe('https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja');
+    });
+  });
+
+  describe('the artist gate', () => {
+    it('fills nothing when artist_name is null (marker/talkset/breakpoint rows, or a track with no artist)', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, youtube_music_url: DRAINED_YOUTUBE },
+        { artist_name: null, album_title: null, track_title: null }
+      );
+
+      expect(filled).toEqual({ ...allNull, youtube_music_url: DRAINED_YOUTUBE });
+    });
+
+    it("fills nothing when artist_name is '' ", () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, youtube_music_url: DRAINED_YOUTUBE },
+        { artist_name: '', album_title: 'DOGA', track_title: null }
+      );
+
+      expect(filled.spotify_url).toBeNull();
+    });
+
+    // Pre-fix this synthesized five buttons opening `%20%20%20` searches.
+    it('fills nothing when artist_name is whitespace-only', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, youtube_music_url: DRAINED_YOUTUBE },
+        { artist_name: '   ', album_title: 'DOGA', track_title: 'la paradoja' }
+      );
+
+      expect(filled.spotify_url).toBeNull();
+      expect(filled.apple_music_url).toBeNull();
+      expect(filled.bandcamp_url).toBeNull();
+      expect(filled.soundcloud_url).toBeNull();
+      expect(filled.youtube_music_url).toBe(DRAINED_YOUTUBE);
+    });
+
+    it('trims a padded artist_name / album_title / track_title out of the search query', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, youtube_music_url: DRAINED_YOUTUBE },
+        { artist_name: '  Juana Molina  ', album_title: '  DOGA  ', track_title: '  la paradoja  ' }
+      );
+
+      expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+      expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina%20DOGA');
+    });
+
+    it('treats a whitespace-only album_title/track_title as absent rather than searching on the padding', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, youtube_music_url: DRAINED_YOUTUBE },
+        { artist_name: 'Juana Molina', album_title: '   ', track_title: '   ' }
+      );
+
+      expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina');
+      expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina');
+    });
   });
 
   it('fills only the absent fields, leaving a populated value untouched', () => {
     const filled = fillSynthesizedSearchUrls(
       { ...allNull, spotify_url: 'https://open.spotify.com/album/genuine' },
-      { artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' }
+      JUANA
     );
 
     expect(filled.spotify_url).toBe('https://open.spotify.com/album/genuine');
@@ -51,24 +156,6 @@ describe('fillSynthesizedSearchUrls', () => {
       soundcloud_url: 'https://soundcloud.com/artist/1',
     };
 
-    const filled = fillSynthesizedSearchUrls(populated, {
-      artist_name: 'Juana Molina',
-      album_title: 'DOGA',
-      track_title: 'la paradoja',
-    });
-
-    expect(filled).toEqual(populated);
-  });
-
-  it('leaves every field null when artist_name is null (marker/talkset/breakpoint rows, or a track with no artist)', () => {
-    const filled = fillSynthesizedSearchUrls(allNull, { artist_name: null, album_title: null, track_title: null });
-
-    expect(filled).toEqual(allNull);
-  });
-
-  it('leaves every field null when artist_name is blank', () => {
-    const filled = fillSynthesizedSearchUrls(allNull, { artist_name: '', album_title: 'DOGA', track_title: null });
-
-    expect(filled).toEqual(allNull);
+    expect(fillSynthesizedSearchUrls(populated, JUANA)).toEqual(populated);
   });
 });

--- a/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
+++ b/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for `fillSynthesizedSearchUrls` (#2339) — the request-time-only
+ * fallback that fills a still-absent streaming URL with a synthesized search
+ * URL, mirroring `GET /proxy/metadata/album`'s degradation (BS#1184/#1185).
+ */
+
+import {
+  fillSynthesizedSearchUrls,
+  type SynthesizableStreamingUrls,
+} from '../../../apps/backend/utils/album-metadata-projection';
+
+const allNull: SynthesizableStreamingUrls = {
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+};
+
+describe('fillSynthesizedSearchUrls', () => {
+  it('fills all five absent URLs from artist/album/track text', () => {
+    const filled = fillSynthesizedSearchUrls(allNull, {
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+    });
+
+    expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+    expect(filled.apple_music_url).toBe('https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja');
+    expect(filled.youtube_music_url).toBe('https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja');
+    expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina%20DOGA');
+    expect(filled.soundcloud_url).toBe('https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja');
+  });
+
+  it('fills only the absent fields, leaving a populated value untouched', () => {
+    const filled = fillSynthesizedSearchUrls(
+      { ...allNull, spotify_url: 'https://open.spotify.com/album/genuine' },
+      { artist_name: 'Juana Molina', album_title: 'DOGA', track_title: 'la paradoja' }
+    );
+
+    expect(filled.spotify_url).toBe('https://open.spotify.com/album/genuine');
+    expect(filled.apple_music_url).not.toBeNull();
+  });
+
+  it('returns the input unchanged when every field is already populated (no synthesis call needed)', () => {
+    const populated: SynthesizableStreamingUrls = {
+      spotify_url: 'https://open.spotify.com/album/1',
+      apple_music_url: 'https://music.apple.com/us/album/1',
+      youtube_music_url: 'https://music.youtube.com/playlist?list=1',
+      bandcamp_url: 'https://artist.bandcamp.com/album/1',
+      soundcloud_url: 'https://soundcloud.com/artist/1',
+    };
+
+    const filled = fillSynthesizedSearchUrls(populated, {
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+    });
+
+    expect(filled).toEqual(populated);
+  });
+
+  it('leaves every field null when artist_name is null (marker/talkset/breakpoint rows, or a track with no artist)', () => {
+    const filled = fillSynthesizedSearchUrls(allNull, { artist_name: null, album_title: null, track_title: null });
+
+    expect(filled).toEqual(allNull);
+  });
+
+  it('leaves every field null when artist_name is blank', () => {
+    const filled = fillSynthesizedSearchUrls(allNull, { artist_name: '', album_title: 'DOGA', track_title: null });
+
+    expect(filled).toEqual(allNull);
+  });
+});

--- a/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
+++ b/tests/unit/utils/album-metadata-projection.fill-synthesized-search-urls.test.ts
@@ -4,13 +4,14 @@
  * URL, mirroring `GET /proxy/metadata/album`'s degradation (BS#1184/#1185).
  *
  * The fill is GATED (owner decision, 2026-08-31): it only fires for a row whose
- * post-host-guard values already carry at least one REAL streaming URL —
- * non-null and non-blank. Shipped iOS 3.2 skips its live
- * `/proxy/metadata/album` fetch on `inline.streaming.hasAny`, so such a row
- * short-circuits inline regardless and the fill can only upgrade grey
- * Spotify/Apple buttons; a zero-streaming row must keep serving NULLs so the
- * live proxy fallback (full metadata plus its own synthesized links) still
- * fires.
+ * post-host-guard values already carry at least one streaming URL the client
+ * would actually see. "Would see" is `wireUrl`'s predicate — absolute http(s),
+ * no parser differential — so the gate bit and shipped iOS 3.2's
+ * `inline.streaming.hasAny` are the same bit by construction. Such a row skips
+ * its live `/proxy/metadata/album` fetch regardless, so the fill can only
+ * upgrade grey Spotify/Apple buttons; a row with no wireable streaming URL must
+ * keep serving NULLs so the live proxy fallback (full metadata plus its own
+ * synthesized links) still fires.
  */
 
 import {
@@ -32,7 +33,7 @@ const JUANA = { artist_name: 'Juana Molina', album_title: 'DOGA', track_title: '
 const DRAINED_YOUTUBE = 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja';
 
 describe('fillSynthesizedSearchUrls', () => {
-  describe('the gate: at least one real streaming URL', () => {
+  describe('the gate: at least one streaming URL the client would see', () => {
     it('fills the absent fields on a row that already carries one', () => {
       const filled = fillSynthesizedSearchUrls({ ...allNull, youtube_music_url: DRAINED_YOUTUBE }, JUANA);
 
@@ -47,7 +48,7 @@ describe('fillSynthesizedSearchUrls', () => {
       expect(fillSynthesizedSearchUrls(allNull, JUANA)).toEqual(allNull);
     });
 
-    it("does not count a blank as real: '' / whitespace-only leave the row zero-streaming", () => {
+    it("does not count a blank as present: '' / whitespace-only leave the row zero-streaming", () => {
       const filled = fillSynthesizedSearchUrls({ ...allNull, spotify_url: '', bandcamp_url: '   ' }, JUANA);
 
       // …and the blanks are normalized to null, so neither can reach the V1
@@ -55,11 +56,27 @@ describe('fillSynthesizedSearchUrls', () => {
       expect(filled).toEqual(allNull);
     });
 
-    it('counts a caller-supplied post-guard null as absent (a suppressed URL never re-qualifies its own row)', () => {
-      // `suppressMislabeledStreamingUrls` has already nulled the mislabeled
-      // spotify_url before this helper sees it, so the row reads as
-      // zero-streaming — BS#1714 degradation, unchanged.
-      expect(fillSynthesizedSearchUrls(allNull, JUANA)).toEqual(allNull);
+    // The adjudicated fix: a non-blank value the wire would never carry must
+    // not qualify its row, or the fill flips `streaming.hasAny` false -> true
+    // out of nothing and suppresses 3.2's live proxy fallback. Every shape here
+    // is one the columns permit and no write path validates — LML values reach
+    // youtube/bandcamp/soundcloud verbatim, and BS#1710's guard covers only
+    // spotify/apple.
+    it.each([
+      ['scheme-relative', '//open.spotify.com/album/xyz'],
+      ['bare hostname', 'juanamolina.bandcamp.com/album/doga'],
+      ['non-web scheme', 'javascript:alert(1)'],
+      ['raw-tab parser differential', 'https://music.youtube.com/playlist?list=OLAK5uy_\tabc'],
+      ['backslash parser differential', 'https://open.spotify.com\\@evil.example/album/1'],
+      ['relative path', '/album/doga'],
+    ])('does not count an unwireable value as present (%s)', (_label, hazard) => {
+      expect(fillSynthesizedSearchUrls({ ...allNull, bandcamp_url: hazard }, JUANA)).toEqual(allNull);
+    });
+
+    it('normalizes an unwireable value to null rather than passing it through', () => {
+      const filled = fillSynthesizedSearchUrls({ ...allNull, soundcloud_url: 'javascript:alert(1)' }, JUANA);
+
+      expect(filled.soundcloud_url).toBeNull();
     });
   });
 
@@ -71,6 +88,18 @@ describe('fillSynthesizedSearchUrls', () => {
       );
 
       expect(filled.spotify_url).toBe('https://open.spotify.com/search/Juana%20Molina%20la%20paradoja');
+    });
+
+    // An unwireable value is absent for the FILL too: on a qualifying row it
+    // degrades to a synthesized URL rather than surviving to be dropped
+    // downstream with no fallback left to run.
+    it('degrades an unwireable persisted value to a synthesized URL on a qualifying row', () => {
+      const filled = fillSynthesizedSearchUrls(
+        { ...allNull, bandcamp_url: 'juanamolina.bandcamp.com/album/doga', youtube_music_url: DRAINED_YOUTUBE },
+        JUANA
+      );
+
+      expect(filled.bandcamp_url).toBe('https://bandcamp.com/search?q=Juana%20Molina%20DOGA');
     });
 
     it('degrades a whitespace-only persisted value the same way', () => {


### PR DESCRIPTION
## Summary

`GET /proxy/metadata/album` has synthesized a search-URL fallback for absent streaming links at request time since #1184/#1185, but the V2 flowsheet read path (`GET /flowsheet`, `GET /v2/flowsheet`, and the legacy `GET /playlists/recentEntries?v=2` grouped payload) served a bare `null` instead — the same album, same play, rendered differently depending on which endpoint the client hit.

**The fill is gated**, per the [owner decision on #2339](https://github.com/WXYC/Backend-Service/issues/2339#issuecomment-5484322149): it fires only when the post-host-guard, pre-fill values already carry **at least one streaming URL the client would actually see** — `wireUrl`'s own predicate (absolute http(s), no parser differential), so the gate bit and iOS 3.2's `inline.streaming.hasAny` are the same bit *by construction*. Shipped iOS 3.2's `PlaycutMetadataService` skips the live `/proxy/metadata/album` fetch when `metadataStatus?.isTerminal == true || inline.streaming.hasAny`, so a row that already has a real streaming URL short-circuits inline regardless of what we serve — the fill can only upgrade grey Spotify/Apple buttons there, and can never suppress a proxy fetch. A row with zero real streaming URLs keeps serving NULLs, so the live proxy fallback (which returns full metadata *plus* its own synthesized links) still fires. An unconditional fill would have re-opened #2103's empty-card bug for every metadata-less row, permanently, including the now-playing track.

This still covers the population the ticket exists for: the post-#2295-drain cohort carries synthesized YouTube Music / Bandcamp / SoundCloud URLs on every matched row, so those rows qualify and their grey Spotify/Apple buttons become clickable.

- Adds `fillSynthesizedSearchUrls` to the shared `album-metadata-projection.ts` module, reusing `SearchUrlProvider.getAllSearchUrls` exactly as `proxy.controller.ts` does. The gate lives there, once, so the two seams cannot drift.
- Moves `wireUrl` / `hasWireUrlParserDifferential` out of `playlist-proxy.service.ts` into that same module and imports them back. `wireUrl` is simultaneously the legacy seam's **output filter** and the read path's **presence predicate**; a second copy would let the fill's gate and the wire's key set drift apart. Same collapse-the-copies rule BS#889 applied to `synthesizeSearchUrls`. Only the output filters still differ per seam (`?v=2` re-runs `wireUrl` on the way out; `/flowsheet` emits verbatim).
- A value that fails the wire predicate is absent for the fill too: on a qualifying row it degrades to a synthesized URL rather than surviving to be dropped downstream with no fallback left to run; on a non-qualifying row it normalizes to `null`, so an unusable value can never reach a hardwired iOS button and a blank can never reach the V1 wire as `""`.
- Wires it into both read-GET serialization seams downstream of the projection — `transformToIFSEntry` (`flowsheet.service.ts`, serving both V1 `/flowsheet` top-level fields and `/v2/flowsheet`) and `applyPlaycutMetadata` (`playlist-proxy.service.ts`, legacy `?v=2`) — running after the BS#1714 host guard, so a suppressed mislabeled URL degrades exactly as an outright-missing one does. A row whose *only* streaming URL was host-guard-suppressed counts as zero-streaming and serves NULLs.
- The mutation/peek echoes (`projectFlowsheetEntry`) and the SSE `liveFs:update` channel (`pickClientFacingColumns`) do **not** route through `transformToIFSEntry` and deliberately stay unfilled. With the gate in place this is safe: the only bit 3.2 branches on (`streaming.hasAny`) can no longer differ between producers for the same row — only button decoration does. Documented in the projection header.
- The legacy seam's `enrichPlaycutMetadata` select gains `flowsheet.artist_name`/`album_title`/`track_title` so it synthesizes from the same text `/flowsheet` does, never from the tubafrenzy-mirror-derived `GroupedPlaycut` fields.
- Synthesis is request-time only — never persisted to `album_metadata` or `flowsheet` (#1192).

## Review fixes

The blocking review's findings, all addressed:

1. **Gate the fill at both seams** — done in the shared helper, not two copies.
2. **Control-field regression** — `hasRenderableInlineMetadata` now takes the pre-fill streaming snapshot explicitly instead of reading it back off the mutated payload, so a synthesized search URL can never count as renderable metadata for the `metadataStatus` control field. (With the gate this is belt-and-braces, but it is the reading that is correct by construction.)
3. **Blank-aware degradation** — the fill matches the proxy's falsy `if (!metadata.spotifyUrl)` branch: a persisted `''`/whitespace value degrades to a synthesized URL on a qualifying row rather than surviving a `??`-nullish check and then being dropped by `wireUrl` with no fallback left to run. Blanks normalize to `null` unconditionally, so one can never reach the V1 `/flowsheet` wire as `""`.
4. **Non-blank artist gate** — trim-aware, so a whitespace-only `artist_name` synthesizes nothing instead of five buttons opening `%20%20%20` searches.
5. **Set the five URL fields exactly once** — `applyPlaycutMetadata` computes the fill before writing any of the five keys, restoring byte-identical JSON key order with pre-#2339 output for unfilled rows.
6. **Test pins** — every arm of the gate is pinned at both seams (see below). The false docstring claiming the mutation/peek echoes project off the same `IFSEntry` is corrected in the test and in the projection header.

### Wire golden

Regenerated once, at the end, and reviewed line by line. Against `main`, exactly **two** rows change, and both qualify under the wireable test:

| Row | Wireable pre-fill streaming URL | Gains |
|---|---|---|
| 9005 Eiko Ishibashi & Jim O'Rourke | spotify / youtube / bandcamp / soundcloud | `appleMusicURL` |
| 9009 Chuquimamani-Condori | bandcamp (spotify was host-guard-suppressed) | spotify / apple / youtube / soundcloud |

Every other probe reverts to its exact pre-#2339 shape, with no key-order churn:

- **9012** "BS2103 Unenriched Artist" — no persisted streaming at all.
- **9011** Stereolab — scheme-relative `spotify_url`, bare-domain `bandcamp_url`. This is the row the re-review traced: under a non-blank gate it shipped zero streaming keys pre-PR and four synthesized ones post-PR, flipping `streaming.hasAny` false → true purely by synthesizing. Under the wire predicate it no longer qualifies.
- **9013** Hermanos Gutiérrez — raw tab / LF / space inside all three of `youtube_music_url`, `bandcamp_url`, `soundcloud_url`, i.e. WHATWG-vs-Foundation parser differentials. None is wireable, so the row does not qualify either.

The invariant is now pinned as a named unit test (`emits no streaming key for a row whose only persisted streaming URLs are unwireable`) rather than only as golden bytes, and in the fill-helper suite as a parameterized sweep over scheme-relative / bare-hostname / non-web-scheme / raw-tab / backslash / relative-path shapes. These are shapes the columns permit and no write path validates: `sanitizeLookupStreamingUrls` guards only spotify/apple (BS#1710), while `normalize-lookup.ts`, all three `enrich.ts` branches and `flowsheet-no-match-recheck/writer.ts` persist LML's youtube/bandcamp/soundcloud values verbatim.

`GOLDEN_SHA256` is re-pinned to `d8cc07bd3d720442cf6ea39f71d12ca641e9330e4145ac7ad6737b3708acfbb8`. **Follow-up required in `wxyc-ios-64`**: copy `tests/fixtures/recent-entries-v2-wire-golden.json` to `Shared/Playlist/Tests/PlaylistTests/Fixtures/bs2103-enriched-payload.json` and update the SHA there, per the two-step contract documented in the golden test header.

## Test plan

- [x] Gate pinned at both seams: zero-streaming terminal-but-empty `enriched_no_match` row (no fill, `metadataStatus` withheld, no streaming keys at all); a qualifying row with one verified `youtube_music_url` (Spotify/Apple synthesized, YT untouched); whitespace-only `artist_name`; persisted `''` on a qualifying row; a row whose only streaming URL is host-guard-suppressed; a row whose only streaming URLs are unwireable
- [x] Wire-golden cross-repo contract test regenerated once and re-pinned, every changed row verified against the gate
- [x] Integration tests updated on both arms — `GET /flowsheet` with a partially-enriched album vs a zero-streaming album; `?v=2` free-text and artwork-only rows reverted to their pre-#2339 (unfilled) expectations
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:unit` (9,083 tests) all green locally
- [ ] CI

Closes #2339
