### PR TITLE
Re-check review state inside the downgrade apply transaction

### DIFF
--- a/jobs/station-signup-review/downgrade.ts
+++ b/jobs/station-signup-review/downgrade.ts
@@ -292,7 +292,10 @@ export interface AppliedDowngrades {
  * `auth_member`. Any future writer that touches both tables in one
  * transaction -- in particular the BS#2362 approve endpoint, which will be
  * the first writer of `self_signup_reviewed_at` -- must take them in the same
- * `auth_user`-first order, or the two deadlock.
+ * `auth_user`-first order, or the two deadlock. That wait is bounded by the
+ * connection-level `statement_timeout` (5s default; this job sets no
+ * override), and a timeout throws -- so the loser lands in `failed` with a
+ * non-zero exit and is retried next run, not silently dropped into `raced`.
  *
  * The role flip and the marker stamp go in ONE transaction. Half of this
  * pair is a defect either way: the role without the marker re-fires on the

--- a/jobs/station-signup-review/downgrade.ts
+++ b/jobs/station-signup-review/downgrade.ts
@@ -245,9 +245,12 @@ export interface AppliedDowngrades {
   /** Accounts whose `auth_member.role` this run actually flipped `dj` -> `member`. */
   downgraded: PendingSignupRow[];
   /**
-   * Planned accounts whose UPDATE matched no row -- the account left `dj`
-   * between the plan phase and the write (a manager edit landing mid-run).
-   * Nothing is written for these, and no marker is stamped, so they are
+   * Planned accounts this run did NOT flip, because something about the
+   * account's state moved between the plan phase and the write: the
+   * `auth_member.role` UPDATE matched no row (a manager edit landing
+   * mid-run), or the in-transaction re-check below found the account was
+   * reviewed or downgraded by something else in the notify window. Nothing
+   * is written for these, and no marker is stamped, so they are
    * re-evaluated from scratch on the next run.
    */
   raced: PendingSignupRow[];
@@ -261,11 +264,21 @@ export interface AppliedDowngrades {
  * succeeded -- see `orchestrate.ts` for why gating the backstop on SES
  * health would be the wrong coupling.
  *
+ * The plan phase reads `self_signup_reviewed_at IS NULL AND
+ * self_signup_downgraded_at IS NULL` once, minutes before this runs (the
+ * SES round trip sits in between). Either column can flip during that
+ * window -- a manager reviews the account, or a concurrent run of this same
+ * job downgrades it -- so the transaction below re-checks BOTH before
+ * touching anything, rather than trusting the plan-phase snapshot. Re-select
+ * over folding the columns into the `auth_member` UPDATE's WHERE because the
+ * columns live on `auth_user`, a different table from the one the role flip
+ * writes.
+ *
  * The role flip and the marker stamp go in ONE transaction. Half of this
  * pair is a defect either way: the role without the marker re-fires on the
- * next re-promotion (the bug this change exists to fix), and the marker
- * without the role permanently exempts an account that still holds `dj`
- * from the only backstop there is.
+ * next re-promotion (the bug BS#2364 exists to fix), and the marker without
+ * the role permanently exempts an account that still holds `dj` from the
+ * only backstop there is.
  *
  * The `WHERE role = 'dj'` guard (not just `WHERE user_id = :id`) keeps the
  * write idempotent against a role edit that lands between plan and apply --
@@ -293,6 +306,14 @@ export const applyDowngrades = async (
 
     try {
       const flipped = await dbClient.transaction(async (tx) => {
+        const stillPending = await tx
+          .select({ id: user.id })
+          .from(user)
+          .where(and(eq(user.id, row.userId), isNull(user.selfSignupReviewedAt), isNull(user.selfSignupDowngradedAt)))
+          .limit(1);
+
+        if (stillPending.length === 0) return false;
+
         const updated = await tx
           .update(member)
           .set({ role: 'member' })

--- a/jobs/station-signup-review/downgrade.ts
+++ b/jobs/station-signup-review/downgrade.ts
@@ -274,6 +274,26 @@ export interface AppliedDowngrades {
  * columns live on `auth_user`, a different table from the one the role flip
  * writes.
  *
+ * **Concurrency.** `db.transaction()` runs at READ COMMITTED, so a bare
+ * re-select would move the check-then-act window rather than close it: a
+ * review committing between the re-select and the `auth_member` UPDATE is
+ * invisible to both writes, because the UPDATE's own guard is `role = 'dj'`
+ * and the marker stamp's is `self_signup_downgraded_at IS NULL`, and a review
+ * touches neither column -- the result would be the reviewed-AND-downgraded
+ * terminal state this re-check exists to prevent. So the re-select takes
+ * `FOR UPDATE` on the `auth_user` row, which is what makes the check and the
+ * act atomic: a concurrent writer of `self_signup_reviewed_at` either waits
+ * on the lock or holds it first, and when it holds it first READ COMMITTED's
+ * EvalPlanQual recheck re-applies the `IS NULL` predicates against the newly
+ * committed row version once the lock is granted, so the row filters out and
+ * this transaction aborts into `raced`.
+ *
+ * **Lock order.** This transaction locks `auth_user`, then writes
+ * `auth_member`. Any future writer that touches both tables in one
+ * transaction -- in particular the BS#2362 approve endpoint, which will be
+ * the first writer of `self_signup_reviewed_at` -- must take them in the same
+ * `auth_user`-first order, or the two deadlock.
+ *
  * The role flip and the marker stamp go in ONE transaction. Half of this
  * pair is a defect either way: the role without the marker re-fires on the
  * next re-promotion (the bug BS#2364 exists to fix), and the marker without
@@ -310,7 +330,8 @@ export const applyDowngrades = async (
           .select({ id: user.id })
           .from(user)
           .where(and(eq(user.id, row.userId), isNull(user.selfSignupReviewedAt), isNull(user.selfSignupDowngradedAt)))
-          .limit(1);
+          .limit(1)
+          .for('update');
 
         if (stillPending.length === 0) return false;
 

--- a/jobs/station-signup-review/orchestrate.ts
+++ b/jobs/station-signup-review/orchestrate.ts
@@ -136,10 +136,12 @@ export const run = async (): Promise<void> => {
       });
     }
     if (applied.raced.length > 0) {
-      // The account left `dj` between the plan and the write. Nothing was
-      // written and no marker was stamped, so the next run re-decides from
-      // scratch; the digest already sent is one line stale for one day.
-      log('warn', 'downgrade_raced', 'planned downgrade matched no auth_member row; role changed mid-run', {
+      // The account's state moved between the plan and the write: it left
+      // `dj`, or a manager reviewed it, or a competing run downgraded it
+      // first. Nothing was written and no marker was stamped, so the next run
+      // re-decides from scratch; the digest already sent is one line stale for
+      // one day. Not a failure -- the run still exits 0 for this.
+      log('warn', 'downgrade_raced', 'planned downgrade aborted; account state changed between plan and apply', {
         user_ids: applied.raced.map((row) => row.userId),
       });
     }

--- a/tests/integration/station-signup-review.spec.js
+++ b/tests/integration/station-signup-review.spec.js
@@ -300,6 +300,56 @@ describe('station-signup-review downgrade (REAL fns, real PG)', () => {
     expect((await authUserRowOf(userId)).self_signup_downgraded_at).toBeNull();
   });
 
+  it('aborts the flip as raced when a review lands between plan and apply', async () => {
+    const userId = await seedAccount({ daysPending: 31, memberRole: 'dj' });
+
+    const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+    const decisions = await planDowngrades(db, pending, new Date());
+    expect(decisions[0].status).toBe('downgraded');
+
+    // A manager reviews the account during the notify window, after the plan
+    // was computed but before the apply transaction runs.
+    await sql`UPDATE auth_user SET self_signup_reviewed_at = now() WHERE id = ${userId}`;
+
+    const applied = await applyDowngrades(db, decisions, new Date());
+
+    expect(applied.downgraded).toEqual([]);
+    expect(applied.raced.map((r) => r.userId)).toEqual([userId]);
+
+    // No flip, no marker: the auth_user.role sentinel and the member role
+    // are both untouched by this run.
+    expect(await memberRoleOf(userId)).toBe('dj');
+    const user = await authUserRowOf(userId);
+    expect(user.role).toBe(SENTINEL_AUTH_USER_ROLE);
+    expect(user.self_signup_downgraded_at).toBeNull();
+  });
+
+  it('does no double work when the marker is stamped concurrently between plan and apply', async () => {
+    const userId = await seedAccount({ daysPending: 31, memberRole: 'dj' });
+
+    const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+    const decisions = await planDowngrades(db, pending, new Date());
+    expect(decisions[0].status).toBe('downgraded');
+
+    // A competing run of this same job downgrades the account first: the
+    // role flip AND the marker land before this run's apply transaction.
+    await sql`UPDATE auth_member SET role = 'member' WHERE user_id = ${userId}`;
+    await sql`UPDATE auth_user SET self_signup_downgraded_at = now() WHERE id = ${userId}`;
+    const concurrentMarker = (await authUserRowOf(userId)).self_signup_downgraded_at;
+
+    const applied = await applyDowngrades(db, decisions, new Date());
+
+    expect(applied.downgraded).toEqual([]);
+    expect(applied.raced.map((r) => r.userId)).toEqual([userId]);
+
+    // The concurrent run's marker is left exactly as it wrote it -- no
+    // double work, no overwrite.
+    expect(await memberRoleOf(userId)).toBe('member');
+    const user = await authUserRowOf(userId);
+    expect(user.role).toBe(SENTINEL_AUTH_USER_ROLE);
+    expect(user.self_signup_downgraded_at).toEqual(concurrentMarker);
+  });
+
   it('never touches an account outside the self-signup cohort', async () => {
     // A plain account with no self_signup_at is invisible to the query, and
     // therefore to the actuator, no matter how old or what role it holds.

--- a/tests/integration/station-signup-review.spec.js
+++ b/tests/integration/station-signup-review.spec.js
@@ -350,6 +350,37 @@ describe('station-signup-review downgrade (REAL fns, real PG)', () => {
     expect(user.self_signup_downgraded_at).toEqual(concurrentMarker);
   });
 
+  it('aborts as raced when the marker is stamped but the account was re-promoted back to dj', async () => {
+    const userId = await seedAccount({ daysPending: 31, memberRole: 'dj' });
+
+    const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+    const decisions = await planDowngrades(db, pending, new Date());
+    expect(decisions[0].status).toBe('downgraded');
+
+    // The discriminating case: a competing run downgraded the account and
+    // stamped the marker, THEN a manager re-promoted it to `dj`. The marker
+    // says "already handled", the member role says "still eligible", and the
+    // `WHERE role = 'dj'` guard alone cannot tell the two apart -- so without
+    // the in-transaction re-check this stale apply would flip the role a
+    // second time and report a downgrade, which is exactly the re-promotion
+    // the marker exists to protect.
+    await sql`UPDATE auth_user SET self_signup_downgraded_at = now() WHERE id = ${userId}`;
+    const concurrentMarker = (await authUserRowOf(userId)).self_signup_downgraded_at;
+    expect(await memberRoleOf(userId)).toBe('dj');
+
+    const applied = await applyDowngrades(db, decisions, new Date());
+
+    expect(applied.downgraded).toEqual([]);
+    expect(applied.raced.map((r) => r.userId)).toEqual([userId]);
+
+    // The manager's re-promotion survives, and the original marker is not
+    // rewritten with this run's timestamp.
+    expect(await memberRoleOf(userId)).toBe('dj');
+    const user = await authUserRowOf(userId);
+    expect(user.role).toBe(SENTINEL_AUTH_USER_ROLE);
+    expect(user.self_signup_downgraded_at).toEqual(concurrentMarker);
+  });
+
   it('never touches an account outside the self-signup cohort', async () => {
     // A plain account with no self_signup_at is invisible to the query, and
     // therefore to the actuator, no matter how old or what role it holds.

--- a/tests/unit/jobs/station-signup-review/downgrade.test.ts
+++ b/tests/unit/jobs/station-signup-review/downgrade.test.ts
@@ -30,12 +30,14 @@ const mockUpdate = jest.fn<(table: unknown) => unknown>();
 // --- SELECT chain (holdsDjRole / hasOpenShow) -----------------------------
 /** Queue of results, one per `.limit()` call, so each read can be steered independently. */
 let selectResults: Array<unknown[] | Error> = [];
+/** Records the lock strength so a test can pin `.for('update')` -- the lock, not just the predicates, is what closes the plan->apply race. */
+const mockFor = jest.fn<(lockStrength: unknown) => unknown>();
 const mockLimit = jest.fn(() => {
   const next = selectResults.shift() ?? [];
   const rows: Promise<unknown[]> = next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
   // The guard SELECTs await `.limit()` directly; the apply re-check chains
   // `.for('update')` onto it. Both resolve to the same queued result.
-  return Object.assign(rows, { for: () => rows });
+  return Object.assign(rows, { for: mockFor.mockImplementation(() => rows) });
 });
 const mockSelectWhere = jest.fn<(clause: unknown) => unknown>().mockReturnValue({ limit: mockLimit });
 const mockFrom = jest.fn<(table: unknown) => unknown>().mockReturnValue({ where: mockSelectWhere });
@@ -313,6 +315,9 @@ describe('applyDowngrades', () => {
         { isNull: USER_TABLE.selfSignupDowngradedAt },
       ],
     });
+    // `FOR UPDATE` specifically: a weaker lock (`for('share')`) does not
+    // conflict with a reviewer's row update and would silently reopen the race.
+    expect(mockFor).toHaveBeenCalledWith('update');
   });
 
   it('aborts as raced -- no role flip, no marker -- when a review landed between plan and apply', async () => {

--- a/tests/unit/jobs/station-signup-review/downgrade.test.ts
+++ b/tests/unit/jobs/station-signup-review/downgrade.test.ts
@@ -32,8 +32,10 @@ const mockUpdate = jest.fn<(table: unknown) => unknown>();
 let selectResults: Array<unknown[] | Error> = [];
 const mockLimit = jest.fn(() => {
   const next = selectResults.shift() ?? [];
-  if (next instanceof Error) return Promise.reject(next);
-  return Promise.resolve(next);
+  const rows: Promise<unknown[]> = next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
+  // The guard SELECTs await `.limit()` directly; the apply re-check chains
+  // `.for('update')` onto it. Both resolve to the same queued result.
+  return Object.assign(rows, { for: () => rows });
 });
 const mockSelectWhere = jest.fn<(clause: unknown) => unknown>().mockReturnValue({ limit: mockLimit });
 const mockFrom = jest.fn<(table: unknown) => unknown>().mockReturnValue({ where: mockSelectWhere });
@@ -333,8 +335,7 @@ describe('applyDowngrades', () => {
     const result = await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
 
     expect(result.raced).toEqual([expect.objectContaining({ userId: 'u1' })]);
-    expect(mockUpdate).not.toHaveBeenCalledWith(MEMBER_TABLE);
-    expect(mockUpdate).not.toHaveBeenCalledWith(USER_TABLE);
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it('writes ONLY auth_member.role and auth_user.self_signup_downgraded_at -- never auth_user.role', async () => {

--- a/tests/unit/jobs/station-signup-review/downgrade.test.ts
+++ b/tests/unit/jobs/station-signup-review/downgrade.test.ts
@@ -47,7 +47,12 @@ const fakeDb: Record<string, unknown> = {
   transaction: mockTransaction,
 };
 
-const USER_TABLE = { __table: 'auth_user', id: 'id', selfSignupDowngradedAt: 'self_signup_downgraded_at' };
+const USER_TABLE = {
+  __table: 'auth_user',
+  id: 'id',
+  selfSignupReviewedAt: 'self_signup_reviewed_at',
+  selfSignupDowngradedAt: 'self_signup_downgraded_at',
+};
 const MEMBER_TABLE = { __table: 'auth_member', id: 'id', userId: 'userId', role: 'role' };
 const SHOWS_TABLE = { __table: 'shows', id: 'id', end_time: 'end_time', primary_dj_id: 'primary_dj_id' };
 const SHOW_DJS_TABLE = { __table: 'show_djs', show_id: 'show_id', dj_id: 'dj_id' };
@@ -288,7 +293,52 @@ describe('applyDowngrades', () => {
     downgradedAt: OVERDUE_NOW,
   });
 
+  /** Steer the in-transaction re-check: still-pending, i.e. neither reviewed nor already downgraded. */
+  const stillPending = (): void => {
+    selectResults.push([{ id: 'u1' }]);
+  };
+
+  it('re-checks self_signup_reviewed_at and self_signup_downgraded_at before touching anything', async () => {
+    stillPending();
+    mockReturning.mockResolvedValueOnce([{ id: 'm1' }]);
+
+    await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
+
+    expect(mockSelectWhere).toHaveBeenCalledWith({
+      and: [
+        { eq: [USER_TABLE.id, 'u1'] },
+        { isNull: USER_TABLE.selfSignupReviewedAt },
+        { isNull: USER_TABLE.selfSignupDowngradedAt },
+      ],
+    });
+  });
+
+  it('aborts as raced -- no role flip, no marker -- when a review landed between plan and apply', async () => {
+    // The re-check finds the account no longer pending: a manager reviewed it
+    // during the notify window.
+    selectResults.push([]);
+
+    const result = await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
+
+    expect(result.downgraded).toEqual([]);
+    expect(result.raced).toEqual([expect.objectContaining({ userId: 'u1' })]);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('aborts as raced when a concurrent run already stamped the downgrade marker', async () => {
+    // Same re-check, different real-world cause: a competing run of this job
+    // downgraded the account first. Either way the row comes back empty.
+    selectResults.push([]);
+
+    const result = await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
+
+    expect(result.raced).toEqual([expect.objectContaining({ userId: 'u1' })]);
+    expect(mockUpdate).not.toHaveBeenCalledWith(MEMBER_TABLE);
+    expect(mockUpdate).not.toHaveBeenCalledWith(USER_TABLE);
+  });
+
   it('writes ONLY auth_member.role and auth_user.self_signup_downgraded_at -- never auth_user.role', async () => {
+    stillPending();
     mockReturning.mockResolvedValueOnce([{ id: 'm1' }]);
 
     const result = await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
@@ -310,6 +360,7 @@ describe('applyDowngrades', () => {
   });
 
   it('puts the role flip and the marker stamp in ONE transaction -- half the pair is a defect either way', async () => {
+    stillPending();
     mockReturning.mockResolvedValueOnce([{ id: 'm1' }]);
 
     await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
@@ -318,6 +369,7 @@ describe('applyDowngrades', () => {
   });
 
   it('scopes the auth_member UPDATE to the account AND role=dj', async () => {
+    stillPending();
     mockReturning.mockResolvedValueOnce([{ id: 'm1' }]);
 
     await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
@@ -328,6 +380,7 @@ describe('applyDowngrades', () => {
   });
 
   it('stamps the marker only where it is still NULL, so a re-run cannot rewrite the original date', async () => {
+    stillPending();
     mockReturning.mockResolvedValueOnce([{ id: 'm1' }]);
 
     await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
@@ -338,7 +391,9 @@ describe('applyDowngrades', () => {
   });
 
   it('reports a raced account and stamps NO marker when the role guard matched nothing', async () => {
-    // The account left `dj` between the plan and the write.
+    // The re-check passes -- still pending -- but the account left `dj`
+    // between the plan and the write.
+    stillPending();
     mockReturning.mockResolvedValueOnce([]);
 
     const result = await applyDowngrades(fakeDb as never, [plannedFor(row())], OVERDUE_NOW);
@@ -363,6 +418,7 @@ describe('applyDowngrades', () => {
     mockTransaction
       .mockImplementationOnce(() => Promise.reject(new Error('deadlock detected')))
       .mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => fn(fakeDb));
+    stillPending();
     mockReturning.mockResolvedValueOnce([{ id: 'm2' }]);
 
     const result = await applyDowngrades(

--- a/tests/unit/jobs/station-signup-review/orchestrate.test.ts
+++ b/tests/unit/jobs/station-signup-review/orchestrate.test.ts
@@ -186,7 +186,7 @@ describe('orchestrate.run()', () => {
     expect(mockLog).toHaveBeenCalledWith('error', 'downgrade_failed', expect.any(String), expect.anything());
   });
 
-  it('logs a raced account (role changed between plan and write) as a warning, not a failure', async () => {
+  it('logs a raced account (state changed between plan and write) as a warning, not a failure', async () => {
     happyPath();
     mockApplyDowngrades.mockResolvedValue({ downgraded: [], raced: [PENDING_ROW], failed: [] } as never);
 


### PR DESCRIPTION
Closes #2373

## What

`applyDowngrades` re-checked only `member.role = 'dj'` inside its transaction. Neither `auth_user.self_signup_reviewed_at` nor `auth_user.self_signup_downgraded_at` was re-evaluated, so the plan-phase snapshot — taken before the SES round trip — was trusted for the write. A review landing during that notify window was still followed by a downgrade, and the marker stamp made it terminal: the account leaves the digest cohort once reviewed, so nothing ever surfaced the incorrect flip. #2362 makes the approve endpoint the first real writer of `self_signup_reviewed_at`, which is why this lands first.

## How

The apply transaction now re-selects the `auth_user` row `FOR UPDATE` and aborts the role flip **and** the marker stamp when either column is non-NULL, before touching anything. The row lock is what closes the race rather than just narrowing it: `db.transaction()` runs at READ COMMITTED, so a bare re-select would still be check-then-act — a review committing between the re-select and the `auth_member` UPDATE is invisible to both writes, since the UPDATE's guard is `role = 'dj'` and the marker stamp's is `self_signup_downgraded_at IS NULL`, and a review touches neither. With `FOR UPDATE`, a concurrent writer of `self_signup_reviewed_at` either waits on the lock or holds it first, and READ COMMITTED's EvalPlanQual recheck re-applies the `IS NULL` predicates against the newly committed row version once the lock is granted, so the row filters out and the transaction aborts. A re-select rather than folding the columns into the guarded UPDATE's predicate, because those columns live on `auth_user` and the role flip writes `auth_member` — a different table. The docstring records the resulting lock order (`auth_user` first, then `auth_member`) so #2362's approve endpoint, which will touch both, adopts the same order and does not deadlock against this job. An aborted flip reports through the existing `applied.raced` accounting: a warning, not a failure, and the run still exits 0. The `downgrade_raced` log line is reworded, since "matched no auth_member row" is no longer the only cause. Kill switch, on-air guard, and the plan and digest semantics are unchanged — only the apply step moves.

## Tests

Unit: the re-check clause is pinned by shape (both `isNull`s against the `auth_user` table object), and both abort paths — review landed, marker stamped by a competing run — assert no role flip, no marker, and a `raced` outcome. Every pre-existing apply test now steers the re-check to "still pending" first, so the happy-path invariants still read as before.

Integration (real Postgres): a review stamped between plan and apply produces no flip and no marker; a concurrent run's role flip plus marker produces no double work and no overwrite of that run's marker instant; and the discriminating case — marker stamped but the account re-promoted back to `dj`, where the `WHERE role = 'dj'` guard alone would happily flip a second time — aborts as `raced` with the re-promotion and the original marker instant both intact. All assert the `auth_user.role` sentinel stays untouched — the invariant this whole epic turns on.
