### PR TITLE
Collapse the duplicated URL well-formedness scan into one exported primitive

### DIFF
--- a/apps/backend/utils/album-metadata-projection.ts
+++ b/apps/backend/utils/album-metadata-projection.ts
@@ -76,7 +76,7 @@
  */
 import { album_metadata, flowsheet } from '@wxyc/database';
 import { sql } from 'drizzle-orm';
-import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
+import { isSpotifyUrl, isAppleMusicUrl, hasUrlParserDifferentialChar } from '@wxyc/lml-client';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 
 /**
@@ -173,14 +173,16 @@ export interface SynthesizableStreamingUrls {
  *     `https://e.com/ab` — a URL that is not what we would emit. `.trim()`
  *     only reaches the ends. Foundation rejects the raw form, which is the
  *     throwing decode this whole helper exists to avoid.
+ *
+ * BS#2356: the scan itself is `@wxyc/lml-client`'s exported
+ * `hasUrlParserDifferentialChar` — this function is a thin, differential-named
+ * wrapper kept for its own callers and this doc comment, which is the source
+ * of truth for the rationale above. `apps/backend` already depends on
+ * `shared/lml-client` (see the `isSpotifyUrl`/`isAppleMusicUrl` import
+ * above), so delegating here doesn't invert the package graph.
  */
 export function hasWireUrlParserDifferential(value: string): boolean {
-  for (const char of value) {
-    const code = char.codePointAt(0) ?? 0;
-    // C0 controls + space (<= 0x20), DEL (0x7f), backslash (0x5c).
-    if (code <= 0x20 || code === 0x7f || code === 0x5c) return true;
-  }
-  return false;
+  return hasUrlParserDifferentialChar(value);
 }
 
 /**

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -72,6 +72,12 @@ export {
   sanitizeLookupStreamingUrls,
 };
 
+// BS#2356: the single exported `<= 0x20 || 0x7f || 0x5c` well-formedness
+// scan behind `safeHttpHostname` above, so `apps/backend`'s
+// `hasWireUrlParserDifferential` can delegate to it instead of carrying its
+// own hand-maintained copy.
+export { hasUrlParserDifferentialChar } from './streaming-url-guard.js';
+
 // BS#1356: shared search_type trust predicates. `isTrustedLmlAlbumMatch` is
 // the single authority every album-context write gate delegates to (the
 // coordinator's `applyTrustGate` in `apps/backend/services/lml/

--- a/shared/lml-client/src/streaming-url-guard.ts
+++ b/shared/lml-client/src/streaming-url-guard.ts
@@ -53,6 +53,29 @@
 import type { LookupResponse } from '@wxyc/shared/dtos';
 
 /**
+ * True iff `value` contains a character that makes `new URL()`'s verdict a
+ * statement about a DIFFERENT string than the one that is actually
+ * persisted or emitted: a C0 control character, space, or DEL
+ * (`<= 0x20` or `0x7f`), or a raw backslash (`0x5c`) — the
+ * WHATWG-vs-Foundation/RFC-3986 authority-folding differential
+ * {@link safeHostname}'s own doc comment describes (BS#1710).
+ *
+ * The single exported primitive behind this module's `safeHttpHostname` and
+ * `apps/backend/utils/album-metadata-projection.ts`'s
+ * `hasWireUrlParserDifferential` (BS#2356) — see that function's doc comment
+ * for the full per-character rationale (backslash-authority spoofing,
+ * WHATWG's strip-and-percent-encode-on-parse behavior for whitespace and
+ * other C0 controls).
+ */
+export function hasUrlParserDifferentialChar(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code <= 0x20 || code === 0x7f || code === 0x5c) return true;
+  }
+  return false;
+}
+
+/**
  * True iff `host` is `apex` or a subdomain of it. The leading-dot check
  * rejects suffix spoofs like `spotify.com.evil.example` (whose host ends
  * in `.evil.example`, not `.spotify.com`).
@@ -110,15 +133,17 @@ export function isAppleMusicUrl(url: string | null | undefined): boolean {
 /**
  * True iff `url` is an absolute `http`/`https` URL free of the
  * backslash-authority parser differential {@link safeHostname} rejects, and
- * free of any C0 control character, space, or DEL anywhere in the string.
- * That second bar mirrors `apps/backend/utils/album-metadata-projection.ts`'s
+ * free of any C0 control character, space, or DEL anywhere in the string
+ * — {@link hasUrlParserDifferentialChar}. That second bar mirrors
+ * `apps/backend/utils/album-metadata-projection.ts`'s
  * `wireUrl`/`hasWireUrlParserDifferential` well-formedness contract — the
  * layer-3 (client-facing) predicate this layer-2 (LML-response) guard is
- * deliberately kept in agreement with, without a cross-workspace import
- * (`shared/lml-client` has no dependency on `apps/backend`, and importing
- * one in would invert the package graph). BS#2339's own `wireUrl` docstring
- * is the source of truth for the contract; this is a same-workspace copy
- * of its predicate, not a re-export.
+ * deliberately kept in agreement with. BS#2356 collapsed the two into one
+ * exported primitive here (`hasUrlParserDifferentialChar`), which
+ * `hasWireUrlParserDifferential` now delegates to (`apps/backend` already
+ * depends on `shared/lml-client`, not the other way around, so that import
+ * doesn't invert the package graph); BS#2339's own `wireUrl` docstring
+ * remains the source of truth for the wire contract's rationale.
  *
  * `spotify_url`/`apple_music_url` deliberately do NOT run through this
  * stricter check — that would risk changing which URLs `isSpotifyUrl` /
@@ -127,19 +152,12 @@ export function isAppleMusicUrl(url: string | null | undefined): boolean {
  *
  * Checks run cheapest-first and share a single `new URL()` parse (unlike
  * {@link safeHostname}, which this function deliberately does not call —
- * calling it would parse `url` a second time): the control-character scan
- * and the backslash check are both plain string scans with no parsing cost,
- * so both run before the one `new URL()` call.
+ * calling it would parse `url` a second time): {@link hasUrlParserDifferentialChar}'s
+ * scan is a plain string scan with no parsing cost, so it runs before the
+ * one `new URL()` call.
  */
 function safeHttpHostname(url: string): string | null {
-  for (const char of url) {
-    const code = char.codePointAt(0) ?? 0;
-    if (code <= 0x20 || code === 0x7f) return null;
-  }
-  // Same backslash-authority differential `safeHostname` rejects (see its
-  // doc comment) — duplicated here rather than delegated to it, since
-  // delegating would mean parsing `url` twice.
-  if (url.includes('\\')) return null;
+  if (hasUrlParserDifferentialChar(url)) return null;
   let parsed: URL;
   try {
     parsed = new URL(url);

--- a/tests/unit/shared/lml-client/streaming-url-guard.test.ts
+++ b/tests/unit/shared/lml-client/streaming-url-guard.test.ts
@@ -27,7 +27,34 @@ import {
   isBandcampUrl,
   isSoundcloudUrl,
   sanitizeLookupStreamingUrls,
+  hasUrlParserDifferentialChar,
 } from '@wxyc/lml-client';
+
+describe('hasUrlParserDifferentialChar', () => {
+  // BS#2356: the single exported scan `safeHttpHostname` and
+  // `apps/backend/utils/album-metadata-projection.ts`'s
+  // `hasWireUrlParserDifferential` both delegate to, instead of each
+  // hand-maintaining their own copy of the `<= 0x20 || 0x7f || 0x5c` bar.
+  it.each([
+    ['space', 'https://e.com/a b'],
+    ['tab', 'https://e.com/a\tb'],
+    ['newline', 'https://e.com/a\nb'],
+    ['carriage return', 'https://e.com/a\rb'],
+    ['DEL (0x7f)', 'https://e.com/a\x7fb'],
+    ['backslash', 'https://e.com\\@evil.example/x'],
+    ['a NUL control character', 'https://e.com/a\x00b'],
+  ])('is true for a string containing %s', (_label, value) => {
+    expect(hasUrlParserDifferentialChar(value)).toBe(true);
+  });
+
+  it.each([
+    ['a well-formed URL with no offending characters', 'https://e.com/a/b?q=1'],
+    ['a raw non-ASCII character (not part of this bar)', 'https://en.wikipedia.org/wiki/Nilüfer_Yanya'],
+    ['the empty string', ''],
+  ])('is false for %s', (_label, value) => {
+    expect(hasUrlParserDifferentialChar(value)).toBe(false);
+  });
+});
 
 describe('isSpotifyUrl', () => {
   it.each([

--- a/tests/unit/utils/album-metadata-projection.wire-url.test.ts
+++ b/tests/unit/utils/album-metadata-projection.wire-url.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for `hasWireUrlParserDifferential`/`wireUrl` (BS#2339, collapsed
+ * onto the shared `@wxyc/lml-client` scan by BS#2356).
+ *
+ * `hasWireUrlParserDifferential` now delegates to `@wxyc/lml-client`'s
+ * exported `hasUrlParserDifferentialChar` — these tests pin that the
+ * delegation is behavior-preserving: the same `<= 0x20 || 0x7f || 0x5c` bar,
+ * plus `wireUrl`'s own trim-then-scan-then-parse contract on top of it.
+ */
+import { hasWireUrlParserDifferential, wireUrl } from '../../../apps/backend/utils/album-metadata-projection';
+
+describe('hasWireUrlParserDifferential', () => {
+  it.each([
+    ['space', 'https://e.com/a b'],
+    ['tab', 'https://e.com/a\tb'],
+    ['newline', 'https://e.com/a\nb'],
+    ['DEL (0x7f)', 'https://e.com/a\x7fb'],
+    ['backslash-authority spoof', 'https://e.com\\@evil.example/x'],
+  ])('is true for a string containing %s', (_label, value) => {
+    expect(hasWireUrlParserDifferential(value)).toBe(true);
+  });
+
+  it.each([
+    ['a well-formed URL', 'https://e.com/a/b?q=1'],
+    [
+      'a raw non-ASCII character (shipped verbatim, not part of this bar)',
+      'https://en.wikipedia.org/wiki/Nilüfer_Yanya',
+    ],
+    ['the empty string', ''],
+  ])('is false for %s', (_label, value) => {
+    expect(hasWireUrlParserDifferential(value)).toBe(false);
+  });
+});
+
+describe('wireUrl', () => {
+  it('returns the trimmed original for a well-formed absolute http(s) URL', () => {
+    expect(wireUrl('  https://open.spotify.com/album/abc  ')).toBe('https://open.spotify.com/album/abc');
+  });
+
+  it('preserves raw non-ASCII bytes verbatim (does not emit parsed.href)', () => {
+    const url = 'https://en.wikipedia.org/wiki/Nilüfer_Yanya';
+    expect(wireUrl(url)).toBe(url);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['relative path', '/album/doga'],
+    ['scheme-relative', '//open.spotify.com/album/abc'],
+    ['non-web scheme', 'javascript:alert(1)'],
+    ['a raw tab (parser differential)', 'https://e.com/a\tb'],
+    ['a raw backslash (parser differential)', 'https://e.com\\@evil.example/x'],
+  ])('returns undefined for %s', (_label, value) => {
+    expect(wireUrl(value)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`shared/lml-client`'s `safeHttpHostname` and `apps/backend/utils/album-metadata-projection.ts`'s `hasWireUrlParserDifferential` hand-maintained the same `<= 0x20 || 0x7f || 0x5c` character bar, just arranged differently (a two-step scan-then-backslash-check vs. a single-pass scan). `apps/backend` already depends on `shared/lml-client` (it imports `isSpotifyUrl`/`isAppleMusicUrl` from it), so the shared scan can live in `shared/lml-client` and be consumed by `apps/backend` without inverting the package graph.

- Extracted the scan into `shared/lml-client/src/streaming-url-guard.ts`'s newly exported `hasUrlParserDifferentialChar`, exported from `shared/lml-client/src/index.ts`.
- `safeHttpHostname` now calls it instead of open-coding the two-step scan.
- `hasWireUrlParserDifferential` keeps its exported name and doc comment, and now delegates to `hasUrlParserDifferentialChar`.
- `isSpotifyUrl`/`isAppleMusicUrl` are untouched — they still go through `safeHostname`, not `safeHttpHostname`, so their characterization tests are unaffected.
- `wireUrl`'s trim semantics and `safeHttpHostname`'s no-trim/lowercased-hostname behavior are both unchanged; only the scan itself moved.

Behavior-preserving by construction: the merged union of `safeHttpHostname`'s two former steps is exactly `hasWireUrlParserDifferential`'s single predicate, and both now literally call the same function.

## Test plan

- [x] Added `hasUrlParserDifferentialChar` characterization tests in `tests/unit/shared/lml-client/streaming-url-guard.test.ts`
- [x] Added a dedicated `hasWireUrlParserDifferential`/`wireUrl` test file (`tests/unit/utils/album-metadata-projection.wire-url.test.ts`) pinning the delegation is behavior-preserving
- [x] `npm run test:unit` (525 suites / 9226 tests green)
- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors; pre-existing warnings only)
- [x] `npm run format:check`

Closes #2356