### PR TITLE
Extend sanitizeLookupStreamingUrls to all five streaming URL fields

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -52,9 +52,25 @@ export type {
 // — `sanitizeLookupStreamingUrls` is applied in `postLookup` +
 // `bulkLookupMetadata` below so every downstream writer + serve seam is
 // covered at one chokepoint. Imported (not just re-exported) so it's in
-// local scope for those callsites.
-import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from './streaming-url-guard.js';
-export { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls };
+// local scope for those callsites. BS#2350 extended the same guard to the
+// three remaining streaming fields (`isYouTubeMusicUrl`/`isBandcampUrl`/
+// `isSoundcloudUrl`).
+import {
+  isSpotifyUrl,
+  isAppleMusicUrl,
+  isYouTubeMusicUrl,
+  isBandcampUrl,
+  isSoundcloudUrl,
+  sanitizeLookupStreamingUrls,
+} from './streaming-url-guard.js';
+export {
+  isSpotifyUrl,
+  isAppleMusicUrl,
+  isYouTubeMusicUrl,
+  isBandcampUrl,
+  isSoundcloudUrl,
+  sanitizeLookupStreamingUrls,
+};
 
 // BS#1356: shared search_type trust predicates. `isTrustedLmlAlbumMatch` is
 // the single authority every album-context write gate delegates to (the

--- a/shared/lml-client/src/streaming-url-guard.ts
+++ b/shared/lml-client/src/streaming-url-guard.ts
@@ -1,5 +1,5 @@
 /**
- * Streaming-URL host guard (BS#1710).
+ * Streaming-URL guard (BS#1710, extended to all five fields by BS#2350).
  *
  * LML's `results[].artwork.spotify_url` is populated from the library
  * `streaming_links.spotify_url` artifact column, which for a subset of
@@ -8,19 +8,47 @@
  * and iOS binds it to a hardwired green "Spotify" button — so the button
  * opens Deezer. See https://github.com/WXYC/Backend-Service/issues/1710.
  *
- * The invariant these guards enforce is purely about the field name: a
- * value stored under `spotify_url` must be a Spotify URL, and a value
- * under `apple_music_url` must be an Apple URL. `sanitizeLookupStreamingUrls`
- * applies it at the LML response boundary — the single chokepoint every
- * downstream writer (enrichment-worker + the backfill/reenrichment jobs)
- * and the request-path serve read from — so a mislabeled URL never reaches
- * a persisted `spotify_url`/`apple_music_url` column. A rejected value falls
- * to `null`; the writers' `?? searchUrls.spotify_url` fallback then persists
- * a real `open.spotify.com/search/…` URL instead.
+ * For `spotify_url`/`apple_music_url` the invariant is purely about the
+ * field name: a value stored under `spotify_url` must be a Spotify URL, and
+ * a value under `apple_music_url` must be an Apple URL — enforced by a host
+ * allowlist (`isSpotifyUrl`/`isAppleMusicUrl`). `youtube_music_url` and
+ * `soundcloud_url` get the same host-allowlist treatment
+ * (`isYouTubeMusicUrl`/`isSoundcloudUrl`), plus the well-formedness bar
+ * below. `bandcamp_url` is the deliberate exception: it gets
+ * well-formedness ONLY, no host allowlist. This `LookupResponse` also
+ * carries LML probe/cache-resolved bandcamp deep links on label-owned
+ * custom domains (LML#1069 album-first; LML's
+ * `clients/bandcamp.py::fix_autocomplete_url` preserves them, pinned by
+ * tests using `music.sufjan.com`) — a `bandcamp.com` allowlist would
+ * silently degrade those to search URLs. The curated-column host check for
+ * `streaming_links.bandcamp_url` lives writer-side in LML instead (see
+ * WXYC/library-metadata-lookup#1296), which is the seam where "is this
+ * really Bandcamp" is actually decidable; here it is not. See
+ * `isBandcampUrl`'s own doc comment for the full rationale.
+ *
+ * `sanitizeLookupStreamingUrls` applies all five checks at the LML response
+ * boundary — the single chokepoint every downstream writer
+ * (enrichment-worker + the backfill/reenrichment jobs) and the request-path
+ * serve read from — so a mislabeled or malformed URL never reaches a
+ * persisted `*_url` column. A rejected value falls to `null`; the writers'
+ * `?? searchUrls.*` fallback then persists a real synthesized search URL
+ * instead.
+ *
+ * BS#2350 also closed a paired correctness gap: suppressing `bandcamp_url`
+ * must also clear the sibling `artwork.streaming_status.bandcamp` verdict,
+ * or `apps/enrichment-worker/enrich.ts`'s status-arbitrated merge persists
+ * `bandcamp_url: null` alongside a stale `bandcamp_status: 'verified'` —
+ * permanently terminal (never re-merged) and permanently un-re-askable
+ * (`precheck.ts`/`streaming-reask.ts` only re-ask an `'unresolved'` status).
+ * See `sanitizeLookupStreamingUrls`'s own doc comment for the mechanics.
+ * `youtube_music_url`/`soundcloud_url` have no `streaming_status` key at all
+ * (LML never emits a resolution verdict for those two search-URL-only
+ * services), so there is nothing paired to clear for them.
  *
  * This does NOT heal rows already persisted before the guard shipped —
  * BS persistence is fill-only, so an existing bad value survives. Those
- * need the separate overwrite migration (BS#1710 fix #3).
+ * need a separate overwrite migration (BS#1710 fix #3 did this for
+ * spotify/apple).
  */
 import type { LookupResponse } from '@wxyc/shared/dtos';
 
@@ -95,15 +123,23 @@ export function isAppleMusicUrl(url: string | null | undefined): boolean {
  * `spotify_url`/`apple_music_url` deliberately do NOT run through this
  * stricter check — that would risk changing which URLs `isSpotifyUrl` /
  * `isAppleMusicUrl` accept, and BS#2350 requires their behavior stay
- * byte-identical. Only the three new-in-BS#2350 predicates below use it.
+ * byte-identical. Only the three BS#2350 predicates below use it.
+ *
+ * Checks run cheapest-first and share a single `new URL()` parse (unlike
+ * {@link safeHostname}, which this function deliberately does not call —
+ * calling it would parse `url` a second time): the control-character scan
+ * and the backslash check are both plain string scans with no parsing cost,
+ * so both run before the one `new URL()` call.
  */
 function safeHttpHostname(url: string): string | null {
-  const host = safeHostname(url);
-  if (host === null) return null;
   for (const char of url) {
     const code = char.codePointAt(0) ?? 0;
     if (code <= 0x20 || code === 0x7f) return null;
   }
+  // Same backslash-authority differential `safeHostname` rejects (see its
+  // doc comment) — duplicated here rather than delegated to it, since
+  // delegating would mean parsing `url` twice.
+  if (url.includes('\\')) return null;
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -111,7 +147,7 @@ function safeHttpHostname(url: string): string | null {
     return null;
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-  return host;
+  return parsed.hostname.toLowerCase();
 }
 
 /**
@@ -119,45 +155,54 @@ function safeHttpHostname(url: string): string | null {
  * `youtube.com` or a subdomain (`music.youtube.com`, the host LML's
  * YouTube Music client and its `build_streaming_search_url` fallback both
  * emit — see `clients/streaming/youtube_music.py` and
- * `lookup/enrichment/search_urls.py` in library-metadata-lookup). Loose on
- * path shape, like `isSpotifyUrl`/`isAppleMusicUrl` — a field-name/host
- * invariant check, not a browse-ID extraction.
+ * `lookup/enrichment/search_urls.py` in library-metadata-lookup), or the
+ * `youtu.be` short-link apex (accepted preemptively, cheap over-suppression
+ * insurance — LML is adding the same host to its own vocabulary so the two
+ * stay in sync). Loose on path shape, like `isSpotifyUrl`/`isAppleMusicUrl`
+ * — a field-name/host invariant check, not a browse-ID extraction.
  */
 export function isYouTubeMusicUrl(url: string | null | undefined): boolean {
   if (typeof url !== 'string') return false;
   const host = safeHttpHostname(url);
-  return host !== null && hostIsUnder(host, 'youtube.com');
+  return host !== null && (hostIsUnder(host, 'youtube.com') || hostIsUnder(host, 'youtu.be'));
 }
 
 /**
- * True iff `url` parses to an absolute http(s) URL whose host is
- * `bandcamp.com` or a subdomain. Bandcamp direct links live on
- * `<artist>.bandcamp.com` (and, per library-metadata-lookup's
- * `docs/scripts.md`, sometimes a *label/imprint* subdomain rather than the
- * performing artist's own — e.g. `into-the-light.bandcamp.com`, not
- * `georgerakis.bandcamp.com`); the synthesized search fallback lives on the
- * bare `bandcamp.com` apex (`lookup/enrichment/search_urls.py`'s
- * `build_streaming_search_url("https://bandcamp.com/search?q=", …)`). Both
- * shapes are `*.bandcamp.com` subdomains, so a host allowlist under that
- * apex covers them without degrading a real link to a search URL.
+ * True iff `url` is a well-formed absolute http(s) URL — see
+ * {@link safeHttpHostname}. Deliberately NOT a host allowlist, unlike
+ * `isYouTubeMusicUrl`/`isSoundcloudUrl` (and unlike this repo's first cut at
+ * this predicate, which did allowlist `bandcamp.com`).
  *
- * A true external custom domain (a label's own domain running a
- * Bandcamp-hosted storefront, rather than a `*.bandcamp.com` subdomain) was
- * the caveat this predicate's design had to rule out per BS#2350 — but
- * LML's own minting parser (`release/url_parser.py`'s `_BANDCAMP_HOST_RE`,
- * `^[a-z0-9][a-z0-9-]*\.bandcamp\.com$`) is exactly this strict: it never
- * mints an identity from a non-`bandcamp.com` host, and the scraper that
- * feeds LML's Bandcamp results (`clients/bandcamp.py`) only ever emits
- * `{slug}.bandcamp.com` URLs. Since LML itself never emits a genuine direct
- * link on a non-`bandcamp.com` host, an apex host allowlist here can't
- * suppress one — so, unlike the well-formedness-only fallback the issue
- * floated for a true custom-domain shape, this guard host-checks
- * `bandcamp_url` exactly like the other four fields.
+ * Bandcamp direct links live on `<artist>.bandcamp.com` (and, per
+ * library-metadata-lookup's `docs/scripts.md`, sometimes a *label/imprint*
+ * subdomain rather than the performing artist's own — e.g.
+ * `into-the-light.bandcamp.com`) — but the `LookupResponse` this guard
+ * checks is not limited to those. Bandcamp supports label-owned CUSTOM
+ * DOMAINS running a Bandcamp-hosted storefront (e.g. `music.sufjan.com`),
+ * genuinely off the `*.bandcamp.com` apex entirely, and LML resolves and
+ * caches those as real direct links (LML#1069, album-first resolution) —
+ * `clients/bandcamp.py::fix_autocomplete_url` in library-metadata-lookup
+ * exists specifically to preserve a custom-domain deep link rather than
+ * rewrite it back onto `bandcamp.com`, and its own test suite pins
+ * `music.sufjan.com` as a genuine shape. A `bandcamp.com` host allowlist at
+ * THIS seam would silently degrade every one of those to the synthesized
+ * `bandcamp.com/search?q=…` fallback — a regression, not a hardening, since
+ * the well-formed custom-domain URL was the better answer.
+ *
+ * The curated `streaming_links.bandcamp_url` column LML also serves (the
+ * seam `isBandcampUrl`'s first cut was actually trying to protect) gets its
+ * host check writer-side in LML instead, where "is this really Bandcamp"
+ * is actually decidable against LML's own minting parser
+ * (`release/url_parser.py`'s `_BANDCAMP_HOST_RE`) — see
+ * WXYC/library-metadata-lookup#1296. This guard, at the `LookupResponse`
+ * boundary, cannot tell a genuine custom-domain deep link apart from a
+ * mislabeled foreign URL by host alone, so it deliberately doesn't try —
+ * it only screens out malformed/spoofed shapes (the same bar
+ * `isYouTubeMusicUrl`/`isSoundcloudUrl` apply on top of their host check).
  */
 export function isBandcampUrl(url: string | null | undefined): boolean {
   if (typeof url !== 'string') return false;
-  const host = safeHttpHostname(url);
-  return host !== null && hostIsUnder(host, 'bandcamp.com');
+  return safeHttpHostname(url) !== null;
 }
 
 /**
@@ -176,14 +221,36 @@ export function isSoundcloudUrl(url: string | null | undefined): boolean {
 }
 
 /**
- * Enforce the field-name/host invariant on every result's artwork across all
- * five streaming URL slots: a value that isn't a host appropriate to its
- * field name is set to `null`. Mutates `response` in place (the caller owns
- * the freshly-parsed object) and returns it for convenience. A suppressed
- * value falls through each writer's `?? searchUrls.*` fallback to a
- * well-formed synthesized search URL, exactly as spotify/apple do today
- * (BS#1710); `spotify_url`/`apple_music_url` behavior is unchanged by
- * BS#2350 (`isSpotifyUrl`/`isAppleMusicUrl` are untouched).
+ * Enforce the field-name/well-formedness invariant on every result's
+ * artwork across all five streaming URL slots: a value that fails its
+ * field's check (host allowlist for spotify/apple/youtube_music/soundcloud;
+ * well-formedness only for bandcamp — see `isBandcampUrl`) is set to
+ * `null`. Mutates `response` in place (the caller owns the freshly-parsed
+ * object) and returns it for convenience. A suppressed value falls through
+ * each writer's `?? searchUrls.*` fallback to a well-formed synthesized
+ * search URL, exactly as spotify/apple do today (BS#1710); `spotify_url`/
+ * `apple_music_url` behavior is unchanged by BS#2350
+ * (`isSpotifyUrl`/`isAppleMusicUrl` are untouched).
+ *
+ * BS#2350's central correctness fix: suppressing `bandcamp_url` also clears
+ * the sibling `artwork.streaming_status.bandcamp` verdict when present.
+ * Without this, a suppressed URL paired with a leftover `'verified'` (or
+ * `'absent'`) verdict reaches `apps/enrichment-worker/enrich.ts`'s
+ * `inferIncomingStreamingStatus`, which trusts the explicit status over the
+ * (now-null) url and returns it unchanged; `mergeStreamingField` then
+ * persists `bandcamp_status: 'verified'` alongside `bandcamp_url: null` —
+ * terminal (rule 1 never revisits a `verified` field) and permanently
+ * un-re-askable (`precheck.ts`/`streaming-reask.ts` only re-ask an
+ * `'unresolved'` status), the BS#1747/#1915 permanent-null freeze. Deleting
+ * the key instead makes this round read as "not consulted": the merge
+ * leaves whatever was already persisted untouched, and the write path
+ * falls back to the synthesized search URL instead of freezing a bare
+ * null. `youtube_music_url`/`soundcloud_url` have no `streaming_status` key
+ * to clear — LML never emits a resolution verdict for those two
+ * search-URL-only services (see `StreamingResolution`'s own doc comment) —
+ * so there is nothing paired to clear for them. `spotify_url`/
+ * `apple_music_url` are untouched by this too, matching their byte-identical
+ * predicate behavior.
  */
 export function sanitizeLookupStreamingUrls(response: LookupResponse): LookupResponse {
   for (const item of response.results ?? []) {
@@ -196,12 +263,21 @@ export function sanitizeLookupStreamingUrls(response: LookupResponse): LookupRes
       artwork.apple_music_url = null;
     }
     if (artwork.youtube_music_url != null && !isYouTubeMusicUrl(artwork.youtube_music_url)) {
+      // No `streaming_status.youtube_music` key exists on this schema at
+      // all (see `StreamingResolution`'s doc comment) — nothing paired to
+      // clear.
       artwork.youtube_music_url = null;
     }
     if (artwork.bandcamp_url != null && !isBandcampUrl(artwork.bandcamp_url)) {
       artwork.bandcamp_url = null;
+      // See this function's doc comment for why the status must go too.
+      if (artwork.streaming_status) {
+        delete artwork.streaming_status.bandcamp;
+      }
     }
     if (artwork.soundcloud_url != null && !isSoundcloudUrl(artwork.soundcloud_url)) {
+      // No `streaming_status.soundcloud` key exists either — see the
+      // youtube_music_url branch above.
       artwork.soundcloud_url = null;
     }
   }

--- a/shared/lml-client/src/streaming-url-guard.ts
+++ b/shared/lml-client/src/streaming-url-guard.ts
@@ -80,12 +80,110 @@ export function isAppleMusicUrl(url: string | null | undefined): boolean {
 }
 
 /**
- * Enforce the field-name/host invariant on every result's artwork: a
- * `spotify_url` that isn't a Spotify host and an `apple_music_url` that
- * isn't an Apple host are set to `null`. Mutates `response` in place (the
- * caller owns the freshly-parsed object) and returns it for convenience.
- * Other streaming slots are left untouched — only these two are rendered
- * under hardwired service-specific buttons in the iOS app.
+ * True iff `url` is an absolute `http`/`https` URL free of the
+ * backslash-authority parser differential {@link safeHostname} rejects, and
+ * free of any C0 control character, space, or DEL anywhere in the string.
+ * That second bar mirrors `apps/backend/utils/album-metadata-projection.ts`'s
+ * `wireUrl`/`hasWireUrlParserDifferential` well-formedness contract — the
+ * layer-3 (client-facing) predicate this layer-2 (LML-response) guard is
+ * deliberately kept in agreement with, without a cross-workspace import
+ * (`shared/lml-client` has no dependency on `apps/backend`, and importing
+ * one in would invert the package graph). BS#2339's own `wireUrl` docstring
+ * is the source of truth for the contract; this is a same-workspace copy
+ * of its predicate, not a re-export.
+ *
+ * `spotify_url`/`apple_music_url` deliberately do NOT run through this
+ * stricter check — that would risk changing which URLs `isSpotifyUrl` /
+ * `isAppleMusicUrl` accept, and BS#2350 requires their behavior stay
+ * byte-identical. Only the three new-in-BS#2350 predicates below use it.
+ */
+function safeHttpHostname(url: string): string | null {
+  const host = safeHostname(url);
+  if (host === null) return null;
+  for (const char of url) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code <= 0x20 || code === 0x7f) return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return host;
+}
+
+/**
+ * True iff `url` parses to an absolute http(s) URL whose host is
+ * `youtube.com` or a subdomain (`music.youtube.com`, the host LML's
+ * YouTube Music client and its `build_streaming_search_url` fallback both
+ * emit — see `clients/streaming/youtube_music.py` and
+ * `lookup/enrichment/search_urls.py` in library-metadata-lookup). Loose on
+ * path shape, like `isSpotifyUrl`/`isAppleMusicUrl` — a field-name/host
+ * invariant check, not a browse-ID extraction.
+ */
+export function isYouTubeMusicUrl(url: string | null | undefined): boolean {
+  if (typeof url !== 'string') return false;
+  const host = safeHttpHostname(url);
+  return host !== null && hostIsUnder(host, 'youtube.com');
+}
+
+/**
+ * True iff `url` parses to an absolute http(s) URL whose host is
+ * `bandcamp.com` or a subdomain. Bandcamp direct links live on
+ * `<artist>.bandcamp.com` (and, per library-metadata-lookup's
+ * `docs/scripts.md`, sometimes a *label/imprint* subdomain rather than the
+ * performing artist's own — e.g. `into-the-light.bandcamp.com`, not
+ * `georgerakis.bandcamp.com`); the synthesized search fallback lives on the
+ * bare `bandcamp.com` apex (`lookup/enrichment/search_urls.py`'s
+ * `build_streaming_search_url("https://bandcamp.com/search?q=", …)`). Both
+ * shapes are `*.bandcamp.com` subdomains, so a host allowlist under that
+ * apex covers them without degrading a real link to a search URL.
+ *
+ * A true external custom domain (a label's own domain running a
+ * Bandcamp-hosted storefront, rather than a `*.bandcamp.com` subdomain) was
+ * the caveat this predicate's design had to rule out per BS#2350 — but
+ * LML's own minting parser (`release/url_parser.py`'s `_BANDCAMP_HOST_RE`,
+ * `^[a-z0-9][a-z0-9-]*\.bandcamp\.com$`) is exactly this strict: it never
+ * mints an identity from a non-`bandcamp.com` host, and the scraper that
+ * feeds LML's Bandcamp results (`clients/bandcamp.py`) only ever emits
+ * `{slug}.bandcamp.com` URLs. Since LML itself never emits a genuine direct
+ * link on a non-`bandcamp.com` host, an apex host allowlist here can't
+ * suppress one — so, unlike the well-formedness-only fallback the issue
+ * floated for a true custom-domain shape, this guard host-checks
+ * `bandcamp_url` exactly like the other four fields.
+ */
+export function isBandcampUrl(url: string | null | undefined): boolean {
+  if (typeof url !== 'string') return false;
+  const host = safeHttpHostname(url);
+  return host !== null && hostIsUnder(host, 'bandcamp.com');
+}
+
+/**
+ * True iff `url` parses to an absolute http(s) URL whose host is
+ * `soundcloud.com` or a subdomain (`www.soundcloud.com`). SoundCloud has no
+ * cache/mint tier in LML (`lookup/enrichment/search_urls.py`'s deferred-fill
+ * docstring: "SoundCloud is deliberately absent — it has no cache tier"), so
+ * its only two shapes are the inline live-probe direct link and the
+ * `https://soundcloud.com/search?q=…` synthesized fallback — both under this
+ * apex.
+ */
+export function isSoundcloudUrl(url: string | null | undefined): boolean {
+  if (typeof url !== 'string') return false;
+  const host = safeHttpHostname(url);
+  return host !== null && hostIsUnder(host, 'soundcloud.com');
+}
+
+/**
+ * Enforce the field-name/host invariant on every result's artwork across all
+ * five streaming URL slots: a value that isn't a host appropriate to its
+ * field name is set to `null`. Mutates `response` in place (the caller owns
+ * the freshly-parsed object) and returns it for convenience. A suppressed
+ * value falls through each writer's `?? searchUrls.*` fallback to a
+ * well-formed synthesized search URL, exactly as spotify/apple do today
+ * (BS#1710); `spotify_url`/`apple_music_url` behavior is unchanged by
+ * BS#2350 (`isSpotifyUrl`/`isAppleMusicUrl` are untouched).
  */
 export function sanitizeLookupStreamingUrls(response: LookupResponse): LookupResponse {
   for (const item of response.results ?? []) {
@@ -96,6 +194,15 @@ export function sanitizeLookupStreamingUrls(response: LookupResponse): LookupRes
     }
     if (artwork.apple_music_url != null && !isAppleMusicUrl(artwork.apple_music_url)) {
       artwork.apple_music_url = null;
+    }
+    if (artwork.youtube_music_url != null && !isYouTubeMusicUrl(artwork.youtube_music_url)) {
+      artwork.youtube_music_url = null;
+    }
+    if (artwork.bandcamp_url != null && !isBandcampUrl(artwork.bandcamp_url)) {
+      artwork.bandcamp_url = null;
+    }
+    if (artwork.soundcloud_url != null && !isSoundcloudUrl(artwork.soundcloud_url)) {
+      artwork.soundcloud_url = null;
     }
   }
   return response;

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -16,6 +16,7 @@
 import { jest } from '@jest/globals';
 
 import { album_metadata, db, flowsheet } from '@wxyc/database';
+import { sanitizeLookupStreamingUrls } from '@wxyc/lml-client';
 import type { LookupResponse, StreamingResolutionStatus } from '@wxyc/lml-client';
 import {
   buildStreamingFieldConflictSet,
@@ -1066,6 +1067,60 @@ describe('finalizeRow (BS#1915) — streaming self-heal merge on the linked-matc
     expect(bandcampUrlValues[0]).toBe(album_metadata.bandcamp_status);
     expect(bandcampUrlValues[1]).toBe(album_metadata.bandcamp_url);
     expect(bandcampUrlValues[2]).toContain('bandcamp.com/search');
+  });
+});
+
+/**
+ * BS#2350 — a suppressed `bandcamp_url` must land as the synthesized search
+ * URL, never a bare persisted null. This runs the REAL boundary guard
+ * (`sanitizeLookupStreamingUrls`, `@wxyc/lml-client`) against a raw LML
+ * response before handing the sanitized result to `finalizeRow`, so the fix
+ * is pinned end to end — guard suppression -> status-clearing ->
+ * merge/UPSERT — rather than only at the guard unit level
+ * (`tests/unit/shared/lml-client/streaming-url-guard.test.ts`) or only at
+ * the merge unit level (the BS#1915 suite above).
+ */
+describe('sanitizeLookupStreamingUrls -> finalizeRow (BS#2350 status-clearing integration)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('a suppressed bandcamp_url (was verified) lands as the synthesized search URL, not null', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    // A raw LML response as it would arrive off the wire: a whitespace-
+    // polluted bandcamp_url (the 2026-08-11 audit shape) paired with an
+    // explicit 'verified' status LML asserted before the pollution.
+    const rawResponse = {
+      search_type: 'direct',
+      results: [
+        {
+          artwork: {
+            artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+            release_url: 'https://discogs.com/release/123',
+            bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo',
+            streaming_status: { bandcamp: 'verified' },
+          },
+        },
+      ],
+    } as unknown as LookupResponse;
+
+    const sanitized = sanitizeLookupStreamingUrls(rawResponse);
+    // Confirms the guard actually suppressed the value and cleared the
+    // paired status before this test hands it to the writer — otherwise a
+    // guard regression would make this test pass for the wrong reason.
+    expect(sanitized.results[0].artwork?.bandcamp_url).toBeNull();
+    expect(sanitized.results[0].artwork?.streaming_status).not.toHaveProperty('bandcamp');
+
+    await finalizeRow(LINKED_ROW, sanitized);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    // Not null: the cleared status reads as "not consulted" this round, so
+    // mergeStreamingField leaves the (fresh, all-null) prior state alone and
+    // the payload falls back to the synthesized search URL — exactly like
+    // the pre-BS#2350 spotify/apple behavior, and the opposite of the
+    // permanent-null freeze a leftover 'verified' status would have caused.
+    expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    expect(insertPayload.bandcamp_status).toBeNull();
   });
 });
 

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -1239,10 +1239,14 @@ describe('playlist-proxy.service', () => {
       // `inline.streaming.hasAny` from false to true purely by synthesizing,
       // and suppressing the live `/proxy/metadata/album` fallback that is the
       // only thing serving it any metadata. Every hazard shape below is one the
-      // columns permit and no write path validates: `youtube_music_url` /
-      // `bandcamp_url` / `soundcloud_url` are written verbatim from LML
-      // (`normalize-lookup.ts`, `enrich.ts`, `flowsheet-no-match-recheck`),
-      // and `sanitizeLookupStreamingUrls` guards only spotify/apple (BS#1710).
+      // columns permit: `sanitizeLookupStreamingUrls` (BS#1710, extended to all
+      // five streaming fields by BS#2350) guards the LML response boundary, but
+      // this fixture writes straight into the mocked DB row, bypassing that
+      // boundary entirely — exactly the shape a row persisted before BS#1710/
+      // BS#2350 shipped, or written via any future path that skips the guard,
+      // would still carry. The wire-level `wireUrl` gate this test exercises is
+      // what actually protects the client in that case, independent of
+      // whichever ingestion-time guard exists.
       it('emits no streaming key for a row whose only persisted streaming URLs are unwireable (#2339 gate uses wire semantics)', async () => {
         mockLimit.mockResolvedValue([jessicaPrattRow]);
         mockMetadataWhere.mockResolvedValue([

--- a/tests/unit/shared/lml-client/streaming-url-guard.test.ts
+++ b/tests/unit/shared/lml-client/streaming-url-guard.test.ts
@@ -10,7 +10,14 @@
  * at the untrusted-upstream boundary, before any writer persists it.
  */
 import type { LookupResponse } from '@wxyc/lml-client';
-import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from '@wxyc/lml-client';
+import {
+  isSpotifyUrl,
+  isAppleMusicUrl,
+  isYouTubeMusicUrl,
+  isBandcampUrl,
+  isSoundcloudUrl,
+  sanitizeLookupStreamingUrls,
+} from '@wxyc/lml-client';
 
 describe('isSpotifyUrl', () => {
   it.each([
@@ -77,6 +84,90 @@ describe('isAppleMusicUrl', () => {
   });
 });
 
+describe('isYouTubeMusicUrl', () => {
+  it.each([
+    ['music.youtube.com browse (direct album link)', 'https://music.youtube.com/browse/MPREb_abc123'],
+    ['music.youtube.com search (synthesized fallback)', 'https://music.youtube.com/search?q=kid%20606'],
+    ['bare youtube.com apex', 'https://youtube.com/watch?v=abc'],
+    ['case-insensitive host', 'HTTPS://MUSIC.YOUTUBE.COM/browse/MPREb_abc123'],
+  ])('accepts a YouTube-host URL (%s)', (_label, url) => {
+    expect(isYouTubeMusicUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ['Spotify', 'https://open.spotify.com/album/abc'],
+    ['scheme-relative', '//music.youtube.com/browse/MPREb_abc123'],
+    ['bare host, no scheme', 'music.youtube.com/browse/MPREb_abc123'],
+    ['non-web scheme', 'javascript:alert(1)'],
+    ['host-suffix spoof', 'https://youtube.com.evil.example/browse/x'],
+    ['backslash-authority spoof', 'https://youtube.com\\@evil.example/x'],
+    ['embedded tab', 'https://music.youtube.com/\tbrowse/x'],
+    ['embedded newline', 'https://music.youtube.com/\nbrowse/x'],
+    ['embedded space', 'https://music.youtube.com/browse/ x'],
+    ['not a URL', 'not a url'],
+    ['empty string', ''],
+    ['null', null],
+  ])('rejects a non-YouTube-Music URL (%s)', (_label, url) => {
+    expect(isYouTubeMusicUrl(url)).toBe(false);
+  });
+});
+
+describe('isBandcampUrl', () => {
+  it.each([
+    ['artist subdomain album (direct link)', 'https://autechre.bandcamp.com/album/confield'],
+    ['label/imprint-hosted subdomain', 'https://into-the-light.bandcamp.com/album/the-rules-of-the-game'],
+    ['bandcamp.com search (synthesized fallback)', 'https://bandcamp.com/search?q=kid%20606'],
+    ['bare bandcamp.com apex', 'https://bandcamp.com/foo'],
+  ])('accepts a Bandcamp-host URL (%s)', (_label, url) => {
+    expect(isBandcampUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ['Spotify', 'https://open.spotify.com/album/abc'],
+    ['scheme-relative', '//artist.bandcamp.com/album/foo'],
+    ['bare host, no scheme', 'artist.bandcamp.com/album/foo'],
+    ['non-web scheme', 'javascript:alert(1)'],
+    ['host-suffix spoof', 'https://bandcamp.com.evil.example/album/foo'],
+    ['backslash-authority spoof', 'https://bandcamp.com\\@evil.example/x'],
+    ['embedded tab', 'https://artist.bandcamp.com/\talbum/foo'],
+    ['embedded newline', 'https://artist.bandcamp.com/\nalbum/foo'],
+    ['embedded space', 'https://artist.bandcamp.com/album/ foo'],
+    ['not a URL', 'not a url'],
+    ['empty string', ''],
+    ['null', null],
+  ])('rejects a non-Bandcamp URL (%s)', (_label, url) => {
+    expect(isBandcampUrl(url)).toBe(false);
+  });
+});
+
+describe('isSoundcloudUrl', () => {
+  it.each([
+    ['artist/track (direct link)', 'https://soundcloud.com/artist/track'],
+    ['soundcloud.com search (synthesized fallback)', 'https://soundcloud.com/search?q=kid%20606'],
+    ['www.soundcloud.com', 'https://www.soundcloud.com/artist/track'],
+    ['case-insensitive host', 'HTTPS://SOUNDCLOUD.COM/artist/track'],
+  ])('accepts a SoundCloud-host URL (%s)', (_label, url) => {
+    expect(isSoundcloudUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ['Spotify', 'https://open.spotify.com/album/abc'],
+    ['scheme-relative', '//soundcloud.com/artist/track'],
+    ['bare host, no scheme', 'soundcloud.com/artist/track'],
+    ['non-web scheme', 'javascript:alert(1)'],
+    ['host-suffix spoof', 'https://soundcloud.com.evil.example/artist/track'],
+    ['backslash-authority spoof', 'https://soundcloud.com\\@evil.example/x'],
+    ['embedded tab', 'https://soundcloud.com/\tartist/track'],
+    ['embedded newline', 'https://soundcloud.com/\nartist/track'],
+    ['embedded space', 'https://soundcloud.com/artist/ track'],
+    ['not a URL', 'not a url'],
+    ['empty string', ''],
+    ['null', null],
+  ])('rejects a non-SoundCloud URL (%s)', (_label, url) => {
+    expect(isSoundcloudUrl(url)).toBe(false);
+  });
+});
+
 describe('sanitizeLookupStreamingUrls', () => {
   // The guard only reads `results[].artwork.{spotify_url,apple_music_url}`;
   // a minimal cast keeps the fixture legible without a full LibraryCatalogItem.
@@ -119,15 +210,49 @@ describe('sanitizeLookupStreamingUrls', () => {
     expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.apple_music_url).toBe(url);
   });
 
-  it('leaves other streaming slots untouched (only spotify/apple are host-guarded)', () => {
+  it('preserves genuine youtube_music_url, bandcamp_url and soundcloud_url values', () => {
     const resp = build({
       spotify_url: 'https://open.spotify.com/album/ok',
+      youtube_music_url: 'https://music.youtube.com/browse/MPREb_abc123',
       bandcamp_url: 'https://artist.bandcamp.com/album/foo',
       soundcloud_url: 'https://soundcloud.com/artist/track',
     });
     const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+    expect(out?.youtube_music_url).toBe('https://music.youtube.com/browse/MPREb_abc123');
     expect(out?.bandcamp_url).toBe('https://artist.bandcamp.com/album/foo');
     expect(out?.soundcloud_url).toBe('https://soundcloud.com/artist/track');
+  });
+
+  it('nulls a mislabeled URL in the youtube_music_url slot', () => {
+    const resp = build({ youtube_music_url: 'https://www.deezer.com/album/1' });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.youtube_music_url).toBeNull();
+  });
+
+  it('nulls a mislabeled URL in the bandcamp_url slot', () => {
+    const resp = build({ bandcamp_url: 'https://www.deezer.com/album/1' });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBeNull();
+  });
+
+  it('nulls a mislabeled URL in the soundcloud_url slot', () => {
+    const resp = build({ soundcloud_url: 'https://www.deezer.com/album/1' });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.soundcloud_url).toBeNull();
+  });
+
+  it('nulls a whitespace-polluted value in the bandcamp_url slot (2026-08-11 audit shape)', () => {
+    const resp = build({ bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo' });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBeNull();
+  });
+
+  it('preserves each genuine synthesized search-URL shape LML emits', () => {
+    const resp = build({
+      youtube_music_url: 'https://music.youtube.com/search?q=kid%20606',
+      bandcamp_url: 'https://bandcamp.com/search?q=kid%20606',
+      soundcloud_url: 'https://soundcloud.com/search?q=kid%20606',
+    });
+    const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+    expect(out?.youtube_music_url).toBe('https://music.youtube.com/search?q=kid%20606');
+    expect(out?.bandcamp_url).toBe('https://bandcamp.com/search?q=kid%20606');
+    expect(out?.soundcloud_url).toBe('https://soundcloud.com/search?q=kid%20606');
   });
 
   it('tolerates a result item with no artwork', () => {

--- a/tests/unit/shared/lml-client/streaming-url-guard.test.ts
+++ b/tests/unit/shared/lml-client/streaming-url-guard.test.ts
@@ -1,5 +1,6 @@
 /**
- * Unit tests for the streaming-URL host guard (BS#1710).
+ * Unit tests for the streaming-URL guard (BS#1710, extended to all five
+ * `LookupResponse` streaming fields by BS#2350).
  *
  * LML's `results[].artwork.spotify_url` is sourced from the library
  * `streaming_links.spotify_url` artifact column, which for a subset of
@@ -8,6 +9,15 @@
  * hardwired green "Spotify" button. The guard enforces the field-name
  * invariant — a value in the `spotify_url` slot must be a Spotify URL —
  * at the untrusted-upstream boundary, before any writer persists it.
+ * `apple_music_url`/`youtube_music_url`/`soundcloud_url` get the same
+ * host-invariant treatment. `bandcamp_url` is the deliberate exception —
+ * well-formedness only, no host allowlist, because this boundary also
+ * carries genuine LML-resolved custom-domain deep links a host allowlist
+ * would wrongly degrade (see `isBandcampUrl`'s doc comment in
+ * `streaming-url-guard.ts` and WXYC/library-metadata-lookup#1296) — and
+ * suppressing `bandcamp_url` also clears the paired
+ * `artwork.streaming_status.bandcamp` verdict, closing the BS#1747/#1915
+ * permanent-null freeze this guard could otherwise cause.
  */
 import type { LookupResponse } from '@wxyc/lml-client';
 import {
@@ -61,6 +71,16 @@ describe('isSpotifyUrl', () => {
   ])('rejects nullish input (%s)', (_label, input) => {
     expect(isSpotifyUrl(input)).toBe(false);
   });
+
+  // BS#2350 characterization: `isSpotifyUrl` must stay byte-identical.
+  // `safeHttpHostname`'s stricter well-formedness bar (no embedded space,
+  // no control chars) is used by the three new-in-BS#2350 predicates only —
+  // it must never leak into this one. `new URL()` percent-encodes a raw
+  // space rather than rejecting it, so this URL is (and must remain) a
+  // genuine accept.
+  it('accepts a raw space in the path (the stricter BS#2350 bar must not leak in here)', () => {
+    expect(isSpotifyUrl('https://open.spotify.com/album/a b')).toBe(true);
+  });
 });
 
 describe('isAppleMusicUrl', () => {
@@ -82,6 +102,12 @@ describe('isAppleMusicUrl', () => {
   ])('rejects a non-Apple URL (%s)', (_label, url) => {
     expect(isAppleMusicUrl(url)).toBe(false);
   });
+
+  // BS#2350 characterization: `isAppleMusicUrl` must stay byte-identical —
+  // see the matching `isSpotifyUrl` characterization test above.
+  it('accepts a raw space in the path (the stricter BS#2350 bar must not leak in here)', () => {
+    expect(isAppleMusicUrl('https://music.apple.com/us/album/a b/123')).toBe(true);
+  });
 });
 
 describe('isYouTubeMusicUrl', () => {
@@ -89,6 +115,10 @@ describe('isYouTubeMusicUrl', () => {
     ['music.youtube.com browse (direct album link)', 'https://music.youtube.com/browse/MPREb_abc123'],
     ['music.youtube.com search (synthesized fallback)', 'https://music.youtube.com/search?q=kid%20606'],
     ['bare youtube.com apex', 'https://youtube.com/watch?v=abc'],
+    ['www.youtube.com', 'https://www.youtube.com/watch?v=abc'],
+    // BS#2350: youtu.be short links accepted preemptively — LML is adding
+    // the same host to its own vocabulary so the two stay in sync.
+    ['youtu.be short link', 'https://youtu.be/abc123'],
     ['case-insensitive host', 'HTTPS://MUSIC.YOUTUBE.COM/browse/MPREb_abc123'],
   ])('accepts a YouTube-host URL (%s)', (_label, url) => {
     expect(isYouTubeMusicUrl(url)).toBe(true);
@@ -100,6 +130,7 @@ describe('isYouTubeMusicUrl', () => {
     ['bare host, no scheme', 'music.youtube.com/browse/MPREb_abc123'],
     ['non-web scheme', 'javascript:alert(1)'],
     ['host-suffix spoof', 'https://youtube.com.evil.example/browse/x'],
+    ['youtu.be host-suffix spoof', 'https://youtu.be.evil.example/abc123'],
     ['backslash-authority spoof', 'https://youtube.com\\@evil.example/x'],
     ['embedded tab', 'https://music.youtube.com/\tbrowse/x'],
     ['embedded newline', 'https://music.youtube.com/\nbrowse/x'],
@@ -113,21 +144,36 @@ describe('isYouTubeMusicUrl', () => {
 });
 
 describe('isBandcampUrl', () => {
+  // BS#2350: NO host allowlist — well-formedness only. This `LookupResponse`
+  // boundary also carries genuine LML-resolved bandcamp deep links on
+  // label-owned custom domains (LML#1069; `clients/bandcamp.py::fix_autocomplete_url`
+  // preserves them), which a `bandcamp.com` allowlist would silently degrade
+  // to search URLs. The curated-column host check lives writer-side in LML
+  // instead (WXYC/library-metadata-lookup#1296). Consequently a well-formed
+  // URL on ANY host — even a different service entirely — passes here; only
+  // malformed/spoofed shapes are rejected (see the reject list below).
   it.each([
     ['artist subdomain album (direct link)', 'https://autechre.bandcamp.com/album/confield'],
     ['label/imprint-hosted subdomain', 'https://into-the-light.bandcamp.com/album/the-rules-of-the-game'],
     ['bandcamp.com search (synthesized fallback)', 'https://bandcamp.com/search?q=kid%20606'],
     ['bare bandcamp.com apex', 'https://bandcamp.com/foo'],
-  ])('accepts a Bandcamp-host URL (%s)', (_label, url) => {
+    ['label-owned custom domain (genuine LML-resolved deep link, LML#1069)', 'https://music.sufjan.com/album/x'],
+    [
+      'host-suffix shape (no host check, so no longer a spoof concern here)',
+      'https://bandcamp.com.evil.example/album/foo',
+    ],
+    ['a different service entirely (no host check)', 'https://open.spotify.com/album/abc'],
+    ['Deezer (no host check)', 'https://www.deezer.com/album/254381182'],
+  ])('accepts any well-formed http(s) URL (%s)', (_label, url) => {
     expect(isBandcampUrl(url)).toBe(true);
   });
 
   it.each([
-    ['Spotify', 'https://open.spotify.com/album/abc'],
     ['scheme-relative', '//artist.bandcamp.com/album/foo'],
     ['bare host, no scheme', 'artist.bandcamp.com/album/foo'],
     ['non-web scheme', 'javascript:alert(1)'],
-    ['host-suffix spoof', 'https://bandcamp.com.evil.example/album/foo'],
+    // Well-formedness failure, not a host mismatch — the parser differential
+    // check still applies regardless of the dropped host allowlist.
     ['backslash-authority spoof', 'https://bandcamp.com\\@evil.example/x'],
     ['embedded tab', 'https://artist.bandcamp.com/\talbum/foo'],
     ['embedded newline', 'https://artist.bandcamp.com/\nalbum/foo'],
@@ -135,7 +181,7 @@ describe('isBandcampUrl', () => {
     ['not a URL', 'not a url'],
     ['empty string', ''],
     ['null', null],
-  ])('rejects a non-Bandcamp URL (%s)', (_label, url) => {
+  ])('rejects a malformed value (%s)', (_label, url) => {
     expect(isBandcampUrl(url)).toBe(false);
   });
 });
@@ -145,6 +191,8 @@ describe('isSoundcloudUrl', () => {
     ['artist/track (direct link)', 'https://soundcloud.com/artist/track'],
     ['soundcloud.com search (synthesized fallback)', 'https://soundcloud.com/search?q=kid%20606'],
     ['www.soundcloud.com', 'https://www.soundcloud.com/artist/track'],
+    // BS#2350: on.soundcloud.com short links.
+    ['on.soundcloud.com short link', 'https://on.soundcloud.com/aBc123'],
     ['case-insensitive host', 'HTTPS://SOUNDCLOUD.COM/artist/track'],
   ])('accepts a SoundCloud-host URL (%s)', (_label, url) => {
     expect(isSoundcloudUrl(url)).toBe(true);
@@ -169,8 +217,9 @@ describe('isSoundcloudUrl', () => {
 });
 
 describe('sanitizeLookupStreamingUrls', () => {
-  // The guard only reads `results[].artwork.{spotify_url,apple_music_url}`;
-  // a minimal cast keeps the fixture legible without a full LibraryCatalogItem.
+  // The guard reads `results[].artwork.{spotify_url,apple_music_url,
+  // youtube_music_url,bandcamp_url,soundcloud_url,streaming_status}`; a
+  // minimal cast keeps the fixture legible without a full LibraryCatalogItem.
   const build = (artwork: Record<string, unknown> | undefined): LookupResponse => ({
     results: [{ library_item: { id: 1 }, artwork }],
     search_type: 'direct',
@@ -228,11 +277,6 @@ describe('sanitizeLookupStreamingUrls', () => {
     expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.youtube_music_url).toBeNull();
   });
 
-  it('nulls a mislabeled URL in the bandcamp_url slot', () => {
-    const resp = build({ bandcamp_url: 'https://www.deezer.com/album/1' });
-    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBeNull();
-  });
-
   it('nulls a mislabeled URL in the soundcloud_url slot', () => {
     const resp = build({ soundcloud_url: 'https://www.deezer.com/album/1' });
     expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.soundcloud_url).toBeNull();
@@ -241,6 +285,92 @@ describe('sanitizeLookupStreamingUrls', () => {
   it('nulls a whitespace-polluted value in the bandcamp_url slot (2026-08-11 audit shape)', () => {
     const resp = build({ bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo' });
     expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBeNull();
+  });
+
+  // BS#2350: bandcamp_url has NO host allowlist, so a well-formed URL on any
+  // host — including a genuine LML-resolved custom-domain deep link
+  // (LML#1069) — is preserved, never degraded to a search URL.
+  it('preserves a bandcamp_url on a label-owned custom domain (LML#1069)', () => {
+    const url = 'https://music.sufjan.com/album/x';
+    const resp = build({ bandcamp_url: url });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBe(url);
+  });
+
+  // BS#2350: a well-formed but foreign-host URL in the bandcamp_url slot is
+  // ALSO preserved now — this is the whole point of dropping the host
+  // allowlist (the curated-column host check moved to LML#1296 instead).
+  // Contrast with the youtube_music_url/soundcloud_url slots just above,
+  // which still null a mislabeled foreign URL.
+  it('preserves a well-formed foreign-host URL in the bandcamp_url slot (no host allowlist)', () => {
+    const url = 'https://www.deezer.com/album/1';
+    const resp = build({ bandcamp_url: url });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBe(url);
+  });
+
+  describe('BS#2350 status-clearing (the permanent-null-freeze fix)', () => {
+    it("clears streaming_status.bandcamp when bandcamp_url is suppressed (was 'verified')", () => {
+      const resp = build({
+        bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo', // whitespace-polluted — suppressed
+        streaming_status: { bandcamp: 'verified' },
+      });
+      const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+      expect(out?.bandcamp_url).toBeNull();
+      expect(out?.streaming_status).not.toHaveProperty('bandcamp');
+    });
+
+    it("clears streaming_status.bandcamp when bandcamp_url is suppressed (was 'absent')", () => {
+      const resp = build({
+        bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo',
+        streaming_status: { bandcamp: 'absent' },
+      });
+      const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+      expect(out?.bandcamp_url).toBeNull();
+      expect(out?.streaming_status).not.toHaveProperty('bandcamp');
+    });
+
+    it('leaves streaming_status.bandcamp untouched when bandcamp_url is preserved (not suppressed)', () => {
+      const resp = build({
+        bandcamp_url: 'https://music.sufjan.com/album/x',
+        streaming_status: { bandcamp: 'verified' },
+      });
+      const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+      expect(out?.bandcamp_url).toBe('https://music.sufjan.com/album/x');
+      expect(out?.streaming_status?.bandcamp).toBe('verified');
+    });
+
+    it('leaves the sibling spotify/apple_music streaming_status verdicts untouched by a bandcamp suppression', () => {
+      const resp = build({
+        spotify_url: 'https://open.spotify.com/album/ok',
+        bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo',
+        streaming_status: { spotify: 'verified', apple_music: 'absent', bandcamp: 'verified' },
+      });
+      const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+      expect(out?.streaming_status?.spotify).toBe('verified');
+      expect(out?.streaming_status?.apple_music).toBe('absent');
+      expect(out?.streaming_status).not.toHaveProperty('bandcamp');
+    });
+
+    it('tolerates a suppressed bandcamp_url with no streaming_status object at all', () => {
+      const resp = build({ bandcamp_url: 'https://artist.bandcamp.com/\talbum/foo' });
+      expect(() => sanitizeLookupStreamingUrls(resp)).not.toThrow();
+      expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.bandcamp_url).toBeNull();
+    });
+
+    // youtube_music_url/soundcloud_url have no `streaming_status` key on the
+    // schema at all (LML never emits a resolution verdict for those two
+    // search-URL-only services) — suppressing them must not touch
+    // streaming_status, since there is nothing there naming either service.
+    it('suppressing youtube_music_url/soundcloud_url leaves an unrelated streaming_status untouched', () => {
+      const resp = build({
+        youtube_music_url: 'https://www.deezer.com/album/1',
+        soundcloud_url: 'https://www.deezer.com/album/1',
+        streaming_status: { spotify: 'verified' },
+      });
+      const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+      expect(out?.youtube_music_url).toBeNull();
+      expect(out?.soundcloud_url).toBeNull();
+      expect(out?.streaming_status).toEqual({ spotify: 'verified' });
+    });
   });
 
   it('preserves each genuine synthesized search-URL shape LML emits', () => {


### PR DESCRIPTION
## Summary

`shared/lml-client/src/streaming-url-guard.ts`'s `sanitizeLookupStreamingUrls` guarded only `spotify_url` and `apple_music_url` (#1714). The other three streaming URL fields LML supplies — `youtube_music_url`, `bandcamp_url`, `soundcloud_url` — passed the LML response boundary unchecked and were persisted verbatim by every downstream writer. This adds `isYouTubeMusicUrl`, `isBandcampUrl` and `isSoundcloudUrl` alongside the existing predicates and wires all five into `sanitizeLookupStreamingUrls`. A suppressed value falls through to each writer's `?? searchUrls.*` fallback to a synthesized search URL, exactly as spotify/apple already do.

The three new predicates also reject the whitespace/control-character pollution the 2026-08-11 wire-golden audit observed, mirroring `apps/backend`'s `wireUrl` well-formedness contract (absolute http(s), no embedded C0/space/DEL, no backslash-authority spoof) without adding a cross-workspace dependency — `shared/lml-client` has no import on `apps/backend`, so the check is a same-workspace copy of that predicate's semantics rather than a re-export. `safeHttpHostname` runs that check with a single `new URL()` parse, cheapest rejection (the char scan) first.

**Bandcamp is the one field that does NOT get a host allowlist, and the original version of this PR was wrong to give it one.** That first cut argued LML never mints or emits a genuine Bandcamp link off a `*.bandcamp.com` host, citing `release/url_parser.py`'s strict `_BANDCAMP_HOST_RE` and the scraper in `clients/bandcamp.py`. That argument doesn't hold at this seam: LML also resolves and caches label-owned **custom-domain** Bandcamp deep links (LML#1069, album-first resolution) — e.g. `music.sufjan.com` — and `clients/bandcamp.py::fix_autocomplete_url` exists specifically to preserve those rather than rewrite them back onto `bandcamp.com`, pinned by LML's own tests. A `bandcamp.com` allowlist on the `LookupResponse` this guard checks would have silently degraded every one of those genuine direct links to the synthesized `bandcamp.com/search?q=…` fallback — a regression dressed up as a hardening.

The fix splits the check by seam instead of by field alone: `isBandcampUrl` here enforces well-formedness only (the same bar the other three new predicates apply on top of their host check, minus the host check itself) — absolute http(s), no C0/space/DEL, no backslash-authority parser differential, no host opinion. The curated `streaming_links.bandcamp_url` column LML also serves gets its host check **writer-side, in LML** instead (WXYC/library-metadata-lookup#1296), where LML's own minting parser can actually decide "is this really Bandcamp" against ground truth it owns. `youtube_music_url` and `soundcloud_url` keep their host allowlists — LML doesn't resolve those two off-apex — and `isYouTubeMusicUrl` also now accepts the `youtu.be` short-link apex (LML is adding the same host to its own vocabulary).

**Correctness fix alongside the host-check change:** suppressing `bandcamp_url` now also clears the paired `artwork.streaming_status.bandcamp` verdict when present. Without this, a suppressed URL that arrived with an explicit `'verified'` (or `'absent'`) status would reach `apps/enrichment-worker/enrich.ts`'s `inferIncomingStreamingStatus`, which trusts the explicit status over the now-null url; `mergeStreamingField` would then persist `bandcamp_status: 'verified'` alongside `bandcamp_url: null` — terminal (never re-merged) and permanently un-re-askable (`precheck.ts`/`streaming-reask.ts` only re-ask an explicit `'unresolved'` status) — the BS#1747/#1915 permanent-null freeze, this time caused by the guard itself rather than by LML. Deleting the `streaming_status.bandcamp` key instead makes the round read as "not consulted": the merge leaves whatever was already persisted untouched, and the write path falls back to the synthesized search URL. `youtube_music_url`/`soundcloud_url` have no `streaming_status` key on the schema at all (LML never emits a resolution verdict for those two search-URL-only services), so there is nothing paired to clear for them. `spotify_url`/`apple_music_url` behavior is unchanged — `isSpotifyUrl`/`isAppleMusicUrl` are untouched, pinned by new characterization tests.

## Test plan

- [x] `tests/unit/shared/lml-client/streaming-url-guard.test.ts`: predicate coverage for all three new fields (genuine direct-link and search-URL shapes accepted; scheme-relative, bare-host, non-web scheme, backslash-authority spoof, and embedded tab/LF/space rejected); `isBandcampUrl` rewritten for the well-formedness-only contract (a custom-domain deep link, a host-suffix shape, and even a foreign-host URL now belong in the accept list; only malformed/spoofed shapes are rejected); `youtu.be` and `on.soundcloud.com` accepted; `isSpotifyUrl`/`isAppleMusicUrl` characterization tests pinning them byte-identical against the stricter bar; `sanitizeLookupStreamingUrls` coverage for the custom-domain preservation and the `streaming_status.bandcamp` clearing in both directions (`'verified'` and `'absent'`), confirming sibling spotify/apple/youtube_music/soundcloud state is untouched by a bandcamp suppression
- [x] `tests/unit/apps/enrichment-worker/enrich.test.ts`: a writer-level test running the real guard against a raw LML response and checking the `album_metadata` payload lands the synthesized bandcamp search URL rather than a null
- [x] `npm run test:unit` — 523 suites / 9182 tests pass
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; only pre-existing warnings, same count as before this change)
- [x] `npm run format:check`

Closes #2350
