### PR TITLE
Add the station-signup manager API: reveal, rotate, revoke, clear-cooldown, status, and approve

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -10,8 +10,15 @@ import {
   auth,
   bootstrapTrustedClients,
   buildTrustedClients,
+  clearSignupCooldown,
+  evaluateSignupCooldown,
   grantsAdminFlag,
   resolveCorsOrigin,
+  revealStationPasscode,
+  revokeStationPasscode,
+  rotateStationPasscode,
+  StationPasscodeCapExceededError,
+  StationPasscodeDecryptionError,
 } from '@wxyc/authentication';
 import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
@@ -32,6 +39,7 @@ import { createAutoDjUser } from './create-auto-dj-user';
 import { createDefaultUser } from './create-default-user';
 import { syncAdminRoles } from './sync-admin-roles';
 import { resolveOrganization } from './resolve-organization';
+import { approveSelfSignup, readStationSignupStatus, StationSignupAdminError } from './station-signup-admin';
 import { shouldCaptureAuthExpressError } from './sentry-error-filter';
 import { E2E_INCOMPLETE_USER_ID, E2E_INCOMPLETE_USER_PASSWORD } from './e2e-test-constants';
 
@@ -294,6 +302,166 @@ app.post('/auth/admin/provision-user', async (req, res) => {
     return res.status(500).json({ error: 'Internal server error' });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Station self-signup manager API (BS#2362)
+// ---------------------------------------------------------------------------
+//
+// Six operations behind the SAME admin-flag gate as /auth/admin/provision-user
+// directly above — `session.user.role !== 'admin'` -> 403. See
+// station-signup-admin.ts's module header for why this is deliberately not a
+// stationManager-only gate. `requirePermissions` is the backend app's
+// middleware and is not available here.
+//
+// Registered before the better-auth handler, like every other /auth/admin
+// route in this file, so they intercept rather than fall through to it.
+
+/**
+ * Resolve the acting manager, or write the 401/403 and return null. The
+ * caller must return immediately on null.
+ *
+ * The returned id is the ONLY source of `actorUserId` for the reveal audit
+ * row and of `reviewedBy` on approve. Neither is ever read from the request
+ * body: an audit trail a caller can forge names the wrong person, and
+ * WXYC/dj-site#1358's any-manager attribution residual is exactly what
+ * deriving it server-side retires.
+ */
+const resolveStationSignupActor = async (req: Request, res: Response): Promise<string | null> => {
+  const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
+  if (!session?.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+  if ((session.user as { role?: string }).role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden: admin role required' });
+    return null;
+  }
+  return session.user.id;
+};
+
+/**
+ * Wrap one manager operation: gate, run, and map the module's typed failures
+ * onto status codes. Every station-signup route below is registered through
+ * this, so no route can be added without the gate.
+ */
+const stationSignupAdminRoute =
+  (subsystem: string, handler: (actorUserId: string, req: Request, res: Response) => Promise<unknown>) =>
+  async (req: Request, res: Response) => {
+    try {
+      const actorUserId = await resolveStationSignupActor(req, res);
+      if (actorUserId === null) return;
+      const body = await handler(actorUserId, req, res);
+      if (res.headersSent) return;
+      return res.json(body);
+    } catch (error) {
+      if (error instanceof StationSignupAdminError) {
+        return res.status(error.statusCode).json({ error: error.message });
+      }
+      if (error instanceof StationPasscodeCapExceededError) {
+        // Not a server fault: two codes are already live and the room is
+        // presumably still using at least one of them. Revoke one first.
+        return res.status(409).json({ error: error.message, code: 'passcode_cap_exceeded' });
+      }
+      if (error instanceof StationPasscodeDecryptionError) {
+        // The gate is down for the same reason every signup attempt is
+        // failing closed. 503, and say what fixes it — the runbook lives at
+        // the top of station-passcode.ts.
+        console.error(`[STATION SIGNUP ADMIN] ${subsystem}: active passcode row will not decrypt`, error);
+        Sentry.captureException(error, { tags: { subsystem: `station-signup-${subsystem}` } });
+        return res.status(503).json({
+          error:
+            'An active station passcode will not decrypt, so the signup gate is failing closed. Set ' +
+            'STATION_PASSCODE_KEY_PREVIOUS to the key that wrote it, or rotate, which administratively ' +
+            'revokes undecryptable active rows.',
+          code: 'passcode_undecryptable',
+        });
+      }
+      console.error(`[STATION SIGNUP ADMIN] ${subsystem}: unexpected error`, error);
+      Sentry.captureException(error, { tags: { subsystem: `station-signup-${subsystem}` } });
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+// Current plaintext code(s), for a manager to read to a stranded DJ by phone.
+// POST, not GET: readable storage removed show-once's structural guarantee
+// that only whoever rotated ever saw the code, so every reveal WRITES a
+// `passcode_revealed` attempt row carrying the acting manager's id — that
+// audit log is what replaces the guarantee, and it is what makes "who could
+// have seen this?" answerable after a suspected leak.
+app.post(
+  '/auth/admin/station-signup/reveal',
+  stationSignupAdminRoute('reveal', async (actorUserId) => ({
+    passcodes: await revealStationPasscode(actorUserId),
+  }))
+);
+
+// Mint a new code and return its plaintext once. Refuses beyond two active
+// rows (409) rather than silently retiring a note the room is still using.
+app.post(
+  '/auth/admin/station-signup/rotate',
+  stationSignupAdminRoute('rotate', async (actorUserId) => await rotateStationPasscode({ createdBy: actorUserId }))
+);
+
+// Manual kill switch for one code.
+app.post(
+  '/auth/admin/station-signup/revoke',
+  stationSignupAdminRoute('revoke', async (_actorUserId, req) => {
+    const passcodeId = (req.body as { passcodeId?: unknown } | undefined)?.passcodeId;
+    if (!passcodeId || typeof passcodeId !== 'string') {
+      throw new StationSignupAdminError('Missing required field: passcodeId', 400);
+    }
+    // 'manual' distinguishes a manager's revoke from rotation's
+    // STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON auto-revoke, which the
+    // status endpoint reports as `revokedByKeyRotation`.
+    const revoked = await revokeStationPasscode(passcodeId, { revokedReason: 'manual' });
+    // `false` is the idempotent no-op: no such row, or already revoked.
+    return { passcodeId, revoked };
+  })
+);
+
+// THE ANTI-LOCKOUT ESCAPE HATCH. Writes a `cooldown_cleared` attempt row,
+// which `evaluateSignupCooldown` already honours as a floor on the failure
+// window — it DELETES NOTHING, because that log is both the cooldown's own
+// input and the 30-day audit trail. Without this a sustained attacker can
+// hold the endpoint in cooldown with nothing in the product able to clear it,
+// and "wait for a manager who is not on site" becomes the failure mode; with
+// it, one phone call.
+app.post(
+  '/auth/admin/station-signup/clear-cooldown',
+  stationSignupAdminRoute('clear-cooldown', async (actorUserId) => {
+    await clearSignupCooldown(actorUserId);
+    return { cleared: true, cooldown: await evaluateSignupCooldown() };
+  })
+);
+
+// Read-only. Writes nothing at all — safe to poll.
+app.get(
+  '/auth/admin/station-signup/status',
+  stationSignupAdminRoute('status', async () => await readStationSignupStatus())
+);
+
+// Clear one account out of the manager review queue, optionally handing back
+// the `dj` role the 30-day actuator took. See approveSelfSignup for the lock
+// order it shares with jobs/station-signup-review, and for why
+// `self_signup_downgraded_at` survives approval.
+app.post(
+  '/auth/admin/station-signup/approve',
+  stationSignupAdminRoute('approve', async (actorUserId, req) => {
+    const body = (req.body ?? {}) as { userId?: unknown; restoreDjRole?: unknown };
+    if (!body.userId || typeof body.userId !== 'string') {
+      throw new StationSignupAdminError('Missing required field: userId', 400);
+    }
+    if (body.restoreDjRole !== undefined && typeof body.restoreDjRole !== 'boolean') {
+      throw new StationSignupAdminError('restoreDjRole must be a boolean', 400);
+    }
+    // reviewerId comes from the session, never the body.
+    return await approveSelfSignup({
+      userId: body.userId,
+      reviewerId: actorUserId,
+      restoreDjRole: body.restoreDjRole === true,
+    });
+  })
+);
 
 // Resolve a login identifier (username or email) to a verification email.
 // Public — rate-limited below alongside the other brute-force-sensitive

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -19,11 +19,12 @@ import {
   rotateStationPasscode,
   StationPasscodeCapExceededError,
   StationPasscodeDecryptionError,
+  StationPasscodeKeyUnsetError,
 } from '@wxyc/authentication';
 import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
 import express from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import { rateLimitKeyFromRequest, sessionRateLimitKeyFromRequest } from './rate-limit-key';
 import { makeHandler as makeRateLimitMetricsHandler, flushRateLimitMetrics } from './auth-rate-limit-metrics';
@@ -313,44 +314,78 @@ app.post('/auth/admin/provision-user', async (req, res) => {
 // stationManager-only gate. `requirePermissions` is the backend app's
 // middleware and is not available here.
 //
-// Registered before the better-auth handler, like every other /auth/admin
-// route in this file, so they intercept rather than fall through to it.
+// They share one path prefix and are mounted as ONE express.Router with the
+// gate on `router.use`, rather than six flat `app.post`s each wrapped in it.
+// The prefix is registered before the better-auth handler, like every other
+// /auth/admin route in this file, so it intercepts rather than falls through.
+
+/** Common mount point for all six. Every path below is this plus one segment. */
+const STATION_SIGNUP_ADMIN_PREFIX = '/auth/admin/station-signup';
+
+/** `res.locals` key the gate writes the acting manager's id under. */
+const STATION_SIGNUP_ACTOR_LOCAL = 'stationSignupActorUserId';
 
 /**
- * Resolve the acting manager, or write the 401/403 and return null. The
- * caller must return immediately on null.
+ * THE GATE. Mounted ONCE with `router.use` at the prefix above, so it runs
+ * ahead of every handler on this router — including one a future change
+ * forgets to think about. It used to be a line inside the per-route wrapper,
+ * which made "no route can be added without the gate" a convention held by
+ * whoever registered the next route; mounting it on the router makes it
+ * structural (BS#2362 review).
  *
- * The returned id is the ONLY source of `actorUserId` for the reveal audit
+ * The id it stashes is the ONLY source of `actorUserId` for the reveal audit
  * row and of `reviewedBy` on approve. Neither is ever read from the request
  * body: an audit trail a caller can forge names the wrong person, and
  * WXYC/dj-site#1358's any-manager attribution residual is exactly what
  * deriving it server-side retires.
+ *
+ * `session.user.role !== 'admin'` -> 403. See station-signup-admin.ts's
+ * module header for why this is deliberately not a stationManager-only gate.
  */
-const resolveStationSignupActor = async (req: Request, res: Response): Promise<string | null> => {
-  const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
-  if (!session?.user) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return null;
+const stationSignupAdminGate = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
+    if (!session?.user) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    if ((session.user as { role?: string }).role !== 'admin') {
+      res.status(403).json({ error: 'Forbidden: admin role required' });
+      return;
+    }
+    res.locals[STATION_SIGNUP_ACTOR_LOCAL] = session.user.id;
+    next();
+  } catch (error) {
+    // A session lookup that throws must not fall through to the routes with
+    // no actor resolved. Same 500 shape the operation wrapper below writes.
+    console.error('[STATION SIGNUP ADMIN] gate: session lookup failed', error);
+    Sentry.captureException(error, { tags: { subsystem: 'station-signup-gate' } });
+    res.status(500).json({ error: 'Internal server error' });
   }
-  if ((session.user as { role?: string }).role !== 'admin') {
-    res.status(403).json({ error: 'Forbidden: admin role required' });
-    return null;
-  }
-  return session.user.id;
 };
 
 /**
- * Wrap one manager operation: gate, run, and map the module's typed failures
- * onto status codes. Every station-signup route below is registered through
- * this, so no route can be added without the gate.
+ * The acting manager the gate resolved. Never optional in practice — the
+ * router cannot reach a handler without running `stationSignupAdminGate`
+ * first — so a miss means the gate was unmounted, and this fails closed with
+ * the same 401 an anonymous caller gets rather than running the operation
+ * with an undefined actor.
+ */
+const stationSignupActorOf = (res: Response): string => {
+  const actorUserId: unknown = res.locals[STATION_SIGNUP_ACTOR_LOCAL];
+  if (typeof actorUserId !== 'string') throw new StationSignupAdminError('Unauthorized', 401);
+  return actorUserId;
+};
+
+/**
+ * Wrap one manager operation: run it, and map the module's typed failures
+ * onto status codes. The gate is the router's, not this wrapper's.
  */
 const stationSignupAdminRoute =
   (subsystem: string, handler: (actorUserId: string, req: Request, res: Response) => Promise<unknown>) =>
   async (req: Request, res: Response) => {
     try {
-      const actorUserId = await resolveStationSignupActor(req, res);
-      if (actorUserId === null) return;
-      const body = await handler(actorUserId, req, res);
+      const body = await handler(stationSignupActorOf(res), req, res);
       if (res.headersSent) return;
       return res.json(body);
     } catch (error) {
@@ -361,6 +396,22 @@ const stationSignupAdminRoute =
         // Not a server fault: two codes are already live and the room is
         // presumably still using at least one of them. Revoke one first.
         return res.status(409).json({ error: error.message, code: 'passcode_cap_exceeded' });
+      }
+      if (error instanceof StationPasscodeKeyUnsetError) {
+        // Unconfigured, not corrupt. Mirrors the decrypt branch below but
+        // names the variable that is actually missing: with no
+        // STATION_PASSCODE_KEY, reveal previously blamed
+        // STATION_PASSCODE_KEY_PREVIOUS (the decrypt path defaults an
+        // untyped throw to `corrupt`) or answered `200 {passcodes: []}` on an
+        // empty table, and rotate fell through to a code-less 500.
+        console.error(`[STATION SIGNUP ADMIN] ${subsystem}: STATION_PASSCODE_KEY is not set`, error);
+        Sentry.captureException(error, { tags: { subsystem: `station-signup-${subsystem}` } });
+        return res.status(503).json({
+          error:
+            'STATION_PASSCODE_KEY is not set on the auth service, so station passcodes can be neither revealed ' +
+            'nor minted. Set it on the host and restart the service.',
+          code: 'passcode_key_unset',
+        });
       }
       if (error instanceof StationPasscodeDecryptionError) {
         // The gate is down for the same reason every signup attempt is
@@ -382,14 +433,27 @@ const stationSignupAdminRoute =
     }
   };
 
+/**
+ * The six operations, on ONE router mounted at STATION_SIGNUP_ADMIN_PREFIX.
+ *
+ * The paths are unchanged — `${prefix}/reveal` and so on — but the gate is
+ * now the router's `use`, so a seventh route added here is gated by
+ * construction rather than by remembering to wrap it (BS#2362 review). The
+ * mount is also a prefix match on segment boundaries, so anything under
+ * `/auth/admin/station-signup/` that this router does not answer meets the
+ * gate before falling through to the better-auth handler below.
+ */
+const stationSignupAdminRouter = express.Router();
+stationSignupAdminRouter.use(stationSignupAdminGate);
+
 // Current plaintext code(s), for a manager to read to a stranded DJ by phone.
 // POST, not GET: readable storage removed show-once's structural guarantee
 // that only whoever rotated ever saw the code, so every reveal WRITES a
 // `passcode_revealed` attempt row carrying the acting manager's id — that
 // audit log is what replaces the guarantee, and it is what makes "who could
 // have seen this?" answerable after a suspected leak.
-app.post(
-  '/auth/admin/station-signup/reveal',
+stationSignupAdminRouter.post(
+  '/reveal',
   stationSignupAdminRoute('reveal', async (actorUserId) => ({
     passcodes: await revealStationPasscode(actorUserId),
   }))
@@ -397,14 +461,14 @@ app.post(
 
 // Mint a new code and return its plaintext once. Refuses beyond two active
 // rows (409) rather than silently retiring a note the room is still using.
-app.post(
-  '/auth/admin/station-signup/rotate',
+stationSignupAdminRouter.post(
+  '/rotate',
   stationSignupAdminRoute('rotate', async (actorUserId) => await rotateStationPasscode({ createdBy: actorUserId }))
 );
 
 // Manual kill switch for one code.
-app.post(
-  '/auth/admin/station-signup/revoke',
+stationSignupAdminRouter.post(
+  '/revoke',
   stationSignupAdminRoute('revoke', async (_actorUserId, req) => {
     const passcodeId = (req.body as { passcodeId?: unknown } | undefined)?.passcodeId;
     if (!passcodeId || typeof passcodeId !== 'string') {
@@ -426,8 +490,8 @@ app.post(
 // hold the endpoint in cooldown with nothing in the product able to clear it,
 // and "wait for a manager who is not on site" becomes the failure mode; with
 // it, one phone call.
-app.post(
-  '/auth/admin/station-signup/clear-cooldown',
+stationSignupAdminRouter.post(
+  '/clear-cooldown',
   stationSignupAdminRoute('clear-cooldown', async (actorUserId) => {
     await clearSignupCooldown(actorUserId);
     return { cleared: true, cooldown: await evaluateSignupCooldown() };
@@ -435,8 +499,8 @@ app.post(
 );
 
 // Read-only. Writes nothing at all — safe to poll.
-app.get(
-  '/auth/admin/station-signup/status',
+stationSignupAdminRouter.get(
+  '/status',
   stationSignupAdminRoute('status', async () => await readStationSignupStatus())
 );
 
@@ -444,8 +508,8 @@ app.get(
 // the `dj` role the 30-day actuator took. See approveSelfSignup for the lock
 // order it shares with jobs/station-signup-review, and for why
 // `self_signup_downgraded_at` survives approval.
-app.post(
-  '/auth/admin/station-signup/approve',
+stationSignupAdminRouter.post(
+  '/approve',
   stationSignupAdminRoute('approve', async (actorUserId, req) => {
     const body = (req.body ?? {}) as { userId?: unknown; restoreDjRole?: unknown };
     if (!body.userId || typeof body.userId !== 'string') {
@@ -462,6 +526,8 @@ app.post(
     });
   })
 );
+
+app.use(STATION_SIGNUP_ADMIN_PREFIX, stationSignupAdminRouter);
 
 // Resolve a login identifier (username or email) to a verification email.
 // Public — rate-limited below alongside the other brute-force-sensitive

--- a/apps/auth/station-signup-admin.ts
+++ b/apps/auth/station-signup-admin.ts
@@ -22,7 +22,9 @@
 import { and, eq, isNotNull, isNull } from 'drizzle-orm';
 import { db, member, user } from '@wxyc/database';
 import {
+  countSignupAttemptOutcomes,
   evaluateSignupCooldown,
+  readLastCooldownClearedAt,
   readRecentSignupAttempts,
   readStationPasscodeStates,
   SIGNUP_COOLDOWN_HOLD_MS,
@@ -46,10 +48,18 @@ export class StationSignupAdminError extends Error {
 // Status
 // ---------------------------------------------------------------------------
 
-/** Attempt-log window the status endpoint reports over, unless the caller narrows it. */
+/**
+ * Attempt-log window the status endpoint reports over. Fixed: the route calls
+ * `readStationSignupStatus()` with no arguments, and the options below are a
+ * test seam, not a query-string contract — no HTTP caller can narrow it.
+ */
 export const STATUS_ATTEMPT_WINDOW_HOURS = 24;
 
-/** Cap on the individual attempt rows returned alongside the counts. */
+/**
+ * Cap on the individual attempt ROWS returned. It bounds the `recent` display
+ * list only. The per-outcome counts beside it are a SQL aggregate over the
+ * whole window and are NOT subject to this (BS#2362 review).
+ */
 export const STATUS_ATTEMPT_ROW_LIMIT = 100;
 
 /**
@@ -111,24 +121,44 @@ export interface StationSignupStatus {
     /** Refusal triggers on MORE than this many no-match failures in the window. */
     threshold: number;
     /**
-     * The most recent `cooldown_cleared` row inside the reported attempt
-     * window, or null. Scoped to that window rather than to all history: an
-     * older clear has no bearing on the cooldown state above, which only ever
-     * looks back window+hold.
+     * The most recent `cooldown_cleared` row in the WHOLE log, or null —
+     * `readLastCooldownClearedAt`, the same indexed query
+     * `evaluateSignupCooldown` uses to floor the counts above, so this field
+     * and those numbers can never disagree about which clear is in effect.
+     *
+     * Deliberately not scoped to the reported attempt window, and deliberately
+     * NOT read off `recent` (BS#2362 review): the display list is capped, so
+     * scanning it for the clear row returned null again the moment
+     * STATUS_ATTEMPT_ROW_LIMIT attempts landed after a clear — during a
+     * `cooldown_refused` storm that is a couple of minutes, and it is exactly
+     * when a manager is polling to confirm their clear took.
      */
     lastClearedAt: Date | null;
   };
   attempts: {
     since: Date;
     windowHours: number;
-    /** Every outcome seen in the window, counted. Absent outcomes are absent, not zero. */
+    /**
+     * WINDOW-WIDE census: every outcome present at or after `since`, counted
+     * in SQL across every matching row. NOT derived from `recent`, which is
+     * capped. Absent outcomes are absent, not zero.
+     */
     countsByOutcome: Record<string, number>;
-    /** Newest first, capped at STATUS_ATTEMPT_ROW_LIMIT. */
+    /**
+     * A display list, not a census: the NEWEST STATUS_ATTEMPT_ROW_LIMIT rows
+     * inside the window, newest first. Older rows in the same window are
+     * simply not here — `countsByOutcome` is what says how many there were.
+     */
     recent: StationSignupAttemptView[];
   };
   pendingReview: PendingReviewAccountView[];
 }
 
+/**
+ * A TEST SEAM. The route calls `readStationSignupStatus()` with no arguments
+ * and parses nothing off the query string, so every field here is fixed to
+ * its constant in production.
+ */
 export interface ReadStationSignupStatusOptions {
   now?: Date;
   windowHours?: number;
@@ -153,9 +183,17 @@ export const readStationSignupStatus = async (
   const attemptLimit = options.attemptLimit ?? STATUS_ATTEMPT_ROW_LIMIT;
   const since = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
 
-  const [passcodes, cooldown, attempts, pending] = await Promise.all([
+  const [passcodes, cooldown, countsByOutcome, lastClearedAt, attempts, pending] = await Promise.all([
     readStationPasscodeStates({ now }),
     evaluateSignupCooldown(now),
+    // WINDOW-WIDE, in SQL. Iterating `attempts` below would cap the total of
+    // every outcome at `attemptLimit` and let this "24 hours" report fewer
+    // passcode_fail than the cooldown block's SQL count over ten minutes.
+    countSignupAttemptOutcomes({ since }),
+    // The clear FLOOR itself, not whatever clear row happened to survive the
+    // display cap. Same query evaluateSignupCooldown runs; a second LIMIT 1
+    // on an indexed column is cheaper than being wrong about it.
+    readLastCooldownClearedAt(),
     readRecentSignupAttempts({ since, limit: attemptLimit }),
     db
       .select({
@@ -177,13 +215,6 @@ export const readStationSignupStatus = async (
       .where(and(isNotNull(user.selfSignupAt), isNull(user.selfSignupReviewedAt))),
   ]);
 
-  const countsByOutcome: Record<string, number> = {};
-  for (const attempt of attempts) {
-    countsByOutcome[attempt.outcome] = (countsByOutcome[attempt.outcome] ?? 0) + 1;
-  }
-
-  const cleared = attempts.find((attempt) => attempt.outcome === 'cooldown_cleared');
-
   return {
     now,
     passcodes,
@@ -194,7 +225,7 @@ export const readStationSignupStatus = async (
       windowMinutes: SIGNUP_COOLDOWN_WINDOW_MS / 60000,
       holdMinutes: SIGNUP_COOLDOWN_HOLD_MS / 60000,
       threshold: SIGNUP_COOLDOWN_THRESHOLD,
-      lastClearedAt: cleared?.attemptedAt ?? null,
+      lastClearedAt,
     },
     attempts: {
       since,

--- a/apps/auth/station-signup-admin.ts
+++ b/apps/auth/station-signup-admin.ts
@@ -1,0 +1,380 @@
+/**
+ * Manager operations for the station self-signup passcode (BS#2362).
+ *
+ * Six operations — reveal, rotate, revoke, clear-cooldown, status, approve —
+ * behind the same admin-flag gate `/auth/admin/provision-user` uses. The
+ * route wiring and that gate live in `app.ts`; this module holds the two
+ * operations with logic of their own (status and approve) plus the shared
+ * error type, and leaves the other four as thin delegations to
+ * `@wxyc/authentication`'s lifecycle module, which owns every statement
+ * against `station_passcode` and `station_signup_attempt`.
+ *
+ * WHY THE GATE IS THE ADMIN FLAG AND NOT "stationManager only". Via
+ * `grantsAdminFlag` the flag also admits a stray `admin`/`owner` membership
+ * row, so this is a slightly wider set than the station-manager role. That is
+ * the right trade rather than an oversight: `/auth/admin/provision-user`
+ * already sits behind exactly this gate and CREATES ACCOUNTS AT ANY ROLE,
+ * `stationManager` included, so nothing here is a wider grant than what the
+ * same gate already protects. A true membership-role gate would need a read
+ * nothing in `apps/auth` does today; if it is ever wanted it is its own
+ * change with its own test, applied to both endpoints at once.
+ */
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+import { db, member, user } from '@wxyc/database';
+import {
+  evaluateSignupCooldown,
+  readRecentSignupAttempts,
+  readStationPasscodeStates,
+  SIGNUP_COOLDOWN_HOLD_MS,
+  SIGNUP_COOLDOWN_THRESHOLD,
+  SIGNUP_COOLDOWN_WINDOW_MS,
+  type StationPasscodeStateRow,
+} from '@wxyc/authentication';
+
+/** Thrown by the operations below; `app.ts` maps `statusCode` straight onto the response. */
+export class StationSignupAdminError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number
+  ) {
+    super(message);
+    this.name = 'StationSignupAdminError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+/** Attempt-log window the status endpoint reports over, unless the caller narrows it. */
+export const STATUS_ATTEMPT_WINDOW_HOURS = 24;
+
+/** Cap on the individual attempt rows returned alongside the counts. */
+export const STATUS_ATTEMPT_ROW_LIMIT = 100;
+
+/**
+ * One attempt row as the status endpoint reports it.
+ *
+ * `ipHash` is included deliberately. It is PSEUDONYMOUS rather than PII (a
+ * keyed HMAC — see `docs/pii.md` and the column's own comment in
+ * `schema.ts`), and "manager forensic tooling" is precisely its allow-listed
+ * read site: the question this endpoint exists to answer after a suspected
+ * leak is what an attack looked like and who revealed the code.
+ */
+export interface StationSignupAttemptView {
+  id: string;
+  attemptedAt: Date;
+  outcome: string;
+  passcodeId: string | null;
+  actorUserId: string | null;
+  ipHash: string | null;
+}
+
+/** One self-signed-up account still awaiting a manager's review. */
+export interface PendingReviewAccountView {
+  userId: string;
+  /**
+   * `auth_user.name` — the derived public display value (on-air handle else
+   * username), NOT the legal name; the `databaseHooks.user` derivation hooks
+   * hold that invariant on every write. `real_name` and `email` are PII and
+   * are deliberately absent: dj-site's roster already carries what a manager
+   * needs to identify the account, and this response has no reason to widen
+   * that surface.
+   */
+  name: string;
+  djName: string | null;
+  selfSignupAt: Date;
+  /** Whole days between `selfSignupAt` and `now`, floored — what the 30-day backstop counts. */
+  daysPending: number;
+  /**
+   * When `jobs/station-signup-review`'s actuator flipped this account
+   * `dj` -> `member`, or null if it never did. Surfaced here because a
+   * manager looking at a `member`-role account in the queue otherwise cannot
+   * tell "auto-downgraded, needs re-promoting" from "signed up as a member".
+   */
+  selfSignupDowngradedAt: Date | null;
+}
+
+export interface StationSignupStatus {
+  now: Date;
+  /** Active rows plus every row that went inactive inside the 30-day horizon. Never any plaintext. */
+  passcodes: StationPasscodeStateRow[];
+  cooldown: {
+    inCooldown: boolean;
+    /** In-window `passcode_fail` count — the only outcome that feeds refusal. */
+    noMatchFailureCount: number;
+    /** In-window count across every failure outcome, including the refusal-exempt ones. */
+    allFailureCount: number;
+    /** The rule the two counts are measured against, so a client need not restate the constants. */
+    windowMinutes: number;
+    holdMinutes: number;
+    /** Refusal triggers on MORE than this many no-match failures in the window. */
+    threshold: number;
+    /**
+     * The most recent `cooldown_cleared` row inside the reported attempt
+     * window, or null. Scoped to that window rather than to all history: an
+     * older clear has no bearing on the cooldown state above, which only ever
+     * looks back window+hold.
+     */
+    lastClearedAt: Date | null;
+  };
+  attempts: {
+    since: Date;
+    windowHours: number;
+    /** Every outcome seen in the window, counted. Absent outcomes are absent, not zero. */
+    countsByOutcome: Record<string, number>;
+    /** Newest first, capped at STATUS_ATTEMPT_ROW_LIMIT. */
+    recent: StationSignupAttemptView[];
+  };
+  pendingReview: PendingReviewAccountView[];
+}
+
+export interface ReadStationSignupStatusOptions {
+  now?: Date;
+  windowHours?: number;
+  attemptLimit?: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Everything a manager needs to answer "is the gate working, and is anything
+ * waiting on me?" in one read. Purely read-only — no attempt row, no audit
+ * row, nothing. That is what makes it safe to poll, and it is why revealing
+ * the plaintext is a separate POST: reveal is the operation that writes the
+ * `passcode_revealed` audit row, and folding it in here would either spam the
+ * log on every poll or quietly hand out the code without one.
+ */
+export const readStationSignupStatus = async (
+  options: ReadStationSignupStatusOptions = {}
+): Promise<StationSignupStatus> => {
+  const now = options.now ?? new Date();
+  const windowHours = options.windowHours ?? STATUS_ATTEMPT_WINDOW_HOURS;
+  const attemptLimit = options.attemptLimit ?? STATUS_ATTEMPT_ROW_LIMIT;
+  const since = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+
+  const [passcodes, cooldown, attempts, pending] = await Promise.all([
+    readStationPasscodeStates({ now }),
+    evaluateSignupCooldown(now),
+    readRecentSignupAttempts({ since, limit: attemptLimit }),
+    db
+      .select({
+        userId: user.id,
+        name: user.name,
+        djName: user.djName,
+        selfSignupAt: user.selfSignupAt,
+        selfSignupDowngradedAt: user.selfSignupDowngradedAt,
+      })
+      .from(user)
+      // The SAME cohort `jobs/station-signup-review/query.ts` digests and
+      // dj-site's roster review queue shows: `self_signup_at IS NOT NULL AND
+      // self_signup_reviewed_at IS NULL`, and deliberately NOT narrowed by
+      // `self_signup_downgraded_at` — an account the actuator already
+      // downgraded must keep appearing until a human actually reviews it.
+      // Restated rather than imported: `apps/auth` cannot depend on a
+      // `jobs/*` workspace, so if that predicate ever moves, both copies
+      // move.
+      .where(and(isNotNull(user.selfSignupAt), isNull(user.selfSignupReviewedAt))),
+  ]);
+
+  const countsByOutcome: Record<string, number> = {};
+  for (const attempt of attempts) {
+    countsByOutcome[attempt.outcome] = (countsByOutcome[attempt.outcome] ?? 0) + 1;
+  }
+
+  const cleared = attempts.find((attempt) => attempt.outcome === 'cooldown_cleared');
+
+  return {
+    now,
+    passcodes,
+    cooldown: {
+      inCooldown: cooldown.inCooldown,
+      noMatchFailureCount: cooldown.noMatchFailureCount,
+      allFailureCount: cooldown.allFailureCount,
+      windowMinutes: SIGNUP_COOLDOWN_WINDOW_MS / 60000,
+      holdMinutes: SIGNUP_COOLDOWN_HOLD_MS / 60000,
+      threshold: SIGNUP_COOLDOWN_THRESHOLD,
+      lastClearedAt: cleared?.attemptedAt ?? null,
+    },
+    attempts: {
+      since,
+      windowHours,
+      countsByOutcome,
+      recent: attempts.map((attempt) => ({
+        id: attempt.id,
+        attemptedAt: attempt.attemptedAt,
+        outcome: attempt.outcome,
+        passcodeId: attempt.passcodeId,
+        actorUserId: attempt.actorUserId,
+        ipHash: attempt.ipHash,
+      })),
+    },
+    pendingReview: pending
+      .filter((row): row is typeof row & { selfSignupAt: Date } => row.selfSignupAt !== null)
+      .map((row) => ({
+        userId: row.userId,
+        name: row.name,
+        djName: row.djName,
+        selfSignupAt: row.selfSignupAt,
+        daysPending: Math.floor((now.getTime() - row.selfSignupAt.getTime()) / MS_PER_DAY),
+        selfSignupDowngradedAt: row.selfSignupDowngradedAt,
+      }))
+      .sort((a, b) => b.daysPending - a.daysPending),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Approve
+// ---------------------------------------------------------------------------
+
+export interface ApproveSelfSignupParams {
+  userId: string;
+  /**
+   * The ACTING manager's `auth_user.id`, derived server-side from the session
+   * by the route — never client-supplied. That is the whole point of the
+   * parameter: the column is an attribution record, and a caller who could
+   * name someone else could file a review under another manager's id.
+   */
+  reviewerId: string;
+  /**
+   * Additionally restore `auth_member.role` `member` -> `dj` in the same
+   * transaction. There is deliberately no free-form role parameter: `'dj'` is
+   * a literal in the UPDATE below, so this endpoint is structurally incapable
+   * of granting anything else.
+   */
+  restoreDjRole?: boolean;
+  now?: Date;
+}
+
+export interface ApproveSelfSignupResult {
+  userId: string;
+  reviewedAt: Date;
+  /** Null only in the degenerate case of a pre-existing review stamp with no reviewer recorded. */
+  reviewedBy: string | null;
+  /** True when this call did the stamping; false when an earlier review already had. */
+  reviewedByThisCall: boolean;
+  /** Preserved as history, never cleared by approval. Null if the actuator never fired. */
+  selfSignupDowngradedAt: Date | null;
+  /** True only when this call actually flipped a `member` row to `dj`. */
+  roleRestored: boolean;
+  /** `auth_member.role` as it stands after this call, or null if the account has no membership row. */
+  memberRole: string | null;
+}
+
+/**
+ * Mark a self-signed-up account reviewed, and optionally hand back the `dj`
+ * role the 30-day actuator took.
+ *
+ * NOT via better-auth's public `POST /update-user`. All three review columns
+ * carry `input: false` (`auth.definition.ts`), which blocks that route BY
+ * DESIGN — it is what stops a signed-in DJ approving their own pending
+ * signup. This writes through `@wxyc/database` directly, which never reaches
+ * `parseUserInput`, exactly as `jobs/station-signup-review` does for
+ * `self_signup_downgraded_at`. A direct write is not merely one of the
+ * permitted bypasses here, it is the only one that can hold the role restore
+ * in the SAME transaction as the review stamp — the admin plugin's
+ * `adminUpdateUser` would put the two writes in different transactions and
+ * reintroduce the half-applied state the lock order below exists to prevent.
+ *
+ * **LOCK ORDER — mandatory.** `SELECT ... FOR UPDATE` on the `auth_user` row
+ * FIRST, then the `auth_member` write. `jobs/station-signup-review`'s
+ * `applyDowngrades` holds the same order and names this endpoint in its
+ * docstring as the writer that has to match it; taking them the other way
+ * round deadlocks the pair, and the job's loser lands in its `failed` /
+ * non-zero path rather than its benign `raced` one. Because both sides lock
+ * the same row first they simply serialize: approve-then-downgrade leaves the
+ * job's re-select filtering the row out into `raced`, and downgrade-then-
+ * approve leaves this call approving an account that is already `member` —
+ * which is precisely what `restoreDjRole` is for.
+ *
+ * **`self_signup_downgraded_at` is PRESERVED**, never cleared. It records
+ * what happened to the account; approving is not a history edit. The column
+ * also suppresses the actuator, so an approved account can never be
+ * auto-downgraded a second time whether or not the review stamp is what did
+ * the suppressing.
+ *
+ * **Without `restoreDjRole`, an already-downgraded account stays `member`**
+ * and simply leaves the pending cohort (`self_signup_reviewed_at` is
+ * non-null). That is a real outcome, not an oversight: a manager reviewing a
+ * self-signup may well decide the person should not be a DJ, and the quiet
+ * default has to be "grant nothing".
+ *
+ * **The review stamp is write-once.** A second approval does not re-attribute
+ * the review to a second manager — the UPDATE carries
+ * `self_signup_reviewed_at IS NULL` — but a `restoreDjRole` on that second
+ * call still applies, so "approve, then realise the role should come back" is
+ * one more call rather than a dead end.
+ */
+export const approveSelfSignup = async (params: ApproveSelfSignupParams): Promise<ApproveSelfSignupResult> => {
+  const now = params.now ?? new Date();
+
+  return db.transaction(async (tx) => {
+    // FIRST — see the lock-order paragraph above. Everything this function
+    // decides is read from the locked row, so a concurrent downgrade either
+    // waits here or has already committed and is visible below.
+    const [account] = await tx
+      .select({
+        id: user.id,
+        selfSignupAt: user.selfSignupAt,
+        selfSignupReviewedAt: user.selfSignupReviewedAt,
+        selfSignupReviewedBy: user.selfSignupReviewedBy,
+        selfSignupDowngradedAt: user.selfSignupDowngradedAt,
+      })
+      .from(user)
+      .where(eq(user.id, params.userId))
+      .limit(1)
+      .for('update');
+
+    if (!account) {
+      throw new StationSignupAdminError(`No such user: ${params.userId}`, 404);
+    }
+    if (account.selfSignupAt === null) {
+      // The three review columns only mean anything for an account that came
+      // in through the self-signup gate. Stamping them on an
+      // admin-provisioned account would put a row in the reviewed state that
+      // was never in the pending one.
+      throw new StationSignupAdminError(`User ${params.userId} did not self-sign up; there is nothing to review`, 409);
+    }
+
+    const stamped = await tx
+      .update(user)
+      .set({ selfSignupReviewedAt: now, selfSignupReviewedBy: params.reviewerId })
+      .where(and(eq(user.id, params.userId), isNull(user.selfSignupReviewedAt)))
+      .returning({ id: user.id });
+    const reviewedByThisCall = stamped.length > 0;
+
+    let roleRestored = false;
+    if (params.restoreDjRole) {
+      // `'dj'` on both sides is a literal, and the WHERE pins the source role
+      // to `'member'`: the only transition this endpoint can perform is the
+      // exact inverse of the actuator's `dj` -> `member`. An account sitting
+      // at `musicDirector` or `stationManager` is left alone rather than
+      // silently demoted to `dj`, which an unguarded `SET role = 'dj'` would
+      // do.
+      const restored = await tx
+        .update(member)
+        .set({ role: 'dj' })
+        .where(and(eq(member.userId, params.userId), eq(member.role, 'member')))
+        .returning({ id: member.id });
+      roleRestored = restored.length > 0;
+    }
+
+    const [membership] = await tx
+      .select({ role: member.role })
+      .from(member)
+      .where(eq(member.userId, params.userId))
+      .limit(1);
+
+    return {
+      userId: params.userId,
+      // `selfSignupReviewedAt` is non-null whenever the stamp did not fire —
+      // that is exactly the condition the UPDATE's WHERE failed on.
+      reviewedAt: reviewedByThisCall ? now : (account.selfSignupReviewedAt as Date),
+      reviewedBy: reviewedByThisCall ? params.reviewerId : account.selfSignupReviewedBy,
+      reviewedByThisCall,
+      selfSignupDowngradedAt: account.selfSignupDowngradedAt,
+      roleRestored,
+      memberRole: membership?.role ?? null,
+    };
+  });
+};

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -37,9 +37,24 @@ export {
   claimStationPasscode,
   revealStationPasscode,
   rotateStationPasscode,
+  // The read-only, never-decrypting view of station_passcode behind BS#2362's
+  // status endpoint. Kept in the module so `station_passcode` keeps exactly
+  // one owner of its SQL, and so the state classifier stays beside the
+  // active/inactive predicates it has to agree with.
+  readStationPasscodeStates,
+  classifyStationPasscodeState,
   revokeStationPasscode,
   evaluateSignupCooldown,
   clearSignupCooldown,
+  // The cooldown's own tunables. BS#2361's endpoint needs the hold duration
+  // for its refusal message ("the gate stays closed for N minutes"), and
+  // BS#2362's status response needs all three so it can describe the rule it
+  // is reporting against ("21 failures in 10 minutes holds for 15") — either
+  // way the number has to come from the module's own constant rather than be
+  // restated by a caller.
+  SIGNUP_COOLDOWN_WINDOW_MS,
+  SIGNUP_COOLDOWN_HOLD_MS,
+  SIGNUP_COOLDOWN_THRESHOLD,
   readRecentSignupAttempts,
   pruneSignupAttempts,
   StationPasscodeCapExceededError,
@@ -49,10 +64,6 @@ export {
   // #2362's admin surface can match the marker exactly instead of by prose,
   // and tell "a manager revoked this" apart from "a key rotation retired it".
   STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON,
-  // The cooldown hold duration (BS#2361): the endpoint's refusal message
-  // tells a caller how long the station-global gate stays closed, so it
-  // must read the module's own constant rather than restate the number.
-  SIGNUP_COOLDOWN_HOLD_MS,
 } from './station-passcode';
 export type {
   StationPasscodeDecryptFailureReason,
@@ -61,6 +72,9 @@ export type {
   RotatedStationPasscode,
   RevokeStationPasscodeOptions,
   RevealedStationPasscode,
+  StationPasscodeState,
+  StationPasscodeStateRow,
+  ReadStationPasscodeStatesOptions,
   VerifyStationPasscodeOptions,
   VerifyStationPasscodeResult,
   MatchStationPasscodeResult,

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -56,9 +56,20 @@ export {
   SIGNUP_COOLDOWN_HOLD_MS,
   SIGNUP_COOLDOWN_THRESHOLD,
   readRecentSignupAttempts,
+  // The WINDOW-WIDE outcome census (BS#2362 review). readRecentSignupAttempts
+  // is a capped display list, so counting its rows saturates at the cap; the
+  // status endpoint's per-outcome numbers come from this SQL aggregate
+  // instead, and its "last clear" from readLastCooldownClearedAt rather than
+  // from whatever survived the cap.
+  countSignupAttemptOutcomes,
+  readLastCooldownClearedAt,
   pruneSignupAttempts,
   StationPasscodeCapExceededError,
   StationPasscodeDecryptionError,
+  // The key-is-not-configured failure, kept distinct from a decrypt failure
+  // so apps/auth can answer 503 `passcode_key_unset` instead of blaming
+  // STATION_PASSCODE_KEY_PREVIOUS for a missing current key.
+  StationPasscodeKeyUnsetError,
   // The `revoked_reason` rotateStationPasscode writes when it administratively
   // revokes an active row that will not decrypt (BS#2359 review). Exported so
   // #2362's admin surface can match the marker exactly instead of by prose,
@@ -80,6 +91,7 @@ export type {
   MatchStationPasscodeResult,
   SignupCooldownEvaluation,
   ReadRecentSignupAttemptsOptions,
+  CountSignupAttemptOutcomesOptions,
   PruneSignupAttemptsOptions,
   StationSignupOutcome,
 } from './station-passcode';

--- a/shared/authentication/src/station-passcode.ts
+++ b/shared/authentication/src/station-passcode.ts
@@ -1474,6 +1474,116 @@ export async function verifyStationPasscode(
 }
 
 // ---------------------------------------------------------------------------
+// Passcode state (BS#2362's status endpoint)
+// ---------------------------------------------------------------------------
+
+export type StationPasscodeState = 'active' | 'revoked' | 'expired';
+
+export interface StationPasscodeStateRow {
+  id: string;
+  state: StationPasscodeState;
+  createdAt: Date;
+  createdBy: string | null;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  revokedReason: string | null;
+  /**
+   * The row was retired by rotation's auto-revoke (its `revoked_reason` is
+   * STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON) rather than by a manager.
+   * Surfaced separately so a status screen can say "a key rotation killed
+   * this code" instead of implying a person did.
+   */
+  revokedByKeyRotation: boolean;
+  lastUsedAt: Date | null;
+  useCount: number;
+  maxUses: number;
+  /**
+   * `use_count >= max_uses`. Such a row is still ACTIVE by the SQL predicate
+   * — nothing revokes it on exhaustion — but `verifyStationPasscode`'s claim
+   * UPDATE carries `use_count < max_uses`, so every further attempt logs
+   * `passcode_exhausted`. A status screen has to say that out loud or a dead
+   * sticky note reads as a live one.
+   */
+  exhausted: boolean;
+}
+
+/**
+ * Pure classifier, kept beside `isStationPasscodeActive` for the same reason
+ * that one exists: the SQL and the JS are two hand-synced statements of one
+ * rule.
+ *
+ * REVOKED WINS over expired when a row is both. Revocation is a deliberate
+ * operator action and expiry is the passage of time, so the operator action
+ * is the more informative of the two — and it is the only one of the pair
+ * that carries a `revoked_reason` worth reading.
+ */
+export function classifyStationPasscodeState(
+  row: { revokedAt: Date | null; expiresAt: Date },
+  now: Date
+): StationPasscodeState {
+  if (row.revokedAt !== null) return 'revoked';
+  return row.expiresAt.getTime() > now.getTime() ? 'active' : 'expired';
+}
+
+export interface ReadStationPasscodeStatesOptions {
+  now?: Date;
+  /** How far back inactive rows are reported. Defaults to the 30-day classification horizon. */
+  horizonMs?: number;
+}
+
+/**
+ * Every passcode row a manager needs to see: the active ones, plus the ones
+ * that went inactive inside the horizon. Read-only, and it NEVER decrypts —
+ * plaintext is `revealStationPasscode`'s job, and only that path writes the
+ * `passcode_revealed` audit row that replaces show-once storage's structural
+ * guarantee. The projection deliberately omits `code_encrypted` entirely so
+ * no caller can be tempted to open it off this path.
+ *
+ * TWO deliberate divergences from `recentlyInactivePasscodePredicate`, whose
+ * job (bounding the classification sweep) is not this one:
+ *
+ *   1. No `revoked_reason IS DISTINCT FROM
+ *      STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON` exclusion. That term
+ *      is mark-and-exclude, and a row rotation auto-revoked is exactly what a
+ *      manager most needs to see here — it means a sticky note in the room is
+ *      dead. Excluding it would hide the one event this screen exists to
+ *      report.
+ *   2. Active rows are included, which the classification predicate excludes
+ *      by construction. No separate OR term is needed for them: an active row
+ *      has `expires_at > now >= since`, so `expires_at >= since` already
+ *      matches it.
+ */
+export async function readStationPasscodeStates(
+  options: ReadStationPasscodeStatesOptions = {}
+): Promise<StationPasscodeStateRow[]> {
+  const now = options.now ?? new Date();
+  const since = new Date(now.getTime() - (options.horizonMs ?? STATION_PASSCODE_CLASSIFICATION_HORIZON_MS));
+
+  const rows = await db
+    .select({
+      id: station_passcode.id,
+      createdAt: station_passcode.createdAt,
+      createdBy: station_passcode.createdBy,
+      expiresAt: station_passcode.expiresAt,
+      revokedAt: station_passcode.revokedAt,
+      revokedReason: station_passcode.revokedReason,
+      lastUsedAt: station_passcode.lastUsedAt,
+      useCount: station_passcode.useCount,
+      maxUses: station_passcode.maxUses,
+    })
+    .from(station_passcode)
+    .where(or(gte(station_passcode.revokedAt, since), gte(station_passcode.expiresAt, since)))
+    .orderBy(desc(station_passcode.createdAt));
+
+  return rows.map((row) => ({
+    ...row,
+    state: classifyStationPasscodeState(row, now),
+    revokedByKeyRotation: row.revokedReason === STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON,
+    exhausted: row.useCount >= row.maxUses,
+  }));
+}
+
+// ---------------------------------------------------------------------------
 // Reveal
 // ---------------------------------------------------------------------------
 

--- a/shared/authentication/src/station-passcode.ts
+++ b/shared/authentication/src/station-passcode.ts
@@ -358,6 +358,42 @@ export class StationPasscodeDecryptionError extends Error {
   }
 }
 
+/**
+ * Thrown when an operation that CANNOT proceed without `STATION_PASSCODE_KEY`
+ * is asked to run on a process that does not have it — reveal, which must
+ * decrypt, and rotate, which must encrypt.
+ *
+ * A DISTINCT type rather than the bare `Error` resolveStationPasscodeKey
+ * throws, because "the key is not configured" and "a row will not open" need
+ * different answers from an operator. Without it the two collapsed in three
+ * different wrong ways at the admin surface (BS#2362 review):
+ *
+ *   - rotate fell through to a generic, code-less 500;
+ *   - reveal WITH an active row surfaced as a StationPasscodeDecryptionError
+ *     with `reason: 'corrupt'` (activeRowDecryptionError's default for a
+ *     non-typed throw), whose remedy names STATION_PASSCODE_KEY_PREVIOUS —
+ *     the one variable that cannot fix a missing current key;
+ *   - reveal with NO rows answered `200 {passcodes: []}`, which reads as "the
+ *     station has no live code" when the truth is "this process cannot read
+ *     one".
+ *
+ * Deliberately NOT thrown from resolveStationPasscodeKey itself. That would
+ * retype the failure on the PUBLIC signup path too, where the current
+ * fail-closed behaviour (an active row that will not open logs
+ * `passcode_unverifiable` and throws) is exactly right and must not start
+ * naming server configuration in a response an unauthenticated caller can
+ * see. The guard is applied at the two admin entry points instead — see
+ * assertStationPasscodeKeyConfigured.
+ */
+export class StationPasscodeKeyUnsetError extends Error {
+  constructor(
+    message = 'STATION_PASSCODE_KEY is not set, so station passcodes can be neither decrypted nor minted by this process.'
+  ) {
+    super(message);
+    this.name = 'StationPasscodeKeyUnsetError';
+  }
+}
+
 /** Thrown by rotateStationPasscode when two passcodes are already active. */
 export class StationPasscodeCapExceededError extends Error {
   constructor() {
@@ -403,6 +439,21 @@ function resolveStationPasscodeKey(): Buffer {
   const raw = process.env.STATION_PASSCODE_KEY;
   if (!raw) throw new Error('STATION_PASSCODE_KEY is not set');
   return parseStationPasscodeKeyEnv('STATION_PASSCODE_KEY', raw);
+}
+
+/**
+ * Upfront presence check for the two ADMIN operations that need the key
+ * (reveal, rotate), run before they touch a row. Cheap, and it is what turns
+ * "unconfigured" into its own typed failure without changing what the public
+ * signup path does — see StationPasscodeKeyUnsetError for why the throw site
+ * is here rather than inside resolveStationPasscodeKey.
+ *
+ * Presence only. A key that is SET but malformed is still
+ * parseStationPasscodeKeyEnv's error to report, since that message names the
+ * actual defect (byte length) and this one cannot.
+ */
+function assertStationPasscodeKeyConfigured(): void {
+  if (!process.env.STATION_PASSCODE_KEY) throw new StationPasscodeKeyUnsetError();
 }
 
 let warnedMalformedPreviousKey = false;
@@ -826,7 +877,17 @@ export interface ReadRecentSignupAttemptsOptions {
   since?: Date;
 }
 
-/** For the admin API (#2362) to display recent attempts. */
+/**
+ * The NEWEST `limit` attempt rows at or after `since` — a display list for
+ * the admin API (#2362), not a census.
+ *
+ * `ORDER BY attempted_at DESC LIMIT n` truncates, so anything a caller
+ * derives from the returned array is a statement about the newest `limit`
+ * rows and NOT about the window. Counting outcomes off this list saturates
+ * at `limit` and loses every clear/reveal/ok row a burst has pushed past the
+ * cap; use countSignupAttemptOutcomes for counts and
+ * evaluateSignupCooldown's `clearedAt` for the last clear.
+ */
 export async function readRecentSignupAttempts(options: ReadRecentSignupAttemptsOptions = {}) {
   const { limit = 100, since = new Date(0) } = options;
   return db
@@ -835,6 +896,47 @@ export async function readRecentSignupAttempts(options: ReadRecentSignupAttempts
     .where(gte(station_signup_attempt.attemptedAt, since))
     .orderBy(desc(station_signup_attempt.attemptedAt))
     .limit(limit);
+}
+
+export interface CountSignupAttemptOutcomesOptions {
+  /** Floor on `attempted_at`. Defaults to the epoch, i.e. the whole log. */
+  since?: Date;
+}
+
+/**
+ * `SELECT outcome, count(*) ... GROUP BY outcome` over the window — one row
+ * per outcome actually present, so an absent outcome is ABSENT rather than
+ * zero.
+ *
+ * Counted in Postgres, deliberately. The status endpoint used to build these
+ * numbers by iterating readRecentSignupAttempts, which is capped at 100 rows
+ * TOTAL, so a "24-hour" figure silently saturated the moment a burst filled
+ * the cap — and it could report fewer `passcode_fail` over 24 hours than
+ * evaluateSignupCooldown's SQL-aggregated count over 10 minutes, which is a
+ * self-contradictory payload. The row cap belongs to the display list only
+ * (BS#2362 review).
+ *
+ * The aggregate is O(1) transfer for this process regardless of how many
+ * rows an attacker put in the window — the same reason evaluateSignupCooldown
+ * moved its two counts into SQL. Served by the composite
+ * (outcome, attempted_at) index; see the table's header comment in schema.ts.
+ */
+export async function countSignupAttemptOutcomes(
+  options: CountSignupAttemptOutcomesOptions = {}
+): Promise<Record<string, number>> {
+  const { since = new Date(0) } = options;
+  const rows = await db
+    .select({
+      outcome: station_signup_attempt.outcome,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(station_signup_attempt)
+    .where(gte(station_signup_attempt.attemptedAt, since))
+    .groupBy(station_signup_attempt.outcome);
+
+  const counts: Record<string, number> = {};
+  for (const row of rows) counts[row.outcome] = row.count;
+  return counts;
 }
 
 export interface PruneSignupAttemptsOptions {
@@ -971,6 +1073,31 @@ export function resolveCooldownCountStart(now: Date, clearedAt: Date | null): Da
 export const SIGNUP_COOLDOWN_TRIGGER_ROW_LIMIT = 500;
 
 /**
+ * `attempted_at` of the most recent `cooldown_cleared` row in the whole log,
+ * or null if a manager has never cleared. Indexed, `LIMIT 1`.
+ *
+ * Query 1 of evaluateSignupCooldown, extracted so the status endpoint can
+ * ask the same question directly (BS#2362 review). It previously answered it
+ * by scanning readRecentSignupAttempts' capped display list for a
+ * `cooldown_cleared` row, which reverts to null as soon as 100 attempts land
+ * after the clear — minutes, during the `cooldown_refused` storm that is
+ * exactly when a manager is polling to confirm their clear took.
+ *
+ * NOT scoped to any window. The clear is a floor on all subsequent evaluation
+ * (see resolveCooldownLookbackStart), so the row that matters is the latest
+ * one there has ever been, whatever the caller's display window happens to be.
+ */
+export async function readLastCooldownClearedAt(): Promise<Date | null> {
+  const [clearedRow] = await db
+    .select({ attemptedAt: station_signup_attempt.attemptedAt })
+    .from(station_signup_attempt)
+    .where(eq(station_signup_attempt.outcome, 'cooldown_cleared'))
+    .orderBy(desc(station_signup_attempt.attemptedAt))
+    .limit(1);
+  return clearedRow?.attemptedAt ?? null;
+}
+
+/**
  * Evaluate the station-global signup cooldown. Read-only — safe to call on
  * every poll of a status endpoint (#2362) without side effects.
  *
@@ -1002,13 +1129,7 @@ export const SIGNUP_COOLDOWN_TRIGGER_ROW_LIMIT = 500;
  * allFailureCount }`.
  */
 export async function evaluateSignupCooldown(now: Date = new Date()): Promise<SignupCooldownEvaluation> {
-  const [clearedRow] = await db
-    .select({ attemptedAt: station_signup_attempt.attemptedAt })
-    .from(station_signup_attempt)
-    .where(eq(station_signup_attempt.outcome, 'cooldown_cleared'))
-    .orderBy(desc(station_signup_attempt.attemptedAt))
-    .limit(1);
-  const clearedAt = clearedRow?.attemptedAt ?? null;
+  const clearedAt = await readLastCooldownClearedAt();
 
   const [counts] = await db
     .select({
@@ -1600,11 +1721,29 @@ export interface RevealedStationPasscode {
  * one `passcode_revealed` attempt per row revealed. Active-row decrypt
  * failure fails closed here too — same gate-integrity argument as
  * verifyStationPasscode.
+ *
+ * TWO PASSES, not one (BS#2362 review). Every row is decrypted first, and
+ * only then are the audit rows written. Interleaving them left a
+ * `passcode_revealed` row for row 1 when row 2 would not decrypt and the call
+ * threw — an audit trail claiming the manager received a code they never saw,
+ * in the one place the audit trail IS the security control (it is what
+ * replaces show-once storage's structural guarantee). All-or-nothing is the
+ * only reading of that log that can be trusted.
+ *
+ * The error semantics are unchanged: an undecryptable active row still logs
+ * `passcode_unverifiable` and throws StationPasscodeDecryptionError, and now
+ * writes NO `passcode_revealed` row at all rather than a partial set.
  */
 export async function revealStationPasscode(
   actorUserId: string,
   now: Date = new Date()
 ): Promise<RevealedStationPasscode[]> {
+  // Before the read: a process with no key cannot open a single row, and
+  // without this the empty-table case answers "no codes exist" and the
+  // non-empty case blames STATION_PASSCODE_KEY_PREVIOUS for a missing
+  // current key. See StationPasscodeKeyUnsetError.
+  assertStationPasscodeKeyConfigured();
+
   const activeRows = await db.select().from(station_passcode).where(activePasscodePredicate(now));
 
   const revealed: RevealedStationPasscode[] = [];
@@ -1636,7 +1775,13 @@ export async function revealStationPasscode(
       useCount: row.useCount,
       maxUses: row.maxUses,
     });
-    await insertSignupAttempt({ outcome: 'passcode_revealed', passcodeId: row.id, actorUserId, attemptedAt: now });
+  }
+
+  // Second pass — see the two-passes note above. Reached only when every
+  // active row opened, so the log says "the manager received exactly these
+  // codes" and never a prefix of them.
+  for (const entry of revealed) {
+    await insertSignupAttempt({ outcome: 'passcode_revealed', passcodeId: entry.id, actorUserId, attemptedAt: now });
   }
   return revealed;
 }
@@ -1705,6 +1850,12 @@ export interface RotatedStationPasscode {
 export async function rotateStationPasscode(
   options: RotateStationPasscodeOptions = {}
 ): Promise<RotatedStationPasscode> {
+  // Before the advisory lock and before generateStationPasscode's encrypt:
+  // without the key this call cannot mint anything, and the bare Error
+  // resolveStationPasscodeKey throws reaches the admin surface as a
+  // code-less 500. See StationPasscodeKeyUnsetError.
+  assertStationPasscodeKeyConfigured();
+
   const now = options.now ?? new Date();
   const ttlMs = options.ttlMs ?? STATION_PASSCODE_DEFAULT_TTL_MS;
   const maxUses = options.maxUses ?? STATION_PASSCODE_DEFAULT_MAX_USES;

--- a/tests/integration/station-signup-admin.spec.js
+++ b/tests/integration/station-signup-admin.spec.js
@@ -1,0 +1,700 @@
+/**
+ * Integration tests for the station-signup manager API (BS#2362): reveal,
+ * rotate, revoke, clear-cooldown, status, and approve.
+ *
+ * These drive the REAL endpoints over HTTP against the running auth service
+ * and assert against real Postgres, because every property worth testing here
+ * is a side effect on a row rather than a return value:
+ *
+ *   - the admin-flag gate is middleware-shaped, so only a real request can
+ *     show that an unauthenticated caller and a plain-DJ session are both
+ *     turned away from all six routes;
+ *   - reveal's audit row is the thing that REPLACES show-once storage's
+ *     structural guarantee, so "the plaintext came back" is only half the
+ *     assertion — the `passcode_revealed` row carrying the acting manager's
+ *     id is the other half, and it must carry the SESSION's id, not one the
+ *     caller could have named;
+ *   - clear-cooldown's whole contract is "writes a floor row, deletes
+ *     nothing", which is a statement about what is still in the attempt log
+ *     afterwards;
+ *   - approve shares a mandatory `auth_user`-first lock order with
+ *     `jobs/station-signup-review`'s actuator, and the last case here runs
+ *     that job's REAL compiled `applyDowngrades` against an account this
+ *     endpoint just approved.
+ *
+ * The auth service needs `STATION_PASSCODE_KEY` to be set; CI's "Start
+ * services" step and `dev_env/docker-compose.yml`'s ci profile both set a
+ * fixed test key. This spec never needs the key itself — it obtains plaintext
+ * only from the endpoints' own responses.
+ */
+
+// `tests/__mocks__/drizzle-orm.ts` is auto-applied to every `drizzle-orm`
+// require (it exists for the ts-jest unit tier). The compiled job bundle the
+// race case drives needs the REAL drizzle-orm, whose query builder produces
+// the SQL `@wxyc/database`'s driver runs. Same pattern as
+// `station-signup-review.spec.js`. Hoisted above the requires below.
+jest.unmock('drizzle-orm');
+
+const path = require('path');
+const { getTestDb } = require('../utils/db');
+
+const distDir = path.join(__dirname, '..', '..', 'jobs', 'station-signup-review', 'dist');
+const { queryPendingSelfSignups } = require(path.join(distDir, 'query.cjs'));
+const { planDowngrades, applyDowngrades } = require(path.join(distDir, 'downgrade.cjs'));
+const { db } = require('@wxyc/database');
+
+const BASE = '/auth/admin/station-signup';
+
+/** Every route this issue adds, with the method it answers on. Drives the gate table below. */
+const ROUTES = [
+  { method: 'POST', path: `${BASE}/reveal` },
+  { method: 'POST', path: `${BASE}/rotate` },
+  { method: 'POST', path: `${BASE}/revoke` },
+  { method: 'POST', path: `${BASE}/clear-cooldown` },
+  { method: 'GET', path: `${BASE}/status` },
+  { method: 'POST', path: `${BASE}/approve` },
+];
+
+function getAuthBaseUrl() {
+  if (process.env.BETTER_AUTH_URL) {
+    try {
+      return new URL(process.env.BETTER_AUTH_URL).toString().replace(/\/$/, '');
+    } catch {
+      // fall through
+    }
+  }
+  const host = process.env.AUTH_HOST || 'localhost';
+  const port = process.env.AUTH_PORT || process.env.CI_AUTH_PORT || 8083;
+  return `http://${host}:${port}/auth`;
+}
+
+/** Root of the auth service (getAuthBaseUrl() already ends in `/auth`, which every route below repeats). */
+const authRoot = () => getAuthBaseUrl().replace(/\/auth$/, '');
+
+async function signIn(username, password = 'testpassword123') {
+  const res = await fetch(`${getAuthBaseUrl()}/sign-in/username`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) throw new Error(`Sign-in as ${username} failed: ${res.status} ${await res.text()}`);
+  const cookies = res.headers.getSetCookie();
+  if (!cookies || cookies.length === 0) throw new Error(`No session cookie returned signing in as ${username}`);
+  return cookies.map((c) => c.split(';')[0].trim()).join('; ');
+}
+
+async function call(method, routePath, { cookie, body } = {}) {
+  const res = await fetch(`${authRoot()}${routePath}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    // Non-JSON body (an HTML 404 from a route that isn't mounted) — the
+    // status assertion still reports usefully, and `raw` carries the rest.
+  }
+  return { status: res.status, body: json, raw: text };
+}
+
+describe('station-signup manager API (BS#2362, real endpoints, real Postgres)', () => {
+  let sql;
+  let managerCookie;
+  let djCookie;
+  let managerUserId;
+  let organizationId;
+  /** Seeded `auth_user` ids, deleted in afterEach (auth_member CASCADEs). */
+  const userIds = [];
+  let previousDowngradeFlag;
+
+  const uniqueId = () => `ssa-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+  /** Seed one self-signed-up account plus its membership row in the default org. */
+  async function seedAccount({ daysPending = 31, memberRole = 'dj', downgraded = false, selfSignup = true } = {}) {
+    const id = uniqueId();
+    await sql`
+      INSERT INTO auth_user (id, name, email, role, self_signup_at, self_signup_downgraded_at)
+      VALUES (
+        ${id},
+        'SSA Test DJ',
+        ${`${id}@test.wxyc.org`},
+        'user',
+        ${selfSignup ? sql`now() - make_interval(days => ${daysPending})` : null},
+        ${downgraded ? sql`now()` : null}
+      )
+    `;
+    userIds.push(id);
+    await sql`
+      INSERT INTO auth_member (id, organization_id, user_id, role)
+      VALUES (${`${id}-m`}, ${organizationId}, ${id}, ${memberRole})
+    `;
+    return id;
+  }
+
+  const authUserRowOf = async (userId) => {
+    const rows = await sql`
+      SELECT self_signup_at, self_signup_reviewed_at, self_signup_reviewed_by, self_signup_downgraded_at, role
+      FROM auth_user WHERE id = ${userId}
+    `;
+    return rows[0];
+  };
+
+  const memberRoleOf = async (userId) => {
+    const rows = await sql`SELECT role FROM auth_member WHERE user_id = ${userId}`;
+    return rows[0]?.role ?? null;
+  };
+
+  const attemptsWithOutcome = async (outcome) =>
+    sql`SELECT * FROM station_signup_attempt WHERE outcome = ${outcome} ORDER BY attempted_at ASC`;
+
+  /** Seed n `passcode_fail` rows spread across the last `spreadSeconds` seconds. */
+  async function seedFailures(n, spreadSeconds = 120) {
+    for (let i = 0; i < n; i += 1) {
+      await sql`
+        INSERT INTO station_signup_attempt (id, attempted_at, outcome)
+        VALUES (${`${uniqueId()}-f${i}`}, now() - make_interval(secs => ${(i * spreadSeconds) / n}), 'passcode_fail')
+      `;
+    }
+  }
+
+  beforeAll(async () => {
+    sql = getTestDb();
+    managerCookie = await signIn('test_station_manager');
+    djCookie = await signIn('test_dj1');
+
+    const managerRows = await sql`SELECT id FROM auth_user WHERE username = 'test_station_manager'`;
+    if (managerRows.length === 0) throw new Error('test_station_manager fixture account is missing');
+    managerUserId = managerRows[0].id;
+
+    const orgs = await sql`SELECT id FROM auth_organization ORDER BY created_at ASC LIMIT 1`;
+    if (orgs.length === 0) throw new Error('No auth_organization row; cannot seed auth_member.');
+    organizationId = orgs[0].id;
+
+    previousDowngradeFlag = process.env.STATION_SIGNUP_DOWNGRADE_ENABLED;
+    process.env.STATION_SIGNUP_DOWNGRADE_ENABLED = 'true';
+  });
+
+  afterAll(async () => {
+    if (previousDowngradeFlag === undefined) delete process.env.STATION_SIGNUP_DOWNGRADE_ENABLED;
+    else process.env.STATION_SIGNUP_DOWNGRADE_ENABLED = previousDowngradeFlag;
+    await sql`DELETE FROM station_signup_attempt`;
+    await sql`DELETE FROM station_passcode`;
+  });
+
+  // Both tables are exclusive to the passcode specs in this database, so a
+  // wholesale wipe between cases is safe — same as station-passcode.spec.js.
+  beforeEach(async () => {
+    await sql`DELETE FROM station_signup_attempt`;
+    await sql`DELETE FROM station_passcode`;
+  });
+
+  afterEach(async () => {
+    if (userIds.length > 0) {
+      // auth_member's FK to auth_user is ON DELETE CASCADE.
+      await sql`DELETE FROM auth_user WHERE id = ANY(${userIds})`;
+      userIds.length = 0;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // The gate
+  // -------------------------------------------------------------------------
+
+  describe('admin-flag gate', () => {
+    it.each(ROUTES)('$method $path rejects an unauthenticated caller with 401', async ({ method, path: routePath }) => {
+      const res = await call(method, routePath, { body: method === 'POST' ? {} : undefined });
+      expect(res.status).toBe(401);
+    });
+
+    it.each(ROUTES)('$method $path rejects a plain DJ session with 403', async ({ method, path: routePath }) => {
+      const res = await call(method, routePath, { cookie: djCookie, body: method === 'POST' ? {} : undefined });
+      expect(res.status).toBe(403);
+    });
+
+    it('a rejected call writes NOTHING — no passcode row, no attempt row', async () => {
+      await call('POST', `${BASE}/rotate`, { cookie: djCookie, body: {} });
+      await call('POST', `${BASE}/reveal`, { cookie: djCookie, body: {} });
+      await call('POST', `${BASE}/clear-cooldown`, { cookie: djCookie, body: {} });
+
+      const passcodes = await sql`SELECT * FROM station_passcode`;
+      const attempts = await sql`SELECT * FROM station_signup_attempt`;
+      expect(passcodes).toHaveLength(0);
+      expect(attempts).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rotate
+  // -------------------------------------------------------------------------
+
+  describe('rotate', () => {
+    it('returns the plaintext once, persists an active row, and attributes created_by to the acting manager', async () => {
+      const res = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      expect(res.status).toBe(200);
+      expect(typeof res.body.code).toBe('string');
+      expect(res.body.code).toMatch(/^[2-9A-HJ-NP-Z]{8}$/);
+      expect(res.body.autoRevokedPasscodeIds).toEqual([]);
+
+      const rows = await sql`SELECT * FROM station_passcode WHERE id = ${res.body.id}`;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].created_by).toBe(managerUserId);
+      expect(rows[0].revoked_at).toBeNull();
+      // The plaintext is never stored — only its ciphertext.
+      expect(rows[0].code_encrypted).not.toContain(res.body.code);
+    });
+
+    it('refuses a THIRD active code with 409 rather than retiring a note the room is using', async () => {
+      const first = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      const second = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+
+      const third = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      expect(third.status).toBe(409);
+      expect(third.body.code).toBe('passcode_cap_exceeded');
+
+      const active = await sql`SELECT * FROM station_passcode WHERE revoked_at IS NULL AND expires_at > now()`;
+      expect(active).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reveal
+  // -------------------------------------------------------------------------
+
+  describe('reveal', () => {
+    it('returns the same plaintext rotate minted, without rotating anything', async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      const revealed = await call('POST', `${BASE}/reveal`, { cookie: managerCookie, body: {} });
+
+      expect(revealed.status).toBe(200);
+      expect(revealed.body.passcodes.map((p) => p.code)).toEqual([rotated.body.code]);
+      // Reveal exists precisely so a manager does NOT have to rotate to read
+      // the code aloud: still one row, still the same one.
+      const active = await sql`SELECT id FROM station_passcode WHERE revoked_at IS NULL AND expires_at > now()`;
+      expect(active.map((r) => r.id)).toEqual([rotated.body.id]);
+    });
+
+    it('writes one passcode_revealed audit row per revealed code, carrying the SESSION actor id', async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await call('POST', `${BASE}/reveal`, { cookie: managerCookie, body: {} });
+
+      const audit = await attemptsWithOutcome('passcode_revealed');
+      expect(audit).toHaveLength(1);
+      expect(audit[0].actor_user_id).toBe(managerUserId);
+      expect(audit[0].passcode_id).toBe(rotated.body.id);
+    });
+
+    it('cannot have its actor spoofed from the request body', async () => {
+      await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      await call('POST', `${BASE}/reveal`, {
+        cookie: managerCookie,
+        body: { actorUserId: 'somebody-else', userId: 'somebody-else' },
+      });
+
+      const audit = await attemptsWithOutcome('passcode_revealed');
+      expect(audit).toHaveLength(1);
+      expect(audit[0].actor_user_id).toBe(managerUserId);
+    });
+
+    it('reveals both active codes and audits both', async () => {
+      const first = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      const second = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      const revealed = await call('POST', `${BASE}/reveal`, { cookie: managerCookie, body: {} });
+
+      expect(revealed.body.passcodes.map((p) => p.code).sort()).toEqual([first.body.code, second.body.code].sort());
+      expect(await attemptsWithOutcome('passcode_revealed')).toHaveLength(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Revoke
+  // -------------------------------------------------------------------------
+
+  describe('revoke', () => {
+    it("sets revoked_reason = 'manual' and takes the row out of the active set", async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      const res = await call('POST', `${BASE}/revoke`, {
+        cookie: managerCookie,
+        body: { passcodeId: rotated.body.id },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ passcodeId: rotated.body.id, revoked: true });
+
+      const rows = await sql`SELECT * FROM station_passcode WHERE id = ${rotated.body.id}`;
+      expect(rows[0].revoked_reason).toBe('manual');
+      expect(rows[0].revoked_at).not.toBeNull();
+    });
+
+    it('is an idempotent no-op the second time, and on an unknown id', async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await call('POST', `${BASE}/revoke`, { cookie: managerCookie, body: { passcodeId: rotated.body.id } });
+
+      const again = await call('POST', `${BASE}/revoke`, {
+        cookie: managerCookie,
+        body: { passcodeId: rotated.body.id },
+      });
+      const unknown = await call('POST', `${BASE}/revoke`, { cookie: managerCookie, body: { passcodeId: 'nope' } });
+
+      expect(again.body.revoked).toBe(false);
+      expect(unknown.body.revoked).toBe(false);
+    });
+
+    it('rejects a missing passcodeId with 400', async () => {
+      const res = await call('POST', `${BASE}/revoke`, { cookie: managerCookie, body: {} });
+      expect(res.status).toBe(400);
+    });
+
+    it('frees a slot under the two-row cap', async () => {
+      const first = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      expect((await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} })).status).toBe(409);
+
+      await call('POST', `${BASE}/revoke`, { cookie: managerCookie, body: { passcodeId: first.body.id } });
+
+      expect((await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} })).status).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Clear cooldown — the anti-lockout escape hatch
+  // -------------------------------------------------------------------------
+
+  describe('clear-cooldown', () => {
+    it('lifts an ACTIVE cooldown by writing a floor row, and deletes nothing', async () => {
+      await seedFailures(25);
+
+      const before = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      expect(before.body.cooldown.inCooldown).toBe(true);
+
+      const cleared = await call('POST', `${BASE}/clear-cooldown`, { cookie: managerCookie, body: {} });
+      expect(cleared.status).toBe(200);
+      expect(cleared.body.cleared).toBe(true);
+      expect(cleared.body.cooldown.inCooldown).toBe(false);
+
+      const after = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      expect(after.body.cooldown.inCooldown).toBe(false);
+      // The floor is a floor, not a rewrite of history: every seeded failure
+      // is still in the log, which is both the cooldown's input and the
+      // 30-day audit trail.
+      expect(await attemptsWithOutcome('passcode_fail')).toHaveLength(25);
+      const clearRows = await attemptsWithOutcome('cooldown_cleared');
+      expect(clearRows).toHaveLength(1);
+      expect(clearRows[0].actor_user_id).toBe(managerUserId);
+    });
+
+    it('re-engages if the attack resumes after the clear — the floor is not a permanent exemption', async () => {
+      await seedFailures(25);
+      await call('POST', `${BASE}/clear-cooldown`, { cookie: managerCookie, body: {} });
+      expect((await call('GET', `${BASE}/status`, { cookie: managerCookie })).body.cooldown.inCooldown).toBe(false);
+
+      // Spread 0, so every resumed failure is stamped `now()` and lands
+      // strictly AFTER the clear row. That is what "the attack resumes" has
+      // to mean here: the clear is a floor on `attempted_at`
+      // (resolveCooldownCountStart), so back-dating these behind it would be
+      // testing that the floor works rather than that it expires, and would
+      // leave the cooldown correctly disengaged.
+      await seedFailures(25, 0);
+
+      expect((await call('GET', `${BASE}/status`, { cookie: managerCookie })).body.cooldown.inCooldown).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Status
+  // -------------------------------------------------------------------------
+
+  describe('status', () => {
+    it('writes nothing — it is safe to poll', async () => {
+      await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      const attemptsBefore = await sql`SELECT count(*)::int AS c FROM station_signup_attempt`;
+
+      await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      await call('GET', `${BASE}/status`, { cookie: managerCookie });
+
+      const attemptsAfter = await sql`SELECT count(*)::int AS c FROM station_signup_attempt`;
+      expect(attemptsAfter[0].c).toBe(attemptsBefore[0].c);
+    });
+
+    it('reports active-code state with use_count/max_uses and last_used_at, and never any plaintext', async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+
+      expect(res.status).toBe(200);
+      const row = res.body.passcodes.find((p) => p.id === rotated.body.id);
+      expect(row).toMatchObject({
+        state: 'active',
+        useCount: 0,
+        maxUses: 25,
+        lastUsedAt: null,
+        exhausted: false,
+        revokedByKeyRotation: false,
+      });
+      expect(JSON.stringify(res.body)).not.toContain(rotated.body.code);
+      expect(row.codeEncrypted).toBeUndefined();
+    });
+
+    it('reports a revoked row with its reason, and an expired row as expired', async () => {
+      const revoked = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await call('POST', `${BASE}/revoke`, { cookie: managerCookie, body: { passcodeId: revoked.body.id } });
+
+      const expiredId = `${uniqueId()}-exp`;
+      await sql`
+        INSERT INTO station_passcode (id, code_encrypted, expires_at)
+        VALUES (${expiredId}, 'not-a-real-ciphertext', now() - interval '1 hour')
+      `;
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      const byId = Object.fromEntries(res.body.passcodes.map((p) => [p.id, p]));
+
+      expect(byId[revoked.body.id]).toMatchObject({ state: 'revoked', revokedReason: 'manual' });
+      expect(byId[expiredId]).toMatchObject({ state: 'expired' });
+    });
+
+    it('flags an exhausted row, which is still "active" by the SQL predicate', async () => {
+      const rotated = await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await sql`UPDATE station_passcode SET use_count = max_uses, last_used_at = now() WHERE id = ${rotated.body.id}`;
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      const row = res.body.passcodes.find((p) => p.id === rotated.body.id);
+
+      expect(row.state).toBe('active');
+      expect(row.exhausted).toBe(true);
+      expect(row.lastUsedAt).not.toBeNull();
+    });
+
+    it('reports the failure counts, the rule they are measured against, and the recent attempts', async () => {
+      await seedFailures(3, 60);
+      await sql`
+        INSERT INTO station_signup_attempt (id, attempted_at, outcome)
+        VALUES (${`${uniqueId()}-x`}, now(), 'passcode_expired')
+      `;
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+
+      expect(res.body.cooldown).toMatchObject({
+        inCooldown: false,
+        noMatchFailureCount: 3,
+        allFailureCount: 4,
+        windowMinutes: 10,
+        holdMinutes: 15,
+        threshold: 20,
+      });
+      expect(res.body.attempts.countsByOutcome).toMatchObject({ passcode_fail: 3, passcode_expired: 1 });
+      expect(res.body.attempts.recent).toHaveLength(4);
+    });
+
+    it('lists pending accounts with their days-pending and self_signup_downgraded_at', async () => {
+      const fresh = await seedAccount({ daysPending: 2, memberRole: 'dj' });
+      const overdue = await seedAccount({ daysPending: 40, memberRole: 'member', downgraded: true });
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+      const byId = Object.fromEntries(res.body.pendingReview.map((p) => [p.userId, p]));
+
+      expect(byId[fresh]).toMatchObject({ daysPending: 2, selfSignupDowngradedAt: null });
+      expect(byId[overdue].daysPending).toBe(40);
+      expect(byId[overdue].selfSignupDowngradedAt).not.toBeNull();
+      // PII stays off this payload: the derived display name is here, the
+      // legal name and the email are not.
+      expect(byId[fresh].name).toBe('SSA Test DJ');
+      expect(byId[fresh].email).toBeUndefined();
+      expect(byId[fresh].realName).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Approve
+  // -------------------------------------------------------------------------
+
+  describe('approve', () => {
+    it('stamps reviewed_at/_by from the SESSION, and refuses a client-supplied reviewer', async () => {
+      const userId = await seedAccount({ daysPending: 5, memberRole: 'dj' });
+
+      const res = await call('POST', `${BASE}/approve`, {
+        cookie: managerCookie,
+        body: { userId, reviewerId: 'somebody-else', selfSignupReviewedBy: 'somebody-else' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ userId, reviewedByThisCall: true, roleRestored: false, memberRole: 'dj' });
+
+      const row = await authUserRowOf(userId);
+      expect(row.self_signup_reviewed_at).not.toBeNull();
+      // The acting manager, never the body — this is what retires dj-site#1358's
+      // any-manager attribution residual.
+      expect(row.self_signup_reviewed_by).toBe(managerUserId);
+    });
+
+    it('takes the account out of the pending cohort the digest and dj-site both read', async () => {
+      const userId = await seedAccount({ daysPending: 5, memberRole: 'dj' });
+      expect((await queryPendingSelfSignups()).map((r) => r.userId)).toContain(userId);
+
+      await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+
+      expect((await queryPendingSelfSignups()).map((r) => r.userId)).not.toContain(userId);
+    });
+
+    describe('against an account the actuator already downgraded', () => {
+      it('WITHOUT restoreDjRole leaves it a member, and PRESERVES the downgrade marker', async () => {
+        const userId = await seedAccount({ daysPending: 40, memberRole: 'member', downgraded: true });
+        const markerBefore = (await authUserRowOf(userId)).self_signup_downgraded_at;
+
+        const res = await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ roleRestored: false, memberRole: 'member' });
+        expect(res.body.selfSignupDowngradedAt).not.toBeNull();
+        // Reviewing is not a history edit; the marker records what happened.
+        expect((await authUserRowOf(userId)).self_signup_downgraded_at).toEqual(markerBefore);
+        expect(await memberRoleOf(userId)).toBe('member');
+      });
+
+      it('WITH restoreDjRole hands the dj role back, and STILL preserves the marker', async () => {
+        const userId = await seedAccount({ daysPending: 40, memberRole: 'member', downgraded: true });
+        const markerBefore = (await authUserRowOf(userId)).self_signup_downgraded_at;
+
+        const res = await call('POST', `${BASE}/approve`, {
+          cookie: managerCookie,
+          body: { userId, restoreDjRole: true },
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ roleRestored: true, memberRole: 'dj' });
+        expect(await memberRoleOf(userId)).toBe('dj');
+        expect((await authUserRowOf(userId)).self_signup_downgraded_at).toEqual(markerBefore);
+        // And the re-promotion sticks, because the marker took the account out
+        // of the actuator for good.
+        expect((await authUserRowOf(userId)).role).toBe('user');
+      });
+
+      it('a re-promotion approved this way is not undone by the next actuator run', async () => {
+        const userId = await seedAccount({ daysPending: 40, memberRole: 'member', downgraded: true });
+        await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId, restoreDjRole: true } });
+
+        const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+        const decisions = await planDowngrades(db, pending, new Date());
+        await applyDowngrades(db, decisions, new Date());
+
+        expect(await memberRoleOf(userId)).toBe('dj');
+      });
+    });
+
+    it('cannot grant any role but dj — a musicDirector is left alone, never demoted', async () => {
+      const userId = await seedAccount({ daysPending: 5, memberRole: 'musicDirector' });
+
+      const res = await call('POST', `${BASE}/approve`, {
+        cookie: managerCookie,
+        body: { userId, restoreDjRole: true },
+      });
+
+      expect(res.body.roleRestored).toBe(false);
+      expect(await memberRoleOf(userId)).toBe('musicDirector');
+    });
+
+    it('is write-once on the review stamp: a second manager cannot re-attribute the review', async () => {
+      const userId = await seedAccount({ daysPending: 5, memberRole: 'dj' });
+      await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+      const first = await authUserRowOf(userId);
+
+      const second = await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+
+      expect(second.body.reviewedByThisCall).toBe(false);
+      const after = await authUserRowOf(userId);
+      expect(after.self_signup_reviewed_at).toEqual(first.self_signup_reviewed_at);
+      expect(after.self_signup_reviewed_by).toBe(managerUserId);
+    });
+
+    it('still applies restoreDjRole on that second call', async () => {
+      const userId = await seedAccount({ daysPending: 40, memberRole: 'member', downgraded: true });
+      await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+
+      const res = await call('POST', `${BASE}/approve`, {
+        cookie: managerCookie,
+        body: { userId, restoreDjRole: true },
+      });
+
+      expect(res.body).toMatchObject({ reviewedByThisCall: false, roleRestored: true, memberRole: 'dj' });
+    });
+
+    it('404s on an unknown user and 409s on an account that never self-signed up', async () => {
+      const notASignup = await seedAccount({ selfSignup: false, memberRole: 'dj' });
+
+      expect((await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId: 'nope' } })).status).toBe(
+        404
+      );
+      const conflict = await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId: notASignup } });
+      expect(conflict.status).toBe(409);
+      expect((await authUserRowOf(notASignup)).self_signup_reviewed_at).toBeNull();
+    });
+
+    it('rejects a missing userId with 400 and a non-boolean restoreDjRole with 400', async () => {
+      expect((await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: {} })).status).toBe(400);
+      const userId = await seedAccount({ daysPending: 5 });
+      expect(
+        (await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId, restoreDjRole: 'yes' } }))
+          .status
+      ).toBe(400);
+      expect((await authUserRowOf(userId)).self_signup_reviewed_at).toBeNull();
+    });
+
+    // -----------------------------------------------------------------------
+    // The race the shared lock order exists for
+    // -----------------------------------------------------------------------
+
+    it('approve-then-downgrade: the actuator aborts into `raced` and writes nothing', async () => {
+      const userId = await seedAccount({ daysPending: 40, memberRole: 'dj' });
+
+      // Plan while the account is still pending — this is the job's own
+      // snapshot, taken minutes before it writes (the SES round trip sits in
+      // between).
+      const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+      const decisions = await planDowngrades(db, pending, new Date());
+      expect(decisions[0].status).toBe('downgraded');
+
+      // The manager approves inside that window.
+      const approved = await call('POST', `${BASE}/approve`, { cookie: managerCookie, body: { userId } });
+      expect(approved.status).toBe(200);
+
+      // `applyDowngrades` re-selects FOR UPDATE and finds the review committed.
+      const applied = await applyDowngrades(db, decisions, new Date());
+
+      expect(applied.downgraded).toEqual([]);
+      expect(applied.failed).toEqual([]);
+      expect(applied.raced.map((r) => r.userId)).toEqual([userId]);
+      // Neither half of the actuator's paired write landed.
+      expect(await memberRoleOf(userId)).toBe('dj');
+      expect((await authUserRowOf(userId)).self_signup_downgraded_at).toBeNull();
+    });
+
+    it('downgrade-then-approve: the account arrives as a member, and restoreDjRole is what fixes it', async () => {
+      const userId = await seedAccount({ daysPending: 40, memberRole: 'dj' });
+
+      const pending = (await queryPendingSelfSignups()).filter((r) => r.userId === userId);
+      const decisions = await planDowngrades(db, pending, new Date());
+      const applied = await applyDowngrades(db, decisions, new Date());
+      expect(applied.downgraded.map((r) => r.userId)).toEqual([userId]);
+      expect(await memberRoleOf(userId)).toBe('member');
+
+      const res = await call('POST', `${BASE}/approve`, {
+        cookie: managerCookie,
+        body: { userId, restoreDjRole: true },
+      });
+
+      expect(res.body).toMatchObject({ roleRestored: true, memberRole: 'dj' });
+      expect(res.body.selfSignupDowngradedAt).not.toBeNull();
+    });
+  });
+});

--- a/tests/integration/station-signup-admin.spec.js
+++ b/tests/integration/station-signup-admin.spec.js
@@ -153,14 +153,23 @@ describe('station-signup manager API (BS#2362, real endpoints, real Postgres)', 
   const attemptsWithOutcome = async (outcome) =>
     sql`SELECT * FROM station_signup_attempt WHERE outcome = ${outcome} ORDER BY attempted_at ASC`;
 
-  /** Seed n `passcode_fail` rows spread across the last `spreadSeconds` seconds. */
-  async function seedFailures(n, spreadSeconds = 120) {
-    for (let i = 0; i < n; i += 1) {
-      await sql`
-        INSERT INTO station_signup_attempt (id, attempted_at, outcome)
-        VALUES (${`${uniqueId()}-f${i}`}, now() - make_interval(secs => ${(i * spreadSeconds) / n}), 'passcode_fail')
-      `;
-    }
+  /**
+   * Seed n attempt rows spread evenly back across the last `spreadSeconds`
+   * seconds (row 0 at `now()`, oldest at `now() - spreadSeconds`).
+   *
+   * ONE statement over `generate_series`, not n round trips: the cases below
+   * seed past the status endpoint's 100-row display cap, and a per-row insert
+   * loop makes that fixture cost more than the assertion it supports.
+   */
+  async function seedFailures(n, spreadSeconds = 120, outcome = 'passcode_fail') {
+    if (n <= 0) return;
+    const prefix = uniqueId();
+    const step = spreadSeconds / n;
+    await sql`
+      INSERT INTO station_signup_attempt (id, attempted_at, outcome)
+      SELECT ${prefix} || '-f' || i::text, now() - make_interval(secs => i * ${step}::float8), ${outcome}
+      FROM generate_series(0, ${n - 1}) AS i
+    `;
   }
 
   beforeAll(async () => {
@@ -314,6 +323,28 @@ describe('station-signup manager API (BS#2362, real endpoints, real Postgres)', 
 
       expect(revealed.body.passcodes.map((p) => p.code).sort()).toEqual([first.body.code, second.body.code].sort());
       expect(await attemptsWithOutcome('passcode_revealed')).toHaveLength(2);
+    });
+
+    it('audits ALL-OR-NOTHING: an undecryptable second row leaves no audit row for the first', async () => {
+      // BS#2362 review. The audit log is what replaces show-once storage's
+      // structural guarantee, so a `passcode_revealed` row for a code the
+      // manager never received is worse than none at all: it is the one place
+      // where the log IS the control. Decrypt every row first, write the
+      // audit rows only once they all opened.
+      await call('POST', `${BASE}/rotate`, { cookie: managerCookie, body: {} });
+      await sql`
+        INSERT INTO station_passcode (id, code_encrypted, expires_at)
+        VALUES (${`${uniqueId()}-bad`}, 'not-a-real-ciphertext', now() + interval '1 hour')
+      `;
+
+      const revealed = await call('POST', `${BASE}/reveal`, { cookie: managerCookie, body: {} });
+
+      // Unchanged error semantics: still the typed 503, still fail-closed.
+      expect(revealed.status).toBe(503);
+      expect(revealed.body.code).toBe('passcode_undecryptable');
+      expect(await attemptsWithOutcome('passcode_revealed')).toHaveLength(0);
+      // The gate-down trace the verify path writes is still there.
+      expect(await attemptsWithOutcome('passcode_unverifiable')).toHaveLength(1);
     });
   });
 
@@ -495,6 +526,40 @@ describe('station-signup manager API (BS#2362, real endpoints, real Postgres)', 
       });
       expect(res.body.attempts.countsByOutcome).toMatchObject({ passcode_fail: 3, passcode_expired: 1 });
       expect(res.body.attempts.recent).toHaveLength(4);
+    });
+
+    // BS#2362 review, the blocking finding. `recent` is `ORDER BY
+    // attempted_at DESC LIMIT 100`; the counts and the last-clear used to be
+    // derived from it, so both were statements about the newest 100 rows
+    // while the payload called them a 24-hour window. Past the cap the
+    // per-outcome totals saturated (and could report fewer 24-hour
+    // passcode_fail than the cooldown block counts over ten minutes), and
+    // lastClearedAt reverted to null — during a refusal storm, which is
+    // exactly when a manager polls to confirm their clear took.
+    it('counts the WHOLE window past the 100-row cap, and keeps lastClearedAt behind the burst', async () => {
+      await sql`
+        INSERT INTO station_signup_attempt (id, attempted_at, outcome, actor_user_id)
+        VALUES (${`${uniqueId()}-clr`}, now() - interval '5 minutes', 'cooldown_cleared', ${managerUserId})
+      `;
+      const [clearRow] = await attemptsWithOutcome('cooldown_cleared');
+      // 120 > STATUS_ATTEMPT_ROW_LIMIT, all of them landing AFTER the clear.
+      await seedFailures(120, 60);
+
+      const res = await call('GET', `${BASE}/status`, { cookie: managerCookie });
+
+      expect(res.status).toBe(200);
+      expect(res.body.attempts.countsByOutcome.passcode_fail).toBe(120);
+      // The clear was pushed clean out of the display list and is still counted.
+      expect(res.body.attempts.countsByOutcome.cooldown_cleared).toBe(1);
+      expect(res.body.attempts.recent).toHaveLength(100);
+      expect(res.body.attempts.recent.every((row) => row.outcome === 'passcode_fail')).toBe(true);
+
+      expect(new Date(res.body.cooldown.lastClearedAt).getTime()).toBe(new Date(clearRow.attempted_at).getTime());
+      // The payload can no longer contradict itself: a 24-hour count is never
+      // smaller than the cooldown block's 10-minute count of the same outcome.
+      expect(res.body.attempts.countsByOutcome.passcode_fail).toBeGreaterThanOrEqual(
+        res.body.cooldown.noMatchFailureCount
+      );
     });
 
     it('lists pending accounts with their days-pending and self_signup_downgraded_at', async () => {

--- a/tests/unit/auth/station-signup-admin.test.ts
+++ b/tests/unit/auth/station-signup-admin.test.ts
@@ -23,6 +23,8 @@
  */
 
 import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 // --- Mocks ---
 
@@ -126,11 +128,15 @@ jest.mock('drizzle-orm', () => ({
 const mockReadStationPasscodeStates = jest.fn<() => Promise<unknown[]>>();
 const mockEvaluateSignupCooldown = jest.fn<() => Promise<unknown>>();
 const mockReadRecentSignupAttempts = jest.fn<() => Promise<Record<string, unknown>[]>>();
+const mockCountSignupAttemptOutcomes = jest.fn<() => Promise<Record<string, number>>>();
+const mockReadLastCooldownClearedAt = jest.fn<() => Promise<Date | null>>();
 
 jest.mock('@wxyc/authentication', () => ({
   readStationPasscodeStates: (...args: unknown[]) => mockReadStationPasscodeStates(...(args as [])),
   evaluateSignupCooldown: (...args: unknown[]) => mockEvaluateSignupCooldown(...(args as [])),
   readRecentSignupAttempts: (...args: unknown[]) => mockReadRecentSignupAttempts(...(args as [])),
+  countSignupAttemptOutcomes: (...args: unknown[]) => mockCountSignupAttemptOutcomes(...(args as [])),
+  readLastCooldownClearedAt: (...args: unknown[]) => mockReadLastCooldownClearedAt(...(args as [])),
   // The module's real values. The status response divides the two durations
   // down to minutes, so stubbing round numbers here would let a
   // milliseconds-for-minutes mixup pass; these are pinned against the real
@@ -164,6 +170,8 @@ beforeEach(() => {
     allFailureCount: 0,
   });
   mockReadRecentSignupAttempts.mockResolvedValue([]);
+  mockCountSignupAttemptOutcomes.mockResolvedValue({});
+  mockReadLastCooldownClearedAt.mockResolvedValue(null);
 });
 
 describe('readStationSignupStatus', () => {
@@ -178,6 +186,7 @@ describe('readStationSignupStatus', () => {
   });
 
   it('counts the attempt log by outcome, leaving absent outcomes absent rather than zero', async () => {
+    mockCountSignupAttemptOutcomes.mockResolvedValue({ passcode_fail: 2, passcode_ok: 1 });
     mockReadRecentSignupAttempts.mockResolvedValue([
       attempt({ id: 'a1', outcome: 'passcode_fail' }),
       attempt({ id: 'a2', outcome: 'passcode_fail' }),
@@ -189,6 +198,27 @@ describe('readStationSignupStatus', () => {
     expect(status.attempts.countsByOutcome).toEqual({ passcode_fail: 2, passcode_ok: 1 });
     expect(status.attempts.countsByOutcome).not.toHaveProperty('passcode_revoked');
     expect(status.attempts.recent).toHaveLength(3);
+    // Window-wide, from the same floor the display list uses.
+    expect(mockCountSignupAttemptOutcomes).toHaveBeenCalledWith({ since: status.attempts.since });
+  });
+
+  // BS#2362 review, the blocking one. `recent` is `ORDER BY attempted_at DESC
+  // LIMIT 100`, so counting ITS rows caps the TOTAL across every outcome at
+  // 100 for a window documented as 24 hours — and lets this payload report
+  // fewer 24-hour `passcode_fail` than the cooldown block's SQL count over
+  // ten minutes.
+  it('takes the counts from the SQL aggregate, NOT from the capped display list', async () => {
+    mockCountSignupAttemptOutcomes.mockResolvedValue({ passcode_fail: 4312, cooldown_cleared: 1 });
+    mockReadRecentSignupAttempts.mockResolvedValue(
+      Array.from({ length: 100 }, (_, i) => attempt({ id: `a${i}`, outcome: 'passcode_fail' }))
+    );
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.attempts.countsByOutcome).toEqual({ passcode_fail: 4312, cooldown_cleared: 1 });
+    expect(status.attempts.recent).toHaveLength(100);
+    // The one outcome the cap pushed out of the display list is still counted.
+    expect(status.attempts.countsByOutcome.cooldown_cleared).toBe(1);
   });
 
   it('reports the cooldown rule in MINUTES, not milliseconds', async () => {
@@ -210,16 +240,32 @@ describe('readStationSignupStatus', () => {
     });
   });
 
-  it('surfaces the most recent cooldown_cleared row in the window, and null when there is none', async () => {
+  it('surfaces the most recent cooldown_cleared row, and null when there is none', async () => {
     const clearedAt = new Date('2026-09-05T11:30:00.000Z');
-    mockReadRecentSignupAttempts.mockResolvedValue([
-      attempt({ id: 'a1', outcome: 'cooldown_cleared', attemptedAt: clearedAt, actorUserId: 'manager-1' }),
-      attempt({ id: 'a2', outcome: 'passcode_fail' }),
-    ]);
+    mockReadLastCooldownClearedAt.mockResolvedValue(clearedAt);
     expect((await readStationSignupStatus({ now: NOW })).cooldown.lastClearedAt).toEqual(clearedAt);
 
-    mockReadRecentSignupAttempts.mockResolvedValue([attempt({ id: 'a2', outcome: 'passcode_fail' })]);
+    mockReadLastCooldownClearedAt.mockResolvedValue(null);
     expect((await readStationSignupStatus({ now: NOW })).cooldown.lastClearedAt).toBeNull();
+  });
+
+  // The other half of the blocking finding: derived from `recent`,
+  // lastClearedAt reverted to null the moment 100 attempts landed after the
+  // clear — during a cooldown_refused storm that is a couple of minutes, and
+  // it is exactly when a manager is polling to confirm the clear took.
+  it('reads the clear from the dedicated floor query, not from the capped display list', async () => {
+    const clearedAt = new Date('2026-09-05T11:30:00.000Z');
+    mockReadLastCooldownClearedAt.mockResolvedValue(clearedAt);
+    // A full display list, every row a refusal — the clear has been pushed
+    // out of it entirely.
+    mockReadRecentSignupAttempts.mockResolvedValue(
+      Array.from({ length: 100 }, (_, i) => attempt({ id: `a${i}`, outcome: 'cooldown_refused' }))
+    );
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.cooldown.lastClearedAt).toEqual(clearedAt);
+    expect(status.attempts.recent.some((row) => row.outcome === 'cooldown_cleared')).toBe(false);
   });
 
   it('floors days-pending and lists the longest-waiting account first', async () => {
@@ -420,5 +466,44 @@ describe('approveSelfSignup', () => {
     expect(mockOps.findIndex((op) => op.kind === 'update' && op.table === 'member')).toBeGreaterThan(0);
     // One transaction, so the stamp and the role flip cannot half-apply.
     expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The route wiring in `apps/auth/app.ts`, asserted against its source text.
+ *
+ * Importing that module starts a server and pulls in better-auth, so the
+ * express app itself is out of reach of this tier — the same reason
+ * `tests/unit/auth/rate-limiting.test.ts` pins its limiters this way. The
+ * integration suite proves the gate REJECTS (401/403 on all six routes); what
+ * it cannot show is that the gate is mounted structurally rather than by
+ * convention, or that a branch only an unconfigured deployment can reach
+ * exists at all — CI always has STATION_PASSCODE_KEY set.
+ */
+describe('station-signup admin route wiring (app.ts source)', () => {
+  const appSource = readFileSync(resolve(__dirname, '../../../apps/auth/app.ts'), 'utf-8');
+
+  it('mounts the admin-flag gate ONCE on the router, so a new route cannot skip it', () => {
+    expect(appSource).toMatch(/const stationSignupAdminRouter = express\.Router\(\);/);
+    expect(appSource).toMatch(/stationSignupAdminRouter\.use\(stationSignupAdminGate\);/);
+    expect(appSource).toMatch(/app\.use\(STATION_SIGNUP_ADMIN_PREFIX, stationSignupAdminRouter\);/);
+  });
+
+  it('keeps the six paths on the same prefix they shipped with', () => {
+    expect(appSource).toMatch(/const STATION_SIGNUP_ADMIN_PREFIX = '\/auth\/admin\/station-signup';/);
+    for (const route of ['/reveal', '/rotate', '/revoke', '/clear-cooldown', '/status', '/approve']) {
+      expect(appSource).toContain(`stationSignupAdminRouter.${route === '/status' ? 'get' : 'post'}(\n  '${route}',`);
+    }
+  });
+
+  it('maps StationPasscodeKeyUnsetError to 503 passcode_key_unset, distinct from the decrypt branch', () => {
+    expect(appSource).toMatch(/error instanceof StationPasscodeKeyUnsetError/);
+    expect(appSource).toMatch(/code: 'passcode_key_unset'/);
+    // The two 503s must stay distinguishable: the decrypt one's remedy is
+    // STATION_PASSCODE_KEY_PREVIOUS, which cannot fix a missing current key.
+    expect(appSource).toMatch(/code: 'passcode_undecryptable'/);
+    expect(appSource.indexOf("code: 'passcode_key_unset'")).toBeLessThan(
+      appSource.indexOf("code: 'passcode_undecryptable'")
+    );
   });
 });

--- a/tests/unit/auth/station-signup-admin.test.ts
+++ b/tests/unit/auth/station-signup-admin.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Unit coverage for the two manager operations that have logic of their own
+ * (BS#2362): `readStationSignupStatus`'s aggregation and
+ * `approveSelfSignup`'s transaction. The other four routes are thin
+ * delegations to `@wxyc/authentication` and are covered where that module is.
+ *
+ * `tests/integration/station-signup-admin.spec.js` is the main harness — it
+ * drives the real endpoints against real Postgres, which is the only place a
+ * WHERE predicate or a row lock can actually be proven. What a recording fake
+ * adds on top is the pair of properties that are about the SHAPE of the calls
+ * rather than their result, and that would otherwise only fail under a real
+ * concurrent race:
+ *
+ *   1. the `auth_user` SELECT takes `FOR UPDATE` and does so BEFORE any
+ *      `auth_member` write — the lock order `jobs/station-signup-review`'s
+ *      `applyDowngrades` docstring makes mandatory, and which a refactor
+ *      could silently invert without any single-threaded test noticing;
+ *   2. `restoreDjRole` off issues NO `auth_member` write at all, rather than
+ *      one that happens to match nothing.
+ *
+ * Everything shared with the `jest.mock` factories carries a `mock` prefix, as
+ * the hoisting transform requires.
+ */
+
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+/** Fake columns. The assertions below check which column an operator was applied to, not rendered SQL. */
+const mockUserTable = {
+  id: { name: 'user.id' },
+  name: { name: 'user.name' },
+  djName: { name: 'user.djName' },
+  selfSignupAt: { name: 'user.selfSignupAt' },
+  selfSignupReviewedAt: { name: 'user.selfSignupReviewedAt' },
+  selfSignupReviewedBy: { name: 'user.selfSignupReviewedBy' },
+  selfSignupDowngradedAt: { name: 'user.selfSignupDowngradedAt' },
+};
+const mockMemberTable = {
+  id: { name: 'member.id' },
+  userId: { name: 'member.userId' },
+  role: { name: 'member.role' },
+};
+
+type Table = typeof mockUserTable | typeof mockMemberTable;
+
+/** Rows each fake query hands back, per scenario. */
+interface Fixtures {
+  selectUser: Record<string, unknown>[];
+  selectMember: Record<string, unknown>[];
+  updateUser: Record<string, unknown>[];
+  updateMember: Record<string, unknown>[];
+}
+
+/** Every statement the fake saw, in order. This is what the lock-order assertion reads. */
+interface RecordedOp {
+  kind: 'select' | 'update';
+  table: 'user' | 'member' | 'unknown';
+  forUpdate?: boolean;
+  values?: Record<string, unknown>;
+  where?: unknown;
+}
+
+let mockFixtures: Fixtures;
+let mockOps: RecordedOp[];
+
+const mockNameOf = (table: Table): RecordedOp['table'] =>
+  table === mockUserTable ? 'user' : table === mockMemberTable ? 'member' : 'unknown';
+
+const mockMakeClient = () => ({
+  select: (_projection: unknown) => ({
+    from: (table: Table) => {
+      let where: unknown;
+      const rows = () => (table === mockUserTable ? mockFixtures.selectUser : mockFixtures.selectMember);
+      const chain = {
+        where: (predicate: unknown) => {
+          where = predicate;
+          return chain;
+        },
+        limit: (_n: number) => chain,
+        for: (_strength: string) => {
+          mockOps.push({ kind: 'select', table: mockNameOf(table), forUpdate: true, where });
+          return Promise.resolve(rows());
+        },
+        // Drizzle's builders are thenable, so an un-`.for()`ed chain resolves
+        // on await. Recording here rather than in from() is what keeps a
+        // locking read distinguishable from a plain one.
+        then: (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) => {
+          mockOps.push({ kind: 'select', table: mockNameOf(table), forUpdate: false, where });
+          return Promise.resolve(rows()).then(resolve, reject);
+        },
+      };
+      return chain;
+    },
+  }),
+  update: (table: Table) => ({
+    set: (values: Record<string, unknown>) => ({
+      where: (predicate: unknown) => ({
+        returning: (_projection: unknown) => {
+          mockOps.push({ kind: 'update', table: mockNameOf(table), values, where: predicate });
+          return Promise.resolve(table === mockUserTable ? mockFixtures.updateUser : mockFixtures.updateMember);
+        },
+      }),
+    }),
+  }),
+});
+
+const mockTransaction = jest.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(mockMakeClient()));
+
+jest.mock('@wxyc/database', () => ({
+  db: {
+    select: (...args: unknown[]) => mockMakeClient().select(...(args as [unknown])),
+    transaction: (...args: unknown[]) => mockTransaction(...(args as [(tx: unknown) => Promise<unknown>])),
+  },
+  user: mockUserTable,
+  member: mockMemberTable,
+}));
+
+jest.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ op: 'and', parts }),
+  eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  isNotNull: (col: unknown) => ({ op: 'isNotNull', col }),
+}));
+
+const mockReadStationPasscodeStates = jest.fn<() => Promise<unknown[]>>();
+const mockEvaluateSignupCooldown = jest.fn<() => Promise<unknown>>();
+const mockReadRecentSignupAttempts = jest.fn<() => Promise<Record<string, unknown>[]>>();
+
+jest.mock('@wxyc/authentication', () => ({
+  readStationPasscodeStates: (...args: unknown[]) => mockReadStationPasscodeStates(...(args as [])),
+  evaluateSignupCooldown: (...args: unknown[]) => mockEvaluateSignupCooldown(...(args as [])),
+  readRecentSignupAttempts: (...args: unknown[]) => mockReadRecentSignupAttempts(...(args as [])),
+  // The module's real values. The status response divides the two durations
+  // down to minutes, so stubbing round numbers here would let a
+  // milliseconds-for-minutes mixup pass; these are pinned against the real
+  // constants in tests/unit/authentication/station-passcode.test.ts.
+  SIGNUP_COOLDOWN_WINDOW_MS: 10 * 60 * 1000,
+  SIGNUP_COOLDOWN_HOLD_MS: 15 * 60 * 1000,
+  SIGNUP_COOLDOWN_THRESHOLD: 20,
+}));
+
+// --- Import after mocks ---
+import {
+  approveSelfSignup,
+  readStationSignupStatus,
+  StationSignupAdminError,
+} from '../../../apps/auth/station-signup-admin';
+
+const NOW = new Date('2026-09-05T12:00:00.000Z');
+
+/** Flatten a nested and()/eq() tree into a comparable list. */
+type Clause = { op: string; parts?: Clause[]; col?: { name?: string }; val?: unknown };
+const flatten = (clause: Clause): Clause[] => (clause.op === 'and' ? (clause.parts ?? []).flatMap(flatten) : [clause]);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOps = [];
+  mockFixtures = { selectUser: [], selectMember: [], updateUser: [], updateMember: [] };
+  mockReadStationPasscodeStates.mockResolvedValue([]);
+  mockEvaluateSignupCooldown.mockResolvedValue({
+    inCooldown: false,
+    noMatchFailureCount: 0,
+    allFailureCount: 0,
+  });
+  mockReadRecentSignupAttempts.mockResolvedValue([]);
+});
+
+describe('readStationSignupStatus', () => {
+  const attempt = (overrides: Record<string, unknown>) => ({
+    id: 'a1',
+    attemptedAt: NOW,
+    outcome: 'passcode_fail',
+    passcodeId: null,
+    actorUserId: null,
+    ipHash: null,
+    ...overrides,
+  });
+
+  it('counts the attempt log by outcome, leaving absent outcomes absent rather than zero', async () => {
+    mockReadRecentSignupAttempts.mockResolvedValue([
+      attempt({ id: 'a1', outcome: 'passcode_fail' }),
+      attempt({ id: 'a2', outcome: 'passcode_fail' }),
+      attempt({ id: 'a3', outcome: 'passcode_ok' }),
+    ]);
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.attempts.countsByOutcome).toEqual({ passcode_fail: 2, passcode_ok: 1 });
+    expect(status.attempts.countsByOutcome).not.toHaveProperty('passcode_revoked');
+    expect(status.attempts.recent).toHaveLength(3);
+  });
+
+  it('reports the cooldown rule in MINUTES, not milliseconds', async () => {
+    mockEvaluateSignupCooldown.mockResolvedValue({
+      inCooldown: true,
+      noMatchFailureCount: 25,
+      allFailureCount: 30,
+    });
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.cooldown).toMatchObject({
+      inCooldown: true,
+      noMatchFailureCount: 25,
+      allFailureCount: 30,
+      windowMinutes: 10,
+      holdMinutes: 15,
+      threshold: 20,
+    });
+  });
+
+  it('surfaces the most recent cooldown_cleared row in the window, and null when there is none', async () => {
+    const clearedAt = new Date('2026-09-05T11:30:00.000Z');
+    mockReadRecentSignupAttempts.mockResolvedValue([
+      attempt({ id: 'a1', outcome: 'cooldown_cleared', attemptedAt: clearedAt, actorUserId: 'manager-1' }),
+      attempt({ id: 'a2', outcome: 'passcode_fail' }),
+    ]);
+    expect((await readStationSignupStatus({ now: NOW })).cooldown.lastClearedAt).toEqual(clearedAt);
+
+    mockReadRecentSignupAttempts.mockResolvedValue([attempt({ id: 'a2', outcome: 'passcode_fail' })]);
+    expect((await readStationSignupStatus({ now: NOW })).cooldown.lastClearedAt).toBeNull();
+  });
+
+  it('floors days-pending and lists the longest-waiting account first', async () => {
+    mockFixtures.selectUser = [
+      {
+        userId: 'u-new',
+        name: 'New',
+        djName: null,
+        // 2 days and 23 hours -- floors to 2, never rounds up to 3.
+        selfSignupAt: new Date(NOW.getTime() - (2 * 24 + 23) * 60 * 60 * 1000),
+        selfSignupDowngradedAt: null,
+      },
+      {
+        userId: 'u-old',
+        name: 'Old',
+        djName: 'DJ Old',
+        selfSignupAt: new Date(NOW.getTime() - 31 * 24 * 60 * 60 * 1000),
+        selfSignupDowngradedAt: new Date('2026-09-04T00:00:00.000Z'),
+      },
+    ];
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.pendingReview.map((row) => row.userId)).toEqual(['u-old', 'u-new']);
+    expect(status.pendingReview[0]).toMatchObject({ daysPending: 31, djName: 'DJ Old' });
+    expect(status.pendingReview[0].selfSignupDowngradedAt).toEqual(new Date('2026-09-04T00:00:00.000Z'));
+    expect(status.pendingReview[1]).toMatchObject({ daysPending: 2, selfSignupDowngradedAt: null });
+  });
+
+  it('reads the pending cohort by self_signup_at IS NOT NULL AND self_signup_reviewed_at IS NULL', async () => {
+    await readStationSignupStatus({ now: NOW });
+
+    const cohortRead = mockOps.find((op) => op.kind === 'select' && op.table === 'user');
+    expect(cohortRead).toBeDefined();
+    const clauses = flatten(cohortRead?.where as Clause);
+    expect(clauses).toContainEqual({ op: 'isNotNull', col: mockUserTable.selfSignupAt });
+    expect(clauses).toContainEqual({ op: 'isNull', col: mockUserTable.selfSignupReviewedAt });
+    // NOT narrowed by self_signup_downgraded_at: an account the actuator
+    // already downgraded must keep appearing until a human reviews it.
+    expect(clauses.some((clause) => clause.col === mockUserTable.selfSignupDowngradedAt)).toBe(false);
+  });
+
+  it('writes nothing at all, which is what makes it safe to poll', async () => {
+    mockFixtures.selectUser = [
+      { userId: 'u1', name: 'A', djName: null, selfSignupAt: NOW, selfSignupDowngradedAt: null },
+    ];
+
+    await readStationSignupStatus({ now: NOW });
+
+    expect(mockOps.every((op) => op.kind === 'select')).toBe(true);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('never carries plaintext — the passcode block is exactly the never-decrypting view', async () => {
+    const stateRows = [{ id: 'p1', state: 'active', useCount: 1, maxUses: 50 }];
+    mockReadStationPasscodeStates.mockResolvedValue(stateRows);
+
+    const status = await readStationSignupStatus({ now: NOW });
+
+    expect(status.passcodes).toEqual(stateRows);
+    expect(JSON.stringify(status)).not.toMatch(/"code"|codeEncrypted/);
+  });
+});
+
+describe('approveSelfSignup', () => {
+  const pendingAccount = (overrides: Record<string, unknown> = {}) => ({
+    id: 'u1',
+    selfSignupAt: new Date('2026-08-01T00:00:00.000Z'),
+    selfSignupReviewedAt: null,
+    selfSignupReviewedBy: null,
+    selfSignupDowngradedAt: null,
+    ...overrides,
+  });
+
+  const approve = (params: Record<string, unknown> = {}) =>
+    approveSelfSignup({ userId: 'u1', reviewerId: 'manager-1', now: NOW, ...params });
+
+  it('404s on an unknown user without writing anything', async () => {
+    mockFixtures.selectUser = [];
+
+    await expect(approve()).rejects.toBeInstanceOf(StationSignupAdminError);
+    await expect(approve()).rejects.toMatchObject({ statusCode: 404 });
+    expect(mockOps.some((op) => op.kind === 'update')).toBe(false);
+  });
+
+  it('409s on an account that never self-signed up, so the review columns stay meaningless there', async () => {
+    mockFixtures.selectUser = [pendingAccount({ selfSignupAt: null })];
+
+    await expect(approve()).rejects.toMatchObject({ statusCode: 409 });
+    expect(mockOps.some((op) => op.kind === 'update')).toBe(false);
+  });
+
+  it('stamps reviewed_at/_by from the reviewerId it was handed, and preserves the downgrade marker', async () => {
+    const downgradedAt = new Date('2026-09-01T00:00:00.000Z');
+    mockFixtures.selectUser = [pendingAccount({ selfSignupDowngradedAt: downgradedAt })];
+    mockFixtures.updateUser = [{ id: 'u1' }];
+    mockFixtures.selectMember = [{ role: 'member' }];
+
+    const result = await approve();
+
+    expect(result).toMatchObject({
+      userId: 'u1',
+      reviewedAt: NOW,
+      reviewedBy: 'manager-1',
+      reviewedByThisCall: true,
+      roleRestored: false,
+      memberRole: 'member',
+    });
+    // Approval is not a history edit: the marker records what happened.
+    expect(result.selfSignupDowngradedAt).toEqual(downgradedAt);
+    const stamp = mockOps.find((op) => op.kind === 'update' && op.table === 'user');
+    expect(stamp?.values).toEqual({ selfSignupReviewedAt: NOW, selfSignupReviewedBy: 'manager-1' });
+    // The stamp is guarded IS NULL, which is what makes it write-once.
+    expect(flatten(stamp?.where as Clause)).toContainEqual({
+      op: 'isNull',
+      col: mockUserTable.selfSignupReviewedAt,
+    });
+  });
+
+  it('is write-once: a second approval reports the ORIGINAL reviewer, not the second caller', async () => {
+    const firstReviewAt = new Date('2026-09-02T00:00:00.000Z');
+    mockFixtures.selectUser = [
+      pendingAccount({ selfSignupReviewedAt: firstReviewAt, selfSignupReviewedBy: 'manager-first' }),
+    ];
+    // The IS NULL guard matched nothing.
+    mockFixtures.updateUser = [];
+    mockFixtures.selectMember = [{ role: 'dj' }];
+
+    const result = await approve({ reviewerId: 'manager-second' });
+
+    expect(result).toMatchObject({
+      reviewedAt: firstReviewAt,
+      reviewedBy: 'manager-first',
+      reviewedByThisCall: false,
+    });
+  });
+
+  it('still applies restoreDjRole on that second call, so a re-promotion is not a dead end', async () => {
+    mockFixtures.selectUser = [
+      pendingAccount({
+        selfSignupReviewedAt: new Date('2026-09-02T00:00:00.000Z'),
+        selfSignupReviewedBy: 'manager-first',
+      }),
+    ];
+    mockFixtures.updateUser = [];
+    mockFixtures.updateMember = [{ id: 'm1' }];
+    mockFixtures.selectMember = [{ role: 'dj' }];
+
+    const result = await approve({ restoreDjRole: true });
+
+    expect(result).toMatchObject({ reviewedByThisCall: false, roleRestored: true, memberRole: 'dj' });
+  });
+
+  it('issues NO auth_member write at all without restoreDjRole', async () => {
+    mockFixtures.selectUser = [pendingAccount({ selfSignupDowngradedAt: new Date('2026-09-01T00:00:00.000Z') })];
+    mockFixtures.updateUser = [{ id: 'u1' }];
+    mockFixtures.selectMember = [{ role: 'member' }];
+
+    const result = await approve();
+
+    // The quiet default has to be "grant nothing" — a manager may well decide
+    // the person should not be a DJ.
+    expect(mockOps.some((op) => op.kind === 'update' && op.table === 'member')).toBe(false);
+    expect(result.roleRestored).toBe(false);
+  });
+
+  it("can only ever set 'dj', and only from 'member' — never a demotion of a higher role", async () => {
+    mockFixtures.selectUser = [pendingAccount()];
+    mockFixtures.updateUser = [{ id: 'u1' }];
+    // A musicDirector matched nothing: the WHERE pinned the source role.
+    mockFixtures.updateMember = [];
+    mockFixtures.selectMember = [{ role: 'musicDirector' }];
+
+    const result = await approve({ restoreDjRole: true });
+
+    const roleWrite = mockOps.find((op) => op.kind === 'update' && op.table === 'member');
+    expect(roleWrite?.values).toEqual({ role: 'dj' });
+    expect(flatten(roleWrite?.where as Clause)).toContainEqual({
+      op: 'eq',
+      col: mockMemberTable.role,
+      val: 'member',
+    });
+    expect(result).toMatchObject({ roleRestored: false, memberRole: 'musicDirector' });
+  });
+
+  it('locks auth_user FOR UPDATE first, BEFORE any auth_member write, all in ONE transaction', async () => {
+    mockFixtures.selectUser = [pendingAccount()];
+    mockFixtures.updateUser = [{ id: 'u1' }];
+    mockFixtures.updateMember = [{ id: 'm1' }];
+    mockFixtures.selectMember = [{ role: 'dj' }];
+
+    await approve({ restoreDjRole: true });
+
+    // The order jobs/station-signup-review/downgrade.ts's applyDowngrades
+    // makes mandatory. Taking these the other way round deadlocks the pair,
+    // and the job's loser lands in `failed` rather than in benign `raced`.
+    expect(mockOps[0]).toMatchObject({ kind: 'select', table: 'user', forUpdate: true });
+    expect(mockOps.findIndex((op) => op.kind === 'update' && op.table === 'member')).toBeGreaterThan(0);
+    // One transaction, so the stamp and the role flip cannot half-apply.
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/authentication/station-passcode.test.ts
+++ b/tests/unit/authentication/station-passcode.test.ts
@@ -19,7 +19,10 @@ import {
   isStationPasscodeActive,
   isStationPasscodeRecentlyInactive,
   classifyStationPasscodeState,
+  revealStationPasscode,
+  rotateStationPasscode,
   StationPasscodeDecryptionError,
+  StationPasscodeKeyUnsetError,
   STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON,
   SIGNUP_COOLDOWN_WINDOW_MS,
   SIGNUP_COOLDOWN_HOLD_MS,
@@ -199,6 +202,36 @@ describe('resolveStationPasscodeKeyRing', () => {
   it('still throws when the CURRENT key is missing — there is no degraded mode for it', () => {
     delete process.env.STATION_PASSCODE_KEY;
     expect(() => resolveStationPasscodeKeyRing()).toThrow(/STATION_PASSCODE_KEY is not set/);
+  });
+
+  // BS#2362 review. The manager operations that need the key must say
+  // "unconfigured" in their own type, because apps/auth maps that to
+  // 503 `passcode_key_unset` and the alternatives are all wrong answers:
+  // rotate fell through to a code-less 500, reveal WITH an active row
+  // surfaced as a StationPasscodeDecryptionError whose remedy names
+  // STATION_PASSCODE_KEY_PREVIOUS (activeRowDecryptionError defaults a
+  // non-typed throw to `corrupt`), and reveal with an empty table answered
+  // `200 {passcodes: []}` — "there is no station code" when the truth is
+  // "this process cannot read one". Only reachable in an unconfigured
+  // deployment, so the integration tier (which always has the key) cannot
+  // cover it.
+  describe('with STATION_PASSCODE_KEY unset', () => {
+    beforeEach(() => {
+      delete process.env.STATION_PASSCODE_KEY;
+    });
+
+    it('reveal throws the typed key-unset error before reading a single row', async () => {
+      await expect(revealStationPasscode('manager-1')).rejects.toBeInstanceOf(StationPasscodeKeyUnsetError);
+      // NOT the decrypt failure: that one's operator remedy is the previous
+      // key, which cannot fix a missing current key.
+      await expect(revealStationPasscode('manager-1')).rejects.not.toBeInstanceOf(StationPasscodeDecryptionError);
+      await expect(revealStationPasscode('manager-1')).rejects.toThrow(/STATION_PASSCODE_KEY/);
+    });
+
+    it('rotate throws it too, before the advisory lock and before minting anything', async () => {
+      await expect(rotateStationPasscode()).rejects.toBeInstanceOf(StationPasscodeKeyUnsetError);
+      await expect(rotateStationPasscode()).rejects.toThrow(/STATION_PASSCODE_KEY/);
+    });
   });
 });
 

--- a/tests/unit/authentication/station-passcode.test.ts
+++ b/tests/unit/authentication/station-passcode.test.ts
@@ -18,6 +18,7 @@ import {
   resolveCooldownCountStart,
   isStationPasscodeActive,
   isStationPasscodeRecentlyInactive,
+  classifyStationPasscodeState,
   StationPasscodeDecryptionError,
   STATION_PASSCODE_UNDECRYPTABLE_REVOKED_REASON,
   SIGNUP_COOLDOWN_WINDOW_MS,
@@ -511,6 +512,53 @@ describe('isStationPasscodeActive / isStationPasscodeRecentlyInactive', () => {
       revokedReason: 'manager revoked it',
     };
     expect(isStationPasscodeRecentlyInactive(row, now, since)).toBe(true);
+  });
+});
+
+describe('classifyStationPasscodeState (BS#2362 status)', () => {
+  const now = new Date('2026-09-05T12:00:00Z');
+
+  it('active when neither revoked nor expired', () => {
+    expect(classifyStationPasscodeState({ revokedAt: null, expiresAt: new Date('2026-09-10T00:00:00Z') }, now)).toBe(
+      'active'
+    );
+  });
+
+  it('expired once past expires_at, never revoked', () => {
+    expect(classifyStationPasscodeState({ revokedAt: null, expiresAt: new Date('2026-09-01T00:00:00Z') }, now)).toBe(
+      'expired'
+    );
+  });
+
+  it('revoked when revoked_at is set and the row has not expired', () => {
+    expect(
+      classifyStationPasscodeState(
+        { revokedAt: new Date('2026-09-02T00:00:00Z'), expiresAt: new Date('2026-09-10T00:00:00Z') },
+        now
+      )
+    ).toBe('revoked');
+  });
+
+  it("reports 'revoked', not 'expired', for a row that is BOTH", () => {
+    // Revocation is a deliberate operator action and the only one of the pair
+    // carrying a revoked_reason worth reading, so it wins the label.
+    expect(
+      classifyStationPasscodeState(
+        { revokedAt: new Date('2026-08-20T00:00:00Z'), expiresAt: new Date('2026-09-01T00:00:00Z') },
+        now
+      )
+    ).toBe('revoked');
+  });
+
+  it('agrees with isStationPasscodeActive on which rows are active', () => {
+    const rows = [
+      { revokedAt: null, expiresAt: new Date('2026-09-10T00:00:00Z') },
+      { revokedAt: null, expiresAt: new Date('2026-09-01T00:00:00Z') },
+      { revokedAt: new Date('2026-09-02T00:00:00Z'), expiresAt: new Date('2026-09-10T00:00:00Z') },
+    ];
+    for (const row of rows) {
+      expect(classifyStationPasscodeState(row, now) === 'active').toBe(isStationPasscodeActive(row, now));
+    }
   });
 });
 


### PR DESCRIPTION
Closes #2362.

Six manager operations for the station self-signup passcode, mounted in `apps/auth/app.ts` beside `/auth/admin/provision-user`, plus the read-only passcode-state helpers the status endpoint needs. Builds on #2375 (the signup endpoint itself), which shipped the two-phase `matchStationPasscode` / `claimStationPasscode` split and the CI passcode-key wiring this PR reuses unchanged — no new environment variables, no new migrations, and nothing here reads or flips `STATION_SIGNUP_DOWNGRADE_ENABLED` or `STATION_SIGNUP_ENABLED`.

## The six operations

`POST /auth/admin/station-signup/reveal` returns the current plaintext code(s). Readable storage exists precisely so a manager can read the code to a stranded DJ by phone without rotating — rotating under the two-row cap can invalidate the sticky note the rest of the room is still using. It is a POST rather than a GET because every reveal WRITES: see the audit row below.

`POST /auth/admin/station-signup/rotate` mints a new code and returns its plaintext once, attributing `created_by` to the acting manager. It refuses a third active row with `409` and `code: 'passcode_cap_exceeded'` rather than silently retiring a note the room is using; the caller revokes one first.

`POST /auth/admin/station-signup/revoke` is the manual kill switch, setting `revoked_reason = 'manual'`. That value is what distinguishes a manager's revoke from rotation's automatic retirement of an undecryptable active row, which the status endpoint reports separately as `revokedByKeyRotation`. Revoking an unknown or already-revoked id is an idempotent `revoked: false` no-op, not an error.

`POST /auth/admin/station-signup/clear-cooldown` is the anti-lockout escape hatch. It writes a `cooldown_cleared` attempt row, which `evaluateSignupCooldown` already honours as a floor on the failure window, and it DELETES NOTHING — that log is simultaneously the cooldown's own input and the 30-day audit trail, so clearing by deletion would destroy the forensic record of the attack that caused the cooldown. Without this operation a sustained attacker can hold the endpoint in cooldown with nothing in the product able to lift it, and the failure mode becomes "wait for a manager who is not on site"; with it, one phone call. The floor is not a permanent exemption: if the attack resumes, the cooldown re-engages on the failures logged after the clear.

`GET /auth/admin/station-signup/status` answers "is the gate working, and is anything waiting on me?" in one read — passcode state (active / revoked-with-reason / expired, `last_used_at`, `use_count` / `max_uses`, and an `exhausted` flag for a row that is still active by the SQL predicate but whose every further use logs `passcode_exhausted`), cooldown state alongside the rule it is measured against, the 24-hour attempt log, and the pending-review queue. It writes nothing at all, which is what makes it safe to poll — and is the reason reveal is a separate operation rather than folded in here, since folding it in would either spam the audit log on every poll or hand out the code without a row.

Two of that payload's fields are window-wide and are computed as such, in SQL, rather than off the row list beside them. `attempts.countsByOutcome` is a `GROUP BY outcome` aggregate over everything at or after `since`, so it cannot saturate and cannot contradict `cooldown.noMatchFailureCount`, which is aggregated the same way over ten minutes; `cooldown.lastClearedAt` is the dedicated indexed `LIMIT 1` on `cooldown_cleared` that `evaluateSignupCooldown` already runs as its window floor, so the reported clear is definitionally the clear the counts were measured from. `attempts.recent` is the only capped field — the newest 100 rows in the window, a display list rather than a census, and documented as one. Deriving either of the first two from that list would have made a "24 hour" number a statement about the newest 100 rows, and would have blanked `lastClearedAt` again a couple of minutes into any refusal storm, which is exactly when a manager polls to confirm their clear took.

`POST /auth/admin/station-signup/approve` clears one account out of the manager review queue.

## The gate is the admin flag, stated precisely

All six routes live on one `express.Router` mounted at `/auth/admin/station-signup`, with the same check `/auth/admin/provision-user` uses — `session.user.role !== 'admin'` → 403 — applied once via `router.use`. The gate is therefore structural rather than a convention: a seventh route added to that router inherits it whether or not anyone remembers the wrapper. `requirePermissions` lives in the backend app and is not available in `apps/auth`.

This is deliberately NOT "stationManager only": via `grantsAdminFlag` the flag also admits a stray `admin` / `owner` membership row, so this is a slightly wider set than the station-manager role. That is the right trade rather than an oversight, because `/auth/admin/provision-user` already sits behind exactly this gate and creates accounts at ANY role, `stationManager` included — so nothing here is a wider grant than what the same gate already protects. A true membership-role gate would need a read nothing in `apps/auth` does today; if it is ever wanted it is its own change with its own test, applied to both endpoints at once.

The routes are mounted unconditionally rather than behind `STATION_SIGNUP_ENABLED`. Lighting the feature up needs a code in the table BEFORE the public endpoint opens, and two ordered flag flips to achieve that would be a worse operational story than one admin-gated surface that is inert until someone with the admin flag calls it.

## Reveal writes the audit row

Readable storage removes the structural guarantee show-once storage had for free — that only whoever rotated ever saw the code. The audit log is what replaces it: every reveal writes one `passcode_revealed` attempt row per code revealed, carrying `actor_user_id`, which is what makes "who could have seen this?" answerable after a suspected leak. The token already exists in `STATION_SIGNUP_OUTCOMES`; no schema change.

That actor, and `approve`'s reviewer, are derived from the SESSION and never read from the request body — an audit trail a caller can forge names the wrong person. The integration spec asserts that a body-supplied actor is ignored rather than honoured.

The audit write is all-or-nothing. Every active row is decrypted first and the `passcode_revealed` rows are written only once all of them opened, so a later row that will not decrypt can never leave a log entry for a code the manager never received. The failure itself is unchanged: `passcode_unverifiable` is still logged and the typed 503 still thrown.

A deployment with no `STATION_PASSCODE_KEY` gets its own answer rather than a misleading one. Reveal and rotate check for the key upfront and throw a distinct `StationPasscodeKeyUnsetError`, which the wrapper maps to 503 `passcode_key_unset`. Previously rotate fell through to a code-less 500, reveal with an active row surfaced as a decrypt failure whose remedy names `STATION_PASSCODE_KEY_PREVIOUS` (the one variable that cannot fix a missing current key), and reveal against an empty table answered `200 {passcodes: []}` — "there is no station code" when the truth was "this process cannot read one". The public signup path is untouched and keeps failing closed exactly as before.

## Approve semantics

Not via better-auth's public `POST /update-user`. All three review columns carry `input: false`, which blocks that route BY DESIGN — that is what stops a signed-in DJ approving their own pending signup. This writes through `@wxyc/database` directly, which never reaches `parseUserInput`, exactly as `jobs/station-signup-review` already does for `self_signup_downgraded_at`. A direct write is not merely one of the permitted bypasses here, it is the only one that can hold the optional role restore in the SAME transaction as the review stamp; the admin plugin's `adminUpdateUser` would put the two writes in different transactions and reintroduce the half-applied state the lock order exists to prevent.

`restoreDjRole` is a boolean, not a role parameter. `'dj'` is a literal in the UPDATE and the WHERE pins the source role to `'member'`, so the only transition this endpoint can perform is the exact inverse of the 30-day actuator's `dj` → `member`. An account sitting at `musicDirector` is left alone rather than silently demoted, and there is no input by which a caller could ask for any other role. Omitting the flag issues no `auth_member` write at all: a manager reviewing a self-signup may well decide the person should not be a DJ, so the quiet default has to be "grant nothing".

`self_signup_downgraded_at` is PRESERVED, never cleared, in both modes. It records what happened to the account, and approving is not a history edit; it also suppresses the actuator, so an approved account can never be auto-downgraded a second time.

The review stamp is write-once — the UPDATE carries `self_signup_reviewed_at IS NULL`, so a second approval does not re-attribute the review to a second manager — but `restoreDjRole` on that second call still applies, so "approve, then realise the role should come back" is one more call rather than a dead end.

## Lock order

The approve transaction takes `SELECT ... FOR UPDATE` on the `auth_user` row FIRST, then writes `auth_member`. `jobs/station-signup-review`'s `applyDowngrades` holds the same order and names this endpoint in its docstring as the writer that has to match it; taking them the other way round deadlocks the pair, and the job's loser lands in its `failed` / non-zero path rather than its benign `raced` one. Because both sides lock the same row first they simply serialize, and both directions are covered: approve-then-downgrade leaves the job's re-select filtering the row out into `raced` having written nothing, and downgrade-then-approve leaves this call approving an account that is already `member` — which is precisely what `restoreDjRole` is for.

## Tests

`tests/integration/station-signup-admin.spec.js` is the main harness: it drives the real endpoints over HTTP against real Postgres, since every property worth testing here is a side effect on a row rather than a return value. It covers the gate as a table across all six routes (401 unauthenticated, 403 plain-DJ, and that a rejected call writes nothing), the two-row cap, reveal's audit row and its unspoofable actor, revoke's reason and idempotence, clear-cooldown's floor-not-delete behaviour and its re-engagement, every field of the status response, and approve including the write-once stamp, the marker preservation, the role-restore guard, and both race directions driven against the job's REAL compiled `applyDowngrades`.

`tests/unit/auth/station-signup-admin.test.ts` adds a recording fake for the two properties that are about the shape of the calls rather than their result, and that a single-threaded test would otherwise never catch: that the `auth_user` read takes `FOR UPDATE` and does so before any `auth_member` write, and that `restoreDjRole` off issues no `auth_member` statement at all rather than one that happens to match nothing. It also pins the status aggregation — outcome counts, the days-pending floor and ordering, the minutes-not-milliseconds conversion of the cooldown rule, and the pending-cohort predicate — and that the counts and the last clear come from the SQL aggregate and the floor query rather than from the capped display list.

Two properties are only reachable at the edges of those two tiers. The integration spec seeds a `cooldown_cleared` row followed by 120 failures, past the 100-row cap, and asserts the true per-outcome totals, the surviving `lastClearedAt`, and that `recent` is still exactly the newest 100; a second case inserts an undecryptable active row alongside a good one and asserts reveal writes no audit row at all. The key-unset branch is the opposite case — CI always has `STATION_PASSCODE_KEY` set, so it is covered where it can be: unit tests that both operations throw the typed error, plus source-text assertions that the router mounts the gate once and that the wrapper maps that error to its own 503.

